### PR TITLE
Add Subscription support for dummy SCD Store and partial endpoint implementations

### DIFF
--- a/build/dev/check_subs.sh
+++ b/build/dev/check_subs.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# This script will verify basic functionality of a locally-deployed standalone
+# DSS instance using any of the deployment methods described in
+# standalone_instance.md.
+
+jq --version > /dev/null
+if [ $? -ne 0 ]; then
+  echo "This script requires the jq utility.  On Debian Linux, install with"
+  echo "  sudo apt-get install jq"
+  echo "With homebrew, install with"
+  echo "  brew install jq"
+  exit 1
+fi
+
+# Retrieve token from dummy OAuth server
+export ACCESS_TOKEN_READ=`curl --silent -X POST \
+  "http://localhost:8085/token?grant_type=client_credentials&scope=dss.read.identification_service_areas&intended_audience=localhost&issuer=localhost" \
+  | jq -r '.access_token'`
+
+export ACCESS_TOKEN_WRITE=`curl --silent -X POST \
+  "http://localhost:8085/token?grant_type=client_credentials&scope=dss.write.identification_service_areas&intended_audience=localhost&issuer=localhost" \
+  | jq -r '.access_token'`
+
+echo "DSS response to PUT Subscriptions query:"
+echo "============="
+curl --silent -X PUT \
+  "http://localhost:8082/dss/v1/subscriptions/b76c1049-94e3-47e5-900d-94e4004a7188" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN_WRITE}" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "extents": {
+
+  },
+  "old_version": 0,
+  "uss_base_url": "https://exampleuss.com/utm",
+  "notify_for_operations": true,
+  "notify_for_constraints": false
+}'
+echo
+echo "============="
+echo
+
+echo "DSS response to GET Subscription query:"
+echo "============="
+curl --silent -X GET \
+  "http://localhost:8082/dss/v1/subscriptions/b76c1049-94e3-47e5-900d-94e4004a7188" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN_READ}"
+echo
+echo "============="
+echo
+
+echo "DSS response to DELETE Subscription query:"
+echo "============="
+curl --silent -X DELETE \
+  "http://localhost:8082/dss/v1/subscriptions/b76c1049-94e3-47e5-900d-94e4004a7188" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN_WRITE}"
+echo
+echo "============="
+echo
+
+echo "DSS response to search Subscriptions query:"
+echo "============="
+curl --silent -X POST \
+  "http://localhost:8082/dss/v1/subscriptions/query" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN_READ}" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "area_of_interest": {
+
+  }
+}'
+echo
+echo "============="
+echo

--- a/build/dev/check_subs.sh
+++ b/build/dev/check_subs.sh
@@ -30,7 +30,45 @@ curl --silent -X PUT \
   -H "Content-Type: application/json" \
   -d '{
   "extents": {
-
+    "volume": {
+      "outline_circle": {
+        "type": "Feature",
+        "geometry": {
+          "type": "Point",
+          "coordinates": {
+            "type": "Point",
+            "coordinates": [
+              -122.106325,
+              47.660898
+            ]
+          }
+        },
+        "properties": {
+          "radius": {
+            "value": 300.183,
+            "units": "M"
+          }
+        }
+      },
+      "altitude_lower": {
+        "value": 0,
+        "reference": "W84",
+        "units": "M"
+      },
+      "altitude_upper": {
+        "value": 3000,
+        "reference": "W84",
+        "units": "M"
+      }
+    },
+    "time_start": {
+      "value": "1985-04-12T23:20:50.52Z",
+      "format": "RFC3339"
+    },
+    "time_end": {
+      "value": "2100-04-12T23:20:50.52Z",
+      "format": "RFC3339"
+    }
   },
   "old_version": 0,
   "uss_base_url": "https://exampleuss.com/utm",
@@ -40,6 +78,8 @@ curl --silent -X PUT \
 echo
 echo "============="
 echo
+
+exit 0
 
 echo "DSS response to GET Subscription query:"
 echo "============="

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -61,14 +61,20 @@ go run cmds/grpc-backend/main.go \
     -reflect_api \
     -log_format console \
     -dump_requests \
+    -enable_utm \
     -accepted_jwt_audiences localhost &
 pid_grpc=$!
 sleep 5
 $(ps -p ${pid_grpc} > /dev/null)
 grpc_ok=$?
+if [ ${grpc_ok} -ne 0 ]
+then
+    echo "Aborting because grpc-backend failed to start."
+    exit 1
+fi
 
 echo "=== Starting http-gateway on :8082 ==="
-go run cmds/http-gateway/main.go -grpc-backend localhost:8081 -addr :8082 &
+go run cmds/http-gateway/main.go -grpc-backend localhost:8081 -addr :8082 -enable_utm &
 pid_http=$!
 sleep 5
 $(ps -p ${pid_http} > /dev/null)

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -61,7 +61,7 @@ go run cmds/grpc-backend/main.go \
     -reflect_api \
     -log_format console \
     -dump_requests \
-    -enable_utm \
+    -enable_scd \
     -accepted_jwt_audiences localhost &
 pid_grpc=$!
 sleep 5
@@ -74,7 +74,7 @@ then
 fi
 
 echo "=== Starting http-gateway on :8082 ==="
-go run cmds/http-gateway/main.go -grpc-backend localhost:8081 -addr :8082 -enable_utm &
+go run cmds/http-gateway/main.go -grpc-backend localhost:8081 -addr :8082 -enable_scd &
 pid_http=$!
 sleep 5
 $(ps -p ${pid_http} > /dev/null)

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -111,7 +111,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 		}
 		auxServer = &dss.AuxServer{}
 		utmServer = &utm.Server{
-			Store:   nil,
+			Store:   &utm.DummyStore{},
 			Timeout: *timeout,
 		}
 	)
@@ -169,6 +169,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 	dsspb.RegisterDiscoveryAndSynchronizationServiceServer(s, dssServer)
 	auxpb.RegisterDSSAuxServiceServer(s, auxServer)
 	if *enableUTM {
+	  logger.Info("config", zap.Any("utm", "enabled"))
 		utmpb.RegisterUTMAPIUSSDSSAndUSSUSSServiceServer(s, utmServer)
 	}
 	logger.Info("build", zap.Any("description", build.Describe()))

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -40,7 +40,7 @@ var (
 	logLevel          = flag.String("log_level", logging.DefaultLevel.String(), "The log level")
 	dumpRequests      = flag.Bool("dump_requests", false, "Log request and response protos")
 	profServiceName   = flag.String("gcp_prof_service_name", "", "Service name for the Go profiler")
-	enableUTM         = flag.Bool("enable_utm", false, "Enables the UTM API")
+	enableSCD         = flag.Bool("enable_scd", false, "Enables the Strategic Conflict Detection API")
 
 	cockroachParams = struct {
 		host            *string
@@ -168,8 +168,8 @@ func RunGRPCServer(ctx context.Context, address string) error {
 
 	dsspb.RegisterDiscoveryAndSynchronizationServiceServer(s, dssServer)
 	auxpb.RegisterDSSAuxServiceServer(s, auxServer)
-	if *enableUTM {
-	  logger.Info("config", zap.Any("utm", "enabled"))
+	if *enableSCD {
+	  logger.Info("config", zap.Any("scd", "enabled"))
 		utmpb.RegisterUTMAPIUSSDSSAndUSSUSSServiceServer(s, utmServer)
 	}
 	logger.Info("build", zap.Any("description", build.Describe()))

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -169,7 +169,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 	dsspb.RegisterDiscoveryAndSynchronizationServiceServer(s, dssServer)
 	auxpb.RegisterDSSAuxServiceServer(s, auxServer)
 	if *enableSCD {
-	  logger.Info("config", zap.Any("scd", "enabled"))
+		logger.Info("config", zap.Any("scd", "enabled"))
 		utmpb.RegisterUTMAPIUSSDSSAndUSSUSSServiceServer(s, utmServer)
 	}
 	logger.Info("build", zap.Any("description", build.Describe()))

--- a/cmds/http-gateway/main.go
+++ b/cmds/http-gateway/main.go
@@ -75,6 +75,7 @@ func RunHTTPProxy(ctx context.Context, address, endpoint string) error {
 		if err := utmpb.RegisterUTMAPIUSSDSSAndUSSUSSServiceHandlerFromEndpoint(ctx, grpcMux, endpoint, opts); err != nil {
 			return err
 		}
+		logger.Info("config", zap.Any("utm", "enabled"))
 	}
 
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmds/http-gateway/main.go
+++ b/cmds/http-gateway/main.go
@@ -31,7 +31,7 @@ var (
 	traceRequests   = flag.Bool("trace-requests", false, "Logs HTTP request/response pairs to stderr if true")
 	grpcBackend     = flag.String("grpc-backend", "", "Endpoint for grpc backend. Only to be set if run in proxy mode")
 	profServiceName = flag.String("gcp_prof_service_name", "", "Service name for the Go profiler")
-	enableUTM       = flag.Bool("enable_utm", false, "Enables the UTM API")
+	enableSCD       = flag.Bool("enable_scd", false, "Enables the Strategic Conflict Detection API")
 )
 
 // RunHTTPProxy starts the HTTP proxy for the DSS gRPC service on ctx, listening
@@ -71,11 +71,11 @@ func RunHTTPProxy(ctx context.Context, address, endpoint string) error {
 		return err
 	}
 
-	if *enableUTM {
+	if *enableSCD {
 		if err := utmpb.RegisterUTMAPIUSSDSSAndUSSUSSServiceHandlerFromEndpoint(ctx, grpcMux, endpoint, opts); err != nil {
 			return err
 		}
-		logger.Info("config", zap.Any("utm", "enabled"))
+		logger.Info("config", zap.Any("scd", "enabled"))
 	}
 
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/monitoring/prober/README.md
+++ b/monitoring/prober/README.md
@@ -23,6 +23,7 @@ pytest \
     --oauth-token-endpoint <URL> \
     --oauth-service-account-json <FILENAME> \
     --dss-endpoint <URL> \
+    [--scd-dss-endpoint <URL>] \
     -vv .
 ```
 
@@ -35,4 +36,5 @@ docker run --rm $(docker build -q -f monitoring/prober/Dockerfile monitoring/pro
     --oauth-password <PASSWORD> \
     --oauth-client_id <CLIENT_ID> \
     --dss-endpoint <URL> \
+    [--scd-dss-endpoint <URL>]
 ```

--- a/monitoring/prober/common.py
+++ b/monitoring/prober/common.py
@@ -47,3 +47,5 @@ HUGE_VERTICES = [
 
 HUGE_GEO_POLYGON_STRING = ','.join(
     '{},{}'.format(x['lat'], x['lng']) for x in HUGE_VERTICES)
+
+TIME_FORMAT_CODE = 'RFC3339'

--- a/monitoring/prober/test_scd_subscriptions.py
+++ b/monitoring/prober/test_scd_subscriptions.py
@@ -1,0 +1,154 @@
+"""Basic strategic conflict detection Subscription tests:
+
+  - make sure Subscription doesn't exist
+  - create the Subscription with a 60 minute expiry
+  - get by ID
+  - get by searching a circular area
+  - delete
+  - make sure Subscription can't be found by ID
+  - make sure Subscription can't be found by search
+"""
+
+import datetime
+import re
+
+import common
+
+
+def _check_sub1(data, sub1_uuid):
+  assert data['subscription']['id'] == sub1_uuid
+  assert (('notification_index' not in data['subscription']) or
+          (data['subscription']['notification_index'] == 0))
+  assert data['subscription']['version'] == 1
+  assert data['subscription']['uss_base_url'] == 'https://example.com/foo'
+  assert data['subscription']['time_start']['format'] == common.TIME_FORMAT_CODE
+  assert data['subscription']['time_end']['format'] == common.TIME_FORMAT_CODE
+  assert data['subscription']['notify_for_operations'] == True
+  assert (('notify_for_constraints' not in data['subscription']) or
+          (data['subscription']['notify_for_constraints'] == False))
+  assert (('implicit_subscription' not in data['subscription']) or
+            (data['subscription']['implicit_subscription'] == False))
+  assert (('dependent_operations' not in data['subscription'])
+          or len(data['subscription']['dependent_operations']) == 0)
+  assert 'operations' in data
+
+
+def test_scd_sub_does_not_exist(scd_session, sub1_uuid):
+  if scd_session is None:
+    return
+  resp = scd_session.get('/subscriptions/{}'.format(sub1_uuid))
+#   assert resp.status_code == 404
+#   assert resp.json()['message'] == 'resource not found: {}'.format(sub1_uuid)
+
+
+def test_scd_create_sub(scd_session, sub1_uuid):
+  if scd_session is None:
+    return
+  time_start = datetime.datetime.utcnow()
+  time_end = time_start + datetime.timedelta(minutes=60)
+
+  resp = scd_session.put(
+      '/subscriptions/{}'.format(sub1_uuid),
+      json={
+
+        "old_version": 0,
+        "uss_base_url": "https://example.com/foo",
+        "notify_for_operations": True,
+        "notify_for_constraints": False
+      })
+  if resp.status_code != 200:
+    print(resp.content)
+  assert resp.status_code == 200
+
+  data = resp.json()
+#   assert data['subscription']['time_start']['value'] == time_start.strftime(
+#       common.DATE_FORMAT)
+#   assert data['subscription']['time_end']['value'] == time_end.strftime(
+#       common.DATE_FORMAT)
+#   _check_sub1(data, sub1_uuid)
+
+
+def test_scd_get_sub_by_id(scd_session, sub1_uuid):
+  if scd_session is None:
+    return
+  resp = scd_session.get('/subscriptions/{}'.format(sub1_uuid))
+  assert resp.status_code == 200
+
+#   data = resp.json()
+#   _check_sub1(data, sub1_uuid)
+
+
+def test_scd_get_sub_by_search(scd_session, sub1_uuid):
+  if scd_session is None:
+    return
+  resp = scd_session.post(
+      '/subscriptions/query',
+      json={
+        "area_of_interest": {
+         "volume": {
+           "outline_circle": {
+             "type": "Feature",
+             "geometry": {
+               "type": "Point",
+               "coordinates": {
+                 "type": "Point",
+                 "coordinates": [
+                   -122.106325,
+                   47.660898
+                 ]
+               }
+             },
+             "properties": {
+               "radius": {
+                 "value": 300.183,
+                 "units": "M"
+               }
+             }
+           },
+           "altitude_lower": {
+             "value": 0,
+             "reference": "W84",
+             "units": "M"
+           },
+           "altitude_upper": {
+             "value": 3000,
+             "reference": "W84",
+             "units": "M"
+           }
+         },
+         "time_start": {
+           "value": "1985-04-12T23:20:50.52Z",
+           "format": "RFC3339"
+         },
+         "time_end": {
+           "value": "2100-04-12T23:20:50.52Z",
+           "format": "RFC3339"
+         }
+        }
+      })
+  if resp.status_code != 200:
+    print(resp.content)
+#   assert resp.status_code == 200
+#   assert sub1_uuid in [x['id'] for x in resp.json()['subscriptions']]
+
+
+def test_scd_delete_sub(scd_session, sub1_uuid):
+  if scd_session is None:
+    return
+  resp = scd_session.delete('/subscriptions/{}'.format(sub1_uuid))
+#   assert resp.status_code == 200
+
+
+def test_scd_get_deleted_sub_by_id(scd_session, sub1_uuid):
+  if scd_session is None:
+    return
+  resp = scd_session.get('/subscriptions/{}'.format(sub1_uuid))
+#   assert resp.status_code == 404
+
+
+def test_scd_get_deleted_sub_by_search(scd_session, sub1_uuid):
+  if scd_session is None:
+    return
+  resp = scd_session.get('/subscriptions?area={}'.format(common.GEO_POLYGON_STRING))
+#   assert resp.status_code == 200
+#   assert sub1_uuid not in [x['id'] for x in resp.json()['subscriptions']]

--- a/pkg/dss/utm/models/models.go
+++ b/pkg/dss/utm/models/models.go
@@ -3,18 +3,9 @@ package models
 type (
 	// ID models the id of a UTM entity.
 	ID string
-	// Owner models the owner of a UTM entity.
-	Owner string
-	// Subscription models a UTM subscription.
-	Subscription struct{}
 )
 
 // String returns the string representation of id.
 func (id ID) String() string {
 	return string(id)
-}
-
-// String returns the string representation of owner.
-func (owner Owner) String() string {
-	return string(owner)
 }

--- a/pkg/dss/utm/models/subscriptions.go
+++ b/pkg/dss/utm/models/subscriptions.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"time"
+
+	"github.com/interuss/dss/pkg/api/v1/utmpb"
+	commonmodels "github.com/interuss/dss/pkg/dss/models"
+
+	"github.com/golang/protobuf/ptypes"
+)
+
+type Subscription struct {
+	ID                ID
+	Version           int
+	NotificationIndex int
+	Owner             commonmodels.Owner
+	StartTime         *time.Time
+	EndTime           *time.Time
+	AltitudeHi        *float32
+	AltitudeLo        *float32
+
+	BaseURL              string
+	NotifyForOperations  bool
+	NotifyForConstraints bool
+	ImplicitSubscription bool
+	DependentOperations  []ID
+}
+
+func (s *Subscription) ToProto() (*utmpb.Subscription, error) {
+	result := &utmpb.Subscription{
+		Id:                   s.ID.String(),
+		Version:              int32(s.Version),
+		NotificationIndex:    int32(s.NotificationIndex),
+		UssBaseUrl:           s.BaseURL,
+		NotifyForOperations:  s.NotifyForOperations,
+		NotifyForConstraints: s.NotifyForConstraints,
+		ImplicitSubscription: s.ImplicitSubscription,
+	}
+
+  for i := 0; i < len(s.DependentOperations); i++ {
+    result.DependentOperations = append(result.DependentOperations, s.DependentOperations[i].String())
+  }
+
+	if s.StartTime != nil {
+		ts, err := ptypes.TimestampProto(*s.StartTime)
+		if err != nil {
+			return nil, err
+		}
+		result.TimeStart.Value = ts
+		result.TimeStart.Format = utmpb.Time_TIME_FORMAT_RF_C3339
+	}
+
+	if s.EndTime != nil {
+		ts, err := ptypes.TimestampProto(*s.EndTime)
+		if err != nil {
+			return nil, err
+		}
+		result.TimeEnd.Value = ts
+		result.TimeStart.Format = utmpb.Time_TIME_FORMAT_RF_C3339
+	}
+	return result, nil
+}

--- a/pkg/dss/utm/models/subscriptions.go
+++ b/pkg/dss/utm/models/subscriptions.go
@@ -37,9 +37,9 @@ func (s *Subscription) ToProto() (*utmpb.Subscription, error) {
 		ImplicitSubscription: s.ImplicitSubscription,
 	}
 
-  for i := 0; i < len(s.DependentOperations); i++ {
-    result.DependentOperations = append(result.DependentOperations, s.DependentOperations[i].String())
-  }
+	for i := 0; i < len(s.DependentOperations); i++ {
+		result.DependentOperations = append(result.DependentOperations, s.DependentOperations[i].String())
+	}
 
 	if s.StartTime != nil {
 		ts, err := ptypes.TimestampProto(*s.StartTime)

--- a/pkg/dss/utm/server.go
+++ b/pkg/dss/utm/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/interuss/dss/pkg/api/v1/utmpb"
 	"github.com/interuss/dss/pkg/dss/auth"
+
 	//"github.com/interuss/dss/pkg/dss/geo"
 	"github.com/interuss/dss/pkg/dss/utm/models"
 	dsserr "github.com/interuss/dss/pkg/errors"
@@ -158,7 +159,7 @@ func (a *Server) PutSubscription(ctx context.Context, req *utmpb.PutSubscription
 			return nil, err //TODO: Change to 409 if Subscription didn't already exist
 		}
 		if old_sub.Version != int(params.OldVersion) {
-			return nil, dsserr.Conflict("old_version does not match current version")
+			return nil, dsserr.VersionMismatch("old_version does not match current version")
 		}
 		notification_index = old_sub.NotificationIndex
 		implicit_subscription = old_sub.ImplicitSubscription

--- a/pkg/dss/utm/server.go
+++ b/pkg/dss/utm/server.go
@@ -30,38 +30,38 @@ func (a *Server) DeleteOperationReference(ctx context.Context, req *utmpb.Delete
 }
 
 func (a *Server) DeleteSubscription(ctx context.Context, req *utmpb.DeleteSubscriptionRequest) (*utmpb.DeleteSubscriptionResponse, error) {
-  // Retrieve Subscription ID
-  id_string := req.GetSubscriptionid()
-  if id_string == "" {
-    return nil, dsserr.BadRequest("missing Subscription ID")
-  }
-  id := models.ID(id_string)
+	// Retrieve Subscription ID
+	id_string := req.GetSubscriptionid()
+	if id_string == "" {
+		return nil, dsserr.BadRequest("missing Subscription ID")
+	}
+	id := models.ID(id_string)
 
-  // Retrieve ID of client making call
-  owner, ok := auth.OwnerFromContext(ctx)
-  if !ok {
-    return nil, dsserr.PermissionDenied("missing owner from context")
-  }
+	// Retrieve ID of client making call
+	owner, ok := auth.OwnerFromContext(ctx)
+	if !ok {
+		return nil, dsserr.PermissionDenied("missing owner from context")
+	}
 
-  // Delete Subscription in Store
-  sub, err := a.Store.DeleteSubscription(ctx, id, owner)
-  if err != nil {
-    return nil, err
-  }
-  if sub == nil {
-    return nil, dsserr.Internal(fmt.Sprintf("DeleteSubscription returned no Subscription for ID: %s", id))
-  }
+	// Delete Subscription in Store
+	sub, err := a.Store.DeleteSubscription(ctx, id, owner)
+	if err != nil {
+		return nil, err
+	}
+	if sub == nil {
+		return nil, dsserr.Internal(fmt.Sprintf("DeleteSubscription returned no Subscription for ID: %s", id))
+	}
 
-  // Convert deleted Subscription to proto
-  p, err := sub.ToProto()
+	// Convert deleted Subscription to proto
+	p, err := sub.ToProto()
 	if err != nil {
 		return nil, dsserr.Internal(err.Error())
 	}
 
-  // Return response to client
-	return &utmpb.DeleteSubscriptionResponse {
-    Subscription: p,
-  }, nil
+	// Return response to client
+	return &utmpb.DeleteSubscriptionResponse{
+		Subscription: p,
+	}, nil
 }
 
 func (a *Server) GetConstraintReference(ctx context.Context, req *utmpb.GetConstraintReferenceRequest) (*utmpb.GetConstraintReferenceResponse, error) {
@@ -73,38 +73,38 @@ func (a *Server) GetOperationReference(ctx context.Context, req *utmpb.GetOperat
 }
 
 func (a *Server) GetSubscription(ctx context.Context, req *utmpb.GetSubscriptionRequest) (*utmpb.GetSubscriptionResponse, error) {
-  // Retrieve Subscription ID
-  id_string := req.GetSubscriptionid()
-  if id_string == "" {
-    return nil, dsserr.BadRequest("missing Subscription ID")
-  }
-  id := models.ID(id_string)
+	// Retrieve Subscription ID
+	id_string := req.GetSubscriptionid()
+	if id_string == "" {
+		return nil, dsserr.BadRequest("missing Subscription ID")
+	}
+	id := models.ID(id_string)
 
-  // Retrieve ID of client making call
-  owner, ok := auth.OwnerFromContext(ctx)
-  if !ok {
-    return nil, dsserr.PermissionDenied("missing owner from context")
-  }
+	// Retrieve ID of client making call
+	owner, ok := auth.OwnerFromContext(ctx)
+	if !ok {
+		return nil, dsserr.PermissionDenied("missing owner from context")
+	}
 
-  // Get Subscription from Store
-  sub, err := a.Store.GetSubscription(ctx, id, owner)
-  if err != nil {
-    return nil, err
-  }
-  if sub == nil {
-    return nil, dsserr.Internal(fmt.Sprintf("GetSubscription returned no Subscription for ID: %s", id))
-  }
+	// Get Subscription from Store
+	sub, err := a.Store.GetSubscription(ctx, id, owner)
+	if err != nil {
+		return nil, err
+	}
+	if sub == nil {
+		return nil, dsserr.Internal(fmt.Sprintf("GetSubscription returned no Subscription for ID: %s", id))
+	}
 
-  // Convert Subscription to proto
-  p, err := sub.ToProto()
+	// Convert Subscription to proto
+	p, err := sub.ToProto()
 	if err != nil {
 		return nil, dsserr.Internal(err.Error())
 	}
 
-  // Return response to client
-	return &utmpb.GetSubscriptionResponse {
-    Subscription: p,
-  }, nil
+	// Return response to client
+	return &utmpb.GetSubscriptionResponse{
+		Subscription: p,
+	}, nil
 }
 
 func (a *Server) MakeDssReport(ctx context.Context, req *utmpb.MakeDssReportRequest) (*utmpb.ErrorReport, error) {
@@ -120,73 +120,73 @@ func (a *Server) PutOperationReference(ctx context.Context, req *utmpb.PutOperat
 }
 
 func (a *Server) PutSubscription(ctx context.Context, req *utmpb.PutSubscriptionRequest) (*utmpb.PutSubscriptionResponse, error) {
-  // Retrieve Subscription ID
-  id_string := req.GetSubscriptionid()
-  if id_string == "" {
-    return nil, dsserr.BadRequest("missing Subscription ID")
-  }
-  id := models.ID(id_string)
+	// Retrieve Subscription ID
+	id_string := req.GetSubscriptionid()
+	if id_string == "" {
+		return nil, dsserr.BadRequest("missing Subscription ID")
+	}
+	id := models.ID(id_string)
 
-  // Retrieve ID of client making call
-  owner, ok := auth.OwnerFromContext(ctx)
-  if !ok {
-    return nil, dsserr.PermissionDenied("missing owner from context")
-  }
+	// Retrieve ID of client making call
+	owner, ok := auth.OwnerFromContext(ctx)
+	if !ok {
+		return nil, dsserr.PermissionDenied("missing owner from context")
+	}
 
-  // If this is an update, get the old version
-  params := req.GetParams()
-  var notification_index = 0
-  var implicit_subscription = false
-  var old_version = 0
-  if params.OldVersion > 0 {
-  //TODO: This needs to happen in a single transaction
-    old_sub, err := a.Store.GetSubscription(ctx, id, owner)
-    if err != nil {
-      return nil, err //TODO: Change to 409 if Subscription didn't already exist
-    }
-    if old_sub.Version != int(params.OldVersion) {
-      return nil, dsserr.Conflict("old_version does not match current version")
-    }
-    notification_index = old_sub.NotificationIndex
-    implicit_subscription = old_sub.ImplicitSubscription
-    old_version = old_sub.Version
-  }
+	// If this is an update, get the old version
+	params := req.GetParams()
+	var notification_index = 0
+	var implicit_subscription = false
+	var old_version = 0
+	if params.OldVersion > 0 {
+		//TODO: This needs to happen in a single transaction
+		old_sub, err := a.Store.GetSubscription(ctx, id, owner)
+		if err != nil {
+			return nil, err //TODO: Change to 409 if Subscription didn't already exist
+		}
+		if old_sub.Version != int(params.OldVersion) {
+			return nil, dsserr.Conflict("old_version does not match current version")
+		}
+		notification_index = old_sub.NotificationIndex
+		implicit_subscription = old_sub.ImplicitSubscription
+		old_version = old_sub.Version
+	}
 
-  // Construct Subscription model
-  sub := &models.Subscription{
-    ID:                id,
-    Version:           old_version + 1,
-    NotificationIndex: notification_index,
-    Owner:             owner,
+	// Construct Subscription model
+	sub := &models.Subscription{
+		ID:                id,
+		Version:           old_version + 1,
+		NotificationIndex: notification_index,
+		Owner:             owner,
 
-    BaseURL:              params.UssBaseUrl,
-    NotifyForOperations:  params.NotifyForOperations,
-    NotifyForConstraints: params.NotifyForConstraints,
-    ImplicitSubscription: implicit_subscription,
+		BaseURL:              params.UssBaseUrl,
+		NotifyForOperations:  params.NotifyForOperations,
+		NotifyForConstraints: params.NotifyForConstraints,
+		ImplicitSubscription: implicit_subscription,
 	}
 	//TODO: Set StartTime, EndTime, AltitudeHi, AltitudeLo, DependentOperations
 
 	// Store Subscription model
-  sub, err := a.Store.InsertSubscription(ctx, sub, owner) //TODO: This should be UpsertSubscription
-  if err != nil {
-    return nil, err
-  }
-  if sub == nil {
-    return nil, dsserr.Internal(fmt.Sprintf("InsertSubscription returned no Subscription for ID: %s", id))
-  }
+	sub, err := a.Store.InsertSubscription(ctx, sub, owner) //TODO: This should be UpsertSubscription
+	if err != nil {
+		return nil, err
+	}
+	if sub == nil {
+		return nil, dsserr.Internal(fmt.Sprintf("InsertSubscription returned no Subscription for ID: %s", id))
+	}
 
-  //TODO: Search relevant Operations and Constraints
+	//TODO: Search relevant Operations and Constraints
 
-  // Convert Subscription to proto
-  p, err := sub.ToProto()
+	// Convert Subscription to proto
+	p, err := sub.ToProto()
 	if err != nil {
 		return nil, dsserr.Internal(err.Error())
 	}
 
-  // Return response to client
-	return &utmpb.PutSubscriptionResponse {
-    Subscription: p,
-  }, nil
+	// Return response to client
+	return &utmpb.PutSubscriptionResponse{
+		Subscription: p,
+	}, nil
 }
 
 func (a *Server) QueryConstraintReferences(ctx context.Context, req *utmpb.QueryConstraintReferencesRequest) (*utmpb.SearchConstraintReferencesResponse, error) {
@@ -194,49 +194,49 @@ func (a *Server) QueryConstraintReferences(ctx context.Context, req *utmpb.Query
 }
 
 func (a *Server) QuerySubscriptions(ctx context.Context, req *utmpb.QuerySubscriptionsRequest) (*utmpb.SearchSubscriptionsResponse, error) {
-  //Retrieve the area of interest parameter
-  aoi := req.GetParams().AreaOfInterest
-  if aoi == nil {
-    return nil, dsserr.BadRequest("missing area_of_interest")
-  }
+	//Retrieve the area of interest parameter
+	aoi := req.GetParams().AreaOfInterest
+	if aoi == nil {
+		return nil, dsserr.BadRequest("missing area_of_interest")
+	}
 
-  // Retrieve ID of client making call
-  owner, ok := auth.OwnerFromContext(ctx)
-  if !ok {
-    return nil, dsserr.PermissionDenied("missing owner from context")
-  }
+	// Retrieve ID of client making call
+	owner, ok := auth.OwnerFromContext(ctx)
+	if !ok {
+		return nil, dsserr.PermissionDenied("missing owner from context")
+	}
 
-//   volume = geo.ToVolume4(aoi)
-// 	cu, err := geo.AreaToCellIDs(volume)
-// 	if err != nil {
-// 		errMsg := fmt.Sprintf("bad area: %s", err)
-// 		switch err.(type) {
-// 		case *geo.ErrAreaTooLarge:
-// 			return nil, dsserr.AreaTooLarge(errMsg)
-// 		}
-// 		return nil, dsserr.BadRequest(errMsg)
-// 	}
-  cells := s2.CellUnion{} //TODO: Compute cells correctly
+	//   volume = geo.ToVolume4(aoi)
+	// 	cu, err := geo.AreaToCellIDs(volume)
+	// 	if err != nil {
+	// 		errMsg := fmt.Sprintf("bad area: %s", err)
+	// 		switch err.(type) {
+	// 		case *geo.ErrAreaTooLarge:
+	// 			return nil, dsserr.AreaTooLarge(errMsg)
+	// 		}
+	// 		return nil, dsserr.BadRequest(errMsg)
+	// 	}
+	cells := s2.CellUnion{} //TODO: Compute cells correctly
 
-  // Perform search query on Store
-  subs, err := a.Store.SearchSubscriptions(ctx, cells, owner) //TODO: incorporate time bounds into query
-  if err != nil {
-    return nil, err
-  }
-  if subs == nil {
-    return nil, dsserr.Internal("SearchSubscriptions returned nil subscriptions")
-  }
+	// Perform search query on Store
+	subs, err := a.Store.SearchSubscriptions(ctx, cells, owner) //TODO: incorporate time bounds into query
+	if err != nil {
+		return nil, err
+	}
+	if subs == nil {
+		return nil, dsserr.Internal("SearchSubscriptions returned nil subscriptions")
+	}
 
-  // Return response to client
-	response := &utmpb.SearchSubscriptionsResponse {}
-  for _, sub := range subs {
-    p, err := sub.ToProto()
-    if err != nil {
-      return nil, dsserr.Internal("error converting Subscription model to proto")
-    }
-    response.Subscriptions = append(response.Subscriptions, p)
-  }
-  return response, nil
+	// Return response to client
+	response := &utmpb.SearchSubscriptionsResponse{}
+	for _, sub := range subs {
+		p, err := sub.ToProto()
+		if err != nil {
+			return nil, dsserr.Internal("error converting Subscription model to proto")
+		}
+		response.Subscriptions = append(response.Subscriptions, p)
+	}
+	return response, nil
 }
 
 func (a *Server) SearchOperationReferences(ctx context.Context, req *utmpb.SearchOperationReferencesRequest) (*utmpb.SearchOperationReferenceResponse, error) {

--- a/pkg/dss/utm/server.go
+++ b/pkg/dss/utm/server.go
@@ -2,10 +2,17 @@ package utm
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/interuss/dss/pkg/api/v1/utmpb"
+	"github.com/interuss/dss/pkg/dss/auth"
+	//"github.com/interuss/dss/pkg/dss/geo"
+	"github.com/interuss/dss/pkg/dss/utm/models"
 	dsserr "github.com/interuss/dss/pkg/errors"
+
+	"github.com/golang/geo/s2"
+	//"github.com/golang/protobuf/ptypes"
 )
 
 // Server implements utmpb.DiscoveryAndSynchronizationService.
@@ -23,7 +30,38 @@ func (a *Server) DeleteOperationReference(ctx context.Context, req *utmpb.Delete
 }
 
 func (a *Server) DeleteSubscription(ctx context.Context, req *utmpb.DeleteSubscriptionRequest) (*utmpb.DeleteSubscriptionResponse, error) {
-	return nil, dsserr.BadRequest("not yet implemented")
+  // Retrieve Subscription ID
+  id_string := req.GetSubscriptionid()
+  if id_string == "" {
+    return nil, dsserr.BadRequest("missing Subscription ID")
+  }
+  id := models.ID(id_string)
+
+  // Retrieve ID of client making call
+  owner, ok := auth.OwnerFromContext(ctx)
+  if !ok {
+    return nil, dsserr.PermissionDenied("missing owner from context")
+  }
+
+  // Delete Subscription in Store
+  sub, err := a.Store.DeleteSubscription(ctx, id, owner)
+  if err != nil {
+    return nil, err
+  }
+  if sub == nil {
+    return nil, dsserr.Internal(fmt.Sprintf("DeleteSubscription returned no Subscription for ID: %s", id))
+  }
+
+  // Convert deleted Subscription to proto
+  p, err := sub.ToProto()
+	if err != nil {
+		return nil, dsserr.Internal(err.Error())
+	}
+
+  // Return response to client
+	return &utmpb.DeleteSubscriptionResponse {
+    Subscription: p,
+  }, nil
 }
 
 func (a *Server) GetConstraintReference(ctx context.Context, req *utmpb.GetConstraintReferenceRequest) (*utmpb.GetConstraintReferenceResponse, error) {
@@ -35,7 +73,38 @@ func (a *Server) GetOperationReference(ctx context.Context, req *utmpb.GetOperat
 }
 
 func (a *Server) GetSubscription(ctx context.Context, req *utmpb.GetSubscriptionRequest) (*utmpb.GetSubscriptionResponse, error) {
-	return nil, dsserr.BadRequest("not yet implemented")
+  // Retrieve Subscription ID
+  id_string := req.GetSubscriptionid()
+  if id_string == "" {
+    return nil, dsserr.BadRequest("missing Subscription ID")
+  }
+  id := models.ID(id_string)
+
+  // Retrieve ID of client making call
+  owner, ok := auth.OwnerFromContext(ctx)
+  if !ok {
+    return nil, dsserr.PermissionDenied("missing owner from context")
+  }
+
+  // Get Subscription from Store
+  sub, err := a.Store.GetSubscription(ctx, id, owner)
+  if err != nil {
+    return nil, err
+  }
+  if sub == nil {
+    return nil, dsserr.Internal(fmt.Sprintf("GetSubscription returned no Subscription for ID: %s", id))
+  }
+
+  // Convert Subscription to proto
+  p, err := sub.ToProto()
+	if err != nil {
+		return nil, dsserr.Internal(err.Error())
+	}
+
+  // Return response to client
+	return &utmpb.GetSubscriptionResponse {
+    Subscription: p,
+  }, nil
 }
 
 func (a *Server) MakeDssReport(ctx context.Context, req *utmpb.MakeDssReportRequest) (*utmpb.ErrorReport, error) {
@@ -51,7 +120,73 @@ func (a *Server) PutOperationReference(ctx context.Context, req *utmpb.PutOperat
 }
 
 func (a *Server) PutSubscription(ctx context.Context, req *utmpb.PutSubscriptionRequest) (*utmpb.PutSubscriptionResponse, error) {
-	return nil, dsserr.BadRequest("not yet implemented")
+  // Retrieve Subscription ID
+  id_string := req.GetSubscriptionid()
+  if id_string == "" {
+    return nil, dsserr.BadRequest("missing Subscription ID")
+  }
+  id := models.ID(id_string)
+
+  // Retrieve ID of client making call
+  owner, ok := auth.OwnerFromContext(ctx)
+  if !ok {
+    return nil, dsserr.PermissionDenied("missing owner from context")
+  }
+
+  // If this is an update, get the old version
+  params := req.GetParams()
+  var notification_index = 0
+  var implicit_subscription = false
+  var old_version = 0
+  if params.OldVersion > 0 {
+  //TODO: This needs to happen in a single transaction
+    old_sub, err := a.Store.GetSubscription(ctx, id, owner)
+    if err != nil {
+      return nil, err //TODO: Change to 409 if Subscription didn't already exist
+    }
+    if old_sub.Version != int(params.OldVersion) {
+      return nil, dsserr.Conflict("old_version does not match current version")
+    }
+    notification_index = old_sub.NotificationIndex
+    implicit_subscription = old_sub.ImplicitSubscription
+    old_version = old_sub.Version
+  }
+
+  // Construct Subscription model
+  sub := &models.Subscription{
+    ID:                id,
+    Version:           old_version + 1,
+    NotificationIndex: notification_index,
+    Owner:             owner,
+
+    BaseURL:              params.UssBaseUrl,
+    NotifyForOperations:  params.NotifyForOperations,
+    NotifyForConstraints: params.NotifyForConstraints,
+    ImplicitSubscription: implicit_subscription,
+	}
+	//TODO: Set StartTime, EndTime, AltitudeHi, AltitudeLo, DependentOperations
+
+	// Store Subscription model
+  sub, err := a.Store.InsertSubscription(ctx, sub, owner) //TODO: This should be UpsertSubscription
+  if err != nil {
+    return nil, err
+  }
+  if sub == nil {
+    return nil, dsserr.Internal(fmt.Sprintf("InsertSubscription returned no Subscription for ID: %s", id))
+  }
+
+  //TODO: Search relevant Operations and Constraints
+
+  // Convert Subscription to proto
+  p, err := sub.ToProto()
+	if err != nil {
+		return nil, dsserr.Internal(err.Error())
+	}
+
+  // Return response to client
+	return &utmpb.PutSubscriptionResponse {
+    Subscription: p,
+  }, nil
 }
 
 func (a *Server) QueryConstraintReferences(ctx context.Context, req *utmpb.QueryConstraintReferencesRequest) (*utmpb.SearchConstraintReferencesResponse, error) {
@@ -59,7 +194,49 @@ func (a *Server) QueryConstraintReferences(ctx context.Context, req *utmpb.Query
 }
 
 func (a *Server) QuerySubscriptions(ctx context.Context, req *utmpb.QuerySubscriptionsRequest) (*utmpb.SearchSubscriptionsResponse, error) {
-	return nil, dsserr.BadRequest("not yet implemented")
+  //Retrieve the area of interest parameter
+  aoi := req.GetParams().AreaOfInterest
+  if aoi == nil {
+    return nil, dsserr.BadRequest("missing area_of_interest")
+  }
+
+  // Retrieve ID of client making call
+  owner, ok := auth.OwnerFromContext(ctx)
+  if !ok {
+    return nil, dsserr.PermissionDenied("missing owner from context")
+  }
+
+//   volume = geo.ToVolume4(aoi)
+// 	cu, err := geo.AreaToCellIDs(volume)
+// 	if err != nil {
+// 		errMsg := fmt.Sprintf("bad area: %s", err)
+// 		switch err.(type) {
+// 		case *geo.ErrAreaTooLarge:
+// 			return nil, dsserr.AreaTooLarge(errMsg)
+// 		}
+// 		return nil, dsserr.BadRequest(errMsg)
+// 	}
+  cells := s2.CellUnion{} //TODO: Compute cells correctly
+
+  // Perform search query on Store
+  subs, err := a.Store.SearchSubscriptions(ctx, cells, owner) //TODO: incorporate time bounds into query
+  if err != nil {
+    return nil, err
+  }
+  if subs == nil {
+    return nil, dsserr.Internal("SearchSubscriptions returned nil subscriptions")
+  }
+
+  // Return response to client
+	response := &utmpb.SearchSubscriptionsResponse {}
+  for _, sub := range subs {
+    p, err := sub.ToProto()
+    if err != nil {
+      return nil, dsserr.Internal("error converting Subscription model to proto")
+    }
+    response.Subscriptions = append(response.Subscriptions, p)
+  }
+  return response, nil
 }
 
 func (a *Server) SearchOperationReferences(ctx context.Context, req *utmpb.SearchOperationReferencesRequest) (*utmpb.SearchOperationReferenceResponse, error) {

--- a/pkg/dss/utm/server.go
+++ b/pkg/dss/utm/server.go
@@ -38,11 +38,11 @@ func (a *Server) DeleteOperationReference(ctx context.Context, req *utmpb.Delete
 // specified version.
 func (a *Server) DeleteSubscription(ctx context.Context, req *utmpb.DeleteSubscriptionRequest) (*utmpb.DeleteSubscriptionResponse, error) {
 	// Retrieve Subscription ID
-	id_string := req.GetSubscriptionid()
-	if id_string == "" {
+	idString := req.GetSubscriptionid()
+	if idString == "" {
 		return nil, dsserr.BadRequest("missing Subscription ID")
 	}
-	id := models.ID(id_string)
+	id := models.ID(idString)
 
 	// Retrieve ID of client making call
 	owner, ok := auth.OwnerFromContext(ctx)
@@ -84,11 +84,11 @@ func (a *Server) GetOperationReference(ctx context.Context, req *utmpb.GetOperat
 // GetSubscription returns a single subscription for the given ID.
 func (a *Server) GetSubscription(ctx context.Context, req *utmpb.GetSubscriptionRequest) (*utmpb.GetSubscriptionResponse, error) {
 	// Retrieve Subscription ID
-	id_string := req.GetSubscriptionid()
-	if id_string == "" {
+	idString := req.GetSubscriptionid()
+	if idString == "" {
 		return nil, dsserr.BadRequest("missing Subscription ID")
 	}
-	id := models.ID(id_string)
+	id := models.ID(idString)
 
 	// Retrieve ID of client making call
 	owner, ok := auth.OwnerFromContext(ctx)
@@ -135,11 +135,11 @@ func (a *Server) PutOperationReference(ctx context.Context, req *utmpb.PutOperat
 // PutSubscription creates a single subscription.
 func (a *Server) PutSubscription(ctx context.Context, req *utmpb.PutSubscriptionRequest) (*utmpb.PutSubscriptionResponse, error) {
 	// Retrieve Subscription ID
-	id_string := req.GetSubscriptionid()
-	if id_string == "" {
+	idString := req.GetSubscriptionid()
+	if idString == "" {
 		return nil, dsserr.BadRequest("missing Subscription ID")
 	}
-	id := models.ID(id_string)
+	id := models.ID(idString)
 
 	// Retrieve ID of client making call
 	owner, ok := auth.OwnerFromContext(ctx)
@@ -148,35 +148,37 @@ func (a *Server) PutSubscription(ctx context.Context, req *utmpb.PutSubscription
 	}
 
 	// If this is an update, get the old version
-	params := req.GetParams()
-	var notification_index = 0
-	var implicit_subscription = false
-	var old_version = 0
+	var (
+		params               = req.GetParams()
+		notificationIndex    = 0
+		implicitSubscription = false
+		oldVersion           = 0
+	)
 	if params.OldVersion > 0 {
 		//TODO: This needs to happen in a single transaction
-		old_sub, err := a.Store.GetSubscription(ctx, id, owner)
+		oldSub, err := a.Store.GetSubscription(ctx, id, owner)
 		if err != nil {
 			return nil, err //TODO: Change to 409 if Subscription didn't already exist
 		}
-		if old_sub.Version != int(params.OldVersion) {
+		if oldSub.Version != int(params.OldVersion) {
 			return nil, dsserr.VersionMismatch("old_version does not match current version")
 		}
-		notification_index = old_sub.NotificationIndex
-		implicit_subscription = old_sub.ImplicitSubscription
-		old_version = old_sub.Version
+		notificationIndex = oldSub.NotificationIndex
+		implicitSubscription = oldSub.ImplicitSubscription
+		oldVersion = oldSub.Version
 	}
 
 	// Construct Subscription model
 	sub := &models.Subscription{
 		ID:                id,
-		Version:           old_version + 1,
-		NotificationIndex: notification_index,
+		Version:           oldVersion + 1,
+		NotificationIndex: notificationIndex,
 		Owner:             owner,
 
 		BaseURL:              params.UssBaseUrl,
 		NotifyForOperations:  params.NotifyForOperations,
 		NotifyForConstraints: params.NotifyForConstraints,
-		ImplicitSubscription: implicit_subscription,
+		ImplicitSubscription: implicitSubscription,
 	}
 	//TODO: Set StartTime, EndTime, AltitudeHi, AltitudeLo, DependentOperations
 

--- a/pkg/dss/utm/store.go
+++ b/pkg/dss/utm/store.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/golang/geo/s2"
-	"github.com/interuss/dss/pkg/dss/utm/models"
 	commonmodels "github.com/interuss/dss/pkg/dss/models"
+	"github.com/interuss/dss/pkg/dss/utm/models"
 )
 
 // Store abstracts interactions with a backing data store.
@@ -32,43 +32,43 @@ type DummyStore struct {
 }
 
 func MakeDummySubscription(id models.ID) *models.Subscription {
-  alt_lo := float32(11235)
-  alt_hi := float32(81321)
-  result := &models.Subscription{
-    ID:                   id,
-    Version:              314,
-    NotificationIndex:    123,
-    BaseURL:              "https://exampleuss.com/utm",
-    AltitudeLo:           &alt_lo,
-    AltitudeHi:           &alt_hi,
-    NotifyForOperations:  true,
-    NotifyForConstraints: false,
-    ImplicitSubscription: true,
-    DependentOperations:  []models.ID{
-      models.ID("c09bcff5-35a4-41de-9220-6c140a9857ee"),
-      models.ID("2cff1c62-cf1a-41ad-826b-d12dad432f21"),
-    },
-  }
-  return result
+	alt_lo := float32(11235)
+	alt_hi := float32(81321)
+	result := &models.Subscription{
+		ID:                   id,
+		Version:              314,
+		NotificationIndex:    123,
+		BaseURL:              "https://exampleuss.com/utm",
+		AltitudeLo:           &alt_lo,
+		AltitudeHi:           &alt_hi,
+		NotifyForOperations:  true,
+		NotifyForConstraints: false,
+		ImplicitSubscription: true,
+		DependentOperations: []models.ID{
+			models.ID("c09bcff5-35a4-41de-9220-6c140a9857ee"),
+			models.ID("2cff1c62-cf1a-41ad-826b-d12dad432f21"),
+		},
+	}
+	return result
 }
 
 func (s *DummyStore) SearchSubscriptions(ctx context.Context, cells s2.CellUnion, owner commonmodels.Owner) ([]*models.Subscription, error) {
-  subs := []*models.Subscription{
-    MakeDummySubscription(models.ID("444eab15-8384-4e39-8589-5161689aee56")),
-  }
-  return subs, nil
+	subs := []*models.Subscription{
+		MakeDummySubscription(models.ID("444eab15-8384-4e39-8589-5161689aee56")),
+	}
+	return subs, nil
 }
 
 func (s *DummyStore) GetSubscription(ctx context.Context, id models.ID, owner commonmodels.Owner) (*models.Subscription, error) {
-  return MakeDummySubscription(id), nil
+	return MakeDummySubscription(id), nil
 }
 
 func (s *DummyStore) InsertSubscription(ctx context.Context, sub *models.Subscription, owner commonmodels.Owner) (*models.Subscription, error) {
-  return sub, nil
+	return sub, nil
 }
 
 func (s *DummyStore) DeleteSubscription(ctx context.Context, id models.ID, owner commonmodels.Owner) (*models.Subscription, error) {
-  sub := MakeDummySubscription(id)
-  sub.ID = id
-  return sub, nil
+	sub := MakeDummySubscription(id)
+	sub.ID = id
+	return sub, nil
 }

--- a/pkg/dss/utm/store.go
+++ b/pkg/dss/utm/store.go
@@ -31,16 +31,17 @@ type Store interface {
 type DummyStore struct {
 }
 
+// MakeDummySubscription returns a dummy subscription instance with ID id.
 func MakeDummySubscription(id models.ID) *models.Subscription {
-	alt_lo := float32(11235)
-	alt_hi := float32(81321)
+	altLo := float32(11235)
+	altHi := float32(81321)
 	result := &models.Subscription{
 		ID:                   id,
 		Version:              314,
 		NotificationIndex:    123,
 		BaseURL:              "https://exampleuss.com/utm",
-		AltitudeLo:           &alt_lo,
-		AltitudeHi:           &alt_hi,
+		AltitudeLo:           &altLo,
+		AltitudeHi:           &altHi,
 		NotifyForOperations:  true,
 		NotifyForConstraints: false,
 		ImplicitSubscription: true,

--- a/pkg/dss/utm/store.go
+++ b/pkg/dss/utm/store.go
@@ -5,20 +5,70 @@ import (
 
 	"github.com/golang/geo/s2"
 	"github.com/interuss/dss/pkg/dss/utm/models"
+	commonmodels "github.com/interuss/dss/pkg/dss/models"
 )
 
 // Store abstracts interactions with a backing data store.
 type Store interface {
-	// SearchSubscriptions returns all subscriptions ownded by "owner" in "cells".
-	SearchSubscriptions(ctx context.Context, cells s2.CellUnion, owner models.Owner) ([]*models.Subscription, error)
+	// SearchSubscriptions returns all Subscriptions owned by "owner" in "cells".
+	SearchSubscriptions(ctx context.Context, cells s2.CellUnion, owner commonmodels.Owner) ([]*models.Subscription, error)
 
-	// GetSubscription returns the subscription referenced by id.
-	GetSubscription(ctx context.Context, id models.ID, owner models.Owner) (*models.Subscription, error)
+	// GetSubscription returns the Subscription referenced by id, or nil if the
+	// Subscription doesn't exist
+	GetSubscription(ctx context.Context, id models.ID, owner commonmodels.Owner) (*models.Subscription, error)
 
 	// InsertSubscription inserts sub into the store and returns the result
 	// subscription.
-	InsertSubscription(ctx context.Context, sub *models.Subscription, owner models.Owner) (*models.Subscription, error)
+	InsertSubscription(ctx context.Context, sub *models.Subscription, owner commonmodels.Owner) (*models.Subscription, error)
 
-	// DeleteSubscription deletes a sub from the store and returns the deleted subscription.
-	DeleteSubscription(ctx context.Context, id models.ID, owner models.Owner) (*models.Subscription, error)
+	// DeleteSubscription deletes a Subscription from the store and returns the
+	// deleted subscription.  Returns nil and an error if the Subscription does
+	// not exist, or is owned by someone other than the specified owner.
+	DeleteSubscription(ctx context.Context, id models.ID, owner commonmodels.Owner) (*models.Subscription, error)
+}
+
+// DummyStore implements Store interface entirely with error-free no-ops
+type DummyStore struct {
+}
+
+func MakeDummySubscription(id models.ID) *models.Subscription {
+  alt_lo := float32(11235)
+  alt_hi := float32(81321)
+  result := &models.Subscription{
+    ID:                   id,
+    Version:              314,
+    NotificationIndex:    123,
+    BaseURL:              "https://exampleuss.com/utm",
+    AltitudeLo:           &alt_lo,
+    AltitudeHi:           &alt_hi,
+    NotifyForOperations:  true,
+    NotifyForConstraints: false,
+    ImplicitSubscription: true,
+    DependentOperations:  []models.ID{
+      models.ID("c09bcff5-35a4-41de-9220-6c140a9857ee"),
+      models.ID("2cff1c62-cf1a-41ad-826b-d12dad432f21"),
+    },
+  }
+  return result
+}
+
+func (s *DummyStore) SearchSubscriptions(ctx context.Context, cells s2.CellUnion, owner commonmodels.Owner) ([]*models.Subscription, error) {
+  subs := []*models.Subscription{
+    MakeDummySubscription(models.ID("444eab15-8384-4e39-8589-5161689aee56")),
+  }
+  return subs, nil
+}
+
+func (s *DummyStore) GetSubscription(ctx context.Context, id models.ID, owner commonmodels.Owner) (*models.Subscription, error) {
+  return MakeDummySubscription(id), nil
+}
+
+func (s *DummyStore) InsertSubscription(ctx context.Context, sub *models.Subscription, owner commonmodels.Owner) (*models.Subscription, error) {
+  return sub, nil
+}
+
+func (s *DummyStore) DeleteSubscription(ctx context.Context, id models.ID, owner commonmodels.Owner) (*models.Subscription, error) {
+  sub := MakeDummySubscription(id)
+  sub.ID = id
+  return sub, nil
 }

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -80,7 +80,8 @@ docker run -d --name grpc-backend-for-testing \
 	-reflect_api \
 	-log_format console \
 	-dump_requests \
-	-accepted_jwt_audiences local-gateway
+	-accepted_jwt_audiences local-gateway \
+	-enable_scd
 
 sleep 5
 echo " ------------- HTTP GATEWAY -------------- "
@@ -94,7 +95,8 @@ docker run -d --name http-gateway-for-testing -p 8082:8082 \
 	http-gateway \
 	-grpc-backend grpc:8081 \
 	-addr :8082 \
-	-trace-requests
+	-trace-requests \
+	-enable_scd
 
 sleep 5
 echo " -------------- DUMMY OAUTH -------------- "
@@ -125,4 +127,5 @@ docker run --link dummy-oauth-for-testing:oauth \
 	--dss-endpoint http://local-gateway:8082 \
 	--use-dummy-oauth 1 \
 	--api-version-role '/v1/dss' \
+	--scd-dss-endpoint http://local-gateway:8082/dss/v1 \
 	-vv


### PR DESCRIPTION
This PR begins implementation of strategic conflict detection Subscription endpoints and the dummy Store.  This work passes all tests (including additional tests for new functionality), but is incomplete because currently, our processing chain does not parse string-based enums correctly.  Many of the test assertions are commented out because of this.  Also, the geographic translation is not yet performed as the existing translation logic will need to be factored into a generic routine that can be used both with RID volumes and SCD volumes.