### PR TITLE
Fix local test failure with double flag.Parse Call

### DIFF
--- a/pkg/dss/cockroach/store_test.go
+++ b/pkg/dss/cockroach/store_test.go
@@ -27,10 +27,6 @@ var (
 	endTime   = fakeClock.Now().Add(time.Hour)
 )
 
-func init() {
-	flag.Parse()
-}
-
 func setUpStore(ctx context.Context, t *testing.T) (*Store, func() error) {
 	// Reset the clock for every test.
 	fakeClock = clockwork.NewFakeClock()


### PR DESCRIPTION
This flag.Parse is not necessary as go test already calls flags.Parse once, calling it again causes failure on local tests