### PR TITLE
Modify CRDB tables to have a "writer" column

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ test:
 .PHONY: test-cockroach
 test-cockroach: cleanup-test-cockroach
 	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v20.1.1 start --insecure > /dev/null
-	go run ./cmds/db-manager/main.go --schemas_dir ./build/deploy/db-schemas/defaultdb --db_version v3.0.0 --cockroach_host localhost
+	go run ./cmds/db-manager/main.go --schemas_dir ./build/deploy/db-schemas/defaultdb --db_version v3.1.0 --cockroach_host localhost
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/store/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/scd/store/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	DSS_ERRORS_OBFUSCATE_INTERNAL_ERRORS=false go test -count=1 -v ./pkg/rid/application -store-uri "postgresql://root@localhost:26257?sslmode=disable"

--- a/build/deploy/db-schemas/defaultdb.libsonnet
+++ b/build/deploy/db-schemas/defaultdb.libsonnet
@@ -10,5 +10,7 @@
     "000004_drop_cells_table.up.sql": importstr "defaultdb/000004_drop_cells_table.up.sql",
     "000005_bump_version.down.sql": importstr "defaultdb/000005_bump_version.down.sql",
     "000005_bump_version.up.sql": importstr "defaultdb/000005_bump_version.up.sql",
+    "000006_add_writer_column.down.sql": importstr "defaultdb/000006_add_writer_column.down.sql",
+    "000006_add_writer_column.up.sql": importstr "defaultdb/000006_add_writer_column.up.sql",
   },
 }

--- a/build/deploy/db-schemas/defaultdb/000006_add_writer_column.down.sql
+++ b/build/deploy/db-schemas/defaultdb/000006_add_writer_column.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE identification_service_areas DROP IF EXISTS writer;
+ALTER TABLE subscriptions DROP IF EXISTS writer;
+UPDATE schema_versions set schema_version = 'v3.0.0' WHERE onerow_enforcer = TRUE

--- a/build/deploy/db-schemas/defaultdb/000006_add_writer_column.up.sql
+++ b/build/deploy/db-schemas/defaultdb/000006_add_writer_column.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE identification_service_areas ADD COLUMN IF NOT EXISTS writer STRING;
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS writer STRING;
+UPDATE schema_versions set schema_version = 'v3.1.0' WHERE onerow_enforcer = TRUE

--- a/build/deploy/examples/minimum/main.jsonnet
+++ b/build/deploy/examples/minimum/main.jsonnet
@@ -22,7 +22,7 @@ local metadata = metadataBase {
   },
   schema_manager+: {
     image: 'your_schema_manager_image_name',
-    desired_rid_db_version: 'v3.0.0'
+    desired_rid_db_version: 'v3.1.0'
   },
 };
 

--- a/build/deploy/examples/prod/main.jsonnet
+++ b/build/deploy/examples/prod/main.jsonnet
@@ -16,7 +16,7 @@ local metadata = prod.metadata {
   },
   schema_manager+: {
     image: 'your_schema_manager_image_name',
-    desired_rid_db_version: 'v3.0.0',
+    desired_rid_db_version: 'v3.1.0',
   },
 };
 

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -75,7 +75,7 @@ docker run --rm --name rid-db-manager \
 	-v $(pwd)/build/deploy/db-schemas/defaultdb:/db-schemas/defaultdb \
 	local-db-manager \
 	--schemas_dir db-schemas/defaultdb \
-	--db_version v3.0.0 \
+	--db_version v3.1.0 \
 	--cockroach_host crdb
 
 sleep 1


### PR DESCRIPTION
Due to the nature of the how the DSS is setup with multiple companies owning a piece of the infrastructure and therefore multiple "GRPC Backend" server running, we've decided to make each instance be responsible for cleaning up its own garbage, therefore with every write to the the DB we need it to also put its name down as the writer so that it can know which row its responsible for GC.