### PR TITLE
Add easy scope specification to integration test suite

### DIFF
--- a/monitoring/prober/conftest.py
+++ b/monitoring/prober/conftest.py
@@ -1,152 +1,9 @@
 import copy
-import requests
-import urllib.parse
 import uuid
-from typing import Dict, List
 
-from google.auth.transport import requests as google_requests
-from google.oauth2 import service_account
+from . import infrastructure
+
 import pytest
-
-ALL_SCOPES = [
-    'dss.write.identification_service_areas',
-    'dss.read.identification_service_areas',
-    'utm.strategic_coordination',
-    'utm.constraint_management',
-    'utm.constraint_consumption'
-]
-
-
-class AuthAdapter(object):
-  """Base class for an adapter that add JWTs to requests."""
-
-  def __init__(self):
-    self._tokens = {}
-
-  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
-    """Subclasses must return a bearer token for the given audience."""
-
-    raise NotImplementedError()
-
-  def get_headers(self, url: str, scopes: List[str] = None) -> Dict[str, str]:
-    if scopes is None:
-      scopes = ALL_SCOPES
-    intended_audience = urllib.parse.urlparse(url).hostname
-    scope_string = ' '.join(scopes)
-    if intended_audience not in self._tokens:
-      self._tokens[intended_audience] = {}
-    if scope_string not in self._tokens[intended_audience]:
-      self._tokens[intended_audience][scope_string] = self.issue_token(intended_audience, scopes)
-    token = self._tokens[intended_audience][scope_string]
-    return {'Authorization': 'Bearer ' + token}
-
-  def add_headers(self, request: requests.PreparedRequest, scopes: List[str]):
-    for k, v in self.get_headers(request.url, scopes).items():
-      request.headers[k] = v
-
-
-class DummyOAuthServerAdapter(AuthAdapter):
-  """Auth adapter that gets JWTs that uses the Dummy OAuth Server"""
-
-  def __init__(self, token_endpoint: str, sub: str):
-    super().__init__()
-
-    self._oauth_token_endpoint = token_endpoint
-    self._sub = sub
-    self._oauth_session = requests.Session()
-
-  # Overrides method in AuthAdapter
-  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
-    url = '{}?grant_type=client_credentials&scope={}&intended_audience={}&issuer=dummy&sub={}'.format(
-        self._oauth_token_endpoint, urllib.parse.quote(' '.join(scopes)),
-        urllib.parse.quote(intended_audience), self._sub)
-    response = self._oauth_session.post(url).json()
-    return response['access_token']
-
-class ServiceAccountAuthAdapter(AuthAdapter):
-  """Auth adapter that gets JWTs using a service account."""
-
-  def __init__(self, token_endpoint, service_account_json):
-    super().__init__()
-
-    credentials = service_account.Credentials.from_service_account_file(
-        service_account_json).with_scopes(['email'])
-    oauth_session = google_requests.AuthorizedSession(credentials)
-
-    self._oauth_token_endpoint = token_endpoint
-    self._oauth_session = oauth_session
-
-  # Overrides method in AuthAdapter
-  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
-    url = '{}?grant_type=client_credentials&scope={}&intended_audience={}'.format(
-        self._oauth_token_endpoint, urllib.parse.quote(' '.join(scopes)),
-        urllib.parse.quote(intended_audience))
-    response = self._oauth_session.post(url).json()
-    return response['access_token']
-
-
-class UsernamePasswordAuthAdapter(AuthAdapter):
-  """Auth adapter that gets JWTs using a username and password."""
-
-  def __init__(self, token_endpoint, username, password, client_id):
-    super().__init__()
-
-    self._oauth_token_endpoint = token_endpoint
-    self._username = username
-    self._password = password
-    self._client_id = client_id
-
-  # Overrides method in AuthAdapter
-  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
-    scopes.append('aud:{}'.format(intended_audience))
-    response = requests.post(self._oauth_token_endpoint, data={
-      'grant_type': "password",
-      'username': self._username,
-      'password': self._password,
-      'client_id': self._client_id,
-      'scope': ' '.join(scopes),
-    }).json()
-    return response['access_token']
-
-
-class DSSTestSession(requests.Session):
-  """
-  Requests session that provides additional functionality for DSS tests:
-    * Adds a prefix to URLs that start with a '/'.
-    * Automatically applies authorization according to adapter, when present
-  """
-
-  def __init__(self, prefix_url: str, auth_adapter: AuthAdapter = None):
-    super().__init__()
-
-    self._prefix_url = prefix_url
-    self._auth_adapter = auth_adapter
-
-  # Overrides method on requests.Session
-  def prepare_request(self, request, **kwargs):
-    # Automatically prefix any unprefixed URLs
-    if request.url.startswith('/'):
-      request.url = self._prefix_url + request.url
-
-    return super().prepare_request(request, **kwargs)
-
-  def request(self, method, url, **kwargs):
-    if 'auth' not in kwargs and self._auth_adapter:
-      scopes = None
-      if 'scopes' in kwargs:
-        scopes = kwargs['scopes']
-        del kwargs['scopes']
-      if 'scope' in kwargs:
-        scopes = [kwargs['scope']]
-        del kwargs['scope']
-      if scopes is None:
-        scopes = ALL_SCOPES
-      def auth(prepared_request: requests.PreparedRequest) -> requests.PreparedRequest:
-        self._auth_adapter.add_headers(prepared_request, scopes)
-        return prepared_request
-      kwargs['auth'] = auth
-
-    return super().request(method, url, **kwargs)
 
 
 def pytest_addoption(parser):
@@ -176,15 +33,17 @@ def make_auth_adapter(pytestconfig, prefix: str, dummy_oauth_sub: str):
   # Create an auth adapter to get JWTs using the given credentials.  We can use
   # either a service account, a username/password/client_id or a dummy oauth server.
   if pytestconfig.getoption(prefix + '_service_account_json') is not None:
-    auth_adapter = ServiceAccountAuthAdapter(oauth_token_endpoint,
-                                             pytestconfig.getoption(prefix + '_service_account_json'))
+    auth_adapter = infrastructure.ServiceAccountAuthAdapter(
+        oauth_token_endpoint,
+        pytestconfig.getoption(prefix + '_service_account_json'))
   elif pytestconfig.getoption(prefix + '_username') is not None:
-    auth_adapter = UsernamePasswordAuthAdapter(oauth_token_endpoint,
-                                               pytestconfig.getoption(prefix + '_username'),
-                                               pytestconfig.getoption(prefix + '_password'),
-                                               pytestconfig.getoption(prefix + '_client_id'))
+    auth_adapter = infrastructure.UsernamePasswordAuthAdapter(
+        oauth_token_endpoint,
+        pytestconfig.getoption(prefix + '_username'),
+        pytestconfig.getoption(prefix + '_password'),
+        pytestconfig.getoption(prefix + '_client_id'))
   elif pytestconfig.getoption('use_dummy_oauth') is not None:
-    auth_adapter = DummyOAuthServerAdapter(oauth_token_endpoint, dummy_oauth_sub)
+    auth_adapter = infrastructure.DummyOAuthServerAdapter(oauth_token_endpoint, dummy_oauth_sub)
   else:
     raise ValueError(
       'You must provide either an OAuth service account, or a username, '
@@ -201,7 +60,7 @@ def session(pytestconfig):
   api_version_role = pytestconfig.getoption('api_version_role', '')
 
   auth_adapter = make_auth_adapter(pytestconfig, 'oauth', 'fake_uss')
-  s = DSSTestSession(dss_endpoint + api_version_role, auth_adapter)
+  s = infrastructure.DSSTestSession(dss_endpoint + api_version_role, auth_adapter)
   return s
 
 
@@ -212,7 +71,7 @@ def scd_session(pytestconfig):
     return None
 
   auth_adapter = make_auth_adapter(pytestconfig, 'oauth', 'fake_uss')
-  s = DSSTestSession(scd_dss_endpoint, auth_adapter)
+  s = infrastructure.DSSTestSession(scd_dss_endpoint, auth_adapter)
   return s
 
 
@@ -223,7 +82,7 @@ def scd_session2(pytestconfig):
     return None
 
   auth_adapter = make_auth_adapter(pytestconfig, 'oauth', 'fake_uss2')
-  s = DSSTestSession(scd_dss_endpoint, auth_adapter)
+  s = infrastructure.DSSTestSession(scd_dss_endpoint, auth_adapter)
   return s
 
 
@@ -234,7 +93,7 @@ def no_auth_session(pytestconfig):
   if dss_endpoint is None:
     raise ValueError('Missing required --dss-endpoint')
 
-  s = DSSTestSession(dss_endpoint + api_version_role, None)
+  s = infrastructure.DSSTestSession(dss_endpoint + api_version_role, None)
   return s
 
 

--- a/monitoring/prober/conftest.py
+++ b/monitoring/prober/conftest.py
@@ -228,7 +228,7 @@ def scd_session2(pytestconfig):
 
 
 @pytest.fixture(scope='function')
-def rogue_session(pytestconfig):
+def no_auth_session(pytestconfig):
   dss_endpoint = pytestconfig.getoption('dss_endpoint')
   api_version_role = pytestconfig.getoption('api_version_role', '')
   if dss_endpoint is None:

--- a/monitoring/prober/conftest.py
+++ b/monitoring/prober/conftest.py
@@ -2,7 +2,6 @@ import copy
 import requests
 import urllib.parse
 import uuid
-import traceback
 from typing import Dict, List
 
 from google.auth.transport import requests as google_requests
@@ -148,10 +147,6 @@ class DSSTestSession(requests.Session):
       kwargs['auth'] = auth
 
     return super().request(method, url, **kwargs)
-
-  def issue_token(self, scopes):
-    intended_audience = urllib.parse.urlparse(self._prefix_url).hostname
-    return self._auth_adapter.issue_token(intended_audience, scopes)
 
 
 def pytest_addoption(parser):

--- a/monitoring/prober/infrastructure.py
+++ b/monitoring/prober/infrastructure.py
@@ -1,0 +1,204 @@
+import functools
+import requests
+from typing import Dict, List
+import urllib.parse
+
+from google.auth.transport import requests as google_requests
+from google.oauth2 import service_account
+
+ALL_SCOPES = [
+  'dss.write.identification_service_areas',
+  'dss.read.identification_service_areas',
+  'utm.strategic_coordination',
+  'utm.constraint_management',
+  'utm.constraint_consumption'
+]
+
+
+class AuthAdapter(object):
+  """Base class for an adapter that add JWTs to requests."""
+
+  def __init__(self):
+    self._tokens = {}
+
+  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
+    """Subclasses must return a bearer token for the given audience."""
+
+    raise NotImplementedError()
+
+  def get_headers(self, url: str, scopes: List[str] = None) -> Dict[str, str]:
+    if scopes is None:
+      scopes = ALL_SCOPES
+    intended_audience = urllib.parse.urlparse(url).hostname
+    scope_string = ' '.join(scopes)
+    if intended_audience not in self._tokens:
+      self._tokens[intended_audience] = {}
+    if scope_string not in self._tokens[intended_audience]:
+      self._tokens[intended_audience][scope_string] = self.issue_token(intended_audience, scopes)
+    token = self._tokens[intended_audience][scope_string]
+    return {'Authorization': 'Bearer ' + token}
+
+  def add_headers(self, request: requests.PreparedRequest, scopes: List[str]):
+    for k, v in self.get_headers(request.url, scopes).items():
+      request.headers[k] = v
+
+
+class DummyOAuthServerAdapter(AuthAdapter):
+  """Auth adapter that gets JWTs that uses the Dummy OAuth Server"""
+
+  def __init__(self, token_endpoint: str, sub: str):
+    super().__init__()
+
+    self._oauth_token_endpoint = token_endpoint
+    self._sub = sub
+    self._oauth_session = requests.Session()
+
+  # Overrides method in AuthAdapter
+  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
+    url = '{}?grant_type=client_credentials&scope={}&intended_audience={}&issuer=dummy&sub={}'.format(
+      self._oauth_token_endpoint, urllib.parse.quote(' '.join(scopes)),
+      urllib.parse.quote(intended_audience), self._sub)
+    response = self._oauth_session.post(url).json()
+    return response['access_token']
+
+class ServiceAccountAuthAdapter(AuthAdapter):
+  """Auth adapter that gets JWTs using a service account."""
+
+  def __init__(self, token_endpoint, service_account_json):
+    super().__init__()
+
+    credentials = service_account.Credentials.from_service_account_file(
+      service_account_json).with_scopes(['email'])
+    oauth_session = google_requests.AuthorizedSession(credentials)
+
+    self._oauth_token_endpoint = token_endpoint
+    self._oauth_session = oauth_session
+
+  # Overrides method in AuthAdapter
+  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
+    url = '{}?grant_type=client_credentials&scope={}&intended_audience={}'.format(
+      self._oauth_token_endpoint, urllib.parse.quote(' '.join(scopes)),
+      urllib.parse.quote(intended_audience))
+    response = self._oauth_session.post(url).json()
+    return response['access_token']
+
+
+class UsernamePasswordAuthAdapter(AuthAdapter):
+  """Auth adapter that gets JWTs using a username and password."""
+
+  def __init__(self, token_endpoint, username, password, client_id):
+    super().__init__()
+
+    self._oauth_token_endpoint = token_endpoint
+    self._username = username
+    self._password = password
+    self._client_id = client_id
+
+  # Overrides method in AuthAdapter
+  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
+    scopes.append('aud:{}'.format(intended_audience))
+    response = requests.post(self._oauth_token_endpoint, data={
+      'grant_type': "password",
+      'username': self._username,
+      'password': self._password,
+      'client_id': self._client_id,
+      'scope': ' '.join(scopes),
+    }).json()
+    return response['access_token']
+
+
+class DSSTestSession(requests.Session):
+  """
+  Requests session that provides additional functionality for DSS tests:
+    * Adds a prefix to URLs that start with a '/'.
+    * Automatically applies authorization according to adapter, when present
+  """
+
+  def __init__(self, prefix_url: str, auth_adapter: AuthAdapter = None):
+    super().__init__()
+
+    self._prefix_url = prefix_url
+    self._auth_adapter = auth_adapter
+    self.default_scopes = ALL_SCOPES
+
+  # Overrides method on requests.Session
+  def prepare_request(self, request, **kwargs):
+    # Automatically prefix any unprefixed URLs
+    if request.url.startswith('/'):
+      request.url = self._prefix_url + request.url
+
+    return super().prepare_request(request, **kwargs)
+
+  def request(self, method, url, **kwargs):
+    if 'auth' not in kwargs and self._auth_adapter:
+      scopes = None
+      if 'scopes' in kwargs:
+        scopes = kwargs['scopes']
+        del kwargs['scopes']
+      if 'scope' in kwargs:
+        scopes = [kwargs['scope']]
+        del kwargs['scope']
+      if scopes is None:
+        scopes = self.default_scopes
+      def auth(prepared_request: requests.PreparedRequest) -> requests.PreparedRequest:
+        self._auth_adapter.add_headers(prepared_request, scopes)
+        return prepared_request
+      kwargs['auth'] = auth
+
+    return super().request(method, url, **kwargs)
+
+
+def default_scopes(scopes: List[str]):
+  """Decorator for tests that modifies DSSTestSession args to use scopes.
+
+  A test function decorated with this decorator will modify all arguments which
+  are DSSTestSessions to set their default_scopes to the scopes specified in
+  this decorator (and restore the original default_scopes afterward).
+
+  :param scopes: List of scopes to retrieve (by default) for tokens used to
+    authorize requests sent using any of the DSSTestSession arguments to the
+    decorated test.
+  """
+  def decorator_default_scope(func):
+    @functools.wraps(func)
+    def wrapper_default_scope(*args, **kwargs):
+      # Change <DSSTestSession>.default_scopes to scopes for all DSSTestSession arguments
+      old_scopes = []
+      for arg in args:
+        if isinstance(arg, DSSTestSession):
+          old_scopes.append(arg.default_scopes)
+          arg.default_scopes = scopes
+      for k, v in kwargs.items():
+        if isinstance(v, DSSTestSession):
+          old_scopes.append(v.default_scopes)
+          v.default_scopes = scopes
+
+      result = func(*args, **kwargs)
+
+      # Restore original values of <DSSTestSession>.default_scopes for all DSSTestSession arguments
+      for arg in args:
+        if isinstance(arg, DSSTestSession):
+          arg.default_scopes = old_scopes[0]
+          old_scopes = old_scopes[1:]
+      for k, v in kwargs.items():
+        if isinstance(v, DSSTestSession):
+          v.default_scopes = old_scopes[0]
+          old_scopes = old_scopes[1:]
+
+      return result
+    return wrapper_default_scope
+  return decorator_default_scope
+
+
+def default_scope(scope: str):
+  """Decorator for tests that modifies DSSTestSession args to use a scope.
+
+    A test function decorated with this decorator will modify all arguments which
+    are DSSTestSessions to set their default_scopes to the scope specified in
+    this decorator (and restore the original default_scopes afterward).
+
+    :param scopes: Single scope to retrieve (by default) for tokens used to
+      authorize requests sent using any of the DSSTestSession arguments to the
+      decorated test.
+    """
+  return default_scopes([scope])

--- a/monitoring/prober/rid/common.py
+++ b/monitoring/prober/rid/common.py
@@ -4,6 +4,9 @@ MAX_SUB_TIME_HRS = 24
 
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
+SCOPE_READ = 'dss.read.identification_service_areas'
+SCOPE_WRITE = 'dss.write.identification_service_areas'
+
 VERTICES = [
     {
         'lng': 130.6205,

--- a/monitoring/prober/rid/test_token_validation.py
+++ b/monitoring/prober/rid/test_token_validation.py
@@ -25,14 +25,11 @@ def test_validate_token_bad_user(session):
   resp = session.get('/validate_oauth?owner=bad_user')
   assert resp.status_code == 403
 
-def test_put_isa_with_read_only_scope_token(rogue_session, session, isa2_uuid):
-  read_only_token = session.issue_token(['dss.read.identification_service_areas'])
-  rogue_session.headers['Authorization'] = f'Bearer {read_only_token}'
-
+def test_put_isa_with_read_only_scope_token(session, isa2_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
 
-  resp = rogue_session.put(
+  resp = session.put(
       '/identification_service_areas/{}'.format(isa2_uuid),
       json={
           'extents': {
@@ -47,7 +44,7 @@ def test_put_isa_with_read_only_scope_token(rogue_session, session, isa2_uuid):
               'time_end': time_end.strftime(common.DATE_FORMAT),
           },
           'flights_url': 'https://example.com/dss',
-      })
+      }, scope='dss.read.identification_service_areas')
   assert resp.status_code == 403
 
 
@@ -87,8 +84,8 @@ def test_get_isa_with_fake_token(rogue_session, isa1_uuid):
   assert resp.json()['message'] == 'token contains an invalid number of segments'
 
 
-def test_get_isa_without_scope(rogue_session, session, isa1_uuid):
-  no_scope_token = session.issue_token([])
-  rogue_session.headers['Authorization'] = f'Bearer {no_scope_token}'
-  resp = rogue_session.get('/identification_service_areas/{}'.format(isa1_uuid))
+def test_get_isa_without_scope(session, isa1_uuid):
+  # TODO: A real OAuth server is unlikely to grant tokens without any scopes.
+  # Adapt this test to work on a real OAuth server, or remove.
+  resp = session.get('/identification_service_areas/{}'.format(isa1_uuid), scope='')
   assert resp.status_code == 403

--- a/monitoring/prober/rid/test_token_validation.py
+++ b/monitoring/prober/rid/test_token_validation.py
@@ -71,15 +71,15 @@ def test_create_isa(session, isa1_uuid):
   assert resp.status_code == 200
 
 
-def test_get_isa_without_token(rogue_session, isa1_uuid):
-  resp = rogue_session.get('/identification_service_areas/{}'.format(isa1_uuid))
+def test_get_isa_without_token(no_auth_session, isa1_uuid):
+  resp = no_auth_session.get('/identification_service_areas/{}'.format(isa1_uuid))
   assert resp.status_code == 401
   assert resp.json()['message'] == 'missing token'
 
 
-def test_get_isa_with_fake_token(rogue_session, isa1_uuid):
-  rogue_session.headers['Authorization'] = 'Bearer fake_token'
-  resp = rogue_session.get('/identification_service_areas/{}'.format(isa1_uuid))
+def test_get_isa_with_fake_token(no_auth_session, isa1_uuid):
+  no_auth_session.headers['Authorization'] = 'Bearer fake_token'
+  resp = no_auth_session.get('/identification_service_areas/{}'.format(isa1_uuid))
   assert resp.status_code == 401
   assert resp.json()['message'] == 'token contains an invalid number of segments'
 

--- a/monitoring/prober/rid/test_token_validation.py
+++ b/monitoring/prober/rid/test_token_validation.py
@@ -44,7 +44,7 @@ def test_put_isa_with_read_only_scope_token(session, isa2_uuid):
               'time_end': time_end.strftime(common.DATE_FORMAT),
           },
           'flights_url': 'https://example.com/dss',
-      }, scope='dss.read.identification_service_areas')
+      }, scope=common.SCOPE_READ)
   assert resp.status_code == 403
 
 

--- a/monitoring/prober/scd/common.py
+++ b/monitoring/prober/scd/common.py
@@ -5,7 +5,9 @@ from typing import Dict, List, Optional, Tuple
 TIME_FORMAT_CODE = 'RFC3339'
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 EARTH_CIRCUMFERENCE_M = 40.075e6
-
+SCOPE_SC = 'utm.strategic_coordination'
+SCOPE_CM = 'utm.constraint_management'
+SCOPE_CI = 'utm.constraint_ingestion'
 
 
 def make_vol4(

--- a/monitoring/prober/scd/common.py
+++ b/monitoring/prober/scd/common.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import functools
 from typing import Dict, List, Optional, Tuple
 
 

--- a/monitoring/prober/scd/test_operation_simple.py
+++ b/monitoring/prober/scd/test_operation_simple.py
@@ -31,7 +31,7 @@ def _make_op1_request():
 # Preconditions: None
 # Mutations: None
 def test_op_does_not_exist_get(scd_session, op1_uuid):
-  resp = scd_session.get('/operation_references/{}'.format(op1_uuid))
+  resp = scd_session.get('/operation_references/{}'.format(op1_uuid), scope=common.SCOPE_SC)
   assert resp.status_code == 404, resp.content
 
 

--- a/monitoring/prober/scd/test_operation_simple.py
+++ b/monitoring/prober/scd/test_operation_simple.py
@@ -10,7 +10,9 @@
 
 import datetime
 
+from ..infrastructure import default_scope
 from . import common
+from .common import SCOPE_SC, SCOPE_CI, SCOPE_CM
 
 
 def _make_op1_request():
@@ -30,8 +32,9 @@ def _make_op1_request():
 
 # Preconditions: None
 # Mutations: None
+@default_scope(SCOPE_SC)
 def test_op_does_not_exist_get(scd_session, op1_uuid):
-  resp = scd_session.get('/operation_references/{}'.format(op1_uuid), scope=common.SCOPE_SC)
+  resp = scd_session.get('/operation_references/{}'.format(op1_uuid))
   assert resp.status_code == 404, resp.content
 
 
@@ -43,13 +46,24 @@ def test_op_does_not_exist_query(scd_session, op1_uuid):
   time_now = datetime.datetime.utcnow()
   resp = scd_session.post('/operation_references/query', json={
     'area_of_interest': common.make_vol4(time_now, time_now, 0, 5000, common.make_circle(-56, 178, 300))
-  })
+  }, scope=SCOPE_SC)
   assert resp.status_code == 200, resp.content
   assert op1_uuid not in [op['id'] for op in resp.json().get('operation_references', [])]
+
+  resp = scd_session.post('/operation_references/query', json={
+    'area_of_interest': common.make_vol4(time_now, time_now, 0, 5000, common.make_circle(-56, 178, 300))
+  }, scope=SCOPE_CI)
+  assert resp.status_code == 403, resp.content
+
+  resp = scd_session.post('/operation_references/query', json={
+    'area_of_interest': common.make_vol4(time_now, time_now, 0, 5000, common.make_circle(-56, 178, 300))
+  }, scope=SCOPE_CM)
+  assert resp.status_code == 403, resp.content
 
 
 # Preconditions: None
 # Mutations: None
+@default_scope(SCOPE_SC)
 def test_create_op_single_extent(scd_session, op1_uuid):
   req = _make_op1_request()
   req['extents'] = req['extents'][0]
@@ -59,6 +73,7 @@ def test_create_op_single_extent(scd_session, op1_uuid):
 
 # Preconditions: None
 # Mutations: None
+@default_scope(SCOPE_SC)
 def test_create_op_missing_time_start(scd_session, op1_uuid):
   req = _make_op1_request()
   del req['extents'][0]['time_start']
@@ -68,6 +83,7 @@ def test_create_op_missing_time_start(scd_session, op1_uuid):
 
 # Preconditions: None
 # Mutations: None
+@default_scope(SCOPE_SC)
 def test_create_op_missing_time_end(scd_session, op1_uuid):
   req = _make_op1_request()
   del req['extents'][0]['time_end']
@@ -79,7 +95,14 @@ def test_create_op_missing_time_end(scd_session, op1_uuid):
 # Mutations: Operation op1_uuid created by scd_session user
 def test_create_op(scd_session, op1_uuid):
   req = _make_op1_request()
-  resp = scd_session.put('/operation_references/{}'.format(op1_uuid), json=req)
+
+  resp = scd_session.put('/operation_references/{}'.format(op1_uuid), json=req, scope=SCOPE_CI)
+  assert resp.status_code == 403, resp.content
+
+  resp = scd_session.put('/operation_references/{}'.format(op1_uuid), json=req, scope=SCOPE_CM)
+  assert resp.status_code == 403, resp.content
+
+  resp = scd_session.put('/operation_references/{}'.format(op1_uuid), json=req, scope=SCOPE_SC)
   assert resp.status_code == 200, resp.content
 
   data = resp.json()
@@ -96,7 +119,13 @@ def test_create_op(scd_session, op1_uuid):
 # Preconditions: Operation op1_uuid created by scd_session user
 # Mutations: None
 def test_get_op_by_id(scd_session, op1_uuid):
-  resp = scd_session.get('/operation_references/{}'.format(op1_uuid))
+  resp = scd_session.get('/operation_references/{}'.format(op1_uuid), scope=SCOPE_CI)
+  assert resp.status_code == 403, resp.content
+
+  resp = scd_session.get('/operation_references/{}'.format(op1_uuid), scope=SCOPE_CM)
+  assert resp.status_code == 403, resp.content
+
+  resp = scd_session.get('/operation_references/{}'.format(op1_uuid), scope=SCOPE_SC)
   assert resp.status_code == 200, resp.content
 
   data = resp.json()
@@ -109,6 +138,7 @@ def test_get_op_by_id(scd_session, op1_uuid):
 
 # Preconditions: None, though preferably Operation op1_uuid created by scd_session user
 # Mutations: None
+@default_scope(SCOPE_SC)
 def test_get_op_by_search_missing_params(scd_session):
   resp = scd_session.post('/operation_references/query')
   assert resp.status_code == 400, resp.content
@@ -116,6 +146,7 @@ def test_get_op_by_search_missing_params(scd_session):
 
 # Preconditions: Operation op1_uuid created by scd_session user
 # Mutations: None
+@default_scope(SCOPE_SC)
 def test_get_op_by_search(scd_session, op1_uuid):
   resp = scd_session.post('/operation_references/query', json={
     'area_of_interest': common.make_vol4(None, None, 0, 5000, common.make_circle(-56, 178, 300))
@@ -126,6 +157,7 @@ def test_get_op_by_search(scd_session, op1_uuid):
 
 # Preconditions: Operation op1_uuid created by scd_session user
 # Mutations: None
+@default_scope(SCOPE_SC)
 def test_get_op_by_search_earliest_time_included(scd_session, op1_uuid):
   earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=59)
   resp = scd_session.post('/operation_references/query', json={
@@ -137,6 +169,7 @@ def test_get_op_by_search_earliest_time_included(scd_session, op1_uuid):
 
 # Preconditions: Operation op1_uuid created by scd_session user
 # Mutations: None
+@default_scope(SCOPE_SC)
 def test_get_op_by_search_earliest_time_excluded(scd_session, op1_uuid):
   earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=61)
   resp = scd_session.post('/operation_references/query', json={
@@ -148,6 +181,7 @@ def test_get_op_by_search_earliest_time_excluded(scd_session, op1_uuid):
 
 # Preconditions: Operation op1_uuid created by scd_session user
 # Mutations: None
+@default_scope(SCOPE_SC)
 def test_get_op_by_search_latest_time_included(scd_session, op1_uuid):
   latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=1)
   resp = scd_session.post('/operation_references/query', json={
@@ -159,6 +193,7 @@ def test_get_op_by_search_latest_time_included(scd_session, op1_uuid):
 
 # Preconditions: Operation op1_uuid created by scd_session user
 # Mutations: None
+@default_scope(SCOPE_SC)
 def test_get_op_by_search_latest_time_excluded(scd_session, op1_uuid):
   latest_time = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
   resp = scd_session.post('/operation_references/query', json={
@@ -170,6 +205,7 @@ def test_get_op_by_search_latest_time_excluded(scd_session, op1_uuid):
 
 # Preconditions: Operation op1_uuid created by scd_session user
 # Mutations: Operation op1_uuid mutated to second version
+@default_scope(SCOPE_SC)
 def test_mutate_op(scd_session, op1_uuid):
   # GET current op
   resp = scd_session.get('/operation_references/{}'.format(op1_uuid))
@@ -178,16 +214,22 @@ def test_mutate_op(scd_session, op1_uuid):
   assert existing_op is not None
 
   req = _make_op1_request()
-  resp = scd_session.put(
-    '/operation_references/{}'.format(op1_uuid),
-    json={
-      'key': [existing_op["ovn"]],
-      'extents': req['extents'],
-      'old_version': existing_op['version'],
-      'state': 'Activated',
-      'uss_base_url': 'https://example.com/dss2',
-      'subscription_id': existing_op['subscription_id']
-    })
+  req = {
+    'key': [existing_op["ovn"]],
+    'extents': req['extents'],
+    'old_version': existing_op['version'],
+    'state': 'Activated',
+    'uss_base_url': 'https://example.com/dss2',
+    'subscription_id': existing_op['subscription_id']
+  }
+
+  resp = scd_session.put('/operation_references/{}'.format(op1_uuid), json=req, scope=SCOPE_CI)
+  assert resp.status_code == 403, resp.content
+
+  resp = scd_session.put('/operation_references/{}'.format(op1_uuid), json=req, scope=SCOPE_CM)
+  assert resp.status_code == 403, resp.content
+
+  resp = scd_session.put('/operation_references/{}'.format(op1_uuid), json=req, scope=SCOPE_SC)
   assert resp.status_code == 200, resp.content
 
   data = resp.json()
@@ -202,7 +244,13 @@ def test_mutate_op(scd_session, op1_uuid):
 # Preconditions: Operation op1_uuid mutated to second version
 # Mutations: Operation op1_uuid deleted
 def test_delete_op(scd_session, op1_uuid):
-  resp = scd_session.delete('/operation_references/{}'.format(op1_uuid))
+  resp = scd_session.delete('/operation_references/{}'.format(op1_uuid), scope=SCOPE_CI)
+  assert resp.status_code == 403, resp.content
+
+  resp = scd_session.delete('/operation_references/{}'.format(op1_uuid), scope=SCOPE_CM)
+  assert resp.status_code == 403, resp.content
+
+  resp = scd_session.delete('/operation_references/{}'.format(op1_uuid), scope=SCOPE_SC)
   assert resp.status_code == 200, resp.content
 
 


### PR DESCRIPTION
Previously, our integration test suite almost always depended on the assumption that every token would be a super token, containing all scopes necessary to perform any action on the system.  This PR begins the process of making intended scopes more explicit and more customizable in tests.

The primary means by which this is accomplished are that 1) a new Session type is used which attaches an `auth` parameter to requests automatically according to an additional `scope` or `scopes` argument in each verb (`get`, `put`, etc) and 2) a test function decorator `default_scope` modifies each of the session inputs to that test function to default to the specified scope for the duration of that test function.

This PR also updates test_operation_simple.py to always explicitly specify scopes (using both the argument and decorator as appropriate), and to include additional tests that verify incorrect scopes do not permit access to the Operation reference endpoints.

Adapting all other existing tests to use explicitly-scoped requests will occur in a future PR, after which the default set of scopes can be removed and an error thrown instead (so that all future tests will be required to be explicit about the scope(s) they are using to perform their test actions).