### PR TITLE
Fix OVN visibility

### DIFF
--- a/pkg/scd/operations_handler.go
+++ b/pkg/scd/operations_handler.go
@@ -120,6 +120,9 @@ func (a *Server) SearchOperationReferences(ctx context.Context, req *scdpb.Searc
 		if err != nil {
 			return nil, dsserr.Internal("error converting Operation model to proto")
 		}
+		if op.Owner != owner {
+			p.Ovn = ""
+		}
 		response.OperationReferences = append(response.OperationReferences, p)
 	}
 	return response, nil

--- a/pkg/scd/subscriptions_handler.go
+++ b/pkg/scd/subscriptions_handler.go
@@ -67,6 +67,12 @@ func (a *Server) PutSubscription(ctx context.Context, req *scdpb.PutSubscription
 		NotifyForConstraints: params.NotifyForConstraints,
 	}
 
+	// Validate requested Subscription
+	if !sub.NotifyForOperations && !sub.NotifyForConstraints {
+		return nil, dsserr.BadRequest("no notification triggers requested for Subscription")
+	}
+	// TODO: validate against DependentOperations when available
+
 	// Store Subscription model
 	sub, ops, err := a.putSubscription(ctx, sub)
 	if err != nil {


### PR DESCRIPTION
This PR adds a number of tests to validate OVN visibility between different USSs when manipulating Operations and Operation-related Subscriptions.  It also adds a simple fix for an issue discovered.

It also adds tests for mutating Subscriptions in ways not allowed by their dependent Operations, but those tests are commented out until we validate Subscription changes with dependent Operations (in another PR).