### PR TITLE
Restructure prober auth configuration

### DIFF
--- a/monitoring/get_access_token.py
+++ b/monitoring/get_access_token.py
@@ -1,0 +1,30 @@
+import argparse
+import sys
+from typing import List
+
+import prober.auth
+
+
+def parse_args(argv: List[str]):
+  parser = argparse.ArgumentParser(description='Retrieve an access token')
+  parser.add_argument(
+    '--spec', action='store', dest='spec', type=str,
+    help='The auth spec for which to retrieve the token.  See README.md in this folder for examples.')
+  parser.add_argument(
+    '--scopes', action='store', dest='scopes', type=str,
+    help='The scope or scopes to request.  Multiple scopes should be space-separated (so, included in quotes on the command line).')
+  parser.add_argument(
+    '--audience', action='store', dest='audience', type=str,
+    help='The audience to request.')
+  return parser.parse_args(argv)
+
+
+def get_access_token(spec: str, scopes: str, audience: str):
+  adapter = prober.auth.make_auth_adapter(spec)
+  return adapter.issue_token(audience, scopes.split(' '))
+
+
+if __name__ == '__main__':
+  args = parse_args(sys.argv[1:])
+  print(get_access_token(args.spec, args.scopes, args.audience))
+

--- a/monitoring/prober/Dockerfile
+++ b/monitoring/prober/Dockerfile
@@ -1,8 +1,11 @@
-FROM python:3.7-alpine
+FROM python:3.7
+# Not -alpine because: https://stackoverflow.com/a/58028091/651139
 # The context for this image should be monitoring/prober
-ADD . /app
+RUN mkdir /app
+COPY requirements.txt /app
 WORKDIR /app
 RUN pip install -r requirements.txt
 RUN rm -rf __pycache__
+ADD . /app
 
 ENTRYPOINT ["pytest"]

--- a/monitoring/prober/README.md
+++ b/monitoring/prober/README.md
@@ -1,11 +1,81 @@
 # Prober (integration tests)
 
 This directory contains integration tests that can be run against a live DSS
-instance.  The tests create, modify and delete subscriptions and ISAs.
+instance.  These integration tests are also run as part of
+[docker_e2e.sh](../../test/docker_e2e.sh) which is a self-contained system
+integration test suite.
+
+## Authorization
+When running this prober pytest suite, you must provide information regarding
+how to obtain access tokens during the tests.  There are three different
+circumstances under which an access token is needed, each with a command line
+flag to specify how to obtain access tokens in that circumstance:
+
+* Performing remote ID operations (`rid-auth` flag).  This user should have
+  permission to be granted all remote ID scopes.
+* Performing strategic conflict detection operations as USS1 (`scd-auth1`
+  flag).  This user should have permission to be granted all SCD scopes.
+* Performing strategic conflict detection operations as USS2 (`scd-auth2`
+  flag).  This user should have permission to perform strategic coordination,
+  and the credentials must be different than those for `scd-auth1`.
+
+The value for each of these flags is a specification for how to retrieve access
+tokens.  Each specification takes the form of `AuthAdapter(value1,value2,...)`.
+All available AuthAdapters are defined in [auth.py](auth.py) and the parameters
+are those accepted by the particular AuthAdapter's `__init__` constructor.  Both
+ordinal and keyword (e.g., `AuthAdapter(param1=value1,param2=value2)`)
+parameters are accepted.  Notes:
+1. The spec must be a singular shell string unbroken by spaces and so should
+   probably be wrapped in quotes on the command line.
+1. All parameter types are strings.
+1. String values are not delimited by any quote-like characters.
+1. If an authorization spec is omitted, the tests that depend on that
+   authorization will be skipped. 
+
+### Examples
+
+* `--rid-auth "UsernamePassword(https://example.com/token, username=uss1,
+   password=uss1, client_id=uss1)"`
+* `--rid-auth "ServiceAccount(https://example.com/token,
+   ~/credentials/account.json)"`
+* `--rid-auth "DummyOAuth(http://localhost:8085/token, sub=fake_uss)"`
+
+## Running pytest via Docker
+This approach takes slightly longer to execute due to building the prober image,
+but it requires no setup and generally obtains more reproducible results than
+running locally.  From the root of this repo:
+
+```shell script
+docker run --rm $(docker build -q -f monitoring/prober/Dockerfile monitoring/prober) \
+    --dss-endpoint <URL> \
+    [--rid-auth <SPEC>] \
+    [--scd-auth1 <SPEC>] \
+    [--scd-auth2 <SPEC>]
+```
+
+Or, execute the two steps separately.  First, build the prober image:
+
+```shell script
+docker build -f monitoring/prober/Dockerfile monitoring/prober -t local-prober
+```
+
+...then run it:
+
+```shell script
+docker run --rm local-prober \
+    --dss-endpoint <URL> \
+    [--rid-auth <SPEC>] \
+    [--scd-auth1 <SPEC>] \
+    [--scd-auth2 <SPEC>]
+```
+
+## Running pytest locally
+This approach will save the time of building the prober Docker container, but
+requires more setup and may not be fully-reproducible due to system differences
+in Python, etc.
 
 ### First time set up
-
-```shell
+```shell script
 sudo apt-get install virtualenv
 virtualenv --python python3 env
 . ./env/bin/activate
@@ -13,28 +83,12 @@ pip install -r requirements.txt
 ```
 
 ### Running the prober
-Run the following command from the project's home directory:
-
-If authenticating with a service account:
-
 ```shell
 . ./env/bin/activate
 pytest \
-    --oauth-token-endpoint <URL> \
-    --oauth-service-account-json <FILENAME> \
     --dss-endpoint <URL> \
-    [--scd-dss-endpoint <URL>] \
+    [--rid-auth <SPEC>] \
+    [--scd-auth1 <SPEC>] \
+    [--scd-auth2 <SPEC>] \
     -vv .
-```
-
-Or if authenticating with a username/password/client_id:
-
-```shell
-docker run --rm $(docker build -q -f monitoring/prober/Dockerfile monitoring/prober) \
-    --oauth-token-endpoint <URL> \
-    --oauth-username <USERNAME> \
-    --oauth-password <PASSWORD> \
-    --oauth-client_id <CLIENT_ID> \
-    --dss-endpoint <URL> \
-    [--scd-dss-endpoint <URL>]
 ```

--- a/monitoring/prober/auth.py
+++ b/monitoring/prober/auth.py
@@ -1,0 +1,256 @@
+import base64
+import datetime
+import re
+from typing import List, Optional
+import urllib.parse
+
+import cryptography.exceptions
+import cryptography.hazmat.backends
+import cryptography.hazmat.primitives.hashes
+import cryptography.hazmat.primitives.serialization
+import cryptography.x509
+import jwcrypto.common
+import jwcrypto.jwk
+import jwcrypto.jws
+import requests
+from google.auth.transport import requests as google_requests
+from google.oauth2 import service_account
+
+from .infrastructure import AuthAdapter
+
+
+class DummyOAuth(AuthAdapter):
+  """Auth adapter that gets JWTs that uses the Dummy OAuth Server"""
+
+  def __init__(self, token_endpoint: str, sub: str):
+    super().__init__()
+
+    self._oauth_token_endpoint = token_endpoint
+    self._sub = sub
+    self._oauth_session = requests.Session()
+
+  # Overrides method in AuthAdapter
+  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
+    url = '{}?grant_type=client_credentials&scope={}&intended_audience={}&issuer=dummy&sub={}'.format(
+      self._oauth_token_endpoint, urllib.parse.quote(' '.join(scopes)),
+      urllib.parse.quote(intended_audience), self._sub)
+    response = self._oauth_session.post(url).json()
+    return response['access_token']
+
+
+class ServiceAccount(AuthAdapter):
+  """Auth adapter that gets JWTs using a service account."""
+
+  def __init__(self, token_endpoint: str, service_account_json: str):
+    super().__init__()
+
+    credentials = service_account.Credentials.from_service_account_file(
+      service_account_json).with_scopes(['email'])
+    oauth_session = google_requests.AuthorizedSession(credentials)
+
+    self._oauth_token_endpoint = token_endpoint
+    self._oauth_session = oauth_session
+
+  # Overrides method in AuthAdapter
+  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
+    url = '{}?grant_type=client_credentials&scope={}&intended_audience={}'.format(
+      self._oauth_token_endpoint, urllib.parse.quote(' '.join(scopes)),
+      urllib.parse.quote(intended_audience))
+    response = self._oauth_session.post(url).json()
+    return response['access_token']
+
+
+class UsernamePassword(AuthAdapter):
+  """Auth adapter that gets JWTs using a username and password."""
+
+  def __init__(self, token_endpoint: str, username: str, password: str, client_id: str):
+    super().__init__()
+
+    self._oauth_token_endpoint = token_endpoint
+    self._username = username
+    self._password = password
+    self._client_id = client_id
+
+  # Overrides method in AuthAdapter
+  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
+    scopes.append('aud:{}'.format(intended_audience))
+    response = requests.post(self._oauth_token_endpoint, data={
+      'grant_type': "password",
+      'username': self._username,
+      'password': self._password,
+      'client_id': self._client_id,
+      'scope': ' '.join(scopes),
+    }).json()
+    return response['access_token']
+
+
+class SignedRequest(AuthAdapter):
+  """Auth adapter that gets JWTs by signing its outgoing requests."""
+
+  def __init__(self, token_endpoint: str, client_id: str, key_path: str, cert_url: str, key_id: Optional[str] = None):
+    """Create an AuthAdapter that retrieves tokens via message signing.
+
+    Args:
+      token_endpoint: URL of the authorization server's token endpoint.
+      client_id: ID of client for which the token is being requested.
+      key_path: Path to private key with which to sign the token request.
+      cert_url: Publicly-accessible URL of certificate containing the public key
+        corresponding to the private key in key_path and signed by an authority
+        recognized by the authorization server.
+      key_id: If specified, the specific ID to supply in the JWS header.  If not
+        specified, defaults to the thumbprint of the certificate's public key.
+    """
+    super().__init__()
+
+    self._token_endpoint = token_endpoint
+    self._client_id = client_id
+    with open(key_path, 'r') as f:
+      self._private_key = f.read()
+    self._cert_url = cert_url
+    self._backend = cryptography.hazmat.backends.default_backend()
+
+    # Retrieve certificate to validate match with private key
+    response = requests.get(self._cert_url)
+    assert response.status_code == 200
+    if cert_url[-4:].lower() == '.der':
+      cert = cryptography.x509.load_der_x509_certificate(response.content, self._backend)
+    elif cert_url[-4:].lower() == '.crt':
+      cert = cryptography.x509.load_pem_x509_certificate(response.content, self._backend)
+    else:
+      raise ValueError('cert_url must end with .der or .crt')
+    cert_public_key = cert.public_key().public_bytes(
+      cryptography.hazmat.primitives.serialization.Encoding.PEM,
+      cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo)
+
+    # Generate public key directly from private key
+    with open(key_path, 'r') as f:
+      key_content = f.read().encode('utf-8')
+    if key_path[-4:].lower() == '.key' or key_path[-4:].lower() == '.pem':
+      private_key = cryptography.hazmat.primitives.serialization.load_pem_private_key(
+        key_content, password=None, backend=self._backend)
+      private_key_bytes = key_content
+    else:
+      raise ValueError('key_path must end with .key or .pem')
+    public_key = private_key.public_key().public_bytes(
+      cryptography.hazmat.primitives.serialization.Encoding.PEM,
+      cryptography.hazmat.primitives.serialization.PublicFormat.SubjectPublicKeyInfo)
+
+    if cert_public_key != public_key:
+      raise ValueError('Public key in certificate does not match private key provided')
+
+    self._private_jwk = jwcrypto.jwk.JWK.from_pem(private_key_bytes)
+    self._public_jwk = jwcrypto.jwk.JWK.from_pem(public_key)
+
+    # Assign key ID
+    if key_id:
+      self._kid = key_id
+    else:
+      self._kid = self._public_jwk.thumbprint()
+
+  # Overrides method in AuthAdapter
+  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
+    # Construct request body
+    query = {
+      'grant_type': 'client_credentials',
+      'client_id': self._client_id,
+      'scope': ' '.join(scopes),
+      'current_timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
+    }
+    payload = '&'.join([k + '=' + v for k, v in query.items()])
+
+    # Construct JWS
+    token_headers = {
+      'typ': 'JOSE',
+      'alg': 'RS256',
+      'x5u': self._cert_url,
+      'kid': self._kid,
+    }
+    jws = jwcrypto.jws.JWS(payload.encode('utf-8'))
+    jws.add_signature(self._private_jwk, 'RS256', protected=jwcrypto.common.json_encode(token_headers))
+    signed = jws.serialize(compact=True)
+
+    # Check JWS
+    jws_check = jwcrypto.jws.JWS()
+    jws_check.deserialize(signed)
+    try:
+      jws_check.verify(self._public_jwk, 'RS256')
+    except jwcrypto.jws.InvalidJWSSignature:
+      raise ValueError('Could not construct a valid cryptographic signature for JWS')
+
+    # Construct signature
+    signature = re.sub(r'\.[^.]*\.', '..', signed)
+
+    # Make token request
+    request_headers = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'x-utm-message-signature': signature,
+    }
+    response = requests.post(self._token_endpoint, data=payload, headers=request_headers)
+    if response.status_code != 200:
+      raise ValueError('Unable to retrieve access token:\n' + response.content.decode('utf-8'))
+    return response.json()['access_token']
+
+
+class ClientIdClientSecret(AuthAdapter):
+  """Auth adapter that gets JWTs using a client ID and client secret."""
+
+  def __init__(self, token_endpoint: str, client_id: str, client_secret: str):
+    super().__init__()
+
+    self._oauth_token_endpoint = token_endpoint
+    self._client_id = client_id
+    self._client_secret = client_secret
+
+  # Overrides method in AuthAdapter
+  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
+    response = requests.post(self._oauth_token_endpoint, json={
+      'grant_type': 'client_credentials',
+      'client_id': self._client_id,
+      'client_secret': self._client_secret,
+      'audience': intended_audience,
+      'scope': ' '.join(scopes),
+    })
+    if response.status_code != 200:
+      raise ValueError('Unable to retrieve access token:\n' + response.content.decode('utf-8'))
+    return response.json()['access_token']
+
+
+def make_auth_adapter(spec: str) -> AuthAdapter:
+  """Make an AuthAdapter according to a string specification.
+
+  Args:
+    spec: Specification of adapter in the form
+      ADAPTER_NAME([VALUE1[,PARAM2=VALUE2][,...]]) where ADAPTER_NAME is the
+      name of a subclass of AuthAdapter and the contents of the parentheses are
+      *args-style and **kwargs-style values for the parameters of ADAPTER_NAME's
+      __init__, but the values (all strings) do not have any quote-like
+      delimiters.
+
+  Returns:
+    An instance of the appropriate AuthAdapter subclass according to the
+    provided spec.
+  """
+  m = re.match(r'^\s*([^\s(]+)\s*\(\s*([^)]*)\s*\)\s*$', spec)
+  if m is None:
+    raise ValueError('Auth adapter specification did not match the pattern `AdapterName(param, param, ...)`')
+
+  adapter_name = m.group(1)
+  adapter_classes = {cls.__name__: cls for cls in AuthAdapter.__subclasses__()}
+  if adapter_name not in adapter_classes:
+    raise ValueError('Auth adapter `%s` does not exist' % adapter_name)
+  Adapter = adapter_classes[adapter_name]
+
+  adapter_param_string = m.group(2)
+  param_strings = [s.strip() for s in adapter_param_string.split(',')]
+  args = []
+  kwargs = {}
+  for param_string in param_strings:
+    if '=' in param_string:
+      kv = param_string.split('=')
+      if len(kv) != 2:
+        raise ValueError('Auth adapter specification contained a parameter with more than one `=` character')
+      kwargs[kv[0].strip()] = kv[1].strip()
+    else:
+      args.append(param_string)
+
+  return Adapter(*args, **kwargs)

--- a/monitoring/prober/aux/test_token_validation.py
+++ b/monitoring/prober/aux/test_token_validation.py
@@ -1,16 +1,23 @@
 """Test Authentication validation
 """
 
+from ..infrastructure import default_scope
 
+
+@default_scope('dss.read.identification_service_areas')
 def test_validate(aux_session):
   resp = aux_session.get('/validate_oauth')
   assert resp.status_code == 200
 
+
+@default_scope('dss.read.identification_service_areas')
 def test_validate_token_good_user(aux_session):
   # TODO: These tests should work with any AuthAdapter, not just the dummy OAuth.  Hardcoding fake_uss here won't work in general.
   resp = aux_session.get('/validate_oauth?owner=fake_uss')
   assert resp.status_code == 200
 
+
+@default_scope('dss.read.identification_service_areas')
 def test_validate_token_bad_user(aux_session):
   resp = aux_session.get('/validate_oauth?owner=bad_user')
   assert resp.status_code == 403

--- a/monitoring/prober/requirements.txt
+++ b/monitoring/prober/requirements.txt
@@ -1,3 +1,5 @@
 google-auth==1.6.3
 pytest==4.4.1
 requests==2.22.0
+cryptography==2.9.2
+jwcrypto==0.7

--- a/monitoring/prober/rid/test_isa_expiry.py
+++ b/monitoring/prober/rid/test_isa_expiry.py
@@ -3,9 +3,12 @@
 import datetime
 import time
 
+from ..infrastructure import default_scope
 from . import common
+from .common import SCOPE_READ, SCOPE_WRITE
 
 
+@default_scope(SCOPE_WRITE)
 def test_create(session, isa1_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=5)
@@ -29,6 +32,7 @@ def test_create(session, isa1_uuid):
   assert resp.status_code == 200
 
 
+@default_scope(SCOPE_READ)
 def test_valid_immediately(session, isa1_uuid):
   # The ISA is still valid immediately after we create it.
   resp = session.get('/identification_service_areas/{}'.format(isa1_uuid))
@@ -40,12 +44,14 @@ def test_sleep_5_seconds():
   time.sleep(5)
 
 
+@default_scope(SCOPE_READ)
 def test_returned_by_id(session, isa1_uuid):
   # And we can't get it by ID...
   resp = session.get('/identification_service_areas/{}'.format(isa1_uuid))
   assert resp.status_code == 200
 
 
+@default_scope(SCOPE_READ)
 def test_not_returned_by_search(session, isa1_uuid):
   # Or by search.
   resp = session.get('/identification_service_areas?area={}'.format(

--- a/monitoring/prober/rid/test_isa_validation.py
+++ b/monitoring/prober/rid/test_isa_validation.py
@@ -8,9 +8,12 @@
 
 import datetime
 
+from ..infrastructure import default_scope
 from . import common
+from .common import SCOPE_WRITE
 
 
+@default_scope(SCOPE_WRITE)
 def test_isa_huge_area(session, isa1_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -35,6 +38,7 @@ def test_isa_huge_area(session, isa1_uuid):
   assert 'area is too large' in resp.json()['message']
 
 
+@default_scope(SCOPE_WRITE)
 def test_isa_empty_vertices(session, isa1_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -59,6 +63,7 @@ def test_isa_empty_vertices(session, isa1_uuid):
   assert resp.json()['message'] == 'bad extents: not enough points in polygon'
 
 
+@default_scope(SCOPE_WRITE)
 def test_isa_missing_footprint(session, isa1_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -81,6 +86,7 @@ def test_isa_missing_footprint(session, isa1_uuid):
   )['message'] == 'bad extents: spatial_volume missing required footprint'
 
 
+@default_scope(SCOPE_WRITE)
 def test_isa_missing_spatial_volume(session, isa1_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -99,6 +105,7 @@ def test_isa_missing_spatial_volume(session, isa1_uuid):
   )['message'] == 'bad extents: missing required spatial_volume'
 
 
+@default_scope(SCOPE_WRITE)
 def test_isa_missing_extents(session, isa1_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -112,6 +119,7 @@ def test_isa_missing_extents(session, isa1_uuid):
   assert resp.json()['message'] == 'missing required extents'
 
 
+@default_scope(SCOPE_WRITE)
 def test_isa_start_time_in_past(session, isa1_uuid):
   time_start = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
   time_end = time_start + datetime.timedelta(minutes=60)
@@ -137,6 +145,7 @@ def test_isa_start_time_in_past(session, isa1_uuid):
   )['message'] == 'IdentificationServiceArea time_start must not be in the past'
 
 
+@default_scope(SCOPE_WRITE)
 def test_isa_start_time_after_time_end(session, isa1_uuid):
   time_start = datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
   time_end = time_start - datetime.timedelta(minutes=5)
@@ -162,6 +171,7 @@ def test_isa_start_time_after_time_end(session, isa1_uuid):
   )['message'] == 'IdentificationServiceArea time_end must be after time_start'
 
 
+@default_scope(SCOPE_WRITE)
 def test_isa_not_on_earth(session, isa1_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(minutes=60)

--- a/monitoring/prober/rid/test_subscription_simple.py
+++ b/monitoring/prober/rid/test_subscription_simple.py
@@ -9,15 +9,20 @@
 import datetime
 import re
 
+from ..infrastructure import default_scope
 from . import common
+from .common import SCOPE_READ
 
 
+
+@default_scope(SCOPE_READ)
 def test_sub_does_not_exist(session, sub1_uuid):
   resp = session.get('/subscriptions/{}'.format(sub1_uuid))
   assert resp.status_code == 404
   assert resp.json()['message'] == 'resource not found: {}'.format(sub1_uuid)
 
 
+@default_scope(SCOPE_READ)
 def test_create_sub(session, sub1_uuid):
   """ASTM Compliance Test: DSS0030_C_PUT_SUB."""
   time_start = datetime.datetime.utcnow()
@@ -57,6 +62,7 @@ def test_create_sub(session, sub1_uuid):
   assert 'service_areas' in data
 
 
+@default_scope(SCOPE_READ)
 def test_get_sub_by_id(session, sub1_uuid):
   """ASTM Compliance Test: DSS0030_E_GET_SUB_BY_ID."""
   resp = session.get('/subscriptions/{}'.format(sub1_uuid))
@@ -70,6 +76,7 @@ def test_get_sub_by_id(session, sub1_uuid):
   }
 
 
+@default_scope(SCOPE_READ)
 def test_get_sub_by_search(session, sub1_uuid):
   """ASTM Compliance Test: DSS0030_F_GET_SUBS_BY_AREA."""
   resp = session.get('/subscriptions?area={}'.format(common.GEO_POLYGON_STRING))
@@ -77,21 +84,25 @@ def test_get_sub_by_search(session, sub1_uuid):
   assert sub1_uuid in [x['id'] for x in resp.json()['subscriptions']]
 
 
+@default_scope(SCOPE_READ)
 def test_get_sub_by_searching_huge_area(session, sub1_uuid):
   resp = session.get('/subscriptions?area={}'.format(common.HUGE_GEO_POLYGON_STRING))
   assert resp.status_code == 413
 
 
+@default_scope(SCOPE_READ)
 def test_delete_sub_empty_version(session, sub1_uuid):
   resp = session.delete('/subscriptions/{}/'.format(sub1_uuid))
   assert resp.status_code == 400
 
 
+@default_scope(SCOPE_READ)
 def test_delete_sub_wrong_version(session, sub1_uuid):
   resp = session.delete('/subscriptions/{}/fake_version'.format(sub1_uuid))
   assert resp.status_code == 400
 
 
+@default_scope(SCOPE_READ)
 def test_delete_sub(session, sub1_uuid):
   """ASTM Compliance Test: DSS0030_D_DELETE_SUB."""
   # GET the sub first to find its version.
@@ -104,11 +115,13 @@ def test_delete_sub(session, sub1_uuid):
   assert resp.status_code == 200
 
 
+@default_scope(SCOPE_READ)
 def test_get_deleted_sub_by_id(session, sub1_uuid):
   resp = session.get('/subscriptions/{}'.format(sub1_uuid))
   assert resp.status_code == 404
 
 
+@default_scope(SCOPE_READ)
 def test_get_deleted_sub_by_search(session, sub1_uuid):
   resp = session.get('/subscriptions?area={}'.format(common.GEO_POLYGON_STRING))
   assert resp.status_code == 200

--- a/monitoring/prober/rid/test_subscription_validation.py
+++ b/monitoring/prober/rid/test_subscription_validation.py
@@ -9,9 +9,12 @@
 import datetime
 import uuid
 
+from ..infrastructure import default_scope
 from . import common
+from .common import SCOPE_READ
 
 
+@default_scope(SCOPE_READ)
 def test_create_sub_empty_vertices(session, sub2_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=10)
@@ -37,6 +40,7 @@ def test_create_sub_empty_vertices(session, sub2_uuid):
   assert resp.status_code == 400
 
 
+@default_scope(SCOPE_READ)
 def test_create_sub_missing_footprint(session, sub2_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=10)
@@ -59,6 +63,7 @@ def test_create_sub_missing_footprint(session, sub2_uuid):
   assert resp.status_code == 400
 
 
+@default_scope(SCOPE_READ)
 def test_create_sub_with_huge_area(session, sub2_uuid):
   time_start = datetime.datetime.utcnow()
   time_end = time_start + datetime.timedelta(seconds=10)
@@ -84,6 +89,7 @@ def test_create_sub_with_huge_area(session, sub2_uuid):
   assert resp.status_code == 400
 
 
+@default_scope(SCOPE_READ)
 def test_create_too_many_subs(session):
   """ASTM Compliance Test: DSS0050_MAX_SUBS_PER_AREA."""
   time_start = datetime.datetime.utcnow()
@@ -134,6 +140,7 @@ def test_create_too_many_subs(session):
   assert all(all_resp)
 
 
+@default_scope(SCOPE_READ)
 def test_create_sub_with_too_long_end_time(session, sub2_uuid):
     """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
     time_start = datetime.datetime.utcnow()
@@ -156,6 +163,8 @@ def test_create_sub_with_too_long_end_time(session, sub2_uuid):
     )
     assert resp.status_code == 400
 
+
+@default_scope(SCOPE_READ)
 def test_update_sub_with_too_long_end_time(session, sub2_uuid):
     """ASTM Compliance Test: DSS0060_MAX_SUBS_DURATION."""
     time_start = datetime.datetime.utcnow()

--- a/monitoring/prober/rid/test_token_validation.py
+++ b/monitoring/prober/rid/test_token_validation.py
@@ -11,6 +11,7 @@
 import datetime
 
 from . import common
+from .common import SCOPE_READ, SCOPE_WRITE
 
 
 def test_put_isa_with_read_only_scope_token(session, isa2_uuid):
@@ -32,7 +33,7 @@ def test_put_isa_with_read_only_scope_token(session, isa2_uuid):
               'time_end': time_end.strftime(common.DATE_FORMAT),
           },
           'flights_url': 'https://example.com/dss',
-      }, scope=common.SCOPE_READ)
+      }, scope=SCOPE_READ)
   assert resp.status_code == 403
 
 
@@ -55,7 +56,7 @@ def test_create_isa(session, isa1_uuid):
               'time_end': time_end.strftime(common.DATE_FORMAT),
           },
           'flights_url': 'https://example.com/dss',
-      })
+      }, scope=SCOPE_WRITE)
   assert resp.status_code == 200
 
 

--- a/pkg/aux_/server.go
+++ b/pkg/aux_/server.go
@@ -7,7 +7,7 @@ import (
 	"github.com/interuss/dss/pkg/api/v1/auxpb"
 	"github.com/interuss/dss/pkg/auth"
 	dsserr "github.com/interuss/dss/pkg/errors"
-	"github.com/interuss/dss/pkg/rid/server"
+	ridserver "github.com/interuss/dss/pkg/rid/server"
 	"github.com/interuss/dss/pkg/version"
 )
 
@@ -17,7 +17,7 @@ type Server struct{}
 // AuthScopes returns a map of endpoint to required Oauth scope.
 func (a *Server) AuthScopes() map[auth.Operation]auth.KeyClaimedScopesValidator {
 	return map[auth.Operation]auth.KeyClaimedScopesValidator{
-		"/auxpb.DSSAuxService/ValidateOauth": auth.RequireAllScopes(server.Scopes.ISA.Write),
+		"/auxpb.DSSAuxService/ValidateOauth": auth.RequireAnyScope(ridserver.Scopes.ISA.Read, ridserver.Scopes.ISA.Write),
 	}
 }
 

--- a/pkg/rid/server/server.go
+++ b/pkg/rid/server/server.go
@@ -39,10 +39,10 @@ func AuthScopes() map[auth.Operation]auth.KeyClaimedScopesValidator {
 		"/ridpb.DiscoveryAndSynchronizationService/GetIdentificationServiceArea":     auth.RequireAllScopes(Scopes.ISA.Read),
 		"/ridpb.DiscoveryAndSynchronizationService/SearchIdentificationServiceAreas": auth.RequireAllScopes(Scopes.ISA.Read),
 		"/ridpb.DiscoveryAndSynchronizationService/UpdateIdentificationServiceArea":  auth.RequireAllScopes(Scopes.ISA.Write),
-		"/ridpb.DiscoveryAndSynchronizationService/CreateSubscription":               auth.RequireAllScopes(Scopes.ISA.Write),
-		"/ridpb.DiscoveryAndSynchronizationService/DeleteSubscription":               auth.RequireAllScopes(Scopes.ISA.Write),
+		"/ridpb.DiscoveryAndSynchronizationService/CreateSubscription":               auth.RequireAllScopes(Scopes.ISA.Read),
+		"/ridpb.DiscoveryAndSynchronizationService/DeleteSubscription":               auth.RequireAllScopes(Scopes.ISA.Read),
 		"/ridpb.DiscoveryAndSynchronizationService/GetSubscription":                  auth.RequireAllScopes(Scopes.ISA.Read),
 		"/ridpb.DiscoveryAndSynchronizationService/SearchSubscriptions":              auth.RequireAllScopes(Scopes.ISA.Read),
-		"/ridpb.DiscoveryAndSynchronizationService/UpdateSubscription":               auth.RequireAllScopes(Scopes.ISA.Write),
+		"/ridpb.DiscoveryAndSynchronizationService/UpdateSubscription":               auth.RequireAllScopes(Scopes.ISA.Read),
 	}
 }

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -148,9 +148,8 @@ docker run --link dummy-oauth-for-testing:oauth \
 	e2e-test \
 	${1:-.} \
 	--junitxml=/app/test_result \
-	--oauth-token-endpoint http://oauth:8085/token \
 	--dss-endpoint http://local-gateway:8082 \
-	--use-dummy-oauth 1 \
-	--api-version-role '/v1/dss' \
-	--scd-dss-endpoint http://local-gateway:8082/dss/v1 \
+	--rid-auth "DummyOAuth(http://oauth:8085/token,sub=fake_uss)" \
+	--scd-auth1 "DummyOAuth(http://oauth:8085/token,sub=fake_uss)" \
+	--scd-auth2 "DummyOAuth(http://oauth:8085/token,sub=fake_uss2)" \
 	-vv


### PR DESCRIPTION
This PR restructures the prober auth specification to be a single command line option for each token source (see changes in docker_e2e.sh for an example).  The format for the specification is reflected from AuthAdapter classes that implement various token retrieval techniques.

This is necessary because the PR also adds two new token retrieval methods (because the DSS is being used in two new settings) and having alternate parameters (in ad-hoc groups) for all methods would have been a big maintenance difficulty.  This PR also eliminates a substantial number of lines of code from the prober while improving the readability of auth option specification.

Prompted by testing with this PR, explicit scopes are added to the RID prober tests and #361 is fixed.