### PR TITLE
Fix incorrect area calculation

### DIFF
--- a/monitoring/prober/rid/test_isa_validation.py
+++ b/monitoring/prober/rid/test_isa_validation.py
@@ -32,9 +32,7 @@ def test_isa_huge_area(session, isa1_uuid):
           'flights_url': 'https://example.com/uss/flights',
       })
   assert resp.status_code == 400
-  assert resp.json(
-  )['message'] == ('bad extents: area is too large (5033985024.455878km² > '
-                   '2500.000000km²)')
+  assert 'area is too large' in resp.json()['message']
 
 
 def test_isa_empty_vertices(session, isa1_uuid):

--- a/monitoring/prober/scd/resources/op_request_4.json
+++ b/monitoring/prober/scd/resources/op_request_4.json
@@ -1,0 +1,39 @@
+{
+  "area_of_interest": {
+    "volume": {
+      "outline_polygon": {
+        "vertices": [{
+          "lng": -96.88579602648282,
+          "lat": 32.59387252346966
+        }, {
+          "lng": -96.88579602648282,
+          "lat": 32.86069708752762
+        }, {
+          "lng": -96.65241275918919,
+          "lat": 32.86069708752762
+        }, {
+          "lng": -96.65241275918919,
+          "lat": 32.59387252346966
+        }]
+      },
+      "altitude_lower": {
+        "value": -158.46905896231343,
+        "reference": "W84",
+        "units": "M"
+      },
+      "altitude_upper": {
+        "value": 911.2196235450058,
+        "reference": "W84",
+        "units": "M"
+      }
+    },
+    "time_start": {
+      "value": "2020-07-06T22:28:00Z",
+      "format": "RFC3339"
+    },
+    "time_end": {
+      "value": "2020-07-06T22:43:41Z",
+      "format": "RFC3339"
+    }
+  }
+}

--- a/monitoring/prober/scd/test_operation_special_cases.py
+++ b/monitoring/prober/scd/test_operation_special_cases.py
@@ -41,3 +41,11 @@ def test_op_query_degenerate_polygon(scd_session):
     req = json.load(f)
   resp = scd_session.post('/operation_references/query', json=req)
   assert resp.status_code == 200, resp.content
+
+# Preconditions: None
+# Mutations: None
+def test_op_query_not_area_too_large(scd_session):
+  with open('./scd/resources/op_request_4.json', 'r') as f:
+    req = json.load(f)
+  resp = scd_session.post('/operation_references/query', json=req)
+  assert resp.status_code == 200, resp.content

--- a/pkg/geo/s2.go
+++ b/pkg/geo/s2.go
@@ -22,6 +22,8 @@ const (
 	DefaultMaximumCellLevel = 13
 	maxAllowedAreaKm2       = 2500.0
 	radiusEarthMeter        = 6371010.0
+
+	earthAreaKm2 = 510072000.0 // rough area of the earth in KM².
 )
 
 var (
@@ -90,16 +92,15 @@ func loopAreaKm2(loop *s2.Loop) float64 {
 	if loop.IsEmpty() {
 		return 0
 	}
-	const earthAreaKm2 = 510072000.0 // rough area of the earth in KM².
-	return (loop.Area() * earthAreaKm2) / 4.0 * math.Pi
+	return (loop.Area() * earthAreaKm2) / (4.0 * math.Pi)
 }
 
 // Covering calculates the S2 covering of a set of S2 points. Will try the loop
 // in both clockwise and counter clockwise.
 func Covering(points []s2.Point) (s2.CellUnion, error) {
 	loop := s2.LoopFromPoints(points)
-	area := loopAreaKm2(loop)
-	if area > maxAllowedAreaKm2 {
+	area1 := loopAreaKm2(loop)
+	if area1 > maxAllowedAreaKm2 {
 		// This may have happened because the vertices were not ordered counter-clockwise.
 		// We can try reversing to see if that's the case.
 		for i, j := 0, len(points)-1; i < j; i, j = i+1, j-1 {
@@ -107,13 +108,13 @@ func Covering(points []s2.Point) (s2.CellUnion, error) {
 		}
 		loop = s2.LoopFromPoints(points)
 	}
-	area = loopAreaKm2(loop)
-	if area > maxAllowedAreaKm2 {
+	area2 := loopAreaKm2(loop)
+	if area2 > maxAllowedAreaKm2 {
 		return nil, &ErrAreaTooLarge{
-			msg: fmt.Sprintf("area is too large (%fkm² > %fkm²)", loopAreaKm2(loop), maxAllowedAreaKm2),
+			msg: fmt.Sprintf("area is too large (%fkm² > %fkm²)", math.Min(area1, area2), maxAllowedAreaKm2),
 		}
 	}
-	if area <= 0 {
+	if area2 <= 0 {
 		// Since the loop has no area, try a PolyLine
 		pl := s2.Polyline(loop.Vertices())
 		return RegionCoverer.Covering(&pl), nil

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -103,7 +103,7 @@ docker run -d --name http-gateway-for-testing -p 8082:8082 \
 
 echo " -------------- DUMMY OAUTH -------------- "
 echo "Building dummy-oauth server container"
-docker build -q --rm -f cmds/dummy-oauth/Dockerfile . -t local-dummy-oauth
+docker build --rm -f cmds/dummy-oauth/Dockerfile . -t local-dummy-oauth > dummy-oauth-build.log
 
 echo "Cleaning up any pre-existing dummy-oauth container"
 docker rm -f dummy-oauth-for-testing &> /dev/null || echo "No dummy oauth to clean up"


### PR DESCRIPTION
We were incorrectly calculating loop area with `(loop.Area() * earthAreaKm2) / 4.0 * math.Pi` instead of `(loop.Area() * earthAreaKm2) / (4.0 * math.Pi)`.  This PR fixes that bug.

It also adds a log file output for building the dummy OAuth image since that can take minutes and it would be valuable to have feedback there to confirm that the process wasn't stalled.