### PR TITLE
Fix return code when searching large area

### DIFF
--- a/cmds/http-gateway/main.go
+++ b/cmds/http-gateway/main.go
@@ -3,16 +3,24 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
+	"io"
 	"net/http"
+	"net/textproto"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/interuss/dss/pkg/dss/build"
 	"github.com/interuss/dss/pkg/dssproto"
+	"github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/logging"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -30,6 +38,8 @@ func RunHTTPProxy(ctx context.Context, address, endpoint string) error {
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	runtime.HTTPError = myHTTPError
 
 	// Register gRPC server endpoint
 	// Note: Make sure the gRPC server is running properly and accessible
@@ -67,6 +77,143 @@ func RunHTTPProxy(ctx context.Context, address, endpoint string) error {
 
 	// Start HTTP server (and proxy calls to gRPC server endpoint)
 	return http.ListenAndServe(address, handler)
+}
+
+func myCodeToHTTPStatus(code codes.Code) int {
+	switch code {
+	case codes.OK:
+		return http.StatusOK
+	case codes.Canceled:
+		return http.StatusRequestTimeout
+	case codes.Unknown:
+		return http.StatusInternalServerError
+	case codes.InvalidArgument:
+		return http.StatusBadRequest
+	case codes.DeadlineExceeded:
+		return http.StatusGatewayTimeout
+	case codes.NotFound:
+		return http.StatusNotFound
+	case codes.AlreadyExists:
+		return http.StatusConflict
+	case codes.PermissionDenied:
+		return http.StatusForbidden
+	case codes.Unauthenticated:
+		return http.StatusUnauthorized
+	case codes.ResourceExhausted:
+		return http.StatusTooManyRequests
+	case codes.FailedPrecondition:
+		// Note, this deliberately doesn't translate to the similarly named '412 Precondition Failed' HTTP response status.
+		return http.StatusBadRequest
+	case codes.Aborted:
+		return http.StatusConflict
+	case codes.OutOfRange:
+		return http.StatusBadRequest
+	case codes.Unimplemented:
+		return http.StatusNotImplemented
+	case codes.Internal:
+		return http.StatusInternalServerError
+	case codes.Unavailable:
+		return http.StatusServiceUnavailable
+	case codes.DataLoss:
+		return http.StatusInternalServerError
+	case errors.AreaTooLargeErr:
+		return http.StatusRequestEntityTooLarge
+	}
+
+	grpclog.Infof("Unknown gRPC error code: %v", code)
+	return http.StatusInternalServerError
+}
+
+type errorBody struct {
+	Error string `protobuf:"bytes,100,name=error" json:"error"`
+	// This is to make the error more compatible with users that expect errors to be Status objects:
+	// https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto
+	// It should be the exact same message as the Error field.
+	Code    int32      `protobuf:"varint,1,name=code" json:"code"`
+	Message string     `protobuf:"bytes,2,name=message" json:"message"`
+	Details []*any.Any `protobuf:"bytes,3,rep,name=details" json:"details,omitempty"`
+}
+
+// this method was copied directly from github.com/grpc-ecosystem/grpc-gateway/runtime/errors
+// we technically only needed to add 1 extra Code to handle but since they didn't
+// export HTTPStatusFromCode we had to copy the whole thing
+func myHTTPError(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w http.ResponseWriter, _ *http.Request, err error) {
+	const fallback = `{"error": "failed to marshal error message"}`
+
+	s, ok := status.FromError(err)
+	if !ok {
+		s = status.New(codes.Unknown, err.Error())
+	}
+
+	w.Header().Del("Trailer")
+
+	contentType := marshaler.ContentType()
+	// Check marshaler on run time in order to keep backwards compatability
+	// An interface param needs to be added to the ContentType() function on
+	// the Marshal interface to be able to remove this check
+	if httpBodyMarshaler, ok := marshaler.(*runtime.HTTPBodyMarshaler); ok {
+		pb := s.Proto()
+		contentType = httpBodyMarshaler.ContentTypeFromMessage(pb)
+	}
+	w.Header().Set("Content-Type", contentType)
+
+	body := &errorBody{
+		Error:   s.Message(),
+		Message: s.Message(),
+		Code:    int32(s.Code()),
+		Details: s.Proto().GetDetails(),
+	}
+
+	buf, merr := marshaler.Marshal(body)
+	if merr != nil {
+		grpclog.Infof("Failed to marshal error message %q: %v", body, merr)
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := io.WriteString(w, fallback); err != nil {
+			grpclog.Infof("Failed to write response: %v", err)
+		}
+		return
+	}
+
+	md, ok := runtime.ServerMetadataFromContext(ctx)
+	if !ok {
+		grpclog.Infof("Failed to extract ServerMetadata from context")
+	}
+
+	handleForwardResponseServerMetadata(w, mux, md)
+	handleForwardResponseTrailerHeader(w, md)
+	st := myCodeToHTTPStatus(s.Code())
+	w.WriteHeader(st)
+	if _, err := w.Write(buf); err != nil {
+		grpclog.Infof("Failed to write response: %v", err)
+	}
+
+	handleForwardResponseTrailer(w, md)
+}
+
+func handleForwardResponseServerMetadata(w http.ResponseWriter, mux *runtime.ServeMux, md runtime.ServerMetadata) {
+	for k, vs := range md.HeaderMD {
+		if h, ok := runtime.DefaultHeaderMatcher(k); ok {
+			for _, v := range vs {
+				w.Header().Add(h, v)
+			}
+		}
+	}
+}
+
+func handleForwardResponseTrailerHeader(w http.ResponseWriter, md runtime.ServerMetadata) {
+	for k := range md.TrailerMD {
+		tKey := textproto.CanonicalMIMEHeaderKey(fmt.Sprintf("%s%s", runtime.MetadataTrailerPrefix, k))
+		w.Header().Add("Trailer", tKey)
+	}
+}
+
+func handleForwardResponseTrailer(w http.ResponseWriter, md runtime.ServerMetadata) {
+	for k, vs := range md.TrailerMD {
+		tKey := fmt.Sprintf("%s%s", runtime.MetadataTrailerPrefix, k)
+		for _, v := range vs {
+			w.Header().Add(tKey, v)
+		}
+	}
 }
 
 func main() {

--- a/pkg/dss/geo/s2.go
+++ b/pkg/dss/geo/s2.go
@@ -42,6 +42,16 @@ var (
 	errBadCoordSet                        = errors.New("coordinates did not create a well formed area")
 )
 
+// ErrAreaTooLarge is the error passed back when the requested Area is larger
+// than maxAllowedAreaKm2
+type ErrAreaTooLarge struct {
+	msg string
+}
+
+func (e *ErrAreaTooLarge) Error() string {
+	return e.msg
+}
+
 func splitAtComma(data []byte, atEOF bool) (int, []byte, error) {
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil
@@ -114,7 +124,9 @@ func Covering(points []s2.Point) (s2.CellUnion, error) {
 		return RegionCoverer.Covering(loop), nil
 	}
 
-	return nil, fmt.Errorf("area is too large (%fkm² > %fkm²)", loopAreaKm2(loop), maxAllowedAreaKm2)
+	return nil, &ErrAreaTooLarge{
+		msg: fmt.Sprintf("area is too large (%fkm² > %fkm²)", loopAreaKm2(loop), maxAllowedAreaKm2),
+	}
 }
 
 // AreaToCellIDs parses "area" in the format 'lat0,lon0,lat1,lon1,...'

--- a/pkg/dss/server.go
+++ b/pkg/dss/server.go
@@ -190,7 +190,12 @@ func (s *Server) GetV1DssIdentificationServiceAreas(
 
 	cu, err := geo.AreaToCellIDs(req.GetArea())
 	if err != nil {
-		return nil, dsserr.BadRequest(fmt.Sprintf("bad area: %s", err))
+		errMsg := fmt.Sprintf("bad area: %s", err)
+		switch err.(type) {
+		case *geo.ErrAreaTooLarge:
+			return nil, dsserr.AreaTooLarge(errMsg)
+		}
+		return nil, dsserr.BadRequest(errMsg)
 	}
 
 	var (
@@ -244,7 +249,12 @@ func (s *Server) GetV1DssSubscriptions(
 
 	cu, err := geo.AreaToCellIDs(req.GetArea())
 	if err != nil {
-		return nil, dsserr.BadRequest(fmt.Sprintf("bad area: %s", err))
+		errMsg := fmt.Sprintf("bad area: %s", err)
+		switch err.(type) {
+		case *geo.ErrAreaTooLarge:
+			return nil, dsserr.AreaTooLarge(errMsg)
+		}
+		return nil, dsserr.BadRequest(errMsg)
 	}
 
 	subscriptions, err := s.Store.SearchSubscriptions(ctx, cu, owner)
@@ -252,7 +262,7 @@ func (s *Server) GetV1DssSubscriptions(
 		return nil, err
 	}
 	sp := make([]*dspb.Subscription, len(subscriptions))
-	for i, _ := range subscriptions {
+	for i := range subscriptions {
 		sp[i], err = subscriptions[i].ToProto()
 		if err != nil {
 			return nil, err

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -13,6 +13,12 @@ var (
 	errInternal = status.Error(codes.Internal, "Internal Server Error")
 )
 
+const (
+	// AreaTooLargeErr is the error that we want to signal to the http gateway
+	// that it should return 413 to client
+	AreaTooLargeErr codes.Code = 18
+)
+
 // Interceptor returns a grpc.UnaryServerInterceptor that inspects outgoing
 // errors and logs (to "logger") and replaces errors that are not *status.Status
 // instances or status instances that indicate an internal/unknown error.
@@ -73,4 +79,8 @@ func PermissionDenied(msg string) error {
 
 func Unauthenticated(msg string) error {
 	return status.Error(codes.Unauthenticated, msg)
+}
+
+func AreaTooLarge(msg string) error {
+	return status.Error(AreaTooLargeErr, msg)
 }

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -73,7 +73,7 @@ docker build -q --rm -f cmds/dummy-oauth/Dockerfile . -t local-dummy-oauth
 echo "Cleaning up any pre-existing dummy-oauth container"
 docker stop dummy-oauth-for-testing || echo "No dummy oauth to clean up"
 
-echo "Starting mock oauth server on : 8085"
+echo "Starting mock oauth server on :8085"
 docker run -d --rm --name dummy-oauth-for-testing -p 8085:8085 \
 	-v $(pwd)/config/test-certs/auth2.key:/app/test.key \
 	local-dummy-oauth \


### PR DESCRIPTION
	Since there was no direct mapping from grpc code to HTTP code
	for 413 I had to replicate the entire method for handling GRPC
	error code from the library just to do this.
	Also fixed an annoying typo in docker_e2e.sh