### PR TITLE
should always return by id, even if expired

### DIFF
--- a/monitoring/prober/rid/test_isa_expiry.py
+++ b/monitoring/prober/rid/test_isa_expiry.py
@@ -40,11 +40,10 @@ def test_sleep_5_seconds():
   time.sleep(5)
 
 
-def test_not_returned_by_id(session, isa1_uuid):
+def test_returned_by_id(session, isa1_uuid):
   # And we can't get it by ID...
   resp = session.get('/identification_service_areas/{}'.format(isa1_uuid))
-  assert resp.status_code == 404
-  assert resp.json()['message'] == 'resource not found: {}'.format(isa1_uuid)
+  assert resp.status_code == 200
 
 
 def test_not_returned_by_search(session, isa1_uuid):

--- a/pkg/rid/cockroach/identification_service_area.go
+++ b/pkg/rid/cockroach/identification_service_area.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dpjacques/clockwork"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/geo"
 	dssmodels "github.com/interuss/dss/pkg/models"
@@ -26,7 +25,6 @@ const (
 type ISAStore struct {
 	dssql.Queryable
 
-	clock  clockwork.Clock
 	logger *zap.Logger
 }
 
@@ -85,10 +83,8 @@ func (c *ISAStore) GetISA(ctx context.Context, id dssmodels.ID) (*ridmodels.Iden
 		SELECT %s FROM
 			identification_service_areas
 		WHERE
-			id = $1
-		AND
-			ends_at > $2`, isaFields)
-	return c.processOne(ctx, query, id, c.clock.Now())
+			id = $1`, isaFields)
+	return c.processOne(ctx, query, id)
 }
 
 // InsertISA inserts the IdentificationServiceArea identified by "id" and owned

--- a/pkg/rid/cockroach/identification_service_area_test.go
+++ b/pkg/rid/cockroach/identification_service_area_test.go
@@ -187,9 +187,10 @@ func TestStoreExpiredISA(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, serviceAreas, 0)
 
+	// A get should work even if it is expired.
 	ret, err = store.GetISA(ctx, serviceArea.ID)
-	require.Error(t, err)
-	require.Nil(t, ret)
+	require.NoError(t, err)
+	require.NotNil(t, ret)
 }
 
 func TestStoreDeleteISAs(t *testing.T) {

--- a/pkg/rid/cockroach/store.go
+++ b/pkg/rid/cockroach/store.go
@@ -84,7 +84,7 @@ func recoverRollbackRepanic(ctx context.Context, tx *sql.Tx) {
 // NewStore returns a Store instance connected to a cockroach instance via db.
 func NewStore(db *cockroach.DB, logger *zap.Logger) *Store {
 	return &Store{
-		ISA:          &ISAStore{db, DefaultClock, logger},
+		ISA:          &ISAStore{db, logger},
 		Subscription: &SubscriptionStore{db, DefaultClock, logger},
 		db:           db,
 		Queryable:    db,

--- a/pkg/rid/cockroach/store_test.go
+++ b/pkg/rid/cockroach/store_test.go
@@ -47,7 +47,7 @@ func newStore() (*Store, error) {
 		return nil, err
 	}
 	return &Store{
-		ISA:          &ISAStore{Queryable: cdb, clock: fakeClock, logger: zap.L()},
+		ISA:          &ISAStore{Queryable: cdb, logger: zap.L()},
 		Subscription: &SubscriptionStore{Queryable: cdb, clock: fakeClock, logger: zap.L()},
 		db:           cdb,
 		Queryable:    cdb,

--- a/pkg/rid/cockroach/subscriptions.go
+++ b/pkg/rid/cockroach/subscriptions.go
@@ -120,10 +120,8 @@ func (c *SubscriptionStore) GetSubscription(ctx context.Context, id dssmodels.ID
 	// TODO(steeling) we should enforce startTime and endTime to not be null at the DB level.
 	var query = fmt.Sprintf(`
 		SELECT %s FROM subscriptions
-		WHERE id = $1
-		AND
-			ends_at > $2`, subscriptionFields)
-	return c.processOne(ctx, query, id, c.clock.Now())
+		WHERE id = $1`, subscriptionFields)
+	return c.processOne(ctx, query, id)
 }
 
 // UpdateSubscription updates the Subscription.. not yet implemented.

--- a/pkg/rid/cockroach/subscriptions_test.go
+++ b/pkg/rid/cockroach/subscriptions_test.go
@@ -238,8 +238,8 @@ func TestStoreExpiredSubscription(t *testing.T) {
 	require.Len(t, subs, 0)
 
 	ret, err = store.GetSubscription(ctx, sub.ID)
-	require.Nil(t, ret)
-	require.Error(t, err)
+	require.NotNil(t, ret)
+	require.NoError(t, err)
 }
 
 func TestStoreSubscriptionWithNoGeoData(t *testing.T) {


### PR DESCRIPTION
RMW breaks if we don't return by ID when expired.