### PR TITLE
Fix issue with allowing too many subs

### DIFF
--- a/monitoring/prober/test_subscription_validation.py
+++ b/monitoring/prober/test_subscription_validation.py
@@ -86,7 +86,7 @@ def test_create_sub_with_huge_area(session, sub2_uuid):
 def test_create_too_many_subs(session):
   """ASTM Compliance Test: DSS0050_MAX_SUBS_PER_AREA."""
   time_start = datetime.datetime.utcnow()
-  time_end = time_start + datetime.timedelta(seconds=1)
+  time_end = time_start + datetime.timedelta(seconds=30)
   all_resp = []
 
   # create 1 more than the max allowed Subscriptions per area


### PR DESCRIPTION
1. SQL MAX statement returns NULL in the event there is no data, which triggers an error unable to convert nil to int even though there is simply no subscriptions

2. Test Subscription was too short lived, the cumulative time it takes to create 11 subscriptions sometimes take longer than the test subscription's life which expires and allows new subs to be created 

This now fixes the test_create_too_many_subs test flakiness 