### PR TITLE
remove the external crdb loadbalancer as we don't need it

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -97,8 +97,6 @@ which ever provider you choose.
       the HTTPS Gateway Ingress needs to be created as a "Global" IP address.
     - If you want to be able to join other clusters, you'll need static IP's
       for each of your CockroachDB nodes (min of 3).
-    - [OPTIONAL] 1 for a loadbalancer across your CockroachDB nodes to provide
-      a single join target for other users.
 
 1.  Use the `make-certs.py` script in this directory to create certificates for
     the new CockroachDB cluster:
@@ -159,9 +157,9 @@ following differences:
     JoinExisting array. You should supply a minimum of 3 seed nodes to every
     CockroachDB node. These 3 nodes should be the same for every node (ie: every
     node points to node 0, 1, and 2). For external clusters you should point to
-    a minimum of 3, or you can use the loadbalanced hostnames or IP addresses
-    of other clusters (the DBBalanced hostname/IP). You should do this for every
-    cluster, including newly joined clusters. See CockroachDB's note on the
+    a minimum of 3, or you can use a loadbalanced hostname or IP address
+    of other clusters. You should do this for every cluster, including newly
+    joined clusters. See CockroachDB's note on the
     [join flag](https://www.cockroachlabs.com/docs/stable/start-a-node.html#flags).
 
 1.  You must run ./make-certs.py with the `--ca-cert-to-join` flag as described

--- a/build/deploy/cockroachdb-auxilliary.libsonnet
+++ b/build/deploy/cockroachdb-auxilliary.libsonnet
@@ -35,8 +35,6 @@ local cockroachLB(metadata, name, ip) = base.Service(metadata, name) {
       },
     } else null,
 
-    Balanced: cockroachLB(metadata, 'cockroach-db-external-balanced', metadata.cockroach.balancedIP),
-
     NodeGateways: [
       cockroachLB(metadata, 'cockroach-db-external-node-' + i, metadata.cockroach.nodeIPs[i]) {
         spec+: {

--- a/build/deploy/examples/minimum.jsonnet
+++ b/build/deploy/examples/minimum.jsonnet
@@ -9,7 +9,6 @@ local metadata = metadataBase {
     hostnameSuffix: 'db.your_hostname_suffix.com',
     locality: 'your_unique_locality',
     nodeIPs: ['0.0.0.0', '1.1.1.1', '2.2.2.2'],
-    balancedIP: '3.3.3.3',
     shouldInit: true, //Set to false if joining a cluster
     JoinExisting: ['0.db.westus.example.com', '1.db.westus.example.com', '2.db.westus.example.com' ], //If joining a cluster, replace these with at least 3 FQDN's of the existing DSS cockroachdb cluster you are joining.
   },

--- a/build/deploy/examples/prod_leaf.jsonnet
+++ b/build/deploy/examples/prod_leaf.jsonnet
@@ -10,7 +10,6 @@ local metadata = prod.metadata {
     hostnameSuffix: 'db.your_hostname_suffix.com',
     locality: 'your_unique_locality',
     nodeIPs: ['0.0.0.0', '1.1.1.1', '2.2.2.2'],
-    balancedIP: '3.3.3.3',
   },
   gateway+: {
     ipName: 'your-ingress-name',

--- a/build/deploy/metadata_base.libsonnet
+++ b/build/deploy/metadata_base.libsonnet
@@ -8,7 +8,6 @@
     grpc_port: 26257,
     http_port: 8080,
     image: 'cockroachdb/cockroach:v19.1.5',
-    balancedIP: error 'must supply the balanced ip address',
     nodeIPs: error 'must supply the per-node ip addresses as an array',
     JoinExisting: [],
   },


### PR DESCRIPTION
This isn't used anywhere, and it's not needed for any ops.

I'm leaving in some small comments below that reference that a user can do it if they choose to.