### PR TITLE
Split SCD data into dedicated `scd` database

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -116,8 +116,9 @@ a PR to that effect would be greatly appreciated.
        -  Name the cluster appropriately; e.g., `dss-us-prod`
        -  Select Zonal and [a compute-zone appropriate to your
           geography](https://cloud.google.com/compute/docs/regions-zones#available)
-       -  For the "default-pool" node pool, check "Enable autoscaling" and enter
-          a range of 2-10 nodes.
+       -  For the "default-pool" node pool:
+          - Enter 2 for number of nodes.
+          - Check "Enable autoscaling" and enter a range of 2-10 nodes.
        -  In the "Nodes" bullet under "default-pool", select N2 series and
           n2-standard-8 for machine type.
        -  In the "Networking" bullet under "Clusters", ensure "Enable [VPC
@@ -226,7 +227,11 @@ a PR to that effect would be greatly appreciated.
    
     1.  `VAR_CLUSTER_CONTEXT`: Same <CLUSTER_CONTEXT> name of the cluster used in
         the `make-certs.py` and `apply-certs.sh` scripts.
-   
+
+    1.  `VAR_ENABLE_SCD`: Set this boolean true to enable strategic conflict
+        detection functionality (currently an R&D project tracking an initial
+        draft of the upcoming ASTM standard).
+
     1.  `VAR_CRDB_HOSTNAME_SUFFIX`: The domain name suffix shared by all of your
         CockroachDB nodes.  For instance, if your CRDB nodes were addressable at
         `0.db.example.com`, `1.db.example.com`, and `2.db.example.com`, then

--- a/build/deploy/db-schemas/scd.libsonnet
+++ b/build/deploy/db-schemas/scd.libsonnet
@@ -1,0 +1,6 @@
+{
+  data:{
+    "000001_create_initial_version.down.sql": importstr "defaultdb/000001_create_initial_version.down.sql",
+    "000001_create_initial_version.up.sql": importstr "defaultdb/000001_create_initial_version.up.sql",
+  },
+}

--- a/build/deploy/db-schemas/scd/000001_create_initial_version.up.sql
+++ b/build/deploy/db-schemas/scd/000001_create_initial_version.up.sql
@@ -1,0 +1,78 @@
+CREATE TABLE IF NOT EXISTS scd_subscriptions (
+  id UUID PRIMARY KEY,
+  owner STRING NOT NULL,
+  version INT4 NOT NULL DEFAULT 0,
+  url STRING NOT NULL,
+  notification_index INT4 DEFAULT 0,
+  notify_for_operations BOOL DEFAULT false,
+  notify_for_constraints BOOL DEFAULT false,
+  implicit BOOL DEFAULT false,
+  starts_at TIMESTAMPTZ,
+  ends_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL,
+  INDEX owner_idx (owner),
+  INDEX starts_at_idx (starts_at),
+  INDEX ends_at_idx (ends_at),
+  CHECK (starts_at IS NULL OR ends_at IS NULL OR starts_at < ends_at),
+  CHECK (notify_for_operations OR notify_for_constraints)
+);
+CREATE TABLE IF NOT EXISTS scd_cells_subscriptions (
+  cell_id INT64 NOT NULL,
+  cell_level INT CHECK (cell_level BETWEEN 0 and 30),
+  subscription_id UUID NOT NULL REFERENCES scd_subscriptions (id) ON DELETE CASCADE,
+  PRIMARY KEY (cell_id, subscription_id),
+  INDEX cell_id_idx (cell_id),
+  INDEX subscription_id_idx (subscription_id)
+);
+CREATE TABLE IF NOT EXISTS scd_operations (
+  id UUID PRIMARY KEY,
+  owner STRING NOT NULL,
+  version INT4 NOT NULL DEFAULT 0,
+  url STRING NOT NULL,
+  altitude_lower REAL,
+  altitude_upper REAL,
+  starts_at TIMESTAMPTZ,
+  ends_at TIMESTAMPTZ,
+  subscription_id UUID NOT NULL REFERENCES scd_subscriptions(id) ON DELETE CASCADE,
+  updated_at TIMESTAMPTZ NOT NULL,
+  INDEX owner_idx (owner),
+  INDEX altitude_lower_idx (altitude_lower),
+  INDEX altitude_upper_idx (altitude_upper),
+  INDEX starts_at_idx (starts_at),
+  INDEX ends_at_idx (ends_at),
+  INDEX updated_at_idx (updated_at),
+  INDEX subscription_id_idx (subscription_id),
+  CHECK (starts_at IS NULL OR ends_at IS NULL OR starts_at < ends_at)
+);
+CREATE TABLE IF NOT EXISTS scd_cells_operations (
+  cell_id INT64 NOT NULL,
+  cell_level INT CHECK (cell_level BETWEEN 0 and 30),
+  operation_id UUID NOT NULL REFERENCES scd_operations (id) ON DELETE CASCADE,
+  PRIMARY KEY (cell_id, operation_id),
+  INDEX cell_id_idx (cell_id),
+  INDEX operation_id_idx (operation_id)
+);
+CREATE TABLE IF NOT EXISTS scd_constraints (
+  id UUID PRIMARY KEY,
+  owner STRING NOT NULL,
+  version INT4 NOT NULL DEFAULT 0,
+  url STRING NOT NULL,
+  altitude_lower REAL,
+  altitude_upper REAL,
+  starts_at TIMESTAMPTZ,
+  ends_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL,
+  cells INT64[] NOT NULL CHECK (array_length(cells, 1) IS NOT NULL),
+  INVERTED INDEX cells_idx (cells),
+  INDEX owner_idx (owner),
+  INDEX starts_at_idx (starts_at),
+  INDEX ends_at_idx (ends_at),
+  CHECK (starts_at IS NULL OR ends_at IS NULL OR starts_at < ends_at)
+);
+
+CREATE TABLE IF NOT EXISTS schema_versions (
+	onerow_enforcer bool PRIMARY KEY DEFAULT TRUE CHECK(onerow_enforcer),
+	schema_version STRING NOT NULL
+);
+
+INSERT INTO schema_versions (schema_version) VALUES ('v1.0.0');

--- a/build/deploy/examples/minimum/main.jsonnet
+++ b/build/deploy/examples/minimum/main.jsonnet
@@ -9,6 +9,7 @@ local metadata = metadataBase {
   clusterName: 'VAR_CLUSTER_CONTEXT',
   enable_istio: true,
   single_cluster: false,
+  enableScd: false, // <-- This boolean value is VAR_ENABLE_SCD
   cockroach+: {
     hostnameSuffix: 'VAR_CRDB_HOSTNAME_SUFFIX',
     locality: 'VAR_CRDB_LOCALITY',
@@ -29,7 +30,8 @@ local metadata = metadataBase {
   },
   schema_manager+: {
     image: 'VAR_SCHEMA_MANAGER_IMAGE_NAME',
-    desired_rid_db_version: 'v3.0.0'
+    desired_rid_db_version: 'v3.0.0',
+    desired_scd_db_version: 'v1.0.0',
   },
 };
 

--- a/build/deploy/grpc-backend.libsonnet
+++ b/build/deploy/grpc-backend.libsonnet
@@ -44,6 +44,7 @@ local volumes = import 'volumes.libsonnet';
                 dump_requests: true,
                 accepted_jwt_audiences: metadata.gateway.hostname,
                 locality: metadata.cockroach.locality,
+                enable_scd: metadata.enableScd,
               },
             },
           },

--- a/build/deploy/metadata_base.libsonnet
+++ b/build/deploy/metadata_base.libsonnet
@@ -7,6 +7,7 @@
   // Set this field if you don't intend to ever join this instance with others.
   // This disables inter cluster crdb<->crdb access when set to true.
   single_cluster: false,
+  enableScd: false,
   cockroach: {
     locality: error 'must supply crdb locality',
     hostnameSuffix: error 'must supply a hostnameSuffix, or override in statefulset',

--- a/build/deploy/schema-manager.libsonnet
+++ b/build/deploy/schema-manager.libsonnet
@@ -1,6 +1,7 @@
 local base = import 'base.libsonnet';
 local volumes = import 'volumes.libsonnet';
 local defaultdb_schema = import "db-schemas/defaultdb.libsonnet";
+local scd_schema = import "db-schemas/scd.libsonnet";
 
 local rid_schema_vol = {
   name: 'db-rid-schema',
@@ -15,12 +16,28 @@ local rid_schema_mount = {
   mountPath: '/db-schemas/defaultdb',
 };
 
+local scd_schema_vol = {
+  name: 'db-scd-schema',
+  configMap: {
+    defaultMode: 420,
+    name: 'db-scd-schema',
+  },
+};
+local scd_schema_mount = {
+  name: 'db-scd-schema',
+  readOnly: false,
+  mountPath: '/db-schemas/scd',
+};
+
 {
   all(metadata): {
     assert metadata.cockroach.shouldInit == true && metadata.cockroach.JoinExisting == [] : "If shouldInit is True, JoinExisiting should be empty",
     rid_schema: base.ConfigMap(metadata, 'db-rid-schema') {
       data: defaultdb_schema.data
     },
+    scd_schema: if metadata.enableScd then base.ConfigMap(metadata, 'db-scd-schema') {
+      data: scd_schema.data
+    } else null,
     RIDSchemaManager: if metadata.cockroach.shouldInit then base.Job(metadata, 'rid-schema-manager') {
       spec+: {
         template+: {
@@ -30,7 +47,7 @@ local rid_schema_mount = {
               ca_certs: volumes.volumes.ca_certs,
               rid_schema: rid_schema_vol,
             },
-            soloContainer:: base.Container('schema-manager') {
+            soloContainer:: base.Container('rid-schema-manager') {
               image: metadata.schema_manager.image,
               args_:: {
                 cockroach_host: 'cockroachdb-balanced.' + metadata.namespace,
@@ -43,6 +60,33 @@ local rid_schema_mount = {
 
               },
               volumeMounts: volumes.mounts.caCert + volumes.mounts.clientCert + [rid_schema_mount],
+            },
+          },
+        },
+      },
+    } else null,
+    SCDSchemaManager: if metadata.cockroach.shouldInit && metadata.enableScd then base.Job(metadata, 'scd-schema-manager') {
+      spec+: {
+        template+: {
+          spec+: {
+            volumes_: {
+              client_certs: volumes.volumes.client_certs,
+              ca_certs: volumes.volumes.ca_certs,
+              scd_schema: scd_schema_vol,
+            },
+            soloContainer:: base.Container('scd-schema-manager') {
+              image: metadata.schema_manager.image,
+              args_:: {
+                cockroach_host: 'cockroachdb-balanced.' + metadata.namespace,
+                cockroach_port: metadata.cockroach.grpc_port,
+                cockroach_ssl_mode: 'verify-full',
+                cockroach_user: 'root',
+                cockroach_ssl_dir: '/cockroach/cockroach-certs',
+                db_version: metadata.schema_manager.desired_scd_db_version,
+                schemas_dir: scd_schema_mount.mountPath,
+
+              },
+              volumeMounts: volumes.mounts.caCert + volumes.mounts.clientCert + [scd_schema_mount],
             },
           },
         },

--- a/cmds/db-manager/main.go
+++ b/cmds/db-manager/main.go
@@ -184,7 +184,7 @@ func createDatabaseIfNotExists(crdbURI string, database string) error {
 	const checkDbQuery = `
 		SELECT EXISTS (
 			SELECT *
-				FROM pg_database 
+				FROM pg_database
 			WHERE datname = $1
 		)
 	`
@@ -196,7 +196,7 @@ func createDatabaseIfNotExists(crdbURI string, database string) error {
 	}
 
 	if !exists {
-		log.Printf("Database \"%s\" doesn't exists, attempt to create", database)
+		log.Printf("Database \"%s\" doesn't exist, attempting to create", database)
 		createDB := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", database)
 		_, err := crdb.Exec(createDB)
 		if err != nil {

--- a/cmds/db-manager/main.go
+++ b/cmds/db-manager/main.go
@@ -215,7 +215,7 @@ func getCurrentDBVersion(crdbURI string, database string) (string, error) {
 		return "", fmt.Errorf("Failed to dial CRDB while getting DB version: %v", err)
 	}
 	version, err := dssCockroach.GetVersion(context.Background(), crdb, database)
-	if err != nil && version == "" {
+	if err != nil {
 		log.Print(err)
 		return "", err
 	}

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -158,7 +158,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 
 	// Initialize remote ID
 
-	ridCrdb, err := ConnectTo("defaultdb")
+	ridCrdb, err := ConnectTo(ridc.DatabaseName)
 	if err != nil {
 		logger.Panic("Failed to connect to remote ID database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", zap.Error(err))
 	}
@@ -177,7 +177,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 	// Initialize strategic conflict detection
 
 	if *enableSCD {
-		scdCrdb, err := ConnectTo("scd")
+		scdCrdb, err := ConnectTo(scdc.DatabaseName)
 		if err != nil {
 			logger.Panic("Failed to connect to strategic conflict detection database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", zap.Error(err))
 		}

--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -35,8 +35,13 @@ import (
 )
 
 const (
-	// The code at this version requires a major schema version equal to 2.
-	RequiredMajorSchemaVersion = "v3"
+	// The code at this version requires a major schema version equal to this
+	// value.
+	RidRequiredMajorSchemaVersion = "v3"
+
+	// The code at this version requires a major schema version equal to this
+	// value.
+	ScdRequiredMajorSchemaVersion = "v1"
 )
 
 var (
@@ -70,20 +75,58 @@ var (
 		applicationName: flag.String("cockroach_application_name", "dss", "application name for tagging the connection to cockroach"),
 	}
 
-	jwtAudiences = flag.String("accepted_jwt_audiences", "", "commad separated acceptable JWT `aud` claims")
+	jwtAudiences = flag.String("accepted_jwt_audiences", "", "comma-separated acceptable JWT `aud` claims")
 )
 
-func MustSupportSchema(ctx context.Context, store *ridc.Store) {
+func MustSupportRidSchema(ctx context.Context, store *ridc.Store) {
 	logger := logging.WithValuesFromContext(ctx, logging.Logger)
 
 	vs, err := store.GetVersion(ctx)
 	if err != nil {
-		logger.Panic("could not get schema version from database", zap.Error(err))
+		logger.Panic("Failed to get database schema version for remote ID",
+			zap.Error(err))
+	}
+	if vs == "v0.0.0" {
+		logger.Panic("Remote ID database has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas")
 	}
 
-	if RequiredMajorSchemaVersion != semver.Major(vs) {
-		logger.Panic(fmt.Sprintf("unsupported schema version! Got %s, requires major version of %s.", vs, RequiredMajorSchemaVersion))
+	if RidRequiredMajorSchemaVersion != semver.Major(vs) {
+		logger.Panic(fmt.Sprintf("unsupported schema version for remote ID! Got %s, requires major version of %s.", vs, RidRequiredMajorSchemaVersion))
 	}
+}
+
+func MustSupportScdSchema(ctx context.Context, store *scdc.Store) {
+	logger := logging.WithValuesFromContext(ctx, logging.Logger)
+
+	vs, err := store.GetVersion(ctx)
+	if err != nil {
+		logger.Panic("Failed to get database schema version for strategic conflict detection",
+			zap.Error(err))
+	}
+	if vs == "v0.0.0" {
+		logger.Panic("Strategic conflict detection database has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas")
+	}
+
+	if ScdRequiredMajorSchemaVersion != semver.Major(vs) {
+		logger.Panic(fmt.Sprintf("unsupported schema version for strategic conflict detection! Got %s, requires major version of %s.", vs, ScdRequiredMajorSchemaVersion))
+	}
+}
+
+func ConnectTo(dbName string) (*cockroach.DB, error) {
+	uriParams := map[string]string{
+		"host":             *cockroachParams.host,
+		"port":             strconv.Itoa(*cockroachParams.port),
+		"user":             *cockroachParams.user,
+		"ssl_mode":         *cockroachParams.sslMode,
+		"ssl_dir":          *cockroachParams.sslDir,
+		"application_name": *cockroachParams.applicationName,
+		"db_name":          dbName,
+	}
+	uri, err := cockroach.BuildURI(uriParams)
+	if err != nil {
+		return nil, err
+	}
+	return cockroach.Dial(uri)
 }
 
 // RunGRPCServer starts the example gRPC service.
@@ -107,55 +150,51 @@ func RunGRPCServer(ctx context.Context, address string) error {
 		}
 	}()
 
-	uriParams := map[string]string{
-		"host":             *cockroachParams.host,
-		"port":             strconv.Itoa(*cockroachParams.port),
-		"user":             *cockroachParams.user,
-		"ssl_mode":         *cockroachParams.sslMode,
-		"ssl_dir":          *cockroachParams.sslDir,
-		"application_name": *cockroachParams.applicationName,
-	}
-	uri, err := cockroach.BuildURI(uriParams)
-	if err != nil {
-		logger.Panic("Failed to build URI", zap.Error(err))
-	}
-
-	crdb, err := cockroach.Dial(uri)
-	if err != nil {
-		logger.Panic("Failed to dial CRDB instance", zap.Error(err))
-	}
-	store := ridc.NewStore(crdb, logger)
-
-	if _, err := store.GetVersion(ctx); err != nil {
-		logger.Panic("Failed to get Database Schema Version", zap.Error(err))
-	}
-
-	MustSupportSchema(ctx, store)
-
 	var (
-		dssServer = &rid.Server{
-			App:     application.NewFromTransactor(store, logger),
-			Timeout: *timeout,
-		}
-		auxServer        = &aux.Server{}
-		scdServer        *scd.Server
-		scopesValidators = auth.MergeOperationsAndScopesValidators(
-			rid.AuthScopes(), auxServer.AuthScopes(),
-		)
+		ridServer *rid.Server
+		scdServer *scd.Server
+		auxServer = &aux.Server{}
 	)
 
-	if *enableSCD {
-		store := scdc.NewStore(crdb, logger)
+	// Initialize remote ID
 
-		if err := store.Bootstrap(ctx); err != nil {
-			logger.Panic("Failed to bootstrap CRDB instance", zap.Error(err))
+	ridCrdb, err := ConnectTo("defaultdb")
+	if err != nil {
+		logger.Panic("Failed to connect to remote ID database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", zap.Error(err))
+	}
+	ridStore := ridc.NewStore(ridCrdb, logger)
+
+	MustSupportRidSchema(ctx, ridStore)
+
+	ridServer = &rid.Server{
+		App:     application.NewFromTransactor(ridStore, logger),
+		Timeout: *timeout,
+	}
+	scopesValidators := auth.MergeOperationsAndScopesValidators(
+		rid.AuthScopes(), auxServer.AuthScopes(),
+	)
+
+	// Initialize strategic conflict detection
+
+	if *enableSCD {
+		scdCrdb, err := ConnectTo("scd")
+		if err != nil {
+			logger.Panic("Failed to connect to strategic conflict detection database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", zap.Error(err))
 		}
+		scdStore := scdc.NewStore(scdCrdb, logger)
+
+		MustSupportScdSchema(ctx, scdStore)
+
 		scdServer = &scd.Server{
-			Store:   store,
+			Store:   scdStore,
 			Timeout: *timeout,
 		}
-		scopesValidators = auth.MergeOperationsAndScopesValidators(scopesValidators, scdServer.AuthScopes())
+		scopesValidators = auth.MergeOperationsAndScopesValidators(
+			scopesValidators, scdServer.AuthScopes(),
+		)
 	}
+
+	// Initialize access token validation
 
 	var keyResolver auth.KeyResolver
 	switch {
@@ -189,6 +228,8 @@ func RunGRPCServer(ctx context.Context, address string) error {
 		return err
 	}
 
+	// Set up server functionality
+
 	interceptors := []grpc.UnaryServerInterceptor{
 		uss_errors.Interceptor(logger),
 		logging.Interceptor(logger),
@@ -207,7 +248,7 @@ func RunGRPCServer(ctx context.Context, address string) error {
 		reflection.Register(s)
 	}
 
-	ridpb.RegisterDiscoveryAndSynchronizationServiceServer(s, dssServer)
+	ridpb.RegisterDiscoveryAndSynchronizationServiceServer(s, ridServer)
 	auxpb.RegisterDSSAuxServiceServer(s, auxServer)
 	if *enableSCD {
 		logger.Info("config", zap.Any("scd", "enabled"))

--- a/pkg/cockroach/cockroach.go
+++ b/pkg/cockroach/cockroach.go
@@ -83,10 +83,10 @@ func GetVersion(ctx context.Context, db *DB, dbName string) (string, error) {
 	}
 	if !ret {
 		// Database has not been bootstrapped using DB Schema Manager
-		return "v0.0.0", fmt.Errorf("%s has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", dbName)
+		return "v0.0.0", nil
 	}
 	getVersionQuery := fmt.Sprintf(`
-		SELECT schema_version 
+		SELECT schema_version
 			FROM %s.schema_versions
 		WHERE onerow_enforcer = TRUE`, dbName)
 	row = db.QueryRowContext(ctx, getVersionQuery)

--- a/pkg/rid/store/cockroach/store.go
+++ b/pkg/rid/store/cockroach/store.go
@@ -24,7 +24,7 @@ var (
 	// TODO: use this in other function calls
 	DefaultTimeout = 10 * time.Second
 
-	// Name of database storing remote ID data.
+	// DatabaseName is the name of database storing remote ID data.
 	DatabaseName = "defaultdb"
 )
 

--- a/pkg/rid/store/cockroach/store.go
+++ b/pkg/rid/store/cockroach/store.go
@@ -23,6 +23,9 @@ var (
 	// deadline is used
 	// TODO: use this in other function calls
 	DefaultTimeout = 10 * time.Second
+
+	// Name of database storing remote ID data.
+	DatabaseName = "defaultdb"
 )
 
 type repo struct {
@@ -122,5 +125,5 @@ func (s *Store) CleanUp(ctx context.Context) error {
 // GetVersion returns the Version string for the Database.
 // If the DB was is not bootstrapped using the schema manager we throw and error
 func (s *Store) GetVersion(ctx context.Context) (string, error) {
-	return cockroach.GetVersion(ctx, s.db, "defaultdb")
+	return cockroach.GetVersion(ctx, s.db, DatabaseName)
 }

--- a/pkg/scd/store/cockroach/store.go
+++ b/pkg/scd/store/cockroach/store.go
@@ -16,7 +16,7 @@ var (
 	// DefaultClock is what is used as the Store's clock, returned from Dial.
 	DefaultClock = clockwork.NewRealClock()
 
-	// Name of database storing strategic conflict detection data.
+	// DatabaseName is the name of database storing strategic conflict detection data.
 	DatabaseName = "scd"
 )
 

--- a/pkg/scd/store/cockroach/store.go
+++ b/pkg/scd/store/cockroach/store.go
@@ -67,67 +67,8 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
-// Bootstrap bootstraps the underlying database with required tables.
-//
-// TODO: We should handle database migrations properly, but bootstrap both us
-// *and* the database with this manual approach here.
-func (s *Store) Bootstrap(ctx context.Context) error {
-	const query = `
-	CREATE TABLE IF NOT EXISTS scd_subscriptions (
-		id UUID PRIMARY KEY,
-		owner STRING NOT NULL,
-		version INT4 NOT NULL DEFAULT 0,
-		url STRING NOT NULL,
-		notification_index INT4 DEFAULT 0,
-		notify_for_operations BOOL DEFAULT false,
-		notify_for_constraints BOOL DEFAULT false,
-		implicit BOOL DEFAULT false,
-		starts_at TIMESTAMPTZ,
-		ends_at TIMESTAMPTZ,
-		updated_at TIMESTAMPTZ NOT NULL,
-		INDEX owner_idx (owner),
-		INDEX starts_at_idx (starts_at),
-		INDEX ends_at_idx (ends_at),
-		CHECK (starts_at IS NULL OR ends_at IS NULL OR starts_at < ends_at),
-		CHECK (notify_for_operations OR notify_for_constraints)
-	);
-	CREATE TABLE IF NOT EXISTS scd_cells_subscriptions (
-		cell_id INT64 NOT NULL,
-		cell_level INT CHECK (cell_level BETWEEN 0 and 30),
-		subscription_id UUID NOT NULL REFERENCES scd_subscriptions (id) ON DELETE CASCADE,
-		PRIMARY KEY (cell_id, subscription_id),
-		INDEX cell_id_idx (cell_id),
-		INDEX subscription_id_idx (subscription_id)
-	);
-	CREATE TABLE IF NOT EXISTS scd_operations (
-		id UUID PRIMARY KEY,
-		owner STRING NOT NULL,
-		version INT4 NOT NULL DEFAULT 0,
-		url STRING NOT NULL,
-		altitude_lower REAL,
-		altitude_upper REAL,
-		starts_at TIMESTAMPTZ,
-		ends_at TIMESTAMPTZ,
-		subscription_id UUID NOT NULL REFERENCES scd_subscriptions(id) ON DELETE CASCADE,
-		updated_at TIMESTAMPTZ NOT NULL,
-		INDEX owner_idx (owner),
-		INDEX altitude_lower_idx (altitude_lower),
-		INDEX altitude_upper_idx (altitude_upper),
-		INDEX starts_at_idx (starts_at),
-		INDEX ends_at_idx (ends_at),
-		INDEX updated_at_idx (updated_at),
-		INDEX subscription_id_idx (subscription_id),
-		CHECK (starts_at IS NULL OR ends_at IS NULL OR starts_at < ends_at)
-	);
-	CREATE TABLE IF NOT EXISTS scd_cells_operations (
-		cell_id INT64 NOT NULL,
-		cell_level INT CHECK (cell_level BETWEEN 0 and 30),
-		operation_id UUID NOT NULL REFERENCES scd_operations (id) ON DELETE CASCADE,
-		PRIMARY KEY (cell_id, operation_id),
-		INDEX cell_id_idx (cell_id),
-		INDEX operation_id_idx (operation_id)
-	);
-	`
-	_, err := s.db.ExecContext(ctx, query)
-	return err
+// GetVersion returns the Version string for the Database.
+// If the DB was is not bootstrapped using the schema manager we throw and error
+func (s *Store) GetVersion(ctx context.Context) (string, error) {
+	return cockroach.GetVersion(ctx, s.db, "scd")
 }

--- a/pkg/scd/store/cockroach/store.go
+++ b/pkg/scd/store/cockroach/store.go
@@ -15,6 +15,9 @@ import (
 var (
 	// DefaultClock is what is used as the Store's clock, returned from Dial.
 	DefaultClock = clockwork.NewRealClock()
+
+	// Name of database storing strategic conflict detection data.
+	DatabaseName = "scd"
 )
 
 // repo is an implementation of repos.Repo using
@@ -70,5 +73,5 @@ func (s *Store) Close() error {
 // GetVersion returns the Version string for the Database.
 // If the DB was is not bootstrapped using the schema manager we throw and error
 func (s *Store) GetVersion(ctx context.Context) (string, error) {
-	return cockroach.GetVersion(ctx, s.db, "scd")
+	return cockroach.GetVersion(ctx, s.db, DatabaseName)
 }

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -79,6 +79,16 @@ docker run --rm --name rid-db-manager \
 	--cockroach_host crdb
 
 sleep 1
+echo "Bootstrapping SCD Database tables"
+docker run --rm --name scd-db-manager \
+	--link dss-crdb-for-debugging:crdb \
+	-v $(pwd)/build/deploy/db-schemas/scd:/db-schemas/scd \
+	local-db-manager \
+	--schemas_dir db-schemas/scd \
+	--db_version v1.0.0 \
+	--cockroach_host crdb
+
+sleep 1
 echo " ------------ GRPC BACKEND ---------------- "
 echo "Cleaning up any pre-existing grpc-backend container"
 docker rm -f grpc-backend-for-testing &> /dev/null || echo "No grpc backend to clean up"


### PR DESCRIPTION
This PR moves SCD data into its own database (named "scd") and introduces migrations to that database.

One consequence of the approach here is that a single CRDB connection is no longer shared between RID & SCD.  We could share a single connection, but all the SQL statements would need to be rewritten to prefix table names with the correct database.  This probably seems worthwhile, but the RID database should be changed from "defaultdb" to "rid" before adding all those database name prefixes, and this is better-suited to a PR separate from this one.

The PR also pipes the enableScd grpc-backend option through deployment configurations.