### PR TITLE
Reject Subscription PUTS if longer than 24hrs

### DIFF
--- a/monitoring/prober/test_subscription_validation.py
+++ b/monitoring/prober/test_subscription_validation.py
@@ -154,3 +154,43 @@ def test_create_sub_with_too_long_end_time(session, sub2_uuid):
         },
     )
     assert resp.status_code == 400
+
+def test_update_sub_with_too_long_end_time(session, sub2_uuid):
+    """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
+    time_start = datetime.datetime.utcnow()
+    time_end = time_start + datetime.timedelta(seconds=10)
+
+    resp = session.put(
+        "/subscriptions/{}".format(sub2_uuid),
+        json={
+            "extents": {
+                "spatial_volume": {
+                    "footprint": {"vertices": common.VERTICES},
+                    "altitude_lo": 20,
+                    "altitude_hi": 400,
+                },
+                "time_start": time_start.strftime(common.DATE_FORMAT),
+                "time_end": time_end.strftime(common.DATE_FORMAT),
+            },
+            "callbacks": {"identification_service_area_url": "https://example.com/foo"},
+        },
+    )
+    assert resp.status_code == 200
+
+    time_end = time_start + datetime.timedelta(hours=(common.MAX_SUB_TIME_HRS + 1))
+    resp = session.put(
+        "/subscriptions/{}/{}".format(sub2_uuid, resp.json()["subscription"]["version"]),
+        json={
+            "extents": {
+                "spatial_volume": {
+                    "footprint": {"vertices": common.VERTICES},
+                    "altitude_lo": 20,
+                    "altitude_hi": 400,
+                },
+                "time_start": time_start.strftime(common.DATE_FORMAT),
+                "time_end": time_end.strftime(common.DATE_FORMAT),
+            },
+            "callbacks": {"identification_service_area_url": "https://example.com/foo"},
+        },
+    )
+    assert resp.status_code == 400

--- a/pkg/dss/cockroach/subscriptions_test.go
+++ b/pkg/dss/cockroach/subscriptions_test.go
@@ -213,8 +213,7 @@ func TestStoreInsertSubscriptionsWithTimes(t *testing.T) {
 			updateFromStartTime: fakeClock.Now().Add(-6 * time.Hour),
 			updateFromEndTime:   fakeClock.Now().Add(6 * time.Hour),
 			endTime:             fakeClock.Now().Add(24 * time.Hour),
-			wantStartTime:       fakeClock.Now().Add(-6 * time.Hour),
-			wantEndTime:         fakeClock.Now().Add(18 * time.Hour),
+			wantErr:             "rpc error: code = InvalidArgument desc = subscription window exceeds 24 hours",
 		},
 	} {
 		t.Run(r.name, func(t *testing.T) {

--- a/pkg/dss/models/subscriptions.go
+++ b/pkg/dss/models/subscriptions.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	// maxSubscriptionDuration is the largest allowed interval between StartTime
+	// MaxSubscriptionDuration is the largest allowed interval between StartTime
 	// and EndTime.
-	maxSubscriptionDuration = time.Hour * 24
+	MaxSubscriptionDuration = time.Hour * 24
 
 	// maxClockSkew is the largest allowed interval between the StartTime of a new
 	// subscription and the server's idea of the current time.
@@ -132,10 +132,9 @@ func (s *Subscription) AdjustTimeRange(now time.Time, old *Subscription) error {
 		s.EndTime = old.EndTime
 	}
 
-	// Or if this is a new subscription default to StartTime + 1 day.  Also
-	// truncate long existing subscriptions to 1 day.
-	if s.EndTime == nil || s.EndTime.Sub(*s.StartTime) > maxSubscriptionDuration {
-		truncatedEndTime := s.StartTime.Add(maxSubscriptionDuration)
+	// Or if this is a new subscription default to StartTime + 1 day.
+	if s.EndTime == nil {
+		truncatedEndTime := s.StartTime.Add(MaxSubscriptionDuration)
 		s.EndTime = &truncatedEndTime
 	}
 

--- a/pkg/dss/server.go
+++ b/pkg/dss/server.go
@@ -298,16 +298,6 @@ func (s *Server) createOrUpdateSubscription(
 	if extents == nil {
 		return nil, dsserr.BadRequest("missing required extents")
 	}
-	var (
-		// if TimeEnd is not supplied default values to 0
-		// later in the code it will defaulted to 1 day after TimeStart
-		endTime   = time.Unix(extents.TimeEnd.GetSeconds(), 0)
-		startTime = time.Unix(extents.TimeStart.GetSeconds(), 0)
-		diff      = endTime.Sub(startTime)
-	)
-	if diff > models.MaxSubscriptionDuration {
-		return nil, dsserr.BadRequest("subscription window exceeds 24 hours")
-	}
 
 	sub := models.Subscription{
 		ID:      models.ID(id),

--- a/pkg/dss/server.go
+++ b/pkg/dss/server.go
@@ -298,6 +298,14 @@ func (s *Server) createOrUpdateSubscription(
 	if extents == nil {
 		return nil, dsserr.BadRequest("missing required extents")
 	}
+	var (
+		endTime   = time.Unix(extents.TimeEnd.GetSeconds(), 0)
+		startTime = time.Unix(extents.TimeStart.GetSeconds(), 0)
+		diff      = endTime.Sub(startTime)
+	)
+	if diff.Hours() > 24 {
+		return nil, dsserr.BadRequest("subscription window exceeds 24 hours")
+	}
 
 	sub := models.Subscription{
 		ID:      models.ID(id),

--- a/pkg/dss/server.go
+++ b/pkg/dss/server.go
@@ -299,11 +299,13 @@ func (s *Server) createOrUpdateSubscription(
 		return nil, dsserr.BadRequest("missing required extents")
 	}
 	var (
+		// if TimeEnd is not supplied default values to 0
+		// later in the code it will defaulted to 1 day after TimeStart
 		endTime   = time.Unix(extents.TimeEnd.GetSeconds(), 0)
 		startTime = time.Unix(extents.TimeStart.GetSeconds(), 0)
 		diff      = endTime.Sub(startTime)
 	)
-	if diff.Hours() > 24 {
+	if diff > models.MaxSubscriptionDuration {
 		return nil, dsserr.BadRequest("subscription window exceeds 24 hours")
 	}
 


### PR DESCRIPTION
Currently the DSS accepts Subscription PUTs even though the subscription duration is longer than 24hrs, but truncates it internally to 24hrs; which could be confusing to the caller. This checks for the duration and returns an Error with appropriate error message 

Issue: #154