### PR TITLE
Remove Bootstrapping Functionality from GRPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ test:
 .PHONY: test-cockroach
 test-cockroach: cleanup-test-cockroach
 	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v20.1.1 start --insecure > /dev/null
+	go run ./cmds/db-manager/main.go --schemas_dir ./build/deploy/db-schemas/defaultdb --db_version v2.0.0 --cockroach_host localhost
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/store/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/scd/store/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/application -store-uri "postgresql://root@localhost:26257?sslmode=disable"

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ test:
 .PHONY: test-cockroach
 test-cockroach: cleanup-test-cockroach
 	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v20.1.1 start --insecure > /dev/null
-	go run ./cmds/db-manager/main.go --schemas_dir ./build/deploy/db-schemas/defaultdb --db_version v2.0.0 --cockroach_host localhost
+	go run ./cmds/db-manager/main.go --schemas_dir ./build/deploy/db-schemas/defaultdb --db_version v3.0.0 --cockroach_host localhost
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/store/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/scd/store/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/application -store-uri "postgresql://root@localhost:26257?sslmode=disable"

--- a/build/deploy/db-schemas/defaultdb.libsonnet
+++ b/build/deploy/db-schemas/defaultdb.libsonnet
@@ -7,6 +7,8 @@
     "000003_migrate_data_to_index.down.sql": importstr "defaultdb/000003_migrate_data_to_index.down.sql",
     "000003_migrate_data_to_index.up.sql": importstr "defaultdb/000003_migrate_data_to_index.up.sql",
     "000004_drop_cells_table.down.sql": importstr "defaultdb/000004_drop_cells_table.down.sql",
-    "000004_drop_cells_table.up.sql": importstr "defaultdb/000004_drop_cells_table.up.sql"
+    "000004_drop_cells_table.up.sql": importstr "defaultdb/000004_drop_cells_table.up.sql",
+    "000005_bump_version.down.sql": importstr "defaultdb/000005_bump_version.down.sql",
+    "000005_bump_version.up.sql": importstr "defaultdb/000005_bump_version.up.sql",
   },
 }

--- a/build/deploy/db-schemas/defaultdb/000002_inverted_index.up.sql
+++ b/build/deploy/db-schemas/defaultdb/000002_inverted_index.up.sql
@@ -1,4 +1,6 @@
-ALTER TABLE identification_service_areas ADD COLUMN IF NOT EXISTS cells INT64[];
+ALTER TABLE identification_service_areas ADD COLUMN IF NOT EXISTS cells INT64[] NOT NULL;
+ALTER TABLE identification_service_areas ADD CONSTRAINT cells_not_null CHECK (array_length(cells, 1) IS NOT NULL);
 CREATE INVERTED INDEX IF NOT EXISTS cell_idx on identification_service_areas (cells);
-ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS cells INT64[];
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS cells INT64[] NOT NULL;
+ALTER TABLE subscriptions ADD CONSTRAINT cells_not_null CHECK (array_length(cells, 1) IS NOT NULL);
 CREATE INVERTED INDEX IF NOT EXISTS cell_idx on subscriptions (cells);

--- a/build/deploy/db-schemas/defaultdb/000005_bump_version.down.sql
+++ b/build/deploy/db-schemas/defaultdb/000005_bump_version.down.sql
@@ -1,0 +1,1 @@
+UPDATE schema_versions set schema_version = 'v2.0.0' WHERE onerow_enforcer = TRUE

--- a/build/deploy/db-schemas/defaultdb/000005_bump_version.up.sql
+++ b/build/deploy/db-schemas/defaultdb/000005_bump_version.up.sql
@@ -1,0 +1,1 @@
+UPDATE schema_versions set schema_version = 'v3.0.0' WHERE onerow_enforcer = TRUE

--- a/build/deploy/examples/minimum/main.jsonnet
+++ b/build/deploy/examples/minimum/main.jsonnet
@@ -10,7 +10,7 @@ local metadata = metadataBase {
     locality: 'your_unique_locality',
     nodeIPs: ['0.0.0.0', '1.1.1.1', '2.2.2.2'],
     shouldInit: true, //Set to false if joining a cluster
-    // JoinExisting: ['0.db.westus.example.com', '1.db.westus.example.com', '2.db.westus.example.com' ], //If joining a cluster, replace these with at least 3 FQDN's of the existing DSS cockroachdb cluster you are joining.
+    //JoinExisting: ['0.db.westus.example.com', '1.db.westus.example.com', '2.db.westus.example.com' ], //If joining a cluster, replace these with at least 3 FQDN's of the existing DSS cockroachdb cluster you are joining.
   },
   gateway+: {
     ipName: 'your-ingress-name', //Set this if using GKE
@@ -22,7 +22,7 @@ local metadata = metadataBase {
   },
   schema_manager+: {
     image: 'your_schema_manager_image_name',
-    desired_rid_db_version: 'v2.0.0',
+    desired_rid_db_version: 'v3.0.0'
   },
 };
 

--- a/build/deploy/examples/prod/main.jsonnet
+++ b/build/deploy/examples/prod/main.jsonnet
@@ -16,7 +16,7 @@ local metadata = prod.metadata {
   },
   schema_manager+: {
     image: 'your_schema_manager_image_name',
-    desired_rid_db_version: 'v2.0.0',
+    desired_rid_db_version: 'v3.0.0',
   },
 };
 

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -126,8 +126,8 @@ func RunGRPCServer(ctx context.Context, address string) error {
 	}
 	store := ridc.NewStore(crdb, logger)
 
-	if err := store.Bootstrap(ctx); err != nil {
-		logger.Panic("Failed to bootstrap CRDB instance", zap.Error(err))
+	if err := store.GetVersion(ctx); err != nil {
+		logger.Panic("Failed to get Database Schema Version", zap.Error(err))
 	}
 
 	MustSupportSchema(ctx, store)
@@ -147,8 +147,8 @@ func RunGRPCServer(ctx context.Context, address string) error {
 	if *enableSCD {
 		store := scdc.NewStore(crdb, logger)
 
-		if err := store.Bootstrap(ctx); err != nil {
-			logger.Panic("Failed to bootstrap CRDB instance", zap.Error(err))
+		if err := store.GetVersion(ctx); err != nil {
+			logger.Panic("Failed to get Database Schema Version", zap.Error(err))
 		}
 		scdServer = &scd.Server{
 			Store:   store,

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// The code at this version requires a major schema version equal to 2.
-	RequiredMajorSchemaVersion = "v2"
+	RequiredMajorSchemaVersion = "v3"
 )
 
 var (

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -126,7 +126,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 	}
 	store := ridc.NewStore(crdb, logger)
 
-	if err := store.GetVersion(ctx); err != nil {
+	if _, err := store.GetVersion(ctx); err != nil {
 		logger.Panic("Failed to get Database Schema Version", zap.Error(err))
 	}
 
@@ -147,7 +147,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 	if *enableSCD {
 		store := scdc.NewStore(crdb, logger)
 
-		if err := store.GetVersion(ctx); err != nil {
+		if err := store.Bootstrap(ctx); err != nil {
 			logger.Panic("Failed to get Database Schema Version", zap.Error(err))
 		}
 		scdServer = &scd.Server{

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -148,7 +148,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 		store := scdc.NewStore(crdb, logger)
 
 		if err := store.Bootstrap(ctx); err != nil {
-			logger.Panic("Failed to get Database Schema Version", zap.Error(err))
+			logger.Panic("Failed to bootstrap CRDB instance", zap.Error(err))
 		}
 		scdServer = &scd.Server{
 			Store:   store,

--- a/pkg/cockroach/cockroach.go
+++ b/pkg/cockroach/cockroach.go
@@ -68,14 +68,14 @@ func BuildURI(params map[string]string) (string, error) {
 
 // GetVersion returns the Schema Version of the requested DB Name
 func GetVersion(ctx context.Context, db *DB, dbName string) (string, error) {
-	query := fmt.Sprintf(`
+	const query = `
 		SELECT EXISTS (
   		SELECT *
 		  FROM information_schema.tables 
 		WHERE table_name = 'schema_versions'
-		AND table_catalog = '%s'
-   )`, dbName)
-	row := db.QueryRowContext(ctx, query)
+		AND table_catalog = $1
+   	)`
+	row := db.QueryRowContext(ctx, query, dbName)
 	var ret bool
 	if err := row.Scan(&ret); err != nil {
 		return "", err

--- a/pkg/cockroach/cockroach.go
+++ b/pkg/cockroach/cockroach.go
@@ -1,6 +1,7 @@
 package cockroach
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -63,4 +64,34 @@ func BuildURI(params map[string]string) (string, error) {
 		"postgresql://%s@%s:%s%s?application_name=%s&sslmode=%s&sslrootcert=%s/ca.crt&sslcert=%s/client.%s.crt&sslkey=%s/client.%s.key",
 		u, h, p, db, an, ssl, dir, dir, u, dir, u,
 	), nil
+}
+
+// GetVersion returns the Schema Version of the requested DB Name
+func GetVersion(ctx context.Context, db *DB, dbName string) (string, error) {
+	query := fmt.Sprintf(`
+		SELECT EXISTS (
+  		SELECT *
+		  FROM information_schema.tables 
+		WHERE table_name = 'schema_versions'
+		AND table_catalog = '%s'
+   )`, dbName)
+	row := db.QueryRowContext(ctx, query)
+	var ret bool
+	if err := row.Scan(&ret); err != nil {
+		return "", err
+	}
+	if !ret {
+		// Database has not been bootstrapped using DB Schema Manager
+		return "", fmt.Errorf("RID DB has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas")
+	}
+	getVersionQuery := fmt.Sprintf(`
+      SELECT schema_version 
+      FROM %s.schema_versions
+	  WHERE onerow_enforcer = TRUE`, dbName)
+	row = db.QueryRowContext(ctx, getVersionQuery)
+	var dbVersion string
+	if err := row.Scan(&dbVersion); err != nil {
+		return "", err
+	}
+	return dbVersion, nil
 }

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -66,7 +66,6 @@ func setUpStore(ctx context.Context, t *testing.T, logger *zap.Logger) (store.St
 	require.NoError(t, err)
 
 	store := ridcrdb.NewStore(cdb, logger)
-	require.NoError(t, store.Bootstrap(ctx))
 	return store, func() {
 		require.NoError(t, CleanUp(ctx, store))
 		require.NoError(t, store.Close())

--- a/pkg/rid/store/cockroach/store_test.go
+++ b/pkg/rid/store/cockroach/store_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/interuss/dss/pkg/rid/repos"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/mod/semver"
 )
 
 var (
@@ -131,20 +130,6 @@ func TestTxnRetrier(t *testing.T) {
 	require.Error(t, err)
 	// Ensure it was retried.
 	require.Greater(t, count, 1)
-}
-
-func TestGetVersion(t *testing.T) {
-	var (
-		ctx                  = context.Background()
-		store, tearDownStore = setUpStore(ctx, t)
-	)
-	defer tearDownStore()
-	version, err := store.GetVersion(ctx)
-	require.NoError(t, err)
-	require.NoError(t, err)
-
-	// TODO: remove the below checks when we have better schema management
-	require.Equal(t, "v2", semver.Major(version))
 }
 
 func TestTransactor(t *testing.T) {

--- a/pkg/rid/store/cockroach/store_test.go
+++ b/pkg/rid/store/cockroach/store_test.go
@@ -39,7 +39,6 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 
 	store, err := newStore()
 	require.NoError(t, err)
-	require.NoError(t, store.Bootstrap(ctx))
 	return store, func() {
 		require.NoError(t, CleanUp(ctx, store))
 		require.NoError(t, store.Close())
@@ -61,20 +60,11 @@ func newStore() (*Store, error) {
 // CleanUp drops all required tables from the store, useful for testing.
 func CleanUp(ctx context.Context, s *Store) error {
 	const query = `
-	DROP TABLE IF EXISTS subscriptions;
-	DROP TABLE IF EXISTS identification_service_areas;`
+	DELETE FROM subscriptions WHERE id IS NOT NULL;
+	DELETE FROM identification_service_areas WHERE id IS NOT NULL;`
 
 	_, err := s.db.ExecContext(ctx, query)
 	return err
-}
-
-func TestStoreBootstrap(t *testing.T) {
-	var (
-		ctx                  = context.Background()
-		store, tearDownStore = setUpStore(ctx, t)
-	)
-	require.NotNil(t, store)
-	tearDownStore()
 }
 
 func TestDatabaseEnsuresBeginsBeforeExpires(t *testing.T) {
@@ -155,17 +145,6 @@ func TestGetVersion(t *testing.T) {
 
 	// TODO: remove the below checks when we have better schema management
 	require.Equal(t, "v2", semver.Major(version))
-
-	_, err = store.db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS cells_subscriptions (id STRING PRIMARY KEY);`)
-	require.NoError(t, err)
-
-	version, err = store.GetVersion(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "v1", semver.Major(version))
-
-	_, err = store.db.ExecContext(ctx, `DROP TABLE cells_subscriptions;`)
-	require.NoError(t, err)
-
 }
 
 func TestTransactor(t *testing.T) {

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -75,7 +75,7 @@ docker run --rm --name rid-db-manager \
 	-v $(pwd)/build/deploy/db-schemas/defaultdb:/db-schemas/defaultdb \
 	local-db-manager \
 	--schemas_dir db-schemas/defaultdb \
-	--db_version v2.0.0 \
+	--db_version v3.0.0 \
 	--cockroach_host crdb
 
 sleep 1

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -54,6 +54,8 @@ trap on_sigint SIGINT
 echo " -------------- BOOTSTRAP ----------------- "
 echo "Building local container for testing (see grpc-backend-build.log for details)"
 docker build --rm . -t local-interuss-dss-image > grpc-backend-build.log
+echo "Building db-manager container for testing"
+docker build --rm -f cmds/db-manager/Dockerfile . -t local-db-manager > db-manager-build.log
 
 echo " ---------------- CRDB -------------------- "
 echo "cleaning up any crdb pre-existing containers"
@@ -65,6 +67,16 @@ docker run -d --rm --name dss-crdb-for-debugging \
 	-p 8080:8080 \
 	cockroachdb/cockroach:v20.1.1 start \
 	--insecure > /dev/null
+
+sleep 1
+echo "Bootstrapping RID Database tables"
+docker run --rm --name rid-db-manager \
+	--link dss-crdb-for-debugging:crdb \
+	-v $(pwd)/build/deploy/db-schemas/defaultdb:/db-schemas/defaultdb \
+	local-db-manager \
+	--schemas_dir db-schemas/defaultdb \
+	--db_version v2.0.0 \
+	--cockroach_host crdb
 
 sleep 1
 echo " ------------ GRPC BACKEND ---------------- "


### PR DESCRIPTION
GRPC will now try to get the DB Schema Version and fail if the DB was not bootstrapped with the Schema Manager