### PR TITLE
Fix Subscription cells lookup

### DIFF
--- a/monitoring/prober/scd/test_subscription_id_conversion.py
+++ b/monitoring/prober/scd/test_subscription_id_conversion.py
@@ -1,0 +1,39 @@
+"""ID conversion bug exposure
+Reproduces issue #314
+"""
+
+import datetime
+
+def test_put_sub1(scd_session):
+  time_ref = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+  time_start = datetime.datetime(time_ref.year, time_ref.month, time_ref.day, 1, 30)
+  time_end = datetime.datetime(time_ref.year, time_ref.month, time_ref.day, 22, 15)
+  req = {
+    "extents": {
+      "volume": {
+        "outline_polygon": {
+          "vertices": [
+            { "lng": -91.49723052978516, "lat": 41.70085834502109 },
+            { "lng": -91.50341033935547, "lat": 41.6770148220322 },
+            { "lng": -91.47989273071289, "lat": 41.67509157220958 },
+            { "lng": -91.4663314819336, "lat": 41.69329603398001 },
+            { "lng": -91.49723052978516, "lat": 41.70085834502109 }
+          ]
+        },
+        "altitude_upper": {"units": "M", "reference": "W84", "value": 764.79037},
+        "altitude_lower": {"units": "M", "reference": "W84", "value": 23.24352}
+      },
+      "time_start": {"value": time_start.isoformat() + "Z", "format": "RFC3339"},
+      "time_end": {"value": time_end.isoformat() + "Z", "format": "RFC3339"}
+    },
+    "old_version": 0,
+    "uss_base_url": "http://localhost:12012/services/uss/public/uss/v1/",
+    "notify_for_constraints": True
+  }
+  resp = scd_session.put('/subscriptions/b61a6450-db42-4d0d-91f2-7c1334eda399', json=req)
+  assert resp.status_code == 200, resp.content
+
+  req["extents"]["time_start"]["value"] = (time_start + datetime.timedelta(hours=1)).isoformat() + "Z"
+  req["old_version"] = 1
+  resp = scd_session.put('/subscriptions/b61a6450-db42-4d0d-91f2-7c1334eda399', json=req)
+  assert resp.status_code == 200, resp.content

--- a/pkg/scd/store/cockroach/subscriptions.go
+++ b/pkg/scd/store/cockroach/subscriptions.go
@@ -3,7 +3,6 @@ package cockroach
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -71,7 +70,7 @@ func (c *Store) fetchCellsForSubscription(ctx context.Context, q dsssql.Queryabl
 
 	rows, err := q.QueryContext(ctx, cellsQuery, id)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("fetchCellsForSubscription Query error: %s", err))
+		return nil, fmt.Errorf("fetchCellsForSubscription Query error: %s", err)
 	}
 	defer rows.Close()
 
@@ -82,7 +81,7 @@ func (c *Store) fetchCellsForSubscription(ctx context.Context, q dsssql.Queryabl
 	)
 	for rows.Next() {
 		if err := rows.Scan(&cidi); err != nil {
-			return nil, errors.New(fmt.Sprintf("fetchCellsForSubscription row scan error: %s", err))
+			return nil, fmt.Errorf("fetchCellsForSubscription row scan error: %s", err)
 		}
 		cid = s2.CellID(cidi)
 		cu = append(cu, cid)

--- a/pkg/scd/store/cockroach/subscriptions.go
+++ b/pkg/scd/store/cockroach/subscriptions.go
@@ -3,6 +3,7 @@ package cockroach
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -70,18 +71,20 @@ func (c *Store) fetchCellsForSubscription(ctx context.Context, q dsssql.Queryabl
 
 	rows, err := q.QueryContext(ctx, cellsQuery, id)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(fmt.Sprintf("fetchCellsForSubscription Query error: %s", err))
 	}
 	defer rows.Close()
 
 	var (
-		cu  s2.CellUnion
-		cid s2.CellID
+		cu   s2.CellUnion
+		cidi int64
+		cid  s2.CellID
 	)
 	for rows.Next() {
-		if err := rows.Scan(&cid); err != nil {
-			return nil, err
+		if err := rows.Scan(&cidi); err != nil {
+			return nil, errors.New(fmt.Sprintf("fetchCellsForSubscription row scan error: %s", err))
 		}
+		cid = s2.CellID(cidi)
 		cu = append(cu, cid)
 	}
 

--- a/pkg/scd/store/cockroach/subscriptions.go
+++ b/pkg/scd/store/cockroach/subscriptions.go
@@ -77,14 +77,12 @@ func (c *Store) fetchCellsForSubscription(ctx context.Context, q dsssql.Queryabl
 	var (
 		cu   s2.CellUnion
 		cidi int64
-		cid  s2.CellID
 	)
 	for rows.Next() {
 		if err := rows.Scan(&cidi); err != nil {
 			return nil, fmt.Errorf("fetchCellsForSubscription row scan error: %s", err)
 		}
-		cid = s2.CellID(cidi)
-		cu = append(cu, cid)
+		cu = append(cu, s2.CellID(cidi))
 	}
 
 	return cu, rows.Err()


### PR DESCRIPTION
This PR fixes #314 by explicitly casting an int64 from the database to a uint64 before constructing an s2.CellID from it.