### PR TITLE
Feature/retry2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ test:
 .PHONY: test-cockroach
 test-cockroach: cleanup-test-cockroach
 	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v20.1.0 start --insecure > /dev/null
+	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/application -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/scd/store/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	@docker stop dss-crdb-for-testing > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,9 @@ test:
 .PHONY: test-cockroach
 test-cockroach: cleanup-test-cockroach
 	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v20.1.0 start --insecure > /dev/null
-	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/application -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/scd/store/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
+	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/application -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	@docker stop dss-crdb-for-testing > /dev/null
 	@docker rm dss-crdb-for-testing > /dev/null
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ format:
 .PHONY: lint
 lint:
 	docker run --rm -v $(CURDIR):/dss -w /dss golangci/golangci-lint:v1.26.0 golangci-lint run --timeout 5m -v -E gofmt,bodyclose,rowserrcheck,misspell,golint -D staticcheck,vet
+	docker run --rm -v $(CURDIR):/dss -w /dss golangci/golangci-lint:v1.26.0 golangci-lint run --timeout 5m -v --disable-all  -E staticcheck --skip-dirs '^cmds/http-gateway,^pkg/logging'
 
 pkg/api/v1/ridpb/rid.pb.go: pkg/api/v1/ridpb/rid.proto
 	protoc -I/usr/local/include -I.   -I$(GOPATH)/src   -I$(GOPATH)/pkg/mod/github.com/grpc-ecosystem/grpc-gateway@v1.14.3/third_party/googleapis   --go_out=plugins=grpc:. $<

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -103,10 +103,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 	if err != nil {
 		logger.Panic("Failed to dial CRDB instance", zap.Error(err))
 	}
-	store, err := ridc.NewStore(crdb, logger)
-	if err != nil {
-		logger.Panic("Failed to open connection to CRDB", zap.String("uri", uri), zap.Error(err))
-	}
+	store := ridc.NewStore(crdb, logger)
 
 	if err := store.Bootstrap(ctx); err != nil {
 		logger.Panic("Failed to bootstrap CRDB instance", zap.Error(err))
@@ -114,7 +111,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 
 	var (
 		dssServer = &rid.Server{
-			App:     application.NewFromRepo(store),
+			App:     application.NewFromRepo(store, logger),
 			Timeout: *timeout,
 		}
 		auxServer      = &aux.Server{}
@@ -125,10 +122,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 	)
 
 	if *enableSCD {
-		store, err := scdc.NewStore(crdb, logger)
-		if err != nil {
-			logger.Panic("Failed to open connection to CRDB", zap.String("uri", uri), zap.Error(err))
-		}
+		store := scdc.NewStore(crdb, logger)
 
 		if err := store.Bootstrap(ctx); err != nil {
 			logger.Panic("Failed to bootstrap CRDB instance", zap.Error(err))

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ go 1.14
 
 require (
 	cloud.google.com/go v0.57.0
+	github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dpjacques/clockwork v0.1.0
 	github.com/gogo/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,7 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200501052902-10377860bb8e h1:hq86ru83GdWTlfQFZGO4nZJTU4Bs2wfHl8oFHRaXsfc=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62 h1:eqJbq0A8ev6101p/zV72eOM+Z3WZkgb66S7PVJQR9wI=
+github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/cockroach/cockroach.go
+++ b/pkg/cockroach/cockroach.go
@@ -4,45 +4,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-
-	"github.com/interuss/dss/pkg/logging"
-	"github.com/interuss/dss/pkg/rid/repos"
-	dssql "github.com/interuss/dss/pkg/sql"
 )
 
 // DB models a connection to a CRDB instance.
 type DB struct {
-	// The Queryable interface is what most calls happen on. Without calling
-	// InTxnRetrier, Queryable is set to the same field as db.
-	dssql.Queryable
-
-	db *sql.DB
+	*sql.DB
 }
-
-// InTxnRetrier supplies a new repo, that will perform all of the DB accesses
-// in a Txn, and will retry any Txn's that fail due to retry-able errors
-// (typically contention).
-// Note: Currently the Newly supplied Repo *does not* support nested calls
-// to InTxnRetrier.
-func (d *DB) InTxnRetrier(f func(repo repos.Repository) error) error {
-	return nil
-}
-
-// TODO: remove this function when SCD transitions to InTxnRetrier
-func (d *DB) Begin() (*sql.Tx, error) {
-	logging.Logger.Warn("this method is deprecated, please use InTxnRetrier")
-	return d.db.Begin()
-}
-
-func (d *DB) Close() error {
-	return d.db.Close()
-}
-
-// tx, err := c.Begin()
-// if err != nil {
-// 	return nil, err
-// }
-// defer recoverRollbackRepanic(ctx, tx)
 
 // Dial returns a DB instance connected to a cockroach instance available at
 // "uri".
@@ -54,7 +21,7 @@ func Dial(uri string) (*DB, error) {
 	}
 
 	return &DB{
-		db: db,
+		DB: db,
 	}, nil
 }
 

--- a/pkg/cockroach/cockroach.go
+++ b/pkg/cockroach/cockroach.go
@@ -11,6 +11,12 @@ type DB struct {
 	*sql.DB
 }
 
+// tx, err := c.Begin()
+// if err != nil {
+// 	return nil, err
+// }
+// defer recoverRollbackRepanic(ctx, tx)
+
 // Dial returns a DB instance connected to a cockroach instance available at
 // "uri".
 // https://www.cockroachlabs.com/docs/stable/connection-parameters.html

--- a/pkg/geo/s2.go
+++ b/pkg/geo/s2.go
@@ -39,6 +39,21 @@ var (
 	errBadCoordSet                        = errors.New("coordinates did not create a well formed area")
 )
 
+// Levelify takes a cell union that might have been normalized and returns to
+// the appropriate level
+func Levelify(cells *s2.CellUnion) {
+	// thirty is the number of s2 cells, we make it negative to get the number
+	// of cells we want
+	cells.Denormalize(DefaultMinimumCellLevel, 1)
+}
+
+func ValidateCell(cell s2.CellID) error {
+	if cell.Level() < DefaultMinimumCellLevel || cell.Level() > DefaultMaximumCellLevel {
+		return errors.New("cells must be at level 13 at current implementation")
+	}
+	return nil
+}
+
 // ErrAreaTooLarge is the error passed back when the requested Area is larger
 // than maxAllowedAreaKm2
 type ErrAreaTooLarge struct {

--- a/pkg/rid/application/application.go
+++ b/pkg/rid/application/application.go
@@ -3,22 +3,33 @@ package application
 import (
 	"github.com/dpjacques/clockwork"
 	"github.com/interuss/dss/pkg/rid/cockroach"
+	"github.com/interuss/dss/pkg/rid/repos"
 )
 
 // DefaultClock allows stubbing out the clock for a test clock.
 var DefaultClock = clockwork.NewRealClock()
 
-// App contains all of the per-entity Applications.
-type App struct {
-	ISA          ISAAppInterface
-	Subscription SubscriptionAppInterface
+// app contains all of the per-entity Applications.
+type app struct {
+	// TODO: don't fully embed the repos once we reduce the complexity in the store.
+	// Right now it's "coincidence" that the repo has the same signatures as the App interface
+	// but we will want to simplify the repos and add the complexity here.
+	repos.ISA
+	repos.Subscription
+	clock clockwork.Clock
+}
+
+type App interface {
+	ISAApp
+	SubscriptionApp
 }
 
 // NewFromRepo is a convenience function for creating an App
 // with the given store.
-func NewFromRepo(repo *cockroach.Store) *App {
-	return &App{
-		ISA:          &ISAApp{repo.ISA, DefaultClock},
-		Subscription: &SubscriptionApp{repo.Subscription, DefaultClock},
+func NewFromRepo(repo *cockroach.Store) App {
+	return &app{
+		ISA:          repo.ISA,
+		Subscription: repo.Subscription,
+		clock:        DefaultClock,
 	}
 }

--- a/pkg/rid/application/application.go
+++ b/pkg/rid/application/application.go
@@ -2,7 +2,6 @@ package application
 
 import (
 	"github.com/dpjacques/clockwork"
-	"github.com/interuss/dss/pkg/rid/cockroach"
 	"github.com/interuss/dss/pkg/rid/repos"
 	"go.uber.org/zap"
 )
@@ -15,8 +14,7 @@ type app struct {
 	// TODO: don't fully embed the repos once we reduce the complexity in the store.
 	// Right now it's "coincidence" that the repo has the same signatures as the App interface
 	// but we will want to simplify the repos and add the complexity here.
-	repos.ISA
-	repos.Subscription
+	repos.Repository
 	clock  clockwork.Clock
 	logger *zap.Logger
 }
@@ -28,11 +26,10 @@ type App interface {
 
 // NewFromRepo is a convenience function for creating an App
 // with the given store.
-func NewFromRepo(repo *cockroach.Store, logger *zap.Logger) App {
+func NewFromRepo(repo repos.Repository, logger *zap.Logger) App {
 	return &app{
-		ISA:          repo.ISA,
-		Subscription: repo.Subscription,
-		clock:        DefaultClock,
-		logger:       logger,
+		Repository: repo,
+		clock:      DefaultClock,
+		logger:     logger,
 	}
 }

--- a/pkg/rid/application/application.go
+++ b/pkg/rid/application/application.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dpjacques/clockwork"
 	"github.com/interuss/dss/pkg/rid/cockroach"
 	"github.com/interuss/dss/pkg/rid/repos"
+	"go.uber.org/zap"
 )
 
 // DefaultClock allows stubbing out the clock for a test clock.
@@ -16,7 +17,8 @@ type app struct {
 	// but we will want to simplify the repos and add the complexity here.
 	repos.ISA
 	repos.Subscription
-	clock clockwork.Clock
+	clock  clockwork.Clock
+	logger *zap.Logger
 }
 
 type App interface {
@@ -26,10 +28,11 @@ type App interface {
 
 // NewFromRepo is a convenience function for creating an App
 // with the given store.
-func NewFromRepo(repo *cockroach.Store) App {
+func NewFromRepo(repo *cockroach.Store, logger *zap.Logger) App {
 	return &app{
 		ISA:          repo.ISA,
 		Subscription: repo.Subscription,
 		clock:        DefaultClock,
+		logger:       logger,
 	}
 }

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -2,7 +2,6 @@ package application
 
 import (
 	"context"
-	"database/sql"
 	"flag"
 	"testing"
 	"time"
@@ -42,10 +41,8 @@ func setUpRepo(ctx context.Context, t *testing.T, logger *zap.Logger) (*ridcrdb.
 	logger.Info("using cockroachDB.")
 
 	// Use a real store.
-	db, err := sql.Open("postgres", *storeURI)
+	cdb, err := cockroach.Dial(*storeURI)
 	require.NoError(t, err)
-
-	cdb := &cockroach.DB{DB: db}
 
 	store := ridcrdb.NewStore(cdb, logger)
 	require.NoError(t, store.Bootstrap(ctx))

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -1,0 +1,53 @@
+package application
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/dpjacques/clockwork"
+	"github.com/interuss/dss/pkg/cockroach"
+	dssmodels "github.com/interuss/dss/pkg/models"
+	ridcrdb "github.com/interuss/dss/pkg/rid/cockroach"
+	ridmodels "github.com/interuss/dss/pkg/rid/models"
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/zap"
+)
+
+var (
+	storeURI  = flag.String("store-uri", "", "URI pointing to a Cockroach node")
+	fakeClock = clockwork.NewFakeClock()
+	startTime = fakeClock.Now().Add(-time.Minute)
+	endTime   = fakeClock.Now().Add(time.Hour)
+)
+
+func setUpRepo(ctx context.Context, t *testing.T, logger *zap.Logger) (*ridcrdb.Store, func() error) {
+	DefaultClock = fakeClock
+
+	if len(*storeURI) == 0 {
+		logger.Info("using the stubbed in memory store.")
+		return &ridcrdb.Store{
+			ISA: &isaStore{
+				isas: make(map[dssmodels.ID]*ridmodels.IdentificationServiceArea),
+			},
+			Subscription: &subscriptionStore{
+				subs: make(map[dssmodels.ID]*ridmodels.Subscription),
+			},
+		}, func() error { return nil }
+	}
+	ridcrdb.DefaultClock = fakeClock
+	logger.Info("using cockroachDB.")
+
+	// Use a real store.
+	db, err := sql.Open("postgres", *storeURI)
+	require.NoError(t, err)
+
+	cdb := &cockroach.DB{DB: db}
+
+	store := ridcrdb.NewStore(cdb, logger)
+	require.NoError(t, store.Bootstrap(ctx))
+	return store, func() error { return cdb.Close() }
+}

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -35,7 +35,11 @@ func (s *mockRepo) InTxnRetrier(ctx context.Context, f func(repo repos.Repositor
 	return f(s)
 }
 
-func setUpRepo(ctx context.Context, t *testing.T, logger *zap.Logger) (repos.Repository, func() error) {
+func (s *mockRepo) Close() error {
+	return nil
+}
+
+func setUpRepo(ctx context.Context, t *testing.T, logger *zap.Logger) (repos.Repository, func()) {
 	DefaultClock = fakeClock
 
 	if len(*storeURI) == 0 {
@@ -47,7 +51,7 @@ func setUpRepo(ctx context.Context, t *testing.T, logger *zap.Logger) (repos.Rep
 			subscriptionStore: &subscriptionStore{
 				subs: make(map[dssmodels.ID]*ridmodels.Subscription),
 			},
-		}, func() error { return nil }
+		}, func() {}
 	}
 	ridcrdb.DefaultClock = fakeClock
 	logger.Info("using cockroachDB.")
@@ -58,5 +62,20 @@ func setUpRepo(ctx context.Context, t *testing.T, logger *zap.Logger) (repos.Rep
 
 	store := ridcrdb.NewStore(cdb, logger)
 	require.NoError(t, store.Bootstrap(ctx))
-	return store, func() error { return cdb.Close() }
+	return store, func() {
+		require.NoError(t, cleanUp(ctx, store))
+		require.NoError(t, store.Close())
+	}
+}
+
+// cleanUp drops all required tables from the store, useful for testing.
+func cleanUp(ctx context.Context, s *ridcrdb.Store) error {
+	const query = `
+	DROP TABLE IF EXISTS cells_subscriptions;
+	DROP TABLE IF EXISTS subscriptions;
+	DROP TABLE IF EXISTS cells_identification_service_areas;
+	DROP TABLE IF EXISTS identification_service_areas;`
+
+	_, err := s.ExecContext(ctx, query)
+	return err
 }

--- a/pkg/rid/application/isa.go
+++ b/pkg/rid/application/isa.go
@@ -106,15 +106,15 @@ func (a *app) InsertISA(ctx context.Context, isa *ridmodels.IdentificationServic
 	// Update the notification index for both cells removed and added.
 	cells := isa.Cells
 	if old != nil {
+		// TODO steeling, we should change this to a Custom type, to obfuscate
+		// some of these metrics and prevent us from doing the wrong thing.
 		cells = s2.CellUnionFromUnion(old.Cells, isa.Cells)
 		geo.Levelify(&cells)
-		fmt.Println(len(cells), len(old.Cells), len(isa.Cells))
 	}
 	subs, err := a.Subscription.UpdateNotificationIdxsInCells(ctx, cells)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	isa, err = a.ISA.InsertISA(ctx, isa)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/rid/application/isa.go
+++ b/pkg/rid/application/isa.go
@@ -66,8 +66,6 @@ func (a *app) DeleteISA(ctx context.Context, id dssmodels.ID, owner dssmodels.Ow
 	)
 	// The following will automatically retry TXN retry errors.
 	err = a.Repository.InTxnRetrier(ctx, func(repo repos.Repository) error {
-		fmt.Println("In the custom func!")
-
 		var err error
 		subs, err = repo.UpdateNotificationIdxsInCells(ctx, old.Cells)
 		if err != nil {

--- a/pkg/rid/application/isa.go
+++ b/pkg/rid/application/isa.go
@@ -65,7 +65,9 @@ func (a *app) DeleteISA(ctx context.Context, id dssmodels.ID, owner dssmodels.Ow
 		subs []*ridmodels.Subscription
 	)
 	// The following will automatically retry TXN retry errors.
-	err = a.Repository.InTxnRetrier(func(repo repos.Repository) error {
+	err = a.Repository.InTxnRetrier(ctx, func(repo repos.Repository) error {
+		fmt.Println("In the custom func!")
+
 		var err error
 		subs, err = repo.UpdateNotificationIdxsInCells(ctx, old.Cells)
 		if err != nil {

--- a/pkg/rid/application/isa_test.go
+++ b/pkg/rid/application/isa_test.go
@@ -214,7 +214,8 @@ func TestInsertISA(t *testing.T) {
 
 			// Insert a pre-existing ISA to simulate updating from something.
 			if !r.updateFromStartTime.IsZero() {
-				existing, err := app.ISA.InsertISA(ctx, &ridmodels.IdentificationServiceArea{
+				// TEMP: this used to be app.Repository
+				existing, _, err := app.InsertISA(ctx, &ridmodels.IdentificationServiceArea{
 					ID:        id,
 					Owner:     owner,
 					StartTime: &r.updateFromStartTime,

--- a/pkg/rid/application/isa_test.go
+++ b/pkg/rid/application/isa_test.go
@@ -3,7 +3,6 @@ package application
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
@@ -20,7 +19,7 @@ var (
 	_ ISAApp = &app{}
 )
 
-func setUpISAApp(ctx context.Context, t *testing.T) (*app, func() error) {
+func setUpISAApp(ctx context.Context, t *testing.T) (*app, func()) {
 	l := zap.L()
 	repo, cleanup := setUpRepo(ctx, t, l)
 	return NewFromRepo(repo, l).(*app), cleanup
@@ -308,11 +307,9 @@ func TestAppDeleteISAs(t *testing.T) {
 	// Delete the ISA.
 	// Ensure a fresh Get, then delete still updates the subscription indexes
 	isa, err = app.GetISA(ctx, isa.ID)
-	fmt.Println("get calls: ", isa)
 	require.NoError(t, err)
 
 	serviceAreaOut, subscriptionsOut, err := app.DeleteISA(ctx, isa.ID, isa.Owner, isa.Version)
-	fmt.Println("SOUT: ", serviceAreaOut)
 	require.NoError(t, err)
 	require.Equal(t, isa, serviceAreaOut)
 	require.NotNil(t, subscriptionsOut)

--- a/pkg/rid/application/isa_test.go
+++ b/pkg/rid/application/isa_test.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -214,8 +215,7 @@ func TestInsertISA(t *testing.T) {
 
 			// Insert a pre-existing ISA to simulate updating from something.
 			if !r.updateFromStartTime.IsZero() {
-				// TEMP: this used to be app.Repository
-				existing, _, err := app.InsertISA(ctx, &ridmodels.IdentificationServiceArea{
+				existing, err := app.Repository.InsertISA(ctx, &ridmodels.IdentificationServiceArea{
 					ID:        id,
 					Owner:     owner,
 					StartTime: &r.updateFromStartTime,
@@ -306,11 +306,13 @@ func TestAppDeleteISAs(t *testing.T) {
 	require.Error(t, err)
 
 	// Delete the ISA.
-	// Ensure a fresh Get, then delete still updates the sub indexes
+	// Ensure a fresh Get, then delete still updates the subscription indexes
 	isa, err = app.GetISA(ctx, isa.ID)
+	fmt.Println("get calls: ", isa)
 	require.NoError(t, err)
 
 	serviceAreaOut, subscriptionsOut, err := app.DeleteISA(ctx, isa.ID, isa.Owner, isa.Version)
+	fmt.Println("SOUT: ", serviceAreaOut)
 	require.NoError(t, err)
 	require.Equal(t, isa, serviceAreaOut)
 	require.NotNil(t, subscriptionsOut)

--- a/pkg/rid/application/isa_test.go
+++ b/pkg/rid/application/isa_test.go
@@ -93,7 +93,8 @@ func TestISAUpdateIdxCells(t *testing.T) {
 		EndTime:   &endTime,
 		Cells:     s2.CellUnion{17106221850767130624, 17106221885126868992, 17106221919486607360},
 	})
-
+	require.NoError(t, err)
+	require.NotNil(t, isa)
 	// Now insert 2 subs, one overlaps with the original isa, and the second, overlaps
 	// with the soon to be new version of the isa. both should increase their
 	// notification index.
@@ -105,6 +106,8 @@ func TestISAUpdateIdxCells(t *testing.T) {
 		EndTime:   &endTime,
 		Cells:     s2.CellUnion{17106221850767130624, 17106221919486607360},
 	})
+	require.NoError(t, err)
+
 	_, err = app.InsertSubscription(ctx, &ridmodels.Subscription{
 		ID:        dssmodels.ID(uuid.New().String()),
 		Owner:     "owner",
@@ -113,9 +116,6 @@ func TestISAUpdateIdxCells(t *testing.T) {
 		Cells:     s2.CellUnion{17106221953846345728},
 	})
 	require.NoError(t, err)
-
-	require.NoError(t, err)
-	require.NotNil(t, isa)
 
 	isa.Cells = s2.CellUnion{17106221953846345728}
 

--- a/pkg/rid/application/subscription.go
+++ b/pkg/rid/application/subscription.go
@@ -40,7 +40,7 @@ type SubscriptionApp interface {
 
 // InsertSubscription implements the App InsertSubscription method
 func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription) (*ridmodels.Subscription, error) {
-	old, err := a.Subscription.GetSubscription(ctx, s.ID)
+	old, err := a.Repository.GetSubscription(ctx, s.ID)
 	switch {
 	case err == sql.ErrNoRows:
 		break
@@ -66,7 +66,7 @@ func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription)
 	}
 
 	// Check the user hasn't created too many subscriptions in this area.
-	count, err := a.Subscription.MaxSubscriptionCountInCellsByOwner(ctx, s.Cells, s.Owner)
+	count, err := a.Repository.MaxSubscriptionCountInCellsByOwner(ctx, s.Cells, s.Owner)
 	if err != nil {
 		a.logger.Error("Error fetching max subscription count", zap.Error(err))
 		return nil, dsserr.Internal(
@@ -77,13 +77,13 @@ func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription)
 			"too many existing subscriptions in this area already")
 	}
 
-	return a.Subscription.InsertSubscription(ctx, s)
+	return a.Repository.InsertSubscription(ctx, s)
 }
 
 // DeleteSubscription deletes the Subscription identified by "id" and owned by "owner".
 func (a *app) DeleteSubscription(ctx context.Context, id dssmodels.ID, owner dssmodels.Owner, version *dssmodels.Version) (*ridmodels.Subscription, error) {
 
-	old, err := a.Subscription.GetSubscription(ctx, id)
+	old, err := a.Repository.GetSubscription(ctx, id)
 	switch {
 	case err == sql.ErrNoRows || old == nil:
 		return nil, dsserr.NotFound(id.String())
@@ -92,7 +92,7 @@ func (a *app) DeleteSubscription(ctx context.Context, id dssmodels.ID, owner dss
 	case old.Owner != owner:
 		return nil, dsserr.PermissionDenied(fmt.Sprintf("ISA is owned by %s", old.Owner))
 	}
-	old, err = a.Subscription.DeleteSubscription(ctx, old)
+	old, err = a.Repository.DeleteSubscription(ctx, old)
 	if err == sql.ErrNoRows {
 		return nil, dsserr.VersionMismatch("old version")
 	}

--- a/pkg/rid/application/subscription_test.go
+++ b/pkg/rid/application/subscription_test.go
@@ -139,9 +139,6 @@ func (store *subscriptionStore) MaxSubscriptionCountInCellsByOwner(ctx context.C
 // SearchSubscriptions returns all IdentificationServiceAreas ownded by "owner" in "cells".
 func (store *subscriptionStore) SearchSubscriptions(ctx context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
 	var subs []*ridmodels.Subscription
-	if len(cells) > 0 {
-	}
-
 	for _, s := range store.subs {
 		// Don't call Intersects, since that's smarter code than we implement in the DB.
 		appended := false

--- a/pkg/rid/application/subscription_test.go
+++ b/pkg/rid/application/subscription_test.go
@@ -304,8 +304,7 @@ func TestInsertSubscriptionsWithTimes(t *testing.T) {
 
 			// Insert a pre-existing subscription to simulate updating from something.
 			if !r.updateFromStartTime.IsZero() {
-				// same here
-				existing, err := app.InsertSubscription(ctx, &ridmodels.Subscription{
+				existing, err := app.Repository.InsertSubscription(ctx, &ridmodels.Subscription{
 					ID:        id,
 					Owner:     owner,
 					StartTime: &r.updateFromStartTime,

--- a/pkg/rid/application/subscription_test.go
+++ b/pkg/rid/application/subscription_test.go
@@ -53,7 +53,7 @@ var (
 	}
 )
 
-func setUpSubApp(ctx context.Context, t *testing.T) (*app, func() error) {
+func setUpSubApp(ctx context.Context, t *testing.T) (*app, func()) {
 	l := zap.L()
 	repo, cleanup := setUpRepo(ctx, t, l)
 	return NewFromRepo(repo, l).(*app), cleanup
@@ -309,6 +309,7 @@ func TestInsertSubscriptionsWithTimes(t *testing.T) {
 					Owner:     owner,
 					StartTime: &r.updateFromStartTime,
 					EndTime:   &r.updateFromEndTime,
+					Cells:     s2.CellUnion{s2.CellID(17106221850767130624)},
 				})
 				require.NoError(t, err)
 				version = existing.Version
@@ -318,6 +319,7 @@ func TestInsertSubscriptionsWithTimes(t *testing.T) {
 				ID:      id,
 				Owner:   owner,
 				Version: version,
+				Cells:   s2.CellUnion{s2.CellID(17106221850767130624)},
 			}
 			if !r.startTime.IsZero() {
 				s.StartTime = &r.startTime
@@ -359,6 +361,7 @@ func TestInsertTooManySubscription(t *testing.T) {
 			Owner:     dssmodels.Owner("bob"),
 			StartTime: &startTime,
 			EndTime:   &endTime,
+			Cells:     s2.CellUnion{s2.CellID(17106221850767130624)},
 		}
 
 		s.Cells = make(s2.CellUnion, len(cellIDs))

--- a/pkg/rid/application/subscription_test.go
+++ b/pkg/rid/application/subscription_test.go
@@ -15,6 +15,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	// Ensure the struct conforms to the interface
+	_                 SubscriptionApp = &app{}
+	subscriptionsPool                 = []struct {
+		name  string
+		input *ridmodels.Subscription
+	}{
+		{
+			name: "a subscription with startTime and endTime",
+			input: &ridmodels.Subscription{
+				ID:                dssmodels.ID(uuid.New().String()),
+				Owner:             dssmodels.Owner(uuid.New().String()),
+				URL:               "https://no/place/like/home",
+				StartTime:         &startTime,
+				EndTime:           &endTime,
+				NotificationIndex: 42,
+				Cells: s2.CellUnion{
+					12494535935418957824,
+				},
+			},
+		},
+		{
+			name: "a subscription without startTime and with endTime",
+			input: &ridmodels.Subscription{
+				ID:                dssmodels.ID(uuid.New().String()),
+				Owner:             dssmodels.Owner(uuid.New().String()),
+				URL:               "https://no/place/like/home",
+				EndTime:           &endTime,
+				NotificationIndex: 42,
+				Cells: s2.CellUnion{
+					12494535935418957824,
+				},
+			},
+		},
+	}
+)
+
 func setUpSubApp() *app {
 	return &app{
 		Subscription: &subscriptionStore{
@@ -74,14 +111,11 @@ func (store *subscriptionStore) SearchSubscriptionsByOwner(ctx context.Context, 
 }
 
 func (store *subscriptionStore) UpdateNotificationIdxsInCells(ctx context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
-	var ret []*ridmodels.Subscription
 	subs, _ := store.SearchSubscriptions(ctx, cells)
-	for _, s := range subs {
-		s.NotificationIndex++
-		s, _ = store.InsertSubscription(ctx, s)
-		ret = append(ret, s)
+	for i := range subs {
+		subs[i].NotificationIndex++
 	}
-	return ret, nil
+	return subs, nil
 }
 
 func (store *subscriptionStore) MaxSubscriptionCountInCellsByOwner(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) (int, error) {
@@ -107,6 +141,8 @@ func (store *subscriptionStore) MaxSubscriptionCountInCellsByOwner(ctx context.C
 // SearchSubscriptions returns all IdentificationServiceAreas ownded by "owner" in "cells".
 func (store *subscriptionStore) SearchSubscriptions(ctx context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
 	var subs []*ridmodels.Subscription
+	if len(cells) > 0 {
+	}
 
 	for _, s := range store.subs {
 		// Don't call Intersects, since that's smarter code than we implement in the DB.
@@ -134,7 +170,7 @@ func TestBadOwner(t *testing.T) {
 	sub := &ridmodels.Subscription{
 		ID:    dssmodels.ID(uuid.New().String()),
 		Owner: "orig Owner",
-		Cells: s2.CellUnion{s2.CellID(42)},
+		Cells: s2.CellUnion{s2.CellID(17106221850767130624)},
 	}
 
 	sub, err := app.InsertSubscription(ctx, sub)

--- a/pkg/rid/cockroach/identification_service_area.go
+++ b/pkg/rid/cockroach/identification_service_area.go
@@ -9,13 +9,12 @@ import (
 	"github.com/dpjacques/clockwork"
 	"github.com/interuss/dss/pkg/cockroach"
 	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/dss/pkg/geo"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
-	dsssql "github.com/interuss/dss/pkg/sql"
 
 	"github.com/golang/geo/s2"
 	"github.com/lib/pq"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
@@ -31,57 +30,8 @@ type ISAStore struct {
 	logger *zap.Logger
 }
 
-func (c *ISAStore) fetchSubscriptionsForNotification(
-	ctx context.Context, q dsssql.Queryable, cells []int64) ([]*ridmodels.Subscription, error) {
-	var updateQuery = fmt.Sprintf(`
-			UPDATE subscriptions
-			SET notification_index = notification_index + 1
-			WHERE
-				cells && $1
-				AND ends_at >= $2
-			RETURNING %s`, subscriptionFields)
-	return c.processSubscriptions(
-		ctx, q, updateQuery, pq.Array(cells), c.clock.Now())
-}
-
-//TODO remove this from this store.. only here to support incrementing sub notification index, but the logic should be placed in application
-func (c *ISAStore) processSubscriptions(ctx context.Context, q dsssql.Queryable, query string, args ...interface{}) ([]*ridmodels.Subscription, error) {
-	rows, err := q.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var payload []*ridmodels.Subscription
-	cids := pq.Int64Array{}
-
-	for rows.Next() {
-		s := new(ridmodels.Subscription)
-
-		err := rows.Scan(
-			&s.ID,
-			&s.Owner,
-			&s.URL,
-			&s.NotificationIndex,
-			&cids,
-			&s.StartTime,
-			&s.EndTime,
-			&s.Version,
-		)
-		if err != nil {
-			return nil, err
-		}
-		s.SetCells(cids)
-		payload = append(payload, s)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return payload, nil
-}
-
-func (c *ISAStore) process(ctx context.Context, q dsssql.Queryable, query string, args ...interface{}) ([]*ridmodels.IdentificationServiceArea, error) {
-	rows, err := q.QueryContext(ctx, query, args...)
+func (c *ISAStore) process(ctx context.Context, query string, args ...interface{}) ([]*ridmodels.IdentificationServiceArea, error) {
+	rows, err := c.DB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -115,8 +65,8 @@ func (c *ISAStore) process(ctx context.Context, q dsssql.Queryable, query string
 	return payload, nil
 }
 
-func (c *ISAStore) processOne(ctx context.Context, q dsssql.Queryable, query string, args ...interface{}) (*ridmodels.IdentificationServiceArea, error) {
-	isas, err := c.process(ctx, q, query, args...)
+func (c *ISAStore) processOne(ctx context.Context, query string, args ...interface{}) (*ridmodels.IdentificationServiceArea, error) {
+	isas, err := c.process(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -129,14 +79,26 @@ func (c *ISAStore) processOne(ctx context.Context, q dsssql.Queryable, query str
 	return isas[0], nil
 }
 
-// push creates/updates the IdentificationServiceArea
-// identified by "id" and owned by "owner", affecting "cells" in the time
-// interval ["starts", "ends"].
+// GetISA returns the isa identified by "id".
+func (c *ISAStore) GetISA(ctx context.Context, id dssmodels.ID) (*ridmodels.IdentificationServiceArea, error) {
+	var query = fmt.Sprintf(`
+		SELECT %s FROM
+			identification_service_areas
+		WHERE
+			id = $1
+		AND
+			ends_at > $2`, isaFields)
+	return c.processOne(ctx, query, id, c.clock.Now())
+}
+
+// InsertISA inserts the IdentificationServiceArea identified by "id" and owned
+// by "owner", affecting "cells" in the time interval ["starts", "ends"].
 //
-// Returns the created/updated IdentificationServiceArea and all Subscriptions
-// affected by the operation.
-func (c *ISAStore) push(ctx context.Context, q dsssql.Queryable, isa *ridmodels.IdentificationServiceArea) (
-	*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error) {
+// Returns the created IdentificationServiceArea and all Subscriptions affected
+// by it.
+// TODO: Simplify the logic to insert without a query, such that the insert fails
+// if there's an existing entity.
+func (c *ISAStore) InsertISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error) {
 	var (
 		updateAreasQuery = fmt.Sprintf(`
 			UPDATE
@@ -158,67 +120,26 @@ func (c *ISAStore) push(ctx context.Context, q dsssql.Queryable, isa *ridmodels.
 	cids := make([]int64, len(isa.Cells))
 
 	for i, cell := range isa.Cells {
+		if err := geo.ValidateCell(cell); err != nil {
+			return nil, err
+		}
 		cids[i] = int64(cell)
 	}
 
 	var err error
 	if isa.Version.Empty() {
-		isa, err = c.processOne(ctx, q, insertAreasQuery, isa.ID, isa.Owner, isa.URL, pq.Array(cids), isa.StartTime, isa.EndTime)
+		ret, err := c.processOne(ctx, insertAreasQuery, isa.ID, isa.Owner, isa.URL, pq.Array(cids), isa.StartTime, isa.EndTime)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-	} else {
-		isa, err = c.processOne(ctx, q, updateAreasQuery, isa.ID, isa.Owner, isa.URL, pq.Array(cids), isa.StartTime, isa.EndTime, isa.Version.ToTimestamp())
-		if err != nil {
-
-			return nil, nil, err
-		}
+		return ret, nil
 	}
 
-	subscriptions, err := c.fetchSubscriptionsForNotification(ctx, q, cids)
+	ret, err := c.processOne(ctx, updateAreasQuery, isa.ID, isa.Owner, isa.URL, pq.Array(cids), isa.StartTime, isa.EndTime, isa.Version.ToTimestamp())
 	if err != nil {
-
-		return nil, nil, err
+		return nil, err
 	}
-
-	return isa, subscriptions, nil
-}
-
-// GetISA returns the isa identified by "id".
-func (c *ISAStore) GetISA(ctx context.Context, id dssmodels.ID) (*ridmodels.IdentificationServiceArea, error) {
-	var query = fmt.Sprintf(`
-		SELECT %s FROM
-			identification_service_areas
-		WHERE
-			id = $1
-		AND
-			ends_at > $2`, isaFields)
-	return c.processOne(ctx, c.DB, query, id, c.clock.Now())
-}
-
-// InsertISA inserts the IdentificationServiceArea identified by "id" and owned
-// by "owner", affecting "cells" in the time interval ["starts", "ends"].
-//
-// Returns the created IdentificationServiceArea and all Subscriptions affected
-// by it.
-// TODO: Simplify the logic to insert without a query, such that the insert fails
-// if there's an existing entity.
-func (c *ISAStore) InsertISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error) {
-	tx, err := c.Begin()
-	if err != nil {
-		return nil, nil, err
-	}
-	defer recoverRollbackRepanic(ctx, tx)
-
-	area, subscribers, err := c.push(ctx, tx, isa)
-	if err != nil {
-		return nil, nil, multierr.Combine(err, tx.Rollback())
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, nil, err
-	}
-	return area, subscribers, nil
+	return ret, nil
 }
 
 // UpdateISA updates the IdentificationServiceArea identified by "id" and owned
@@ -227,13 +148,13 @@ func (c *ISAStore) InsertISA(ctx context.Context, isa *ridmodels.IdentificationS
 // Returns the created IdentificationServiceArea and all Subscriptions affected
 // by it.
 // TODO: simplify the logic to just update, without the primary query.
-func (c *ISAStore) UpdateISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error) {
-	return nil, nil, dsserr.BadRequest("not yet implemented")
+func (c *ISAStore) UpdateISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error) {
+	return nil, dsserr.BadRequest("not yet implemented")
 }
 
 // DeleteISA deletes the IdentificationServiceArea identified by "id" and owned by "owner".
 // Returns the delete IdentificationServiceArea and all Subscriptions affected by the delete.
-func (c *ISAStore) DeleteISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error) {
+func (c *ISAStore) DeleteISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error) {
 	var (
 		deleteQuery = fmt.Sprintf(`
 			DELETE FROM
@@ -252,27 +173,7 @@ func (c *ISAStore) DeleteISA(ctx context.Context, isa *ridmodels.IdentificationS
 		cids[i] = int64(cell)
 	}
 
-	tx, err := c.Begin()
-	if err != nil {
-		return nil, nil, err
-	}
-	defer recoverRollbackRepanic(ctx, tx)
-
-	subscriptions, err := c.fetchSubscriptionsForNotification(ctx, tx, cids)
-	if err != nil {
-		return nil, nil, multierr.Combine(err, tx.Rollback())
-	}
-
-	isa, err = c.processOne(ctx, tx, deleteQuery, isa.ID, isa.Owner, isa.Version.ToTimestamp())
-	if err != nil {
-		return nil, nil, multierr.Combine(err, tx.Rollback())
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, nil, err
-	}
-
-	return isa, subscriptions, nil
+	return c.processOne(ctx, deleteQuery, isa.ID, isa.Owner, isa.Version.ToTimestamp())
 }
 
 // SearchISAs searches IdentificationServiceArea
@@ -308,5 +209,5 @@ func (c *ISAStore) SearchISAs(ctx context.Context, cells s2.CellUnion, earliest 
 		cids[i] = int64(cid)
 	}
 
-	return c.process(ctx, c.DB, isasInCellsQuery, earliest, latest, pq.Int64Array(cids))
+	return c.process(ctx, isasInCellsQuery, earliest, latest, pq.Int64Array(cids))
 }

--- a/pkg/rid/cockroach/identification_service_area.go
+++ b/pkg/rid/cockroach/identification_service_area.go
@@ -7,13 +7,13 @@ import (
 	"time"
 
 	"github.com/dpjacques/clockwork"
-	"github.com/interuss/dss/pkg/cockroach"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/geo"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
 
 	"github.com/golang/geo/s2"
+	dssql "github.com/interuss/dss/pkg/sql"
 	"github.com/lib/pq"
 	"go.uber.org/zap"
 )
@@ -24,14 +24,14 @@ const (
 
 // ISAStore is an implementation of the ISARepo for CRDB.
 type ISAStore struct {
-	*cockroach.DB
+	dssql.Queryable
 
 	clock  clockwork.Clock
 	logger *zap.Logger
 }
 
 func (c *ISAStore) process(ctx context.Context, query string, args ...interface{}) ([]*ridmodels.IdentificationServiceArea, error) {
-	rows, err := c.DB.QueryContext(ctx, query, args...)
+	rows, err := c.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rid/cockroach/store.go
+++ b/pkg/rid/cockroach/store.go
@@ -19,8 +19,8 @@ var (
 // Store is an implementation of dss.Store using
 // Cockroach DB as its backend store.
 type Store struct {
-	ISA          repos.ISA
-	Subscription repos.Subscription
+	repos.ISA
+	repos.Subscription
 	*cockroach.DB
 }
 

--- a/pkg/rid/cockroach/store.go
+++ b/pkg/rid/cockroach/store.go
@@ -35,12 +35,12 @@ func recoverRollbackRepanic(ctx context.Context, tx *sql.Tx) {
 }
 
 // NewStore returns a Store instance connected to a cockroach instance via db.
-func NewStore(db *cockroach.DB, logger *zap.Logger) (*Store, error) {
+func NewStore(db *cockroach.DB, logger *zap.Logger) *Store {
 	return &Store{
 		ISA:          &ISAStore{db, DefaultClock, logger},
 		Subscription: &SubscriptionStore{db, DefaultClock, logger},
 		DB:           db,
-	}, nil
+	}
 }
 
 // Close closes the underlying DB connection.

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -139,6 +139,7 @@ func TestTxnRetrier(t *testing.T) {
 		// Postgre retryable error
 		return &pq.Error{Code: "40001"}
 	})
+	require.Error(t, err)
 	// Ensure it was retried.
 	require.Greater(t, count, 1)
 }

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -2,7 +2,6 @@ package cockroach
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"testing"
 	"time"
@@ -27,6 +26,9 @@ var (
 )
 
 func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
+	if len(*storeURI) == 0 {
+		t.Skip()
+	}
 	// Reset the clock for every test.
 	fakeClock = clockwork.NewFakeClock()
 
@@ -40,10 +42,6 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 }
 
 func newStore() (*Store, error) {
-	if len(*storeURI) == 0 {
-		return nil, errors.New("Missing command-line parameter store-uri")
-	}
-
 	cdb, err := cockroach.Dial(*storeURI)
 	if err != nil {
 		return nil, err

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -25,7 +25,7 @@ var (
 	endTime   = fakeClock.Now().Add(time.Hour)
 )
 
-func setUpStore(ctx context.Context, t *testing.T) (*Store, func() error) {
+func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	// Reset the clock for every test.
 	fakeClock = clockwork.NewFakeClock()
 
@@ -34,8 +34,8 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func() error) {
 		t.Skip(err)
 	}
 	require.NoError(t, store.Bootstrap(ctx))
-	return store, func() error {
-		return cleanUp(ctx, store)
+	return store, func() {
+		require.NoError(t, cleanUp(ctx, store))
 	}
 }
 
@@ -76,7 +76,7 @@ func TestStoreBootstrap(t *testing.T) {
 		store, tearDownStore = setUpStore(ctx, t)
 	)
 	require.NotNil(t, store)
-	require.NoError(t, tearDownStore())
+	tearDownStore()
 }
 
 func TestDatabaseEnsuresBeginsBeforeExpires(t *testing.T) {
@@ -85,9 +85,7 @@ func TestDatabaseEnsuresBeginsBeforeExpires(t *testing.T) {
 		store, tearDownStore = setUpStore(ctx, t)
 	)
 	require.NotNil(t, store)
-	defer func() {
-		require.NoError(t, tearDownStore())
-	}()
+	defer tearDownStore()
 
 	var (
 		begins  = time.Now()

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -48,9 +48,9 @@ func newStore() (*Store, error) {
 		return nil, err
 	}
 	return &Store{
-		ISA:          &ISAStore{DB: cdb, clock: fakeClock, logger: zap.L()},
-		Subscription: &SubscriptionStore{cdb, fakeClock, zap.L()},
-		DB:           cdb,
+		ISA:          &ISAStore{Queryable: cdb, clock: fakeClock, logger: zap.L()},
+		Subscription: &SubscriptionStore{Queryable: cdb, clock: fakeClock, logger: zap.L()},
+		db:           cdb,
 	}, nil
 }
 

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -29,12 +29,11 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	fakeClock = clockwork.NewFakeClock()
 
 	store, err := newStore()
-	if err != nil {
-		t.Skip(err)
-	}
+	require.NoError(t, err)
 	require.NoError(t, store.Bootstrap(ctx))
 	return store, func() {
 		require.NoError(t, cleanUp(ctx, store))
+		require.NoError(t, store.Close())
 	}
 }
 
@@ -51,6 +50,7 @@ func newStore() (*Store, error) {
 		ISA:          &ISAStore{Queryable: cdb, clock: fakeClock, logger: zap.L()},
 		Subscription: &SubscriptionStore{Queryable: cdb, clock: fakeClock, logger: zap.L()},
 		db:           cdb,
+		Queryable:    cdb,
 	}, nil
 }
 

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -2,7 +2,6 @@ package cockroach
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"flag"
 	"testing"
@@ -44,13 +43,10 @@ func newStore() (*Store, error) {
 		return nil, errors.New("Missing command-line parameter store-uri")
 	}
 
-	db, err := sql.Open("postgres", *storeURI)
+	cdb, err := cockroach.Dial(*storeURI)
 	if err != nil {
 		return nil, err
 	}
-
-	cdb := &cockroach.DB{DB: db}
-
 	return &Store{
 		ISA:          &ISAStore{DB: cdb, clock: fakeClock, logger: zap.L()},
 		Subscription: &SubscriptionStore{cdb, fakeClock, zap.L()},

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -93,7 +93,7 @@ func TestDatabaseEnsuresBeginsBeforeExpires(t *testing.T) {
 		begins  = time.Now()
 		expires = begins.Add(-5 * time.Minute)
 	)
-	_, err := store.Subscription.Insert(ctx, &ridmodels.Subscription{
+	_, err := store.InsertSubscription(ctx, &ridmodels.Subscription{
 		ID:                dssmodels.ID(uuid.New().String()),
 		Owner:             "me-myself-and-i",
 		URL:               "https://no/place/like/home",

--- a/pkg/rid/cockroach/subscriptions.go
+++ b/pkg/rid/cockroach/subscriptions.go
@@ -231,7 +231,7 @@ func (c *SubscriptionStore) SearchSubscriptions(ctx context.Context, cells s2.Ce
 			WHERE
 				cells && $1
 			AND
-				ends_at >= $3`, subscriptionFields)
+				ends_at >= $2`, subscriptionFields)
 	)
 
 	if len(cells) == 0 {
@@ -243,7 +243,7 @@ func (c *SubscriptionStore) SearchSubscriptions(ctx context.Context, cells s2.Ce
 		cids[i] = int64(cell)
 	}
 
-	return c.process(ctx, query, pq.Array(cids), c.clock.Now())
+	return c.process(ctx, query, pq.Int64Array(cids), c.clock.Now())
 }
 
 // SearchSubscriptionsByOwner returns all subscriptions in "cells".

--- a/pkg/rid/cockroach/subscriptions.go
+++ b/pkg/rid/cockroach/subscriptions.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 
 	"github.com/dpjacques/clockwork"
-	"github.com/interuss/dss/pkg/cockroach"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/geo"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
 
 	"github.com/golang/geo/s2"
+	dssql "github.com/interuss/dss/pkg/sql"
 	"github.com/lib/pq"
 	"go.uber.org/zap"
 )
@@ -23,7 +23,7 @@ const (
 
 // SubscriptionStore is an implementation of the SubscriptionRepo for CRDB.
 type SubscriptionStore struct {
-	*cockroach.DB
+	dssql.Queryable
 
 	clock  clockwork.Clock
 	logger *zap.Logger
@@ -31,7 +31,7 @@ type SubscriptionStore struct {
 
 // process a query that should return one or many subscriptions.
 func (c *SubscriptionStore) process(ctx context.Context, query string, args ...interface{}) ([]*ridmodels.Subscription, error) {
-	rows, err := c.DB.QueryContext(ctx, query, args...)
+	rows, err := c.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (c *SubscriptionStore) MaxSubscriptionCountInCellsByOwner(ctx context.Conte
 		cids[i] = int64(cell)
 	}
 
-	row := c.DB.QueryRowContext(ctx, query, owner, c.clock.Now(), pq.Int64Array(cids))
+	row := c.QueryRowContext(ctx, query, owner, c.clock.Now(), pq.Int64Array(cids))
 	var ret int
 	err := row.Scan(&ret)
 	return ret, err

--- a/pkg/rid/cockroach/subscriptions_test.go
+++ b/pkg/rid/cockroach/subscriptions_test.go
@@ -188,7 +188,11 @@ func TestStoreSearchSubscription(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, sub1)
 	}
-
+	// Test normal search
+	found, err := store.SearchSubscriptions(ctx, cells)
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	require.Len(t, found, 2)
 	for _, owner := range owners {
 		found, err := store.SearchSubscriptionsByOwner(ctx, cells, owner)
 		require.NoError(t, err)

--- a/pkg/rid/repos/isa.go
+++ b/pkg/rid/repos/isa.go
@@ -11,18 +11,18 @@ import (
 
 // ISA is an interface to a storage layer for the ISA entity
 type ISA interface {
-	Get(ctx context.Context, id dssmodels.ID) (*ridmodels.IdentificationServiceArea, error)
+	GetISA(ctx context.Context, id dssmodels.ID) (*ridmodels.IdentificationServiceArea, error)
 
-	// Delete deletes the IdentificationServiceArea identified by "id" and owned by "owner".
+	// DeleteISA deletes the IdentificationServiceArea identified by "id" and owned by "owner".
 	// Returns the delete IdentificationServiceArea and all Subscriptions affected by the delete.
-	Delete(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error)
+	DeleteISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error)
 
 	// InsertISA inserts or updates an ISA.
-	Insert(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error)
+	InsertISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error)
 
-	// Update
-	Update(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error)
+	// UpdateISA
+	UpdateISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error)
 
-	// SearchSubscriptions returns all subscriptions ownded by "owner" in "cells".
-	Search(ctx context.Context, cells s2.CellUnion, earliest *time.Time, latest *time.Time) ([]*ridmodels.IdentificationServiceArea, error)
+	// SearchISAs returns all subscriptions ownded by "owner" in "cells".
+	SearchISAs(ctx context.Context, cells s2.CellUnion, earliest *time.Time, latest *time.Time) ([]*ridmodels.IdentificationServiceArea, error)
 }

--- a/pkg/rid/repos/isa.go
+++ b/pkg/rid/repos/isa.go
@@ -15,13 +15,13 @@ type ISA interface {
 
 	// DeleteISA deletes the IdentificationServiceArea identified by "id" and owned by "owner".
 	// Returns the delete IdentificationServiceArea and all Subscriptions affected by the delete.
-	DeleteISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error)
+	DeleteISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error)
 
 	// InsertISA inserts or updates an ISA.
-	InsertISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error)
+	InsertISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error)
 
 	// UpdateISA
-	UpdateISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, []*ridmodels.Subscription, error)
+	UpdateISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error)
 
 	// SearchISAs returns all subscriptions ownded by "owner" in "cells".
 	SearchISAs(ctx context.Context, cells s2.CellUnion, earliest *time.Time, latest *time.Time) ([]*ridmodels.IdentificationServiceArea, error)

--- a/pkg/rid/repos/repo.go
+++ b/pkg/rid/repos/repo.go
@@ -1,5 +1,7 @@
 package repos
 
+import "context"
+
 // Repository contains all of the repo interfaces.
 type Repository interface {
 	ISA
@@ -7,5 +9,5 @@ type Repository interface {
 	// InTxnRetrier supplies a new repo, that will perform all of the DB accesses
 	// in a Txn, and will retry any Txn's that fail due to retry-able errors
 	// (typically contention).
-	InTxnRetrier(func(repo Repository) error) error
+	InTxnRetrier(ctx context.Context, f func(repo Repository) error) error
 }

--- a/pkg/rid/repos/repo.go
+++ b/pkg/rid/repos/repo.go
@@ -10,4 +10,5 @@ type Repository interface {
 	// in a Txn, and will retry any Txn's that fail due to retry-able errors
 	// (typically contention).
 	InTxnRetrier(ctx context.Context, f func(repo Repository) error) error
+	Close() error
 }

--- a/pkg/rid/repos/repo.go
+++ b/pkg/rid/repos/repo.go
@@ -1,0 +1,11 @@
+package repos
+
+// Repository contains all of the repo interfaces.
+type Repository interface {
+	ISA
+	Subscription
+	// InTxnRetrier supplies a new repo, that will perform all of the DB accesses
+	// in a Txn, and will retry any Txn's that fail due to retry-able errors
+	// (typically contention).
+	InTxnRetrier(func(repo Repository) error) error
+}

--- a/pkg/rid/repos/subscription.go
+++ b/pkg/rid/repos/subscription.go
@@ -10,21 +10,21 @@ import (
 
 // Subscription is an interface to a storage layer for the Subscription entity
 type Subscription interface {
-	Get(ctx context.Context, id dssmodels.ID) (*ridmodels.Subscription, error)
+	GetSubscription(ctx context.Context, id dssmodels.ID) (*ridmodels.Subscription, error)
 
-	// Delete deletes the IdentificationServiceArea identified by "id" and owned by "owner".
+	// DeleteSubscription deletes the IdentificationServiceArea identified by "id" and owned by "owner".
 	// Returns the delete IdentificationServiceArea and all Subscriptions affected by the delete.
-	Delete(ctx context.Context, sub *ridmodels.Subscription) (*ridmodels.Subscription, error)
+	DeleteSubscription(ctx context.Context, sub *ridmodels.Subscription) (*ridmodels.Subscription, error)
 
-	// Insert inserts or updates an ISA.
-	Insert(ctx context.Context, sub *ridmodels.Subscription) (*ridmodels.Subscription, error)
+	// InsertSubscription inserts or updates an ISA.
+	InsertSubscription(ctx context.Context, sub *ridmodels.Subscription) (*ridmodels.Subscription, error)
 
-	// Update
-	Update(ctx context.Context, sub *ridmodels.Subscription) (*ridmodels.Subscription, error)
+	// UpdateSubscription
+	UpdateSubscription(ctx context.Context, sub *ridmodels.Subscription) (*ridmodels.Subscription, error)
 
-	// Search returns all subscriptions ownded by in "cells".
-	Search(ctx context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error)
+	// SearchSubscriptions returns all subscriptions ownded by in "cells".
+	SearchSubscriptions(ctx context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error)
 
-	// SearchByOwner returns all subscriptions ownded by "owner" in "cells".
-	SearchByOwner(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) ([]*ridmodels.Subscription, error)
+	// SearchSubscriptionsByOwner returns all subscriptions ownded by "owner" in "cells".
+	SearchSubscriptionsByOwner(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) ([]*ridmodels.Subscription, error)
 }

--- a/pkg/rid/repos/subscription.go
+++ b/pkg/rid/repos/subscription.go
@@ -27,4 +27,11 @@ type Subscription interface {
 
 	// SearchSubscriptionsByOwner returns all subscriptions ownded by "owner" in "cells".
 	SearchSubscriptionsByOwner(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) ([]*ridmodels.Subscription, error)
+
+	// UpdateNotificationIdxsInCells incremement the notification for each sub in the given cells.
+	UpdateNotificationIdxsInCells(ctx context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error)
+
+	// MaxSubscriptionCountInCellsByOwner finds, out of a set of cells, the cell with the most subscriptions
+	// belonging to the given owner, and returns that number.
+	MaxSubscriptionCountInCellsByOwner(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) (int, error)
 }

--- a/pkg/rid/server/isa_handler.go
+++ b/pkg/rid/server/isa_handler.go
@@ -46,6 +46,7 @@ func (s *Server) createOrUpdateISA(
 	if !ok {
 		return nil, dsserr.PermissionDenied("missing owner from context")
 	}
+	// TODO: put the validation logic in the models layer
 	if flightsURL == "" {
 		return nil, dsserr.BadRequest("missing required flightsURL")
 	}

--- a/pkg/rid/server/isa_handler.go
+++ b/pkg/rid/server/isa_handler.go
@@ -22,7 +22,7 @@ func (s *Server) GetIdentificationServiceArea(
 
 	ctx, cancel := context.WithTimeout(ctx, s.Timeout)
 	defer cancel()
-	isa, err := s.App.ISA.Get(ctx, dssmodels.ID(req.GetId()))
+	isa, err := s.App.GetISA(ctx, dssmodels.ID(req.GetId()))
 	if err == sql.ErrNoRows {
 		return nil, dsserr.NotFound(req.GetId())
 	}
@@ -64,7 +64,7 @@ func (s *Server) createOrUpdateISA(
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad extents: %s", err))
 	}
 
-	insertedISA, subscribers, err := s.App.ISA.Insert(ctx, isa)
+	insertedISA, subscribers, err := s.App.InsertISA(ctx, isa)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (s *Server) DeleteIdentificationServiceArea(
 	}
 	ctx, cancel := context.WithTimeout(ctx, s.Timeout)
 	defer cancel()
-	isa, subscribers, err := s.App.ISA.Delete(ctx, dssmodels.ID(req.GetId()), owner, version)
+	isa, subscribers, err := s.App.DeleteISA(ctx, dssmodels.ID(req.GetId()), owner, version)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (s *Server) SearchIdentificationServiceAreas(
 
 	ctx, cancel := context.WithTimeout(ctx, s.Timeout)
 	defer cancel()
-	isas, err := s.App.ISA.Search(ctx, cu, earliest, latest)
+	isas, err := s.App.SearchISAs(ctx, cu, earliest, latest)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rid/server/server.go
+++ b/pkg/rid/server/server.go
@@ -27,7 +27,7 @@ var (
 
 // Server implements ridpb.DiscoveryAndSynchronizationService.
 type Server struct {
-	App     *application.App
+	App     application.App
 	Timeout time.Duration
 }
 

--- a/pkg/rid/server/subscription_handler.go
+++ b/pkg/rid/server/subscription_handler.go
@@ -103,6 +103,7 @@ func (s *Server) GetSubscription(
 	}, nil
 }
 
+// TODO: put the validation logic in the models layer
 func (s *Server) createOrUpdateSubscription(
 	ctx context.Context, id string, version *dssmodels.Version, callbacks *ridpb.SubscriptionCallbacks, extents *ridpb.Volume4D) (
 	*ridpb.PutSubscriptionResponse, error) {

--- a/pkg/rid/server/subscription_handler.go
+++ b/pkg/rid/server/subscription_handler.go
@@ -28,7 +28,7 @@ func (s *Server) DeleteSubscription(
 	}
 	ctx, cancel := context.WithTimeout(ctx, s.Timeout)
 	defer cancel()
-	subscription, err := s.App.Subscription.Delete(ctx, dssmodels.ID(req.GetId()), owner, version)
+	subscription, err := s.App.DeleteSubscription(ctx, dssmodels.ID(req.GetId()), owner, version)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (s *Server) SearchSubscriptions(
 
 	ctx, cancel := context.WithTimeout(ctx, s.Timeout)
 	defer cancel()
-	subscriptions, err := s.App.Subscription.SearchByOwner(ctx, cu, owner)
+	subscriptions, err := s.App.SearchSubscriptionsByOwner(ctx, cu, owner)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (s *Server) GetSubscription(
 
 	ctx, cancel := context.WithTimeout(ctx, s.Timeout)
 	defer cancel()
-	subscription, err := s.App.Subscription.Get(ctx, dssmodels.ID(req.GetId()))
+	subscription, err := s.App.GetSubscription(ctx, dssmodels.ID(req.GetId()))
 	if err == sql.ErrNoRows {
 		return nil, dsserr.NotFound(req.GetId())
 	}
@@ -129,7 +129,7 @@ func (s *Server) createOrUpdateSubscription(
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad extents: %s", err))
 	}
 
-	insertedSub, err := s.App.Subscription.Insert(ctx, sub)
+	insertedSub, err := s.App.InsertSubscription(ctx, sub)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (s *Server) createOrUpdateSubscription(
 	}
 
 	// Find ISAs that were in this subscription's area.
-	isas, err := s.App.ISA.Search(ctx, sub.Cells, nil, nil)
+	isas, err := s.App.SearchISAs(ctx, sub.Cells, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scd/store/cockroach/store.go
+++ b/pkg/scd/store/cockroach/store.go
@@ -22,12 +22,12 @@ type Store struct {
 }
 
 // NewStore returns a Store instance connected to a cockroach instance via db.
-func NewStore(db *cockroach.DB, logger *zap.Logger) (*Store, error) {
+func NewStore(db *cockroach.DB, logger *zap.Logger) *Store {
 	return &Store{
 		DB:     db,
 		logger: logger,
 		clock:  DefaultClock,
-	}, nil
+	}
 }
 
 // Close closes the underlying DB connection.

--- a/pkg/scd/store/cockroach/store_test.go
+++ b/pkg/scd/store/cockroach/store_test.go
@@ -2,7 +2,6 @@ package cockroach
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"testing"
 	"time"
@@ -29,13 +28,14 @@ var (
 )
 
 func setUpStore(ctx context.Context, t *testing.T) (*Store, func() error) {
+	if len(*storeURI) == 0 {
+		t.Skip()
+	}
 	// Reset the clock for every test.
 	fakeClock = clockwork.NewFakeClock()
 
 	store, err := newStore()
-	if err != nil {
-		t.Skip(err)
-	}
+	require.NoError(t, err)
 	require.NoError(t, store.Bootstrap(ctx))
 	return store, func() error {
 		return cleanUp(ctx, store)
@@ -43,10 +43,6 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func() error) {
 }
 
 func newStore() (*Store, error) {
-	if len(*storeURI) == 0 {
-		return nil, errors.New("Missing command-line parameter store-uri")
-	}
-
 	cdb, err := cockroach.Dial(*storeURI)
 	if err != nil {
 		return nil, err

--- a/pkg/scd/store/cockroach/store_test.go
+++ b/pkg/scd/store/cockroach/store_test.go
@@ -2,7 +2,6 @@ package cockroach
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"flag"
 	"testing"
@@ -48,13 +47,12 @@ func newStore() (*Store, error) {
 		return nil, errors.New("Missing command-line parameter store-uri")
 	}
 
-	db, err := sql.Open("postgres", *storeURI)
+	cdb, err := cockroach.Dial(*storeURI)
 	if err != nil {
 		return nil, err
 	}
-
 	return &Store{
-		DB:     &cockroach.DB{DB: db},
+		DB:     cdb,
 		logger: zap.L(),
 		clock:  fakeClock,
 	}, nil


### PR DESCRIPTION
Factor out the remainder of the logic from rid/store that should be in rid/application.

We also add a Txn retrier for the remaining transactions (of which there are only 2, each with only 2 queries), so we can perform client side retries for contended transactions