### PR TITLE
Robustify e2e test script

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"


### PR DESCRIPTION
This PR renders the e2e test script more robust by:
 * relying on `/usr/bin/env` to resolve the location of `bash`
 * installing traps for `exit` and `sigint`
 * not removing containers automatically to support gathering partial logs