### PR TITLE
Use Volume4D in SearchSubscriptions

### DIFF
--- a/monitoring/prober/conftest.py
+++ b/monitoring/prober/conftest.py
@@ -267,6 +267,11 @@ def sub2_uuid():
 
 
 @pytest.fixture(scope='module')
+def sub3_uuid():
+  return str(uuid.uuid4())
+
+
+@pytest.fixture(scope='module')
 def op1_uuid():
   return str(uuid.uuid4())
 

--- a/monitoring/prober/scd/common.py
+++ b/monitoring/prober/scd/common.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Optional, Tuple
 
 
 TIME_FORMAT_CODE = 'RFC3339'
-
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+EARTH_CIRCUMFERENCE_M = 40.075e6
 
 
 
@@ -72,3 +72,7 @@ def iso8601_equal(dts1: str, dts2: str) -> bool:
   dt1 = datetime.fromisoformat(dts1.replace("Z", "+00:00"))
   dt2 = datetime.fromisoformat(dts2.replace("Z", "+00:00"))
   return dt1 == dt2
+
+
+def latitude_degrees(distance_meters: float) -> float:
+  return 360 * distance_meters / EARTH_CIRCUMFERENCE_M

--- a/monitoring/prober/scd/test_subscription_queries.py
+++ b/monitoring/prober/scd/test_subscription_queries.py
@@ -1,0 +1,219 @@
+"""Strategic conflict detection Subscription query tests:
+
+  - add a few Subscriptions spaced in time and footprints
+  - query with various combinations of arguments
+"""
+
+import datetime
+
+from . import common
+
+
+LAT0 = 23
+LNG0 = 56
+
+# This value should be large enough to ensure areas separated by this distance
+# will lie in separate grid cells.
+FOOTPRINT_SPACING_M = 10000
+
+
+def _make_sub1_req():
+  time_start = datetime.datetime.utcnow()
+  time_end = time_start + datetime.timedelta(minutes=60)
+  lat = LAT0 - common.latitude_degrees(FOOTPRINT_SPACING_M)
+  return {
+    "extents": common.make_vol4(time_start, time_end, 0, 300, common.make_circle(lat, LNG0, 100)),
+    "old_version": 0,
+    "uss_base_url": "https://example.com/foo",
+    "notify_for_operations": True,
+    "notify_for_constraints": False
+  }
+
+
+def _make_sub2_req():
+  time_start = datetime.datetime.utcnow() + datetime.timedelta(hours=2)
+  time_end = time_start + datetime.timedelta(minutes=60)
+  return {
+    "extents": common.make_vol4(time_start, time_end, 350, 650, common.make_circle(LAT0, LNG0, 100)),
+    "old_version": 0,
+    "uss_base_url": "https://example.com/foo",
+    "notify_for_operations": True,
+    "notify_for_constraints": False
+  }
+
+
+def _make_sub3_req():
+  time_start = datetime.datetime.utcnow() + datetime.timedelta(hours=4)
+  time_end = time_start + datetime.timedelta(minutes=60)
+  lat = LAT0 + common.latitude_degrees(FOOTPRINT_SPACING_M)
+  return {
+    "extents": common.make_vol4(time_start, time_end, 700, 1000, common.make_circle(lat, LNG0, 100)),
+    "old_version": 0,
+    "uss_base_url": "https://example.com/foo",
+    "notify_for_operations": True,
+    "notify_for_constraints": False
+  }
+
+
+# Preconditions: No named Subscriptions exist
+# Mutations: None
+def test_subs_do_not_exist_get(scd_session, sub1_uuid, sub2_uuid, sub3_uuid):
+  for sub_uuid in (sub1_uuid, sub2_uuid, sub3_uuid):
+    resp = scd_session.get('/subscriptions/{}'.format(sub_uuid))
+    assert resp.status_code == 404, resp.content
+
+
+# Preconditions: No named Subscriptions exist
+# Mutations: None
+def test_subs_do_not_exist_query(scd_session, sub1_uuid, sub2_uuid, sub3_uuid):
+  resp = scd_session.post('/subscriptions/query', json={
+    'area_of_interest': common.make_vol4(None, None, 0, 5000, common.make_circle(LAT0, LNG0, FOOTPRINT_SPACING_M))
+  })
+  assert resp.status_code == 200, resp.content
+  result_ids = [x['id'] for x in resp.json()['subscriptions']]
+  for sub_uuid in (sub1_uuid, sub2_uuid, sub3_uuid):
+    assert sub_uuid not in result_ids
+
+
+# Preconditions: No named Subscriptions exist
+# Mutations: Subscriptions 1, 2, and 3 created
+def test_create_subs(scd_session, sub1_uuid, sub2_uuid, sub3_uuid):
+  resp = scd_session.put('/subscriptions/{}'.format(sub1_uuid), json=_make_sub1_req())
+  assert resp.status_code == 200, resp.content
+
+  resp = scd_session.put('/subscriptions/{}'.format(sub2_uuid), json=_make_sub2_req())
+  assert resp.status_code == 200, resp.content
+
+  resp = scd_session.put('/subscriptions/{}'.format(sub3_uuid), json=_make_sub3_req())
+  assert resp.status_code == 200, resp.content
+
+
+# Preconditions: Subscriptions 1, 2, and 3 created
+# Mutations: None
+def test_search_find_all_subs(scd_session, sub1_uuid, sub2_uuid, sub3_uuid):
+  resp = scd_session.post(
+      '/subscriptions/query',
+      json={
+        "area_of_interest": common.make_vol4(None, None, 0, 3000,
+                                             common.make_circle(LAT0, LNG0, FOOTPRINT_SPACING_M))
+      })
+  assert resp.status_code == 200, resp.content
+  result_ids = [x['id'] for x in resp.json()['subscriptions']]
+  for sub_uuid in (sub1_uuid, sub2_uuid, sub3_uuid):
+    assert sub_uuid in result_ids
+
+
+# Preconditions: Subscriptions 1, 2, and 3 created
+# Mutations: None
+def test_search_footprint(scd_session, sub1_uuid, sub2_uuid, sub3_uuid):
+  lat = LAT0 - common.latitude_degrees(FOOTPRINT_SPACING_M)
+  print(lat)
+  resp = scd_session.post(
+    '/subscriptions/query',
+    json={
+      "area_of_interest": common.make_vol4(None, None, 0, 3000,
+                                           common.make_circle(lat, LNG0, 50))
+    })
+  assert resp.status_code == 200, resp.content
+  result_ids = [x['id'] for x in resp.json()['subscriptions']]
+  assert sub1_uuid in result_ids
+  assert sub2_uuid not in result_ids
+  assert sub3_uuid not in result_ids
+
+  resp = scd_session.post(
+    '/subscriptions/query',
+    json={
+      "area_of_interest": common.make_vol4(None, None, 0, 3000,
+                                           common.make_circle(LAT0, LNG0, 50))
+    })
+  assert resp.status_code == 200, resp.content
+  result_ids = [x['id'] for x in resp.json()['subscriptions']]
+  assert sub1_uuid not in result_ids
+  assert sub2_uuid in result_ids
+  assert sub3_uuid not in result_ids
+
+
+# Preconditions: Subscriptions 1, 2, and 3 created
+# Mutations: None
+def test_search_time(scd_session, sub1_uuid, sub2_uuid, sub3_uuid):
+  time_start = datetime.datetime.utcnow()
+  time_end = time_start + datetime.timedelta(minutes=1)
+
+  resp = scd_session.post(
+    '/subscriptions/query',
+    json={
+      "area_of_interest": common.make_vol4(time_start, time_end, 0, 3000,
+                                           common.make_circle(LAT0, LNG0, FOOTPRINT_SPACING_M))
+    })
+  assert resp.status_code == 200, resp.content
+  result_ids = [x['id'] for x in resp.json()['subscriptions']]
+  assert sub1_uuid in result_ids
+  assert sub2_uuid not in result_ids
+  assert sub3_uuid not in result_ids
+
+  resp = scd_session.post(
+    '/subscriptions/query',
+    json={
+      "area_of_interest": common.make_vol4(None, time_end, 0, 3000,
+                                           common.make_circle(LAT0, LNG0, FOOTPRINT_SPACING_M))
+    })
+  assert resp.status_code == 200, resp.content
+  result_ids = [x['id'] for x in resp.json()['subscriptions']]
+  assert sub1_uuid in result_ids
+  assert sub2_uuid not in result_ids
+  assert sub3_uuid not in result_ids
+
+  time_start = datetime.datetime.utcnow() + datetime.timedelta(hours=4)
+  time_end = time_start + datetime.timedelta(minutes=1)
+
+  resp = scd_session.post(
+    '/subscriptions/query',
+    json={
+      "area_of_interest": common.make_vol4(time_start, time_end, 0, 3000,
+                                           common.make_circle(LAT0, LNG0, FOOTPRINT_SPACING_M))
+    })
+  assert resp.status_code == 200, resp.content
+  result_ids = [x['id'] for x in resp.json()['subscriptions']]
+  assert sub1_uuid not in result_ids
+  assert sub2_uuid not in result_ids
+  assert sub3_uuid in result_ids
+
+  resp = scd_session.post(
+    '/subscriptions/query',
+    json={
+      "area_of_interest": common.make_vol4(time_start, None, 0, 3000,
+                                           common.make_circle(LAT0, LNG0, FOOTPRINT_SPACING_M))
+    })
+  assert resp.status_code == 200, resp.content
+  result_ids = [x['id'] for x in resp.json()['subscriptions']]
+  assert sub1_uuid not in result_ids
+  assert sub2_uuid not in result_ids
+  assert sub3_uuid in result_ids
+
+
+# Preconditions: Subscriptions 1, 2, and 3 created
+# Mutations: None
+def test_search_time_footprint(scd_session, sub1_uuid, sub2_uuid, sub3_uuid):
+  time_start = datetime.datetime.utcnow()
+  time_end = time_start + datetime.timedelta(hours=2.5)
+  lat = LAT0 + common.latitude_degrees(FOOTPRINT_SPACING_M)
+  resp = scd_session.post(
+    '/subscriptions/query',
+    json={
+      "area_of_interest": common.make_vol4(time_start, time_end, 0, 3000,
+                                           common.make_circle(lat, LNG0, FOOTPRINT_SPACING_M))
+    })
+  assert resp.status_code == 200, resp.content
+  result_ids = [x['id'] for x in resp.json()['subscriptions']]
+  assert sub1_uuid not in result_ids
+  assert sub2_uuid in result_ids
+  assert sub3_uuid not in result_ids
+
+
+
+# Preconditions: Subscriptions 1, 2, and 3 created
+# Mutations: Subscriptions 1, 2, and 3 deleted
+def test_delete_subs(scd_session, sub1_uuid, sub2_uuid, sub3_uuid):
+  for sub_uuid in (sub1_uuid, sub2_uuid, sub3_uuid):
+    resp = scd_session.delete('/subscriptions/{}'.format(sub_uuid))
+    assert resp.status_code == 200, resp.content

--- a/pkg/scd/store/store.go
+++ b/pkg/scd/store/store.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/golang/geo/s2"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 )
@@ -31,8 +30,8 @@ type OperationStore interface {
 
 // SubscriptionStore abstracts subscription-specific interactions with the backing data store.
 type SubscriptionStore interface {
-	// SearchSubscriptions returns all Subscriptions owned by "owner" in "cells".
-	SearchSubscriptions(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) ([]*scdmodels.Subscription, error)
+	// SearchSubscriptions returns all Subscriptions in "v4d".
+	SearchSubscriptions(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error)
 
 	// GetSubscription returns the Subscription referenced by id, or nil if the
 	// Subscription doesn't exist


### PR DESCRIPTION
This PR changes SearchSubscriptions to accept a Volume4D rather than a simple set of cells and owner.  This is done to move toward simpler Store operations that don't embed application logic (like checking the owner of Subscriptions) and therefore can be more easily combined into application-level operations and more easily mocked (while still testing all application logic).

A suite of Subscription query integration tests are added to verify functionality, and they also revealed an incorrect SQL query that has been corrected.