### PR TITLE
Deletion of ISA and SUB were permitted w/o version

### DIFF
--- a/monitoring/prober/test_isa_simple.py
+++ b/monitoring/prober/test_isa_simple.py
@@ -131,6 +131,11 @@ def test_delete_isa_wrong_version(session, isa1_uuid):
   assert resp.status_code == 400
 
 
+def test_delete_isa_empty_version(session, isa1_uuid):
+  resp = session.delete('/identification_service_areas/{}/'.format(isa1_uuid))
+  assert resp.status_code == 400
+
+
 def test_delete_isa(session, isa1_uuid):
   """ASTM Compliance Test: DSS0030_B_DELETE_ISA."""
   # GET the ISA first to find its version.

--- a/monitoring/prober/test_subscription_simple.py
+++ b/monitoring/prober/test_subscription_simple.py
@@ -82,6 +82,16 @@ def test_get_sub_by_searching_huge_area(session, sub1_uuid):
   assert resp.status_code == 413 
 
 
+def test_delete_sub_empty_version(session, sub1_uuid):
+  resp = session.delete('/subscriptions/{}/'.format(sub1_uuid))
+  assert resp.status_code == 400
+
+
+def test_delete_sub_wrong_version(session, sub1_uuid):
+  resp = session.delete('/subscriptions/{}/fake_version'.format(sub1_uuid))
+  assert resp.status_code == 400
+
+
 def test_delete_sub(session, sub1_uuid):
   """ASTM Compliance Test: DSS0030_D_DELETE_SUB."""
   # GET the sub first to find its version.

--- a/pkg/dss/cockroach/subscriptions_test.go
+++ b/pkg/dss/cockroach/subscriptions_test.go
@@ -330,7 +330,7 @@ func TestStoreDeleteSubscription(t *testing.T) {
 			require.NotNil(t, sub1)
 
 			// Ensure mismatched versions return an error
-			v, err := models.VersionFromString("a3cg3tcuhk000")
+			v, err := models.VersionFromString("a3cg3tcuhk000", true)
 			require.NoError(t, err)
 			sub2, err := store.DeleteSubscription(ctx, sub1.ID, sub1.Owner, v)
 			require.Error(t, err)

--- a/pkg/dss/cockroach/subscriptions_test.go
+++ b/pkg/dss/cockroach/subscriptions_test.go
@@ -330,7 +330,7 @@ func TestStoreDeleteSubscription(t *testing.T) {
 			require.NotNil(t, sub1)
 
 			// Ensure mismatched versions return an error
-			v, err := models.VersionFromString("a3cg3tcuhk000", true)
+			v, err := models.VersionFromString("a3cg3tcuhk000", models.EmptyVersionPolicyRequireNonEmpty)
 			require.NoError(t, err)
 			sub2, err := store.DeleteSubscription(ctx, sub1.ID, sub1.Owner, v)
 			require.Error(t, err)

--- a/pkg/dss/models/models.go
+++ b/pkg/dss/models/models.go
@@ -6,13 +6,6 @@ import (
 	"time"
 )
 
-const (
-	// Convert updatedAt to a string, why not make it smaller
-	// WARNING: Changing this will cause RMW errors
-	// 32 is the highest value allowed by strconv
-	versionBase = 32
-)
-
 type (
 	ID      string
 	Owner   string
@@ -20,6 +13,16 @@ type (
 		t time.Time
 		s string
 	}
+	EmptyVersionPolicy int
+)
+
+const (
+	// Convert updatedAt to a string, why not make it smaller
+	// WARNING: Changing this will cause RMW errors
+	// 32 is the highest value allowed by strconv
+	versionBase                                          = 32
+	EmptyVersionPolicyRequireNonEmpty EmptyVersionPolicy = 0
+	EmptyVersionPolicyRelaxed         EmptyVersionPolicy = 1
 )
 
 func (id ID) String() string {
@@ -30,10 +33,10 @@ func (owner Owner) String() string {
 	return string(owner)
 }
 
-func VersionFromString(s string, required bool) (*Version, error) {
+func VersionFromString(s string, evp EmptyVersionPolicy) (*Version, error) {
 	v := &Version{s: s}
 	if s == "" {
-		if required {
+		if evp == EmptyVersionPolicyRequireNonEmpty {
 			return nil, errors.New("requires version string")
 		}
 		return nil, nil

--- a/pkg/dss/models/models.go
+++ b/pkg/dss/models/models.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"strconv"
 	"time"
 )
@@ -29,9 +30,12 @@ func (owner Owner) String() string {
 	return string(owner)
 }
 
-func VersionFromString(s string) (*Version, error) {
+func VersionFromString(s string, required bool) (*Version, error) {
 	v := &Version{s: s}
 	if s == "" {
+		if required {
+			return nil, errors.New("requires version string")
+		}
 		return nil, nil
 	}
 	nanos, err := strconv.ParseUint(string(s), versionBase, 64)

--- a/pkg/dss/server.go
+++ b/pkg/dss/server.go
@@ -122,7 +122,7 @@ func (s *Server) UpdateIdentificationServiceArea(
 
 	params := req.GetParams()
 
-	version, err := models.VersionFromString(req.GetVersion(), true)
+	version, err := models.VersionFromString(req.GetVersion(), models.EmptyVersionPolicyRequireNonEmpty)
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}
@@ -138,7 +138,7 @@ func (s *Server) DeleteIdentificationServiceArea(
 	if !ok {
 		return nil, dsserr.PermissionDenied("missing owner from context")
 	}
-	version, err := models.VersionFromString(req.GetVersion(), true)
+	version, err := models.VersionFromString(req.GetVersion(), models.EmptyVersionPolicyRequireNonEmpty)
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}
@@ -170,7 +170,7 @@ func (s *Server) DeleteSubscription(
 	if !ok {
 		return nil, dsserr.PermissionDenied("missing owner from context")
 	}
-	version, err := models.VersionFromString(req.GetVersion(), true)
+	version, err := models.VersionFromString(req.GetVersion(), models.EmptyVersionPolicyRequireNonEmpty)
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}
@@ -368,7 +368,7 @@ func (s *Server) UpdateSubscription(
 
 	params := req.GetParams()
 
-	version, err := models.VersionFromString(req.GetVersion(), true)
+	version, err := models.VersionFromString(req.GetVersion(), models.EmptyVersionPolicyRequireNonEmpty)
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}

--- a/pkg/dss/server.go
+++ b/pkg/dss/server.go
@@ -122,7 +122,7 @@ func (s *Server) UpdateIdentificationServiceArea(
 
 	params := req.GetParams()
 
-	version, err := models.VersionFromString(req.GetVersion())
+	version, err := models.VersionFromString(req.GetVersion(), true)
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}
@@ -138,7 +138,7 @@ func (s *Server) DeleteIdentificationServiceArea(
 	if !ok {
 		return nil, dsserr.PermissionDenied("missing owner from context")
 	}
-	version, err := models.VersionFromString(req.GetVersion())
+	version, err := models.VersionFromString(req.GetVersion(), true)
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}
@@ -170,7 +170,7 @@ func (s *Server) DeleteSubscription(
 	if !ok {
 		return nil, dsserr.PermissionDenied("missing owner from context")
 	}
-	version, err := models.VersionFromString(req.GetVersion())
+	version, err := models.VersionFromString(req.GetVersion(), true)
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}
@@ -368,7 +368,7 @@ func (s *Server) UpdateSubscription(
 
 	params := req.GetParams()
 
-	version, err := models.VersionFromString(req.GetVersion())
+	version, err := models.VersionFromString(req.GetVersion(), true)
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}

--- a/pkg/dss/server_test.go
+++ b/pkg/dss/server_test.go
@@ -87,7 +87,7 @@ func (ms *mockStore) SearchISAs(ctx context.Context, cells s2.CellUnion, earlies
 
 func TestDeleteSubscription(t *testing.T) {
 	ctx := auth.ContextWithOwner(context.Background(), "foo")
-	version, _ := models.VersionFromString("bar", true)
+	version, _ := models.VersionFromString("bar", models.EmptyVersionPolicyRequireNonEmpty)
 
 	for _, r := range []struct {
 		name         string
@@ -492,7 +492,7 @@ func TestDeleteIdentificationServiceArea(t *testing.T) {
 	var (
 		owner        = models.Owner("foo")
 		id           = models.ID(uuid.New().String())
-		version, err = models.VersionFromString("bar", true)
+		version, err = models.VersionFromString("bar", models.EmptyVersionPolicyRequireNonEmpty)
 		ctx          = auth.ContextWithOwner(context.Background(), owner)
 		ms           = &mockStore{}
 		s            = &Server{

--- a/pkg/dss/server_test.go
+++ b/pkg/dss/server_test.go
@@ -87,27 +87,31 @@ func (ms *mockStore) SearchISAs(ctx context.Context, cells s2.CellUnion, earlies
 
 func TestDeleteSubscription(t *testing.T) {
 	ctx := auth.ContextWithOwner(context.Background(), "foo")
+	version, _ := models.VersionFromString("bar", true)
 
 	for _, r := range []struct {
 		name         string
 		id           models.ID
+		version      *models.Version
 		subscription *models.Subscription
 		err          error
 	}{
 		{
 			name:         "subscription-is-returned-if-returned-from-store",
 			id:           models.ID(uuid.New().String()),
+			version:      version,
 			subscription: &models.Subscription{},
 		},
 		{
-			name: "error-is-returned-if-returned-from-store",
-			id:   models.ID(uuid.New().String()),
-			err:  errors.New("failed to look up subscription for ID"),
+			name:    "error-is-returned-if-returned-from-store",
+			id:      models.ID(uuid.New().String()),
+			version: version,
+			err:     errors.New("failed to look up subscription for ID"),
 		},
 	} {
 		t.Run(r.name, func(t *testing.T) {
 			store := &mockStore{}
-			store.On("DeleteSubscription", mock.Anything, r.id, mock.Anything, mock.Anything).Return(
+			store.On("DeleteSubscription", mock.Anything, r.id, mock.Anything, r.version).Return(
 				r.subscription, r.err,
 			)
 			s := &Server{
@@ -486,20 +490,22 @@ func TestDeleteIdentificationServiceAreaRequiresOwnerInContext(t *testing.T) {
 
 func TestDeleteIdentificationServiceArea(t *testing.T) {
 	var (
-		owner = models.Owner("foo")
-		id    = models.ID(uuid.New().String())
-		ctx   = auth.ContextWithOwner(context.Background(), owner)
-		ms    = &mockStore{}
-		s     = &Server{
+		owner        = models.Owner("foo")
+		id           = models.ID(uuid.New().String())
+		version, err = models.VersionFromString("bar", true)
+		ctx          = auth.ContextWithOwner(context.Background(), owner)
+		ms           = &mockStore{}
+		s            = &Server{
 			Store: ms,
 		}
 	)
 
 	ms.On("DeleteISA", ctx, id, owner, mock.Anything).Return(
 		&models.IdentificationServiceArea{
-			ID:    models.ID(id),
-			Owner: models.Owner("me-myself-and-i"),
-			Url:   "https://no/place/like/home",
+			ID:      models.ID(id),
+			Owner:   models.Owner("me-myself-and-i"),
+			Url:     "https://no/place/like/home",
+			Version: version,
 		},
 		[]*models.Subscription{
 			{

--- a/pkg/dss/server_test.go
+++ b/pkg/dss/server_test.go
@@ -119,7 +119,7 @@ func TestDeleteSubscription(t *testing.T) {
 			}
 
 			_, err := s.DeleteSubscription(ctx, &dspb.DeleteSubscriptionRequest{
-				Id: r.id.String(),
+				Id: r.id.String(), Version: r.version.String(),
 			})
 			require.Equal(t, r.err, err)
 			require.True(t, store.AssertExpectations(t))
@@ -515,7 +515,7 @@ func TestDeleteIdentificationServiceArea(t *testing.T) {
 		}, error(nil),
 	)
 	resp, err := s.DeleteIdentificationServiceArea(ctx, &dspb.DeleteIdentificationServiceAreaRequest{
-		Id: id.String(),
+		Id: id.String(), Version: version.String(),
 	})
 
 	require.NoError(t, err)

--- a/test/interoperability/clients.py
+++ b/test/interoperability/clients.py
@@ -64,7 +64,7 @@ class OAuthClient:
         return self.token_response_cache[(scopes, audience)].get("access_token", "")
 
     def _issueToken(self, scopes, audience) -> Dict[str, Any]:
-        data = {"scope": scopes, "intended_audience": audience}
+        data = {"scope": scopes, "intended_audience": audience, "issuer": "dummy"}
         data.update(self._req_params)
         request_time = time.time()
         # Parameteterized URL is required to work with the Dummy Oauth Server


### PR DESCRIPTION
	Interoperability test exposed that this was allowed in the DSS
	while the specs states that Version is a required field
	New behivior is to return Bad Request Error with proper message