### PR TITLE
Add clarity to run_locally.sh output

### DIFF
--- a/build/check_dss.sh
+++ b/build/check_dss.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+jq --version > /dev/null
+if [ $? -ne 0 ]; then
+  echo "This script requires the jq utility.  On Debian Linux, install with"
+  echo "  sudo apt-get install jq"
+  exit 1
+fi
+
+# Retrieve token from dummy OAuth server
+export ACCESS_TOKEN=`curl --silent -X POST \
+  "http://localhost:8085/token?grant_type=client_credentials&scope=dss.read.identification_service_areas&intended_audience=localhost&issuer=localhost" \
+  | jq -r '.access_token'`
+
+# Retrieve Identification Service Areas currently active on Mauna Loa
+echo "DSS response to Mauna Loa ISA query:"
+echo "============="
+export TIMESTAMP_NOW=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+curl --silent -X GET \
+  "http://localhost:8082/v1/dss/identification_service_areas?area=19.4763,-155.6043,19.4884,-155.5746,19.4516,-155.5941&earliest_time=${TIMESTAMP_NOW}&latest_time=${TIMESTAMP_NOW}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}"
+echo
+echo "============="
+echo "See https://tiny.cc/dssapi_rid for a more complete DSS API description."
+echo

--- a/build/run-locally.sh
+++ b/build/run-locally.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-echo "cleaning up any pre-existing containers"
-docker stop dss-crdb-for-debugging
 
-echo "starting cockroachdb with admin port on :8080"
+if [[ ! -z "docker container ls --filter name=dss-crdb-for-debugging --quiet" ]]; then
+  echo "=== Cleaning up pre-existing CockroachDB container... ==="
+  docker stop dss-crdb-for-debugging
+fi
+
+echo "=== Starting CockroachDB with admin port on :8080... ==="
 docker run -d --rm --name dss-crdb-for-debugging -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v19.1.2 start --insecure > /dev/null
 
 BASEDIR=$(readlink -e "$(dirname "$0")/..")
@@ -10,7 +13,7 @@ BASEDIR=$(readlink -e "$(dirname "$0")/..")
 cd "${BASEDIR}"
 
 sleep 5
-echo "starting grpc backend on :8081"
+echo "=== Starting grpc-backend on :8081 ==="
 go run cmds/grpc-backend/main.go \
     -cockroach_host localhost \
     -public_key_file build/test-certs/auth2.pem \
@@ -18,28 +21,38 @@ go run cmds/grpc-backend/main.go \
     -log_format console \
     -dump_requests \
     -jwt_audience localhost &
-pid1=$!
+pid_grpc=$!
 
 sleep 5
-echo "starting http-gateway on :8082"
+echo "=== Starting http-gateway on :8082 ==="
 go run cmds/http-gateway/main.go -grpc-backend localhost:8081 -addr :8082 &
-pid2=$!
+pid_http=$!
 
 sleep 5
-echo "starting dummy oauth server on :8085"
+echo "=== Starting dummy OAuth server on :8085 ==="
 go run cmds/dummy-oauth/main.go -private_key_file build/test-certs/auth2.key &
-pid3=$!
+pid_oauth=$!
 
 
-if [ -d "/proc/${pid1}" ] && [ -d "/proc/${pid2}" ] && [ -d "/proc/${pid3}" ]
+if [ -d "/proc/${pid_grpc}" ] && [ -d "/proc/${pid_http}" ] && [ -d "/proc/${pid_oauth}" ]
 then
-    echo "All system, GO!"
+    echo "=============================================================="
+    echo "All systems GO; DSS instance is running locally!"
+    echo "  CockroachDB container `docker container ls --filter name=dss-crdb-for-debugging --quiet`"
+    echo "  grpc-backend PID ${pid_grpc}"
+    echo "  http-gateway PID ${pid_http}"
+    echo "  Dummy OAuth PID ${pid_oauth}"
     echo "Dummy OAuth Server Address:      http://localhost:8085/token"
     echo "DSS HTTP Gateway Server Address: http://localhost:8082/healthy"
+    echo
+    echo "Run ./check_dss.sh from another terminal to verify minimal DSS functionality"
+    echo "Press ctrl-c here to stop the DSS"
+    echo "=============================================================="
 else
-    echo "Process did not start correctly."
+    echo "Processes did not start correctly."
 fi
 
 
-wait $pid1 && wait $pid2 && wait $pid3
+wait $pid_grpc && wait $pid_http && wait $pid_oauth
+echo "Stopping CockroachDB container..."
 docker stop dss-crdb-for-debugging

--- a/cmds/dummy-oauth/main.go
+++ b/cmds/dummy-oauth/main.go
@@ -1,4 +1,6 @@
-// ?grant_type=client_credentials&scope={}&intended_audience={}
+// Query parameters for dummy-oauth (at http://hostname:addr/token):
+// ?grant_type=client_credentials&scope={}&intended_audience={}&issuer={}
+
 package main
 
 import (


### PR DESCRIPTION
Also add check_dss.sh script to verify that the local DSS supports an example call.

Given the clarity difficulties of #171, this PR makes it even more clear what is happening in `run_locally.sh` and provides hints for what the user should do next to explore further, including a `check_dss.sh` script that makes an example call to the DSS.