### PR TITLE
Add Check for Token Issuer and Expiration

### DIFF
--- a/cmds/dummy-oauth/main.go
+++ b/cmds/dummy-oauth/main.go
@@ -34,32 +34,27 @@ func createGetTokenHandler(privateKey *rsa.PrivateKey) http.Handler {
 		params := r.URL.Query()
 
 		var (
-			aud  string   = ""
-			auds []string = params["intended_audience"]
+			aud         string   = ""
+			auds        []string = params["intended_audience"]
+			scope       string   = ""
+			scopes      []string = params["scope"]
+			issuer      string   = ""
+			issuers     []string = params["issuer"]
+			expireTime  int64    = time.Now().Add(time.Hour).Unix()
+			expireTimes []string = params["expire"]
 		)
 		if len(auds) == 1 {
 			aud = auds[0]
 		}
 
-		var (
-			scope  string   = ""
-			scopes []string = params["scope"]
-		)
 		if len(scopes) == 1 {
 			scope = scopes[0]
 		}
 
-		var (
-			issuer  string   = ""
-			issuers []string = params["issuer"]
-		)
 		if len(issuers) == 1 {
 			issuer = issuers[0]
 		}
-		var (
-			expireTime  int64    = time.Now().Add(time.Hour).Unix()
-			expireTimes []string = params["expire"]
-		)
+
 		if len(expireTimes) == 1 {
 			parsedTime, err := strconv.ParseInt(expireTimes[0], 10, 64)
 			if err != nil {

--- a/cmds/dummy-oauth/main.go
+++ b/cmds/dummy-oauth/main.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"strconv"
+	"time"
 
 	"github.com/dgrijalva/jwt-go"
 )
@@ -46,9 +48,29 @@ func createGetTokenHandler(privateKey *rsa.PrivateKey) http.Handler {
 		if len(scopes) == 1 {
 			scope = scopes[0]
 		}
+
+		var (
+			issuer  string   = ""
+			issuers []string = params["issuer"]
+		)
+		if len(issuers) == 1 {
+			issuer = issuers[0]
+		}
+		var (
+			expireTime  int64    = time.Now().Add(time.Hour).Unix()
+			expireTimes []string = params["expire"]
+		)
+		if len(expireTimes) == 1 {
+			parsedTime, err := strconv.ParseInt(expireTimes[0], 10, 64)
+			if err != nil {
+				expireTime = parsedTime
+			}
+		}
 		token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 			"aud":   aud,
 			"scope": scope,
+			"iss":   issuer,
+			"exp":   expireTime,
 			"sub":   "fake-user",
 		})
 

--- a/monitoring/prober/conftest.py
+++ b/monitoring/prober/conftest.py
@@ -42,7 +42,7 @@ class DummyOAuthServerAdapter(AuthAdapter):
     self._tokens = {}
 
   def issue_token(self, intended_audience, scopes):
-    url = '{}?grant_type=client_credentials&scope={}&intended_audience={}'.format(
+    url = '{}?grant_type=client_credentials&scope={}&intended_audience={}&issuer=dummy'.format(
         self._oauth_token_endpoint, urllib.parse.quote(' '.join(scopes)),
         urllib.parse.quote(intended_audience))
     response = self._oauth_session.post(url).json()

--- a/pkg/dss/auth/auth.go
+++ b/pkg/dss/auth/auth.go
@@ -42,6 +42,14 @@ func (m *missingScopesError) Error() string {
 	return strings.Join(m.s, ", ")
 }
 
+type tokenExpireError struct {
+	msg string
+}
+
+func (m *tokenExpireError) Error() string {
+	return m.msg
+}
+
 // ContextWithOwner adds "owner" to "ctx".
 func ContextWithOwner(ctx context.Context, owner models.Owner) context.Context {
 	return context.WithValue(ctx, ContextKeyOwner, owner)
@@ -229,7 +237,29 @@ func (a *Authorizer) AuthInterceptor(ctx context.Context, req interface{}, info 
 		return nil, dsserr.PermissionDenied(fmt.Sprintf("missing scopes: %v", err))
 	}
 
+	if claims.Issuer == "" {
+		return nil, dsserr.Unauthenticated("missing issuer URI")
+	}
+
+	if err := a.checkExpired(claims.ExpiresAt); err != nil {
+		return nil, dsserr.Unauthenticated(fmt.Sprintf("%v", err))
+	}
+
 	return handler(ContextWithOwner(ctx, models.Owner(claims.Subject)), req)
+}
+
+func (a *Authorizer) checkExpired(claimedExpireTime int64) error {
+	now := time.Now()
+	if claimedExpireTime < now.Unix() {
+		return &tokenExpireError{msg: "Token Expired or Expiration missing"}
+	}
+
+	if claimedExpireTime > now.Add(time.Hour).Unix() {
+		return &tokenExpireError{
+			msg: "Token expiration time is too far in the furture, Max token duration is 1 Hour",
+		}
+	}
+	return nil
 }
 
 // Returns all of the required scopes that are missing.

--- a/pkg/dss/auth/auth.go
+++ b/pkg/dss/auth/auth.go
@@ -29,6 +29,8 @@ import (
 var (
 	// ContextKeyOwner is the key to an owner value.
 	ContextKeyOwner ContextKey = "owner"
+	// Now allows test to override with specific time values
+	Now = time.Now
 )
 
 // ContextKey models auth-specific keys in a context.
@@ -257,9 +259,10 @@ func (a *Authorizer) AuthInterceptor(ctx context.Context, req interface{}, info 
 }
 
 func (a *Authorizer) checkExpired(claimedExpireTime int64) error {
-	now := time.Now()
+	now := Now()
 	if claimedExpireTime < now.Unix() {
-		return &tokenExpireError{msg: "Token Expired or Expiration missing"}
+		msga := fmt.Sprintf("Token Expired or Expiration missing %v, %v", claimedExpireTime, now.Unix())
+		return &tokenExpireError{msg: msga}
 	}
 
 	if claimedExpireTime > now.Add(time.Hour).Unix() {

--- a/pkg/dss/auth/auth.go
+++ b/pkg/dss/auth/auth.go
@@ -50,6 +50,14 @@ func (m *tokenExpireError) Error() string {
 	return m.msg
 }
 
+type tokenExpireTooFarError struct {
+	msg string
+}
+
+func (m *tokenExpireTooFarError) Error() string {
+	return m.msg
+}
+
 // ContextWithOwner adds "owner" to "ctx".
 func ContextWithOwner(ctx context.Context, owner models.Owner) context.Context {
 	return context.WithValue(ctx, ContextKeyOwner, owner)
@@ -255,7 +263,7 @@ func (a *Authorizer) checkExpired(claimedExpireTime int64) error {
 	}
 
 	if claimedExpireTime > now.Add(time.Hour).Unix() {
-		return &tokenExpireError{
+		return &tokenExpireTooFarError{
 			msg: "Token expiration time is too far in the furture, Max token duration is 1 Hour",
 		}
 	}

--- a/pkg/dss/auth/auth_test.go
+++ b/pkg/dss/auth/auth_test.go
@@ -28,6 +28,7 @@ func rsaTokenCtx(ctx context.Context, key *rsa.PrivateKey, exp, nbf int64) conte
 		"exp": exp,
 		"nbf": nbf,
 		"sub": "real_owner",
+		"iss": "baz",
 	})
 
 	// Sign and get the complete encoded token as a string using the secret
@@ -93,9 +94,11 @@ func TestNewRSAAuthClient(t *testing.T) {
 }
 
 func TestRSAAuthInterceptor(t *testing.T) {
-	jwt.TimeFunc = func() time.Time {
+	Now = func() time.Time {
 		return time.Unix(42, 0)
 	}
+	jwt.TimeFunc = Now
+
 	defer func() { jwt.TimeFunc = time.Now }()
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Makes the DSS reject token with missing Expiration and Issuer field #127 
In addition the standard mentions that the token cannot be valid for more than 1 hour into the future so we also check it and reject token are are given too wide of a window