### PR TITLE
[docs] Fix nits and introduce top-level doc.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# USS to USS Communication and Synchronization Wrapper
-
+# USS to USS Communication and Synchronization Wrapper [![Build Status](https://dev.azure.com/astm/dss/_apis/build/status/interuss.dss?branchName=master)](https://dev.azure.com/astm/dss/_build/latest?definitionId=2&branchName=master)
 This repository contains a simple and open API used for separate UAS Service
 Suppliers (USS) to communicate during UAS operations, known as a Discovery and
 Synchronization Service (DSS) as described in the ASTM remote ID standard.

--- a/README.md
+++ b/README.md
@@ -9,31 +9,27 @@ operator and consumer privacy. The system is focused on facilitating
 communication amongst actively operating USSs with no details about UAS
 operations stored or processed in the DSS.
 
-
 ## Architecture
-
 
 See the [API specification here](https://tiny.cc/dssapi_rid)
 
 ### HTTP Frontend
 
-Serves as an Https gateway to the business logic, translating between Http Request
-and gRPC to allow users to communicate to the DSS via simple Https calls. This
+Serves as an HTTP gateway to the business logic, translating between HTTP Request
+and gRPC to allow users to communicate to the DSS via simple HTTP calls. This
 code is currently generated via
 [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway), and does not do
 much other than translation.
 
 ### gRPC Backend
 
-
 Component responsible for all the business logic as well as authentication. This
 backend talks directly to CockroachDB.
 
-
 ### CockroachDB (CRDB)
 
-Individual CockroachDB instances hosting sharded data. More information about 
-CockroachDB 
+Individual CockroachDB instances hosting sharded data. More information about
+CockroachDB
 [here](https://www.cockroachlabs.com/docs/stable/architecture/overview.html).
 
 ## Directories of Interest:
@@ -67,8 +63,8 @@ CockroachDB
     about the entire cluster through a gossip protocol.
 *   Each CRDB node must be uniquely addressable and routable.
     *   Because of this, we expect each node to have it's own static IP and/or
-    publicly resolvable hostname. In the future, we likely want to explore the
-    use of service mesh frameworks.
+        publicly resolvable hostname. In the future, we likely want to explore
+        the use of service mesh frameworks.
 *   CRDB splits up data based on the locality string. Data replication strategy
     is a database variable. The CRDB nodes will traverse the key,values of the
     locality flag to determine how to divy up the replicas. This means there

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,8 @@
+// Package dss provides an implementation of a Discovery and Synchronization
+// Service (DSS) as described in the ASTM remote ID standard. It is a flexible
+// and distributed system used to connect multiple UAS Service Suppliers (USSs)
+// operating in the same general area to share information while protecting
+// operator and consumer privacy. The system is focused on facilitating
+// communication amongst actively operating USSs with no details about UAS
+// operations stored or processed in the DSS.
+package dss


### PR DESCRIPTION
We are introducing a top-level `doc.go` such that `godoc.org/github.com/interuss/dss` picks up the package properly.