### PR TITLE
Healthy is not part of GRPC backend

### DIFF
--- a/cmds/http-gateway/main.go
+++ b/cmds/http-gateway/main.go
@@ -65,8 +65,9 @@ func RunHTTPProxy(ctx context.Context, address, endpoint string) error {
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/healthy" {
 			w.Write([]byte("ok"))
+		} else {
+			grpcMux.ServeHTTP(w, r)
 		}
-		grpcMux.ServeHTTP(w, r)
 	})
 
 	if *traceRequests {


### PR DESCRIPTION
we should not forward the healthy call to grpcMux since it is not a valid method in the GRPC backend