### PR TITLE
Introduce scd cockroach store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,8 @@ test: kubecfg
 .PHONY: test-cockroach
 test-cockroach: cleanup-test-cockroach
 	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v19.1.2 start --insecure > /dev/null
-	go test -count=1 -v ./pkg/dss/rid/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
+	# go test -count=1 -v ./pkg/dss/rid/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
+	go test -count=1 -v ./pkg/dss/scd/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	@docker stop dss-crdb-for-testing > /dev/null
 	@docker rm dss-crdb-for-testing > /dev/null
 

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test: kubecfg
 .PHONY: test-cockroach
 test-cockroach: cleanup-test-cockroach
 	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v19.1.2 start --insecure > /dev/null
-	# go test -count=1 -v ./pkg/dss/rid/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
+	go test -count=1 -v ./pkg/dss/rid/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	go test -count=1 -v ./pkg/dss/scd/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	@docker stop dss-crdb-for-testing > /dev/null
 	@docker rm dss-crdb-for-testing > /dev/null

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.22.0
 	gopkg.in/square/go-jose.v2 v2.4.0
-	gopkg.in/yaml.v2 v2.2.8 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
 )
 

--- a/pkg/dss/scd/cockroach/doc.go
+++ b/pkg/dss/scd/cockroach/doc.go
@@ -1,3 +1,3 @@
-// Package cockroach provides an implementation of a dss.Store on top of a
+// Package cockroach provides an implementation of a scd.Store on top of a
 // cockroach DB instance.
 package cockroach

--- a/pkg/dss/scd/cockroach/doc.go
+++ b/pkg/dss/scd/cockroach/doc.go
@@ -1,0 +1,3 @@
+// Package cockroach provides an implementation of a dss.Store on top of a
+// cockroach DB instance.
+package cockroach

--- a/pkg/dss/scd/cockroach/store.go
+++ b/pkg/dss/scd/cockroach/store.go
@@ -1,0 +1,124 @@
+package cockroach
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/dpjacques/clockwork"
+	"go.uber.org/zap"
+)
+
+var (
+	// DefaultClock is what is used as the Store's clock, returned from Dial.
+	DefaultClock = clockwork.NewRealClock()
+)
+
+// Store is an implementation of dss.Store using
+// Cockroach DB as its backend store.
+type Store struct {
+	*sql.DB
+	logger *zap.Logger
+	clock  clockwork.Clock
+}
+
+// Dial returns a Store instance connected to a cockroach instance available at
+// "uri".
+// https://www.cockroachlabs.com/docs/stable/connection-parameters.html
+func Dial(uri string, logger *zap.Logger) (*Store, error) {
+	db, err := sql.Open("postgres", uri)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Store{
+		DB:     db,
+		logger: logger,
+		clock:  DefaultClock,
+	}, nil
+}
+
+// BuildURI returns a cockroachdb connection string from a params map.
+func BuildURI(params map[string]string) (string, error) {
+	an := params["application_name"]
+	if an == "" {
+		an = "dss"
+	}
+	h := params["host"]
+	if h == "" {
+		return "", errors.New("missing crdb hostname")
+	}
+	p := params["port"]
+	if p == "" {
+		return "", errors.New("missing crdb port")
+	}
+	u := params["user"]
+	if u == "" {
+		return "", errors.New("missing crdb user")
+	}
+	ssl := params["ssl_mode"]
+	if ssl == "" {
+		return "", errors.New("missing crdb ssl_mode")
+	}
+	if ssl == "disable" {
+		return fmt.Sprintf("postgresql://%s@%s:%s?application_name=%s&sslmode=disable", u, h, p, an), nil
+	}
+	dir := params["ssl_dir"]
+	if dir == "" {
+		return "", errors.New("missing crdb ssl_dir")
+	}
+
+	return fmt.Sprintf(
+		"postgresql://%s@%s:%s?application_name=%s&sslmode=%s&sslrootcert=%s/ca.crt&sslcert=%s/client.%s.crt&sslkey=%s/client.%s.key",
+		u, h, p, an, ssl, dir, dir, u, dir, u,
+	), nil
+}
+
+type queryable interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}
+
+// Close closes the underlying DB connection.
+func (s *Store) Close() error {
+	return s.DB.Close()
+}
+
+// Bootstrap bootstraps the underlying database with required tables.
+//
+// TODO: We should handle database migrations properly, but bootstrap both us
+// *and* the database with this manual approach here.
+func (s *Store) Bootstrap(ctx context.Context) error {
+	const query = `
+	CREATE TABLE IF NOT EXISTS scd_subscriptions (
+		id UUID PRIMARY KEY,
+		owner STRING NOT NULL,
+		version INT4 NOT NULL DEFAULT 0,
+		url STRING NOT NULL,
+		notification_index INT4 DEFAULT 0,
+		notify_for_operations BOOL DEFAULT false,
+		notify_for_constraints BOOL DEFAULT false,
+		implicit BOOL DEFAULT false,
+		starts_at TIMESTAMPTZ,
+		ends_at TIMESTAMPTZ,
+		updated_at TIMESTAMPTZ NOT NULL,
+		INDEX owner_idx (owner),
+		INDEX starts_at_idx (starts_at),
+		INDEX ends_at_idx (ends_at),
+		CHECK (starts_at IS NULL OR ends_at IS NULL OR starts_at < ends_at),
+		CHECK (notify_for_operations OR notify_for_constraints)
+	);
+	CREATE TABLE IF NOT EXISTS scd_cells_subscriptions (
+		cell_id INT64 NOT NULL,
+		cell_level INT CHECK (cell_level BETWEEN 0 and 30),
+		subscription_id UUID NOT NULL REFERENCES scd_subscriptions (id) ON DELETE CASCADE,
+		PRIMARY KEY (cell_id, subscription_id),
+		INDEX cell_id_idx (cell_id),
+		INDEX subscription_id_idx (subscription_id)
+	);
+	`
+	_, err := s.ExecContext(ctx, query)
+	return err
+}

--- a/pkg/dss/scd/cockroach/store_test.go
+++ b/pkg/dss/scd/cockroach/store_test.go
@@ -1,0 +1,214 @@
+package cockroach
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/interuss/dss/pkg/dss/scd"
+	scdmodels "github.com/interuss/dss/pkg/dss/scd/models"
+
+	"github.com/dpjacques/clockwork"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+var (
+	// Make sure that Store implements rid.Store.
+	_ scd.Store = &Store{}
+
+	storeURI  = flag.String("store-uri", "", "URI pointing to a Cockroach node")
+	fakeClock = clockwork.NewFakeClock()
+	startTime = fakeClock.Now().Add(-time.Minute)
+	endTime   = fakeClock.Now().Add(time.Hour)
+)
+
+func setUpStore(ctx context.Context, t *testing.T) (*Store, func() error) {
+	// Reset the clock for every test.
+	fakeClock = clockwork.NewFakeClock()
+
+	store, err := newStore()
+	if err != nil {
+		t.Skip(err)
+	}
+	require.NoError(t, store.Bootstrap(ctx))
+	return store, func() error {
+		return cleanUp(ctx, store)
+	}
+}
+
+func newStore() (*Store, error) {
+	if len(*storeURI) == 0 {
+		return nil, errors.New("Missing command-line parameter store-uri")
+	}
+
+	db, err := sql.Open("postgres", *storeURI)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Store{
+		DB:     db,
+		logger: zap.L(),
+		clock:  fakeClock,
+	}, nil
+}
+
+// cleanUp drops all required tables from the store, useful for testing.
+func cleanUp(ctx context.Context, s *Store) error {
+	const query = `
+	DROP TABLE IF EXISTS scd_cells_subscriptions;
+	DROP TABLE IF EXISTS scd_subscriptions;`
+
+	_, err := s.ExecContext(ctx, query)
+	return err
+}
+
+func TestStoreBootstrap(t *testing.T) {
+	var (
+		ctx                  = context.Background()
+		store, tearDownStore = setUpStore(ctx, t)
+	)
+	require.NotNil(t, store)
+	require.NoError(t, tearDownStore())
+}
+
+func TestDatabaseEnsuresBeginsBeforeExpires(t *testing.T) {
+	var (
+		ctx                  = context.Background()
+		store, tearDownStore = setUpStore(ctx, t)
+	)
+	require.NotNil(t, store)
+	defer func() {
+		require.NoError(t, tearDownStore())
+	}()
+
+	var (
+		begins  = time.Now()
+		expires = begins.Add(-5 * time.Minute)
+	)
+	_, err := store.InsertSubscription(ctx, &scdmodels.Subscription{
+		ID:                   scdmodels.ID(uuid.New().String()),
+		Owner:                "me-myself-and-i",
+		BaseURL:              "https://no/place/like/home",
+		NotificationIndex:    42,
+		NotifyForConstraints: true,
+		StartTime:            &begins,
+		EndTime:              &expires,
+	})
+	require.Error(t, err)
+}
+
+func TestDatabaseEnsuresOneNotifyFlagTrue(t *testing.T) {
+	var (
+		ctx                  = context.Background()
+		store, tearDownStore = setUpStore(ctx, t)
+	)
+	require.NotNil(t, store)
+	defer func() {
+		require.NoError(t, tearDownStore())
+	}()
+
+	var (
+		begins  = time.Now()
+		expires = begins.Add(5 * time.Minute)
+	)
+	_, err := store.InsertSubscription(ctx, &scdmodels.Subscription{
+		ID:                scdmodels.ID(uuid.New().String()),
+		Owner:             "me-myself-and-i",
+		BaseURL:           "https://no/place/like/home",
+		NotificationIndex: 42,
+		StartTime:         &begins,
+		EndTime:           &expires,
+	})
+	require.Error(t, err)
+}
+
+func TestBuildURI(t *testing.T) {
+	cases := []struct {
+		name   string
+		params map[string]string
+		want   string
+	}{
+		{
+			name: "valid URI",
+			params: map[string]string{
+				"host":             "localhost",
+				"port":             "26257",
+				"user":             "root",
+				"ssl_mode":         "enable",
+				"ssl_dir":          "/tmp",
+				"application_name": "test-app",
+			},
+			want: "postgresql://root@localhost:26257?application_name=test-app&sslmode=enable&sslrootcert=/tmp/ca.crt&sslcert=/tmp/client.root.crt&sslkey=/tmp/client.root.key",
+		},
+		{
+			name: "missing host",
+			params: map[string]string{
+				"port":     "26257",
+				"user":     "root",
+				"ssl_mode": "enable",
+				"ssl_dir":  "/tmp",
+			},
+			want: "",
+		},
+		{
+			name: "missing port",
+			params: map[string]string{
+				"host":     "localhost",
+				"user":     "root",
+				"ssl_mode": "enable",
+				"ssl_dir":  "/tmp",
+			},
+			want: "",
+		},
+		{
+			name: "missing user",
+			params: map[string]string{
+				"host":     "localhost",
+				"port":     "26257",
+				"ssl_mode": "enable",
+				"ssl_dir":  "/tmp",
+			},
+			want: "",
+		},
+		{
+			name: "missing ssl_mode",
+			params: map[string]string{
+				"host":    "localhost",
+				"port":    "26257",
+				"user":    "root",
+				"ssl_dir": "/tmp",
+			},
+			want: "",
+		},
+		{
+			name: "ssl_disabled",
+			params: map[string]string{
+				"host":     "localhost",
+				"port":     "26257",
+				"user":     "root",
+				"ssl_mode": "disable",
+			},
+			want: "postgresql://root@localhost:26257?application_name=dss&sslmode=disable",
+		},
+		{
+			name: "missing ssl_dir",
+			params: map[string]string{
+				"host":     "localhost",
+				"port":     "26257",
+				"user":     "root",
+				"ssl_mode": "enable",
+			},
+			want: "",
+		},
+	}
+	for _, c := range cases {
+		got, _ := BuildURI(c.params)
+		require.Equal(t, c.want, got)
+	}
+}

--- a/pkg/dss/scd/cockroach/subscriptions.go
+++ b/pkg/dss/scd/cockroach/subscriptions.go
@@ -1,0 +1,445 @@
+package cockroach
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	dssmodels "github.com/interuss/dss/pkg/dss/models"
+	scdmodels "github.com/interuss/dss/pkg/dss/scd/models"
+	dsserr "github.com/interuss/dss/pkg/errors"
+
+	"github.com/golang/geo/s2"
+	"github.com/lib/pq"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+const (
+	// Defined in requirement DSS0030.
+	maxSubscriptionsPerArea = 10
+)
+
+var (
+	subscriptionFieldsWithIndices   [11]string
+	subscriptionFieldsWithPrefix    string
+	subscriptionFieldsWithoutPrefix string
+)
+
+func init() {
+	subscriptionFieldsWithIndices[0] = "id"
+	subscriptionFieldsWithIndices[1] = "owner"
+	subscriptionFieldsWithIndices[2] = "version"
+	subscriptionFieldsWithIndices[3] = "url"
+	subscriptionFieldsWithIndices[4] = "notification_index"
+	subscriptionFieldsWithIndices[5] = "notify_for_operations"
+	subscriptionFieldsWithIndices[6] = "notify_for_constraints"
+	subscriptionFieldsWithIndices[7] = "implicit"
+	subscriptionFieldsWithIndices[8] = "starts_at"
+	subscriptionFieldsWithIndices[9] = "ends_at"
+	subscriptionFieldsWithIndices[10] = "updated_at"
+
+	subscriptionFieldsWithoutPrefix = strings.Join(
+		subscriptionFieldsWithIndices[:], ",",
+	)
+
+	withPrefix := make([]string, 11)
+	for idx, field := range subscriptionFieldsWithIndices {
+		withPrefix[idx] = "scd_subscriptions." + field
+	}
+
+	subscriptionFieldsWithPrefix = strings.Join(
+		withPrefix[:], ",",
+	)
+}
+
+func (c *Store) fetchSubscriptions(ctx context.Context, q queryable, query string, args ...interface{}) ([]*scdmodels.Subscription, error) {
+	rows, err := q.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var payload []*scdmodels.Subscription
+	for rows.Next() {
+		var (
+			s         = new(scdmodels.Subscription)
+			updatedAt time.Time
+		)
+		err := rows.Scan(
+			&s.ID,
+			&s.Owner,
+			&s.Version,
+			&s.BaseURL,
+			&s.NotificationIndex,
+			&s.NotifyForOperations,
+			&s.NotifyForConstraints,
+			&s.ImplicitSubscription,
+			&s.StartTime,
+			&s.EndTime,
+			&updatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		payload = append(payload, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func (c *Store) fetchSubscriptionsForNotification(
+	ctx context.Context, q queryable, cells []int64) ([]*scdmodels.Subscription, error) {
+	// TODO(dsansome): upgrade to cockroachdb 19.2.0 and convert this to a single
+	// UPDATE FROM query.
+
+	// First: get unique subscription IDs.
+	var query = `
+			SELECT DISTINCT
+				subscription_id
+			FROM
+				scd_cells_subscriptions
+			WHERE
+				cell_id = ANY($1)`
+	rows, err := q.QueryContext(ctx, query, pq.Array(cells))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var subscriptionIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		subscriptionIDs = append(subscriptionIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Next: update the notification_index of each one and return the rest of the
+	// data.
+	var updateQuery = fmt.Sprintf(`
+			UPDATE
+				scd_subscriptions
+			SET
+				notification_index = notification_index + 1
+			WHERE
+				id = ANY($1)
+			AND
+				ends_at >= $2
+			RETURNING
+				%s`, subscriptionFieldsWithoutPrefix)
+	return c.fetchSubscriptions(
+		ctx, q, updateQuery, pq.Array(subscriptionIDs), c.clock.Now())
+}
+
+func (c *Store) fetchSubscription(ctx context.Context, q queryable, query string, args ...interface{}) (*scdmodels.Subscription, error) {
+	subs, err := c.fetchSubscriptions(ctx, q, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	if len(subs) > 1 {
+		return nil, multierr.Combine(err, fmt.Errorf("query returned %d subscriptions", len(subs)))
+	}
+	if len(subs) == 0 {
+		return nil, sql.ErrNoRows
+	}
+	return subs[0], nil
+}
+
+func (c *Store) fetchSubscriptionByID(ctx context.Context, q queryable, id scdmodels.ID) (*scdmodels.Subscription, error) {
+	var query = fmt.Sprintf(`
+		SELECT
+			%s
+		FROM
+			scd_subscriptions
+		WHERE
+			id = $1
+		AND
+			ends_at >= $2`, subscriptionFieldsWithPrefix)
+	return c.fetchSubscription(ctx, q, query, id, c.clock.Now())
+}
+
+func (c *Store) fetchSubscriptionByIDAndOwner(ctx context.Context, q queryable, id scdmodels.ID, owner dssmodels.Owner) (*scdmodels.Subscription, error) {
+	var query = fmt.Sprintf(`
+		SELECT
+			%s
+		FROM
+			scd_subscriptions
+		WHERE
+			id = $1
+		AND
+			owner = $2
+		AND
+			ends_at >= $3`, subscriptionFieldsWithPrefix)
+	return c.fetchSubscription(ctx, q, query, id, owner, c.clock.Now())
+}
+
+// fetchMaxSubscriptionCountByCellAndOwner counts how many subscriptions the
+// owner has in each one of these cells, and returns the number of subscriptions
+// in the cell with the highest number of subscriptions.
+func (c *Store) fetchMaxSubscriptionCountByCellAndOwner(
+	ctx context.Context, q queryable, cells s2.CellUnion, owner dssmodels.Owner) (int, error) {
+	var query = `
+    SELECT
+      IFNULL(MAX(subscriptions_per_cell_id), 0)
+    FROM (
+      SELECT
+        COUNT(*) AS subscriptions_per_cell_id
+      FROM
+        scd_subscriptions AS s,
+        scd_cells_subscriptions as c
+      WHERE
+        s.id = c.subscription_id AND
+        s.owner = $1 AND
+        c.cell_id = ANY($2) AND
+        s.ends_at >= $3
+      GROUP BY c.cell_id
+    )`
+
+	cids := make([]int64, len(cells))
+	for i, cell := range cells {
+		cids[i] = int64(cell)
+	}
+
+	row := q.QueryRowContext(ctx, query, owner, pq.Array(cids), c.clock.Now())
+	var ret int
+	err := row.Scan(&ret)
+	return ret, err
+}
+
+func (c *Store) pushSubscription(ctx context.Context, q queryable, s *scdmodels.Subscription) (*scdmodels.Subscription, error) {
+	var (
+		upsertQuery = fmt.Sprintf(`
+		WITH v AS (
+			SELECT
+				version
+			FROM
+				scd_subscriptions
+			WHERE
+				id = $1
+		)
+		UPSERT INTO
+		  scd_subscriptions
+		  (%s)
+		VALUES
+			($1, $2, COALESCE((SELECT version from v), 0) + 1, $3, $4, $5, $6, false, $7, $8, transaction_timestamp())
+		RETURNING
+			%s`, subscriptionFieldsWithoutPrefix, subscriptionFieldsWithPrefix)
+		subscriptionCellQuery = `
+		UPSERT INTO
+			scd_cells_subscriptions
+			(cell_id, cell_level, subscription_id)
+		VALUES
+			($1, $2, $3)
+		`
+		deleteLeftOverCellsForSubscriptionQuery = `
+			DELETE FROM
+				scd_cells_subscriptions
+			WHERE
+				cell_id != ALL($1)
+			AND
+				subscription_id = $2`
+	)
+
+	cids := make([]int64, len(s.Cells))
+	clevels := make([]int, len(s.Cells))
+
+	for i, cell := range s.Cells {
+		cids[i] = int64(cell)
+		clevels[i] = cell.Level()
+	}
+
+	cells := s.Cells
+	s, err := c.fetchSubscription(ctx, q, upsertQuery,
+		s.ID,
+		s.Owner,
+		s.BaseURL,
+		s.NotificationIndex,
+		s.NotifyForOperations,
+		s.NotifyForConstraints,
+		s.StartTime,
+		s.EndTime)
+	if err != nil {
+		return nil, err
+	}
+	s.Cells = cells
+
+	for i := range cids {
+		if _, err := q.ExecContext(ctx, subscriptionCellQuery, cids[i], clevels[i], s.ID); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, err := q.ExecContext(ctx, deleteLeftOverCellsForSubscriptionQuery, pq.Array(cids), s.ID); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// GetSubscription returns the subscription identified by "id".
+func (c *Store) GetSubscription(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner) (*scdmodels.Subscription, error) {
+	return c.fetchSubscriptionByIDAndOwner(ctx, c.DB, id, owner)
+}
+
+// InsertSubscription inserts subscription into the store and returns
+// the resulting subscription including its ID.
+func (c *Store) InsertSubscription(ctx context.Context, s *scdmodels.Subscription) (*scdmodels.Subscription, error) {
+
+	tx, err := c.Begin()
+	if err != nil {
+		return nil, err
+	}
+	old, err := c.fetchSubscriptionByID(ctx, tx, s.ID)
+	switch {
+	case err == sql.ErrNoRows:
+		break
+	case err != nil:
+		return nil, multierr.Combine(err, tx.Rollback())
+	}
+
+	switch {
+	case old == nil && !s.Version.Empty():
+		// The user wants to update an existing subscription, but one wasn't found.
+		return nil, multierr.Combine(dsserr.NotFound(s.ID.String()), tx.Rollback())
+	case old != nil && s.Version.Empty():
+		// The user wants to create a new subscription but it already exists.
+		return nil, multierr.Combine(dsserr.AlreadyExists(s.ID.String()), tx.Rollback())
+	case old != nil && !s.Version.Matches(old.Version):
+		// The user wants to update a subscription but the version doesn't match.
+		return nil, multierr.Combine(dsserr.VersionMismatch("old version"), tx.Rollback())
+	case old != nil && old.Owner != s.Owner:
+		return nil, multierr.Combine(dsserr.PermissionDenied(fmt.Sprintf("Subscription is owned by %s", old.Owner)), tx.Rollback())
+	}
+
+	// Validate and perhaps correct StartTime and EndTime.
+	if err := s.AdjustTimeRange(c.clock.Now(), old); err != nil {
+		return nil, multierr.Combine(err, tx.Rollback())
+	}
+
+	// Check the user hasn't created too many subscriptions in this area.
+	count, err := c.fetchMaxSubscriptionCountByCellAndOwner(ctx, tx, s.Cells, s.Owner)
+	if err != nil {
+		c.logger.Warn("Error fetching max subscription count", zap.Error(err))
+		return nil, multierr.Combine(dsserr.Internal(
+			"failed to fetch subscription count, rejecting request"), tx.Rollback())
+	} else if count >= maxSubscriptionsPerArea {
+		errMsg := "too many existing subscriptions in this area already"
+		if old != nil {
+			errMsg = errMsg + ", rejecting update request"
+		}
+		return nil, multierr.Combine(dsserr.Exhausted(errMsg), tx.Rollback())
+	}
+
+	newSubscription, err := c.pushSubscription(ctx, tx, s)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return newSubscription, nil
+}
+
+// DeleteSubscription deletes the subscription identified by "id" and
+// returns the deleted subscription.
+func (c *Store) DeleteSubscription(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner, version scdmodels.Version) (*scdmodels.Subscription, error) {
+	const (
+		query = `
+		DELETE FROM
+			scd_subscriptions
+		WHERE
+			id = $1
+		AND
+			owner = $2`
+	)
+
+	tx, err := c.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	// We fetch to know whether to return a concurrency error, or a not found error
+	old, err := c.fetchSubscriptionByID(ctx, tx, id)
+	switch {
+	case err == sql.ErrNoRows: // Return a 404 here.
+		return nil, multierr.Combine(dsserr.NotFound(id.String()), tx.Rollback())
+	case err != nil:
+		return nil, multierr.Combine(err, tx.Rollback())
+	case !version.Empty() && !version.Matches(old.Version):
+		return nil, multierr.Combine(dsserr.VersionMismatch("old version"), tx.Rollback())
+	case old != nil && old.Owner != owner:
+		return nil, multierr.Combine(dsserr.PermissionDenied(fmt.Sprintf("ISA is owned by %s", old.Owner)), tx.Rollback())
+	}
+
+	if _, err := tx.ExecContext(ctx, query, id, owner); err != nil {
+		return nil, multierr.Combine(err, tx.Rollback())
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return old, nil
+}
+
+// SearchSubscriptions returns all subscriptions in "cells".
+func (c *Store) SearchSubscriptions(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) ([]*scdmodels.Subscription, error) {
+	var (
+		query = fmt.Sprintf(`
+			SELECT
+				%s
+			FROM
+				scd_subscriptions
+			LEFT JOIN
+				(SELECT DISTINCT 
+					scd_cells_subscriptions.subscription_id
+				FROM
+					scd_cells_subscriptions
+				WHERE
+					scd_cells_subscriptions.cell_id = ANY($1)
+				)
+			AS
+				unique_subscription_ids
+			ON
+				scd_subscriptions.id = unique_subscription_ids.subscription_id
+			WHERE
+				scd_subscriptions.owner = $2
+			AND
+				ends_at >= $3`, subscriptionFieldsWithPrefix)
+	)
+
+	if len(cells) == 0 {
+		return nil, dsserr.BadRequest("no location provided")
+	}
+
+	tx, err := c.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	cids := make([]int64, len(cells))
+	for i, cell := range cells {
+		cids[i] = int64(cell)
+	}
+
+	subscriptions, err := c.fetchSubscriptions(
+		ctx, tx, query, pq.Array(cids), owner, c.clock.Now())
+	if err != nil {
+		return nil, multierr.Combine(err, tx.Rollback())
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return subscriptions, nil
+}

--- a/pkg/dss/scd/cockroach/subscriptions_test.go
+++ b/pkg/dss/scd/cockroach/subscriptions_test.go
@@ -1,0 +1,454 @@
+package cockroach
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/geo/s2"
+	"github.com/google/uuid"
+	dssmodels "github.com/interuss/dss/pkg/dss/models"
+	scdmodels "github.com/interuss/dss/pkg/dss/scd/models"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	subscriptionsPool = []struct {
+		name  string
+		input *scdmodels.Subscription
+	}{
+		{
+			name: "a subscription without startTime and endTime",
+			input: &scdmodels.Subscription{
+				ID:                   scdmodels.ID(uuid.New().String()),
+				Owner:                dssmodels.Owner(uuid.New().String()),
+				BaseURL:              "https://no/place/like/home",
+				NotificationIndex:    42,
+				NotifyForConstraints: true,
+			},
+		},
+		{
+			name: "a subscription with startTime and endTime",
+			input: &scdmodels.Subscription{
+				ID:                   scdmodels.ID(uuid.New().String()),
+				Owner:                dssmodels.Owner(uuid.New().String()),
+				BaseURL:              "https://no/place/like/home",
+				StartTime:            &startTime,
+				EndTime:              &endTime,
+				NotificationIndex:    42,
+				NotifyForConstraints: true,
+			},
+		},
+		{
+			name: "a subscription with startTime and without endTime",
+			input: &scdmodels.Subscription{
+				ID:                   scdmodels.ID(uuid.New().String()),
+				Owner:                dssmodels.Owner(uuid.New().String()),
+				BaseURL:              "https://no/place/like/home",
+				StartTime:            &startTime,
+				NotificationIndex:    42,
+				NotifyForConstraints: true,
+			},
+		},
+		{
+			name: "a subscription without startTime and with endTime",
+			input: &scdmodels.Subscription{
+				ID:                   scdmodels.ID(uuid.New().String()),
+				Owner:                dssmodels.Owner(uuid.New().String()),
+				BaseURL:              "https://no/place/like/home",
+				EndTime:              &endTime,
+				NotificationIndex:    42,
+				NotifyForConstraints: true,
+			},
+		},
+	}
+)
+
+func TestStoreGetSubscription(t *testing.T) {
+	var (
+		ctx                  = context.Background()
+		store, tearDownStore = setUpStore(ctx, t)
+	)
+	defer func() {
+		require.NoError(t, tearDownStore())
+	}()
+
+	for _, r := range subscriptionsPool {
+		t.Run(r.name, func(t *testing.T) {
+			sub1, err := store.InsertSubscription(ctx, r.input)
+			require.NoError(t, err)
+			require.NotNil(t, sub1)
+
+			sub2, err := store.GetSubscription(ctx, sub1.ID, sub1.Owner)
+			require.NoError(t, err)
+			require.NotNil(t, sub2)
+
+			require.Equal(t, *sub1, *sub2)
+		})
+	}
+}
+
+func TestStoreInsertSubscription(t *testing.T) {
+	var (
+		ctx                  = context.Background()
+		store, tearDownStore = setUpStore(ctx, t)
+	)
+	defer func() {
+		require.NoError(t, tearDownStore())
+	}()
+
+	for _, r := range subscriptionsPool {
+		t.Run(r.name, func(t *testing.T) {
+			sub1, err := store.InsertSubscription(ctx, r.input)
+			require.NoError(t, err)
+			require.NotNil(t, sub1)
+
+			// Test changes without the version differing.
+			r2 := *sub1
+			r2.BaseURL = "new url"
+			sub2, err := store.InsertSubscription(ctx, &r2)
+			require.NoError(t, err)
+			require.NotNil(t, sub2)
+			require.Equal(t, "new url", sub2.BaseURL)
+
+			// Test it doesn't work when Version is nil.
+			r3 := *sub2
+			r3.BaseURL = "new url 2"
+			r3.Version = scdmodels.Version(0)
+			sub3, err := store.InsertSubscription(ctx, &r3)
+			require.Error(t, err)
+			require.Nil(t, sub3)
+
+			// Bad version doesn't work.
+			r4 := *sub2
+			r4.BaseURL = "new url 3"
+			r4.Version--
+			sub4, err := store.InsertSubscription(ctx, &r4)
+			require.Error(t, err)
+			require.Nil(t, sub4)
+
+			sub5, err := store.GetSubscription(ctx, sub1.ID, sub1.Owner)
+			require.NoError(t, err)
+			require.NotNil(t, sub5)
+
+			require.Equal(t, *sub2, *sub5)
+
+			// Test changing owner fails
+			sub5.Owner = "new bad owner"
+			_, err = store.InsertSubscription(ctx, sub5)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestStoreInsertSubscriptionsWithTimes(t *testing.T) {
+	ctx := context.Background()
+	store, tearDownStore := setUpStore(ctx, t)
+
+	defer func() {
+		require.NoError(t, tearDownStore())
+	}()
+
+	for _, r := range []struct {
+		name                string
+		updateFromStartTime time.Time
+		updateFromEndTime   time.Time
+		startTime           time.Time
+		endTime             time.Time
+		wantErr             string
+		wantStartTime       time.Time
+		wantEndTime         time.Time
+	}{
+		{
+			name:          "start-time-defaults-to-now",
+			endTime:       fakeClock.Now().Add(time.Hour),
+			wantStartTime: fakeClock.Now(),
+			wantEndTime:   fakeClock.Now().Add(time.Hour),
+		},
+		{
+			name:          "end-time-defaults-to-24h",
+			wantStartTime: fakeClock.Now(),
+			wantEndTime:   fakeClock.Now().Add(24 * time.Hour),
+		},
+		{
+			name:      "start-time-in-the-past",
+			startTime: fakeClock.Now().Add(-6 * time.Minute),
+			endTime:   fakeClock.Now().Add(time.Hour),
+			wantErr:   "rpc error: code = InvalidArgument desc = subscription time_start must not be in the past",
+		},
+		{
+			name:          "start-time-slightly-in-the-past",
+			startTime:     fakeClock.Now().Add(-4 * time.Minute),
+			endTime:       fakeClock.Now().Add(time.Hour),
+			wantStartTime: fakeClock.Now().Add(-4 * time.Minute),
+		},
+		{
+			name:      "end-time-before-start-time",
+			startTime: fakeClock.Now().Add(20 * time.Minute),
+			endTime:   fakeClock.Now().Add(10 * time.Minute),
+			wantErr:   "rpc error: code = InvalidArgument desc = subscription time_end must be after time_start",
+		},
+		{
+			name:                "updating-keeps-old-times",
+			updateFromStartTime: fakeClock.Now().Add(-6 * time.Hour),
+			updateFromEndTime:   fakeClock.Now().Add(6 * time.Hour),
+			wantStartTime:       fakeClock.Now().Add(-6 * time.Hour),
+			wantEndTime:         fakeClock.Now().Add(6 * time.Hour),
+		},
+		{
+			name:                "changing-start-time-to-past",
+			updateFromStartTime: fakeClock.Now().Add(-6 * time.Hour),
+			updateFromEndTime:   fakeClock.Now().Add(6 * time.Hour),
+			startTime:           fakeClock.Now().Add(-3 * time.Hour),
+			wantErr:             "rpc error: code = InvalidArgument desc = subscription time_start must not be in the past",
+		},
+		{
+			name:                "changing-start-time-to-future",
+			updateFromStartTime: fakeClock.Now().Add(-6 * time.Hour),
+			updateFromEndTime:   fakeClock.Now().Add(6 * time.Hour),
+			startTime:           fakeClock.Now().Add(3 * time.Hour),
+			wantStartTime:       fakeClock.Now().Add(3 * time.Hour),
+			wantEndTime:         fakeClock.Now().Add(6 * time.Hour),
+		},
+		{
+			name:                "changing-end-time-to-future",
+			updateFromStartTime: fakeClock.Now().Add(-6 * time.Hour),
+			updateFromEndTime:   fakeClock.Now().Add(6 * time.Hour),
+			endTime:             fakeClock.Now().Add(3 * time.Hour),
+			wantStartTime:       fakeClock.Now().Add(-6 * time.Hour),
+			wantEndTime:         fakeClock.Now().Add(3 * time.Hour),
+		},
+		{
+			name:                "changing-end-time-more-than-24h",
+			updateFromStartTime: fakeClock.Now().Add(-6 * time.Hour),
+			updateFromEndTime:   fakeClock.Now().Add(6 * time.Hour),
+			endTime:             fakeClock.Now().Add(24 * time.Hour),
+			wantErr:             "rpc error: code = InvalidArgument desc = subscription window exceeds 24 hours",
+		},
+	} {
+		t.Run(r.name, func(t *testing.T) {
+			var (
+				id      = scdmodels.ID(uuid.New().String())
+				owner   = dssmodels.Owner(uuid.New().String())
+				version scdmodels.Version
+			)
+			// Insert a pre-existing subscription to simulate updating from something.
+			if !r.updateFromStartTime.IsZero() {
+				tx, err := store.Begin()
+				require.NoError(t, err)
+				existing, err := store.pushSubscription(ctx, tx, &scdmodels.Subscription{
+					ID:                   id,
+					Owner:                owner,
+					StartTime:            &r.updateFromStartTime,
+					EndTime:              &r.updateFromEndTime,
+					NotifyForConstraints: true,
+					NotifyForOperations:  true,
+				})
+				require.NoError(t, err)
+				require.NoError(t, tx.Commit())
+				version = existing.Version
+			}
+
+			s := &scdmodels.Subscription{
+				ID:                   id,
+				Owner:                owner,
+				Version:              version,
+				NotifyForConstraints: true,
+				NotifyForOperations:  true,
+			}
+			if !r.startTime.IsZero() {
+				s.StartTime = &r.startTime
+			}
+			if !r.endTime.IsZero() {
+				s.EndTime = &r.endTime
+			}
+			sub, err := store.InsertSubscription(ctx, s)
+
+			if r.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, r.wantErr)
+			}
+
+			if !r.wantStartTime.IsZero() {
+				require.NotNil(t, sub.StartTime)
+				require.Equal(t, r.wantStartTime, *sub.StartTime)
+			}
+			if !r.wantEndTime.IsZero() {
+				require.NotNil(t, sub.EndTime)
+				require.Equal(t, r.wantEndTime, *sub.EndTime)
+			}
+		})
+	}
+}
+
+func TestStoreInsertTooManySubscription(t *testing.T) {
+	var (
+		ctx                  = context.Background()
+		store, tearDownStore = setUpStore(ctx, t)
+	)
+
+	defer func() {
+		require.NoError(t, tearDownStore())
+	}()
+
+	// Helper function that makes a subscription with a random ID, fixed owner,
+	// and provided cellIDs.
+	makeSubscription := func(cellIDs []uint64) *scdmodels.Subscription {
+		s := *subscriptionsPool[0].input
+		s.Owner = dssmodels.Owner("bob")
+		s.ID = scdmodels.ID(uuid.New().String())
+
+		s.Cells = make(s2.CellUnion, len(cellIDs))
+		for i, id := range cellIDs {
+			s.Cells[i] = s2.CellID(id)
+		}
+		return &s
+	}
+
+	// We should be able to insert 10 subscriptions without error.
+	for i := 0; i < 10; i++ {
+		ret, err := store.InsertSubscription(ctx, makeSubscription([]uint64{42, 43}))
+		require.NoError(t, err)
+		require.NotNil(t, &ret)
+	}
+
+	// Inserting the 11th subscription will fail.
+	ret, err := store.InsertSubscription(ctx, makeSubscription([]uint64{42, 43}))
+	require.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many existing subscriptions in this area already")
+	require.Nil(t, ret)
+
+	// Inserting a subscription in a different cell will succeed.
+	ret, err = store.InsertSubscription(ctx, makeSubscription([]uint64{45}))
+	require.NoError(t, err)
+	require.NotNil(t, &ret)
+
+	// Inserting a subscription that overlaps with 42 or 43 will fail.
+	ret, err = store.InsertSubscription(ctx, makeSubscription([]uint64{7, 43}))
+	require.EqualError(t, err, "rpc error: code = ResourceExhausted desc = too many existing subscriptions in this area already")
+	require.Nil(t, ret)
+}
+
+func TestStoreDeleteSubscription(t *testing.T) {
+	var (
+		ctx                  = context.Background()
+		store, tearDownStore = setUpStore(ctx, t)
+	)
+	defer func() {
+		require.NoError(t, tearDownStore())
+	}()
+
+	for _, r := range subscriptionsPool {
+		t.Run(r.name, func(t *testing.T) {
+			sub1, err := store.InsertSubscription(ctx, r.input)
+			require.NoError(t, err)
+			require.NotNil(t, sub1)
+
+			// Ensure mismatched versions return an error
+			v := scdmodels.Version(42)
+			sub2, err := store.DeleteSubscription(ctx, sub1.ID, sub1.Owner, v)
+			require.Error(t, err)
+			require.Nil(t, sub2)
+
+			// Can't delete other users data.
+			sub3, err := store.DeleteSubscription(ctx, sub1.ID, "wrong owner", sub1.Version)
+			require.Error(t, err)
+			require.Nil(t, sub3)
+
+			sub4, err := store.DeleteSubscription(ctx, sub1.ID, sub1.Owner, sub1.Version)
+			require.NoError(t, err)
+			require.NotNil(t, sub4)
+
+			require.Equal(t, *sub1, *sub4)
+		})
+	}
+}
+
+func TestStoreSearchSubscription(t *testing.T) {
+	var (
+		ctx                  = context.Background()
+		store, tearDownStore = setUpStore(ctx, t)
+	)
+	defer func() {
+		require.NoError(t, tearDownStore())
+	}()
+
+	var (
+		overflow = -1
+		cells    = s2.CellUnion{
+			s2.CellID(42),
+			s2.CellID(84),
+			s2.CellID(126),
+			s2.CellID(168),
+			s2.CellID(200),
+			s2.CellID(overflow),
+		}
+		owners = []dssmodels.Owner{
+			"me",
+			"my",
+			"self",
+			"and",
+		}
+	)
+
+	for i, r := range subscriptionsPool {
+		subscription := *r.input
+		subscription.Owner = owners[i]
+		subscription.Cells = cells[:i]
+		sub1, err := store.InsertSubscription(ctx, &subscription)
+		require.NoError(t, err)
+		require.NotNil(t, sub1)
+
+	}
+
+	for _, owner := range owners {
+		found, err := store.SearchSubscriptions(ctx, cells, owner)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		// We insert one subscription per owner. Hence, no matter how many cells are touched by the subscription,
+		// the result should always be 1.
+		require.Len(t, found, 1)
+	}
+}
+
+func TestStoreExpiredSubscription(t *testing.T) {
+	ctx := context.Background()
+	store, tearDownStore := setUpStore(ctx, t)
+	defer func() {
+		require.NoError(t, tearDownStore())
+	}()
+
+	sub := &scdmodels.Subscription{
+		ID:                   scdmodels.ID(uuid.New().String()),
+		Owner:                dssmodels.Owner(uuid.New().String()),
+		NotifyForOperations:  true,
+		NotifyForConstraints: true,
+		Cells:                s2.CellUnion{s2.CellID(42)},
+	}
+
+	_, err := store.InsertSubscription(ctx, sub)
+	require.NoError(t, err)
+
+	// The subscription's endTime is 24 hours from now.
+	fakeClock.Advance(23 * time.Hour)
+
+	// We should still be able to find the subscription by searching and by ID.
+	subs, err := store.SearchSubscriptions(ctx, sub.Cells, sub.Owner)
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+
+	ret, err := store.GetSubscription(ctx, sub.ID, sub.Owner)
+	require.NoError(t, err)
+	require.NotNil(t, &ret)
+
+	// But now the subscription has expired.
+	fakeClock.Advance(2 * time.Hour)
+
+	subs, err = store.SearchSubscriptions(ctx, sub.Cells, sub.Owner)
+	require.NoError(t, err)
+	require.Len(t, subs, 0)
+
+	ret, err = store.GetSubscription(ctx, sub.ID, sub.Owner)
+	require.Nil(t, ret)
+	require.Error(t, err)
+}

--- a/pkg/dss/scd/models/models.go
+++ b/pkg/dss/scd/models/models.go
@@ -1,11 +1,26 @@
 package models
 
 type (
-	// ID models the id of a UTM entity.
+	// ID models the id of an entity.
 	ID string
+
+	// Version models the version of an entity.
+	//
+	// Primarily used as a fencing token in data mutations.
+	Version int32
 )
 
 // String returns the string representation of id.
 func (id ID) String() string {
 	return string(id)
+}
+
+// Empty returns true if the value of v indicates an empty version.
+func (v Version) Empty() bool {
+	return v <= 0
+}
+
+// Matches returns true if v matches w.
+func (v Version) Matches(w Version) bool {
+	return v == w
 }

--- a/pkg/dss/scd/models/subscriptions.go
+++ b/pkg/dss/scd/models/subscriptions.go
@@ -4,16 +4,28 @@ import (
 	"time"
 
 	"github.com/interuss/dss/pkg/api/v1/scdpb"
-	commonmodels "github.com/interuss/dss/pkg/dss/models"
+	dssmodels "github.com/interuss/dss/pkg/dss/models"
+	dsserr "github.com/interuss/dss/pkg/errors"
 
+	"github.com/golang/geo/s2"
 	"github.com/golang/protobuf/ptypes"
+)
+
+const (
+	// maxSubscriptionDuration is the largest allowed interval between StartTime
+	// and EndTime.
+	maxSubscriptionDuration = time.Hour * 24
+
+	// maxClockSkew is the largest allowed interval between the StartTime of a new
+	// subscription and the server's idea of the current time.
+	maxClockSkew = time.Minute * 5
 )
 
 type Subscription struct {
 	ID                ID
-	Version           int
+	Version           Version
 	NotificationIndex int
-	Owner             commonmodels.Owner
+	Owner             dssmodels.Owner
 	StartTime         *time.Time
 	EndTime           *time.Time
 	AltitudeHi        *float32
@@ -24,6 +36,7 @@ type Subscription struct {
 	NotifyForConstraints bool
 	ImplicitSubscription bool
 	DependentOperations  []ID
+	Cells                s2.CellUnion
 }
 
 func (s *Subscription) ToProto() (*scdpb.Subscription, error) {
@@ -59,4 +72,46 @@ func (s *Subscription) ToProto() (*scdpb.Subscription, error) {
 		result.TimeStart.Format = TimeFormatRfc3339
 	}
 	return result, nil
+}
+
+// AdjustTimeRange adjusts the time range to the max allowed ranges on a
+// subscription.
+func (s *Subscription) AdjustTimeRange(now time.Time, old *Subscription) error {
+	if s.StartTime == nil {
+		// If StartTime was omitted, default to Now() for new subscriptions or re-
+		// use the existing time of existing subscriptions.
+		if old == nil {
+			s.StartTime = &now
+		} else {
+			s.StartTime = old.StartTime
+		}
+	} else {
+		// If setting the StartTime explicitly ensure it is not too far in the past.
+		if now.Sub(*s.StartTime) > maxClockSkew {
+			return dsserr.BadRequest("subscription time_start must not be in the past")
+		}
+	}
+
+	// If EndTime was omitted default to the existing subscription's EndTime.
+	if s.EndTime == nil && old != nil {
+		s.EndTime = old.EndTime
+	}
+
+	// Or if this is a new subscription default to StartTime + 1 day.
+	if s.EndTime == nil {
+		truncatedEndTime := s.StartTime.Add(maxSubscriptionDuration)
+		s.EndTime = &truncatedEndTime
+	}
+
+	// EndTime cannot be before StartTime.
+	if s.EndTime.Sub(*s.StartTime) < 0 {
+		return dsserr.BadRequest("subscription time_end must be after time_start")
+	}
+
+	// EndTime cannot be 24 hrs after StartTime
+	if s.EndTime.Sub(*s.StartTime) > maxSubscriptionDuration {
+		return dsserr.BadRequest("subscription window exceeds 24 hours")
+	}
+
+	return nil
 }

--- a/pkg/dss/scd/store.go
+++ b/pkg/dss/scd/store.go
@@ -64,11 +64,11 @@ func (s *DummyStore) GetSubscription(ctx context.Context, id scdmodels.ID, owner
 	return MakeDummySubscription(id), nil
 }
 
-func (s *DummyStore) InsertSubscription(ctx context.Context, sub *scdmodels.Subscription, owner dssmodels.Owner) (*scdmodels.Subscription, error) {
+func (s *DummyStore) InsertSubscription(ctx context.Context, sub *scdmodels.Subscription) (*scdmodels.Subscription, error) {
 	return sub, nil
 }
 
-func (s *DummyStore) DeleteSubscription(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner, version *scdmodels.Version) (*scdmodels.Subscription, error) {
+func (s *DummyStore) DeleteSubscription(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner, version scdmodels.Version) (*scdmodels.Subscription, error) {
 	sub := MakeDummySubscription(id)
 	sub.ID = id
 	return sub, nil

--- a/pkg/dss/scd/store.go
+++ b/pkg/dss/scd/store.go
@@ -4,27 +4,27 @@ import (
 	"context"
 
 	"github.com/golang/geo/s2"
-	commonmodels "github.com/interuss/dss/pkg/dss/models"
-	"github.com/interuss/dss/pkg/dss/scd/models"
+	dssmodels "github.com/interuss/dss/pkg/dss/models"
+	scdmodels "github.com/interuss/dss/pkg/dss/scd/models"
 )
 
 // Store abstracts interactions with a backing data store.
 type Store interface {
 	// SearchSubscriptions returns all Subscriptions owned by "owner" in "cells".
-	SearchSubscriptions(ctx context.Context, cells s2.CellUnion, owner commonmodels.Owner) ([]*models.Subscription, error)
+	SearchSubscriptions(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) ([]*scdmodels.Subscription, error)
 
 	// GetSubscription returns the Subscription referenced by id, or nil if the
 	// Subscription doesn't exist
-	GetSubscription(ctx context.Context, id models.ID, owner commonmodels.Owner) (*models.Subscription, error)
+	GetSubscription(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner) (*scdmodels.Subscription, error)
 
 	// InsertSubscription inserts sub into the store and returns the result
 	// subscription.
-	InsertSubscription(ctx context.Context, sub *models.Subscription, owner commonmodels.Owner) (*models.Subscription, error)
+	InsertSubscription(ctx context.Context, sub *scdmodels.Subscription) (*scdmodels.Subscription, error)
 
 	// DeleteSubscription deletes a Subscription from the store and returns the
 	// deleted subscription.  Returns nil and an error if the Subscription does
 	// not exist, or is owned by someone other than the specified owner.
-	DeleteSubscription(ctx context.Context, id models.ID, owner commonmodels.Owner) (*models.Subscription, error)
+	DeleteSubscription(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner, version scdmodels.Version) (*scdmodels.Subscription, error)
 }
 
 // DummyStore implements Store interface entirely with error-free no-ops
@@ -32,10 +32,10 @@ type DummyStore struct {
 }
 
 // MakeDummySubscription returns a dummy subscription instance with ID id.
-func MakeDummySubscription(id models.ID) *models.Subscription {
+func MakeDummySubscription(id scdmodels.ID) *scdmodels.Subscription {
 	altLo := float32(11235)
 	altHi := float32(81321)
-	result := &models.Subscription{
+	result := &scdmodels.Subscription{
 		ID:                   id,
 		Version:              314,
 		NotificationIndex:    123,
@@ -45,30 +45,30 @@ func MakeDummySubscription(id models.ID) *models.Subscription {
 		NotifyForOperations:  true,
 		NotifyForConstraints: false,
 		ImplicitSubscription: true,
-		DependentOperations: []models.ID{
-			models.ID("c09bcff5-35a4-41de-9220-6c140a9857ee"),
-			models.ID("2cff1c62-cf1a-41ad-826b-d12dad432f21"),
+		DependentOperations: []scdmodels.ID{
+			scdmodels.ID("c09bcff5-35a4-41de-9220-6c140a9857ee"),
+			scdmodels.ID("2cff1c62-cf1a-41ad-826b-d12dad432f21"),
 		},
 	}
 	return result
 }
 
-func (s *DummyStore) SearchSubscriptions(ctx context.Context, cells s2.CellUnion, owner commonmodels.Owner) ([]*models.Subscription, error) {
-	subs := []*models.Subscription{
-		MakeDummySubscription(models.ID("444eab15-8384-4e39-8589-5161689aee56")),
+func (s *DummyStore) SearchSubscriptions(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) ([]*scdmodels.Subscription, error) {
+	subs := []*scdmodels.Subscription{
+		MakeDummySubscription(scdmodels.ID("444eab15-8384-4e39-8589-5161689aee56")),
 	}
 	return subs, nil
 }
 
-func (s *DummyStore) GetSubscription(ctx context.Context, id models.ID, owner commonmodels.Owner) (*models.Subscription, error) {
+func (s *DummyStore) GetSubscription(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner) (*scdmodels.Subscription, error) {
 	return MakeDummySubscription(id), nil
 }
 
-func (s *DummyStore) InsertSubscription(ctx context.Context, sub *models.Subscription, owner commonmodels.Owner) (*models.Subscription, error) {
+func (s *DummyStore) InsertSubscription(ctx context.Context, sub *scdmodels.Subscription, owner dssmodels.Owner) (*scdmodels.Subscription, error) {
 	return sub, nil
 }
 
-func (s *DummyStore) DeleteSubscription(ctx context.Context, id models.ID, owner commonmodels.Owner) (*models.Subscription, error) {
+func (s *DummyStore) DeleteSubscription(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner, version *scdmodels.Version) (*scdmodels.Subscription, error) {
 	sub := MakeDummySubscription(id)
 	sub.ID = id
 	return sub, nil


### PR DESCRIPTION
This PR:
  * introduces an implementation of `scd.Store` talking to a `cockroach` DB, drawing heavy inspiration from the existing `rid.Store` CRDB implementation (read as: copy'n'pasted mostly and adjusted)
  * adjusts models as required by the differing versioning schemes in `rid` and `scd`
  * adjusts and occasionally simplifies the `scd.Server` implementation
  * provides plenty of future opportunity to consolidate types and methods across `rid` and `scd`