### PR TITLE
Fix SCD test

### DIFF
--- a/monitoring/prober/scd/test_operation_special_cases.py
+++ b/monitoring/prober/scd/test_operation_special_cases.py
@@ -8,9 +8,7 @@
   - delete
 """
 
-import datetime
 import json
-import os
 
 from . import common
 
@@ -18,7 +16,6 @@ from . import common
 # Preconditions: None
 # Mutations: None
 def test_op_request_1(scd_session):
-  print(os.getcwd())
   with open('./scd/resources/op_request_1.json', 'r') as f:
     req = json.load(f)
   resp = scd_session.put('/operation_references/2df6b920-b6ee-4082-b6e7-75eb4fde25d1', json=req)

--- a/pkg/scd/operations_handler.go
+++ b/pkg/scd/operations_handler.go
@@ -41,9 +41,6 @@ func (a *Server) DeleteOperationReference(ctx context.Context, req *scdpb.Delete
 		if op == nil {
 			return dsserr.Internal(fmt.Sprintf("DeleteOperation returned no Operation for ID: %s", id))
 		}
-		if subs == nil {
-			return dsserr.Internal(fmt.Sprintf("DeleteOperation returned nil Subscriptions for ID: %s", id))
-		}
 
 		// Convert deleted Operation to proto
 		opProto, err := op.ToProto()

--- a/pkg/scd/store/cockroach/operations.go
+++ b/pkg/scd/store/cockroach/operations.go
@@ -105,10 +105,8 @@ func (s *Store) fetchOperationByID(ctx context.Context, q dsssql.Queryable, id s
 		SELECT %s FROM
 			scd_operations
 		WHERE
-			id = $1
-		AND
-			ends_at >= $2`, operationFieldsWithoutPrefix)
-	return s.fetchOperation(ctx, q, query, id, s.clock.Now())
+			id = $1`, operationFieldsWithoutPrefix)
+	return s.fetchOperation(ctx, q, query, id)
 }
 
 // pushOperation creates/updates the Operation identified by "id" and owned by
@@ -397,9 +395,7 @@ func (s *Store) searchOperations(ctx context.Context, q dsssql.Queryable, v4d *d
 			AND
 				COALESCE(scd_operations.ends_at >= $4, true)
 			AND
-				COALESCE(scd_operations.starts_at <= $5, true)
-			AND
-				scd_operations.ends_at >= $6`, operationFieldsWithPrefix)
+				COALESCE(scd_operations.starts_at <= $5, true)`, operationFieldsWithPrefix)
 	)
 
 	if v4d.SpatialVolume == nil || v4d.SpatialVolume.Footprint == nil {
@@ -425,7 +421,6 @@ func (s *Store) searchOperations(ctx context.Context, q dsssql.Queryable, v4d *d
 		v4d.SpatialVolume.AltitudeHi,
 		v4d.StartTime,
 		v4d.EndTime,
-		s.clock.Now(),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
An SCD test started failing on master despite passing at merge time because a time was hardcoded into a test resource (based on an error report submitted by a user).  This caused an Operation to be created in the past, which may be acceptable in SCD.  However, when the system went to look up the implicit Subscription created for that Operation, it did not appear in the query because of the real-time constraint.  The PR fixes the test by removing the real-time constraint and adds a TODO to improve logic in a future PR.  It also fixes a latent bug where deleting a lone Operation may result in a 500.