### PR TITLE
Rudimentary schema version enforcement

### DIFF
--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// The code at this version requires a major schema version equal to 2.
-	RequiredMajorSchemaVersion = "2"
+	RequiredMajorSchemaVersion = "v2"
 )
 
 var (

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/interuss/dss/pkg/scd"
 	scdc "github.com/interuss/dss/pkg/scd/store/cockroach"
 	"github.com/interuss/dss/pkg/validations"
+	"golang.org/x/mod/semver"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"go.uber.org/zap"

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -27,7 +27,6 @@ import (
 	scdc "github.com/interuss/dss/pkg/scd/store/cockroach"
 	"github.com/interuss/dss/pkg/validations"
 
-	"github.com/blang/semver"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -36,7 +35,7 @@ import (
 
 const (
 	// The code at this version requires a major schema version equal to 2.
-	RequiredMajorSchemaVersion uint64 = 2
+	RequiredMajorSchemaVersion = "2"
 )
 
 var (
@@ -80,9 +79,8 @@ func MustSupportSchema(ctx context.Context, store *ridc.Store) {
 		logger.Panic("could not get schema version from database", zap.Error(err))
 	}
 
-	v := semver.MustParse(vs)
-	if RequiredMajorSchemaVersion != v.Major {
-		logger.Panic(fmt.Sprintf("unsupported schema version! Got %s, requires major version of %d", vs, RequiredMajorSchemaVersion))
+	if RequiredMajorSchemaVersion != semver.Major(vs) {
+		logger.Panic(fmt.Sprintf("unsupported schema version! Got %s, requires major version of %s.", vs, RequiredMajorSchemaVersion))
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.15.0
+	golang.org/x/mod v0.2.0
 	google.golang.org/genproto v0.0.0-20200519141106-08726f379972
 	google.golang.org/grpc v1.29.1
 	google.golang.org/protobuf v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,7 @@ require (
 	github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dpjacques/clockwork v0.1.0
-	github.com/gogo/protobuf v1.3.1
-	github.com/gogo/status v1.1.0
+	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec
 	github.com/golang/protobuf v1.4.2
 	github.com/google/uuid v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ go 1.14
 
 require (
 	cloud.google.com/go v0.57.0
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/cockroachdb/cockroach-go v0.0.0-20200504194139-73ffeee90b62
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dpjacques/clockwork v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,9 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
+github.com/blang/semver v1.1.0 h1:ol1rO7QQB5uy7umSNV7VAmLugfLRD+17sYJujRNYPhg=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/go.sum
+++ b/go.sum
@@ -25,7 +25,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
-github.com/blang/semver v1.1.0 h1:ol1rO7QQB5uy7umSNV7VAmLugfLRD+17sYJujRNYPhg=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -54,14 +53,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a h1:dR8+Q0uO5S2ZBcs2IH6VBKYwSxPo2vYCYq0ot0mu7xA=
-github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
-github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/gogo/status v1.1.0 h1:+eIkrewn5q6b30y+g/BJINVVdi2xH7je5MPJ3ZPK3JA=
-github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY1WM=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec h1:lJwO/92dFXWeXOZdoGXgptLmNLwynMSHUmU6besqtiw=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -242,7 +235,6 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200501052902-10377860bb8e h1:hq86ru83GdWTlfQFZGO4nZJTU4Bs2wfHl8oFHRaXsfc=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -306,7 +298,6 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
-google.golang.org/genproto v0.0.0-20180518175338-11a468237815/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -328,7 +319,6 @@ google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200519141106-08726f379972 h1:6ydLqG65DIMNJf6p97WudGsmd1w3Ickm/LiZnBrREPI=
 google.golang.org/genproto v0.0.0-20200519141106-08726f379972/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
-google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -235,6 +236,7 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200501052902-10377860bb8e h1:hq86ru83GdWTlfQFZGO4nZJTU4Bs2wfHl8oFHRaXsfc=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/rid/cockroach/store.go
+++ b/pkg/rid/cockroach/store.go
@@ -164,7 +164,7 @@ func (s *Store) Bootstrap(ctx context.Context) error {
 
 // GetVersion returns the current semver of the schema
 func (s *Store) GetVersion(ctx context.Context) (string, error) {
-	// We treat the existance of cells_subscriptions as running on the initial
+	// We treat the existence of cells_subscriptions as running on the initial
 	// version, 1.0.0
 	const query = `
 		SELECT EXISTS (

--- a/pkg/rid/cockroach/store.go
+++ b/pkg/rid/cockroach/store.go
@@ -180,11 +180,11 @@ func (s *Store) GetVersion(ctx context.Context) (string, error) {
 	}
 	if ret {
 		// Base version
-		return "1.0.0", nil
+		return "v1.0.0", nil
 	}
 	// Version without cells joins table.
 	// TODO: leverage proper migrations and use something like the query below.
-	return "2.0.0", nil
+	return "v2.0.0", nil
 }
 
 // 	// TODO steeling: we should leverage this function. Instead, we don't have
@@ -194,7 +194,7 @@ func (s *Store) GetVersion(ctx context.Context) (string, error) {
 
 // 	const query = `
 //     SELECT
-//       IFNULL(schema_version, '1.0.0')
+//       IFNULL(schema_version, 'v1.0.0')
 //     FROM
 //     	schema_versions
 //   	LIMIT 1`

--- a/pkg/rid/cockroach/store.go
+++ b/pkg/rid/cockroach/store.go
@@ -162,6 +162,7 @@ func (s *Store) Bootstrap(ctx context.Context) error {
 	return err
 }
 
+// GetVersion returns the current semver of the schema
 func (s *Store) GetVersion(ctx context.Context) (string, error) {
 	const query = `
 		SELECT EXISTS (

--- a/pkg/rid/cockroach/store.go
+++ b/pkg/rid/cockroach/store.go
@@ -164,11 +164,13 @@ func (s *Store) Bootstrap(ctx context.Context) error {
 
 // GetVersion returns the current semver of the schema
 func (s *Store) GetVersion(ctx context.Context) (string, error) {
+	// We treat the existance of cells_subscriptions as running on the initial
+	// version, 1.0.0
 	const query = `
 		SELECT EXISTS (
   		SELECT *
 		  FROM information_schema.tables 
-   		WHERE  table_name   = 'my_t'
+   		WHERE table_name = 'cells_subscriptions'
    )`
 	row := s.QueryRowContext(ctx, query)
 	var ret bool

--- a/pkg/rid/cockroach/store.go
+++ b/pkg/rid/cockroach/store.go
@@ -162,7 +162,7 @@ func (s *Store) Bootstrap(ctx context.Context) error {
 	return err
 }
 
-func (s *Store) GetVersion() string {
+func (s *Store) GetVersion(ctx context.Context) (string, error) {
 	const query = `
 		SELECT EXISTS (
   		SELECT *
@@ -181,7 +181,7 @@ func (s *Store) GetVersion() string {
 	}
 	// Version without cells joins table.
 	// TODO: leverage proper migrations and use something like the query below.
-	return "2.0.0"
+	return "2.0.0", nil
 }
 
 // 	// TODO steeling: we should leverage this function. Instead, we don't have

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -100,6 +100,10 @@ func TestDatabaseEnsuresBeginsBeforeExpires(t *testing.T) {
 }
 
 func TestTxnRetrier(t *testing.T) {
+	var (
+		ctx                  = context.Background()
+		store, tearDownStore = setUpStore(ctx, t)
+	)
 	require.NotNil(t, store)
 	defer tearDownStore()
 
@@ -137,8 +141,8 @@ func TestTxnRetrier(t *testing.T) {
 	require.Error(t, err)
 	// Ensure it was retried.
 	require.Greater(t, count, 1)
-
 }
+
 func TestGetVersion(t *testing.T) {
 	var (
 		ctx                  = context.Background()

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/google/uuid"
 	"github.com/interuss/dss/pkg/cockroach"
 	dssmodels "github.com/interuss/dss/pkg/models"
@@ -151,6 +150,16 @@ func TestGetVersion(t *testing.T) {
 	defer tearDownStore()
 	version, err := store.GetVersion(ctx)
 	require.NoError(t, err)
-	_, err = semver.Parse(version)
 	require.NoError(t, err)
+
+	// TODO: remove the below checks when we have better schema management
+	require.Equal(t, "2.0.0", version)
+
+	_, err = store.Queryable.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS cells_subscriptions (id STRING PRIMARY KEY);`)
+	require.NoError(t, err)
+
+	version, err = store.GetVersion(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", version)
+
 }

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/google/uuid"
 	"github.com/interuss/dss/pkg/cockroach"
 	dssmodels "github.com/interuss/dss/pkg/models"
@@ -99,10 +100,6 @@ func TestDatabaseEnsuresBeginsBeforeExpires(t *testing.T) {
 }
 
 func TestTxnRetrier(t *testing.T) {
-	var (
-		ctx                  = context.Background()
-		store, tearDownStore = setUpStore(ctx, t)
-	)
 	require.NotNil(t, store)
 	defer tearDownStore()
 
@@ -140,4 +137,15 @@ func TestTxnRetrier(t *testing.T) {
 	require.Error(t, err)
 	// Ensure it was retried.
 	require.Greater(t, count, 1)
+
+}
+func TestGetVersion(t *testing.T) {
+	var (
+		ctx                  = context.Background()
+		store, tearDownStore = setUpStore(ctx, t)
+	)
+	version, err := store.GetVersion(ctx)
+	require.NoError(t, err)
+	vs, err := semver.Parse(version)
+	require.NoError(t, err)
 }

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -144,8 +144,9 @@ func TestGetVersion(t *testing.T) {
 		ctx                  = context.Background()
 		store, tearDownStore = setUpStore(ctx, t)
 	)
+	defer tearDownStore()
 	version, err := store.GetVersion(ctx)
 	require.NoError(t, err)
-	vs, err := semver.Parse(version)
+	_, err = semver.Parse(version)
 	require.NoError(t, err)
 }

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -6,16 +6,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dpjacques/clockwork"
 	"github.com/google/uuid"
 	"github.com/interuss/dss/pkg/cockroach"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
 	"github.com/interuss/dss/pkg/rid/repos"
 	"github.com/lib/pq"
-	"go.uber.org/zap"
-
-	"github.com/dpjacques/clockwork"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/mod/semver"
 )
 
 var (
@@ -153,13 +153,13 @@ func TestGetVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	// TODO: remove the below checks when we have better schema management
-	require.Equal(t, "2.0.0", version)
+	require.Equal(t, "v2", semver.Major(version))
 
 	_, err = store.Queryable.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS cells_subscriptions (id STRING PRIMARY KEY);`)
 	require.NoError(t, err)
 
 	version, err = store.GetVersion(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "1.0.0", version)
+	require.Equal(t, "v1", semver.Major(version))
 
 }


### PR DESCRIPTION
This is not meant to be a long term solution, but meant to hold until we have a supported schema migration pipeline. 

it also includes with example code of what it should be doing, if we had an external versioning system