### PR TITLE
Simplify SCD repo APIs (Subscription + SearchOperations)

### DIFF
--- a/pkg/scd/operations_handler.go
+++ b/pkg/scd/operations_handler.go
@@ -248,7 +248,7 @@ func (a *Server) PutOperationReference(ctx context.Context, req *scdpb.PutOperat
 				return dsserr.BadRequest(err.Error())
 			}
 
-			sub, _, err := r.UpsertSubscription(ctx, &scdmodels.Subscription{
+			sub, err := r.UpsertSubscription(ctx, &scdmodels.Subscription{
 				ID:         scdmodels.ID(uuid.New().String()),
 				Owner:      owner,
 				StartTime:  uExtent.StartTime,

--- a/pkg/scd/operations_handler.go
+++ b/pkg/scd/operations_handler.go
@@ -143,7 +143,7 @@ func (a *Server) SearchOperationReferences(ctx context.Context, req *scdpb.Searc
 	var response *scdpb.SearchOperationReferenceResponse
 	action := func(ctx context.Context, r repos.Repository) (err error) {
 		// Perform search query on Store
-		ops, err := r.SearchOperations(ctx, vol4, owner)
+		ops, err := r.SearchOperations(ctx, vol4)
 		if err != nil {
 			return err
 		}
@@ -296,7 +296,7 @@ func (a *Server) PutOperationReference(ctx context.Context, req *scdpb.PutOperat
 		if err == scderr.MissingOVNsInternalError() {
 			// The client is missing some OVNs; provide the pointers to the
 			// information they need
-			ops, err := r.SearchOperations(ctx, uExtent, owner)
+			ops, err := r.SearchOperations(ctx, uExtent)
 			if err != nil {
 				return err
 			}

--- a/pkg/scd/repos/repos.go
+++ b/pkg/scd/repos/repos.go
@@ -31,18 +31,18 @@ type Subscription interface {
 	// SearchSubscriptions returns all Subscriptions in "v4d".
 	SearchSubscriptions(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error)
 
-	// GetSubscription returns the Subscription referenced by id, or nil if the
-	// Subscription doesn't exist
-	GetSubscription(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner) (*scdmodels.Subscription, error)
+	// GetSubscription returns the Subscription referenced by id, or nil and no
+	// error if the Subscription doesn't exist
+	GetSubscription(ctx context.Context, id scdmodels.ID) (*scdmodels.Subscription, error)
 
 	// UpsertSubscription upserts sub into the store and returns the result
 	// subscription.
 	UpsertSubscription(ctx context.Context, sub *scdmodels.Subscription) (*scdmodels.Subscription, []*scdmodels.Operation, error)
 
 	// DeleteSubscription deletes a Subscription from the store and returns the
-	// deleted subscription.  Returns nil and an error if the Subscription does
-	// not exist, or is owned by someone other than the specified owner.
-	DeleteSubscription(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner, version scdmodels.Version) (*scdmodels.Subscription, error)
+	// deleted subscription.  Returns an error if the Subscription does not
+	// exist.
+	DeleteSubscription(ctx context.Context, id scdmodels.ID) error
 }
 
 // Repository aggregates all SCD-specific repo interfaces.

--- a/pkg/scd/repos/repos.go
+++ b/pkg/scd/repos/repos.go
@@ -22,8 +22,8 @@ type Operation interface {
 	// and subscriptionBaseURL is created.
 	UpsertOperation(ctx context.Context, operation *scdmodels.Operation, key []scdmodels.OVN) (*scdmodels.Operation, []*scdmodels.Subscription, error)
 
-	// SearchOperations returns all operations ownded by "owner" intersecting "v4d".
-	SearchOperations(ctx context.Context, v4d *dssmodels.Volume4D, owner dssmodels.Owner) ([]*scdmodels.Operation, error)
+	// SearchOperations returns all operations intersecting "v4d".
+	SearchOperations(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Operation, error)
 }
 
 // Subscription abstracts subscription-specific interactions with the backing repository.

--- a/pkg/scd/repos/repos.go
+++ b/pkg/scd/repos/repos.go
@@ -37,7 +37,7 @@ type Subscription interface {
 
 	// UpsertSubscription upserts sub into the store and returns the result
 	// subscription.
-	UpsertSubscription(ctx context.Context, sub *scdmodels.Subscription) (*scdmodels.Subscription, []*scdmodels.Operation, error)
+	UpsertSubscription(ctx context.Context, sub *scdmodels.Subscription) (*scdmodels.Subscription, error)
 
 	// DeleteSubscription deletes a Subscription from the store and returns the
 	// deleted subscription.  Returns an error if the Subscription does not

--- a/pkg/scd/store/cockroach/operations.go
+++ b/pkg/scd/store/cockroach/operations.go
@@ -342,7 +342,7 @@ func (s *repo) UpsertOperation(ctx context.Context, operation *scdmodels.Operati
 					return operation.Cells, nil
 				}),
 			},
-		}, operation.Owner)
+		})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -373,7 +373,7 @@ func (s *repo) UpsertOperation(ctx context.Context, operation *scdmodels.Operati
 	return area, subscribers, nil
 }
 
-func (s *repo) searchOperations(ctx context.Context, q dsssql.Queryable, v4d *dssmodels.Volume4D, owner dssmodels.Owner) ([]*scdmodels.Operation, error) {
+func (s *repo) searchOperations(ctx context.Context, q dsssql.Queryable, v4d *dssmodels.Volume4D) ([]*scdmodels.Operation, error) {
 	var (
 		operationsIntersectingVolumeQuery = fmt.Sprintf(`
 			SELECT
@@ -434,8 +434,8 @@ func (s *repo) searchOperations(ctx context.Context, q dsssql.Queryable, v4d *ds
 }
 
 // SearchOperations returns operations within the 4D volume from CockroachDB
-func (s *repo) SearchOperations(ctx context.Context, v4d *dssmodels.Volume4D, owner dssmodels.Owner) ([]*scdmodels.Operation, error) {
-	result, err := s.searchOperations(ctx, s.q, v4d, owner)
+func (s *repo) SearchOperations(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Operation, error) {
+	result, err := s.searchOperations(ctx, s.q, v4d)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scd/store/cockroach/subscriptions.go
+++ b/pkg/scd/store/cockroach/subscriptions.go
@@ -238,7 +238,7 @@ func (c *repo) fetchSubscriptionByIDAndOwner(ctx context.Context, q dsssql.Query
 		},
 		StartTime: result.StartTime,
 		EndTime:   result.EndTime,
-	}, owner)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -424,7 +424,7 @@ func (c *repo) UpsertSubscription(ctx context.Context, s *scdmodels.Subscription
 					return s.Cells, nil
 				}),
 			},
-		}, s.Owner)
+		})
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/scd/store/cockroach/subscriptions.go
+++ b/pkg/scd/store/cockroach/subscriptions.go
@@ -15,7 +15,6 @@ import (
 	"github.com/golang/geo/s2"
 	"github.com/lib/pq"
 	"go.uber.org/multierr"
-	"go.uber.org/zap"
 )
 
 const (
@@ -210,39 +209,6 @@ func (c *repo) fetchSubscriptionByID(ctx context.Context, q dsssql.Queryable, id
 	return result, nil
 }
 
-// fetchMaxSubscriptionCountByCellAndOwner counts how many subscriptions the
-// owner has in each one of these cells, and returns the number of subscriptions
-// in the cell with the highest number of subscriptions.
-func (c *repo) fetchMaxSubscriptionCountByCellAndOwner(
-	ctx context.Context, q dsssql.Queryable, cells s2.CellUnion, owner dssmodels.Owner) (int, error) {
-	var query = `
-    SELECT
-      IFNULL(MAX(subscriptions_per_cell_id), 0)
-    FROM (
-      SELECT
-        COUNT(*) AS subscriptions_per_cell_id
-      FROM
-        scd_subscriptions AS s,
-        scd_cells_subscriptions as c
-      WHERE
-        s.id = c.subscription_id AND
-        s.owner = $1 AND
-        c.cell_id = ANY($2) AND
-        s.ends_at >= $3
-      GROUP BY c.cell_id
-    )`
-
-	cids := make([]int64, len(cells))
-	for i, cell := range cells {
-		cids[i] = int64(cell)
-	}
-
-	row := q.QueryRowContext(ctx, query, owner, pq.Array(cids), c.clock.Now())
-	var ret int
-	err := row.Scan(&ret)
-	return ret, err
-}
-
 func (c *repo) pushSubscription(ctx context.Context, q dsssql.Queryable, s *scdmodels.Subscription) (*scdmodels.Subscription, error) {
 	var (
 		upsertQuery = fmt.Sprintf(`
@@ -327,73 +293,15 @@ func (c *repo) GetSubscription(ctx context.Context, id scdmodels.ID) (*scdmodels
 	}
 }
 
-// UpsertSubscription upserts subscription into the store and returns
-// the resulting subscription including its ID.
-func (c *repo) UpsertSubscription(ctx context.Context, s *scdmodels.Subscription) (*scdmodels.Subscription, []*scdmodels.Operation, error) {
-	old, err := c.fetchSubscriptionByID(ctx, c.q, s.ID)
-	switch {
-	case err == sql.ErrNoRows:
-		break
-	case err != nil:
-		return nil, nil, err
-	}
-
-	switch {
-	case old == nil && !s.Version.Empty():
-		// The user wants to update an existing subscription, but one wasn't found.
-		return nil, nil, dsserr.NotFound(s.ID.String())
-	case old != nil && s.Version.Empty():
-		// The user wants to create a new subscription but it already exists.
-		return nil, nil, dsserr.AlreadyExists(s.ID.String())
-	case old != nil && !s.Version.Matches(old.Version):
-		// The user wants to update a subscription but the version doesn't match.
-		return nil, nil, dsserr.VersionMismatch("old version")
-	case old != nil && old.Owner != s.Owner:
-		return nil, nil, dsserr.PermissionDenied(fmt.Sprintf("Subscription is owned by %s", old.Owner))
-	}
-
-	// Check the user hasn't created too many subscriptions in this area.
-	// TODO: Revisit this logic since the SCD standard does not specify a maximum
-	// number of Subscriptions
-	count, err := c.fetchMaxSubscriptionCountByCellAndOwner(ctx, c.q, s.Cells, s.Owner)
-	if err != nil {
-		c.logger.Warn("Error fetching max subscription count", zap.Error(err))
-		return nil, nil, dsserr.Internal(
-			"failed to fetch subscription count, rejecting request")
-	} else if count >= maxSubscriptionsPerArea {
-		errMsg := "too many existing subscriptions in this area already"
-		if old != nil {
-			errMsg = errMsg + ", rejecting update request"
-		}
-		return nil, nil, dsserr.Exhausted(errMsg)
-	}
-
+// Implements repos.Subscription.UpsertSubscription
+func (c *repo) UpsertSubscription(ctx context.Context, s *scdmodels.Subscription) (*scdmodels.Subscription, error) {
 	newSubscription, err := c.pushSubscription(ctx, c.q, s)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	newSubscription.Cells = s.Cells
 
-	var affectedOperations []*scdmodels.Operation
-	if len(s.Cells) > 0 {
-		ops, err := c.searchOperations(ctx, c.q, &dssmodels.Volume4D{
-			StartTime: s.StartTime,
-			EndTime:   s.EndTime,
-			SpatialVolume: &dssmodels.Volume3D{
-				AltitudeLo: s.AltitudeLo,
-				AltitudeHi: s.AltitudeHi,
-				Footprint: dssmodels.GeometryFunc(func() (s2.CellUnion, error) {
-					return s.Cells, nil
-				}),
-			},
-		})
-		if err != nil {
-			return nil, nil, err
-		}
-		affectedOperations = ops
-	}
-
-	return newSubscription, affectedOperations, nil
+	return newSubscription, nil
 }
 
 // DeleteSubscription deletes the subscription identified by "id" and

--- a/pkg/scd/store/cockroach/subscriptions.go
+++ b/pkg/scd/store/cockroach/subscriptions.go
@@ -17,11 +17,6 @@ import (
 	"go.uber.org/multierr"
 )
 
-const (
-	// Defined in requirement DSS0030.
-	maxSubscriptionsPerArea = 10
-)
-
 var (
 	subscriptionFieldsWithIndices   [11]string
 	subscriptionFieldsWithPrefix    string

--- a/pkg/scd/subscriptions_handler.go
+++ b/pkg/scd/subscriptions_handler.go
@@ -68,9 +68,9 @@ func (a *Server) PutSubscription(ctx context.Context, req *scdpb.PutSubscription
 		NotifyForConstraints: params.NotifyForConstraints,
 	}
 
-	// Validate subrequested Subscription
+	// Validate requested Subscription
 	if !subreq.NotifyForOperations && !subreq.NotifyForConstraints {
-		return nil, dsserr.BadRequest("no notification triggers subrequested for Subscription")
+		return nil, dsserr.BadRequest("no notification triggers requested for Subscription")
 	}
 
 	// Validate and perhaps correct StartTime and EndTime.


### PR DESCRIPTION
This PR extracts most application logic embedded in the SCD store/repo layer for Subscription repo actions as well as SearchOperations.  This allows us to move toward a simple CRUD store which allows simpler mocks that more realistically test the application logic checks and behavior currently embedded in the store implementation.

One functional change in this PR is that the Subscription count is no longer checked in SCD because there is no maximum Subscription count requirement in the SCD draft standard, and there is unlikely to be a maximum requirement because of implicit Subscriptions for Operations.