### PR TITLE
Make image version names consistent

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -16,7 +16,7 @@ else
 fi
 cd ${BASEDIR}
 
-VERSION=$(date -u +%Y-%m-%d)-$(git rev-parse --short HEAD)
+VERSION=$(date -u +%Y-%m-%d)-$(shell ../scripts/git/commit.sh)
 
 if [[ -z "${DOCKER_URL}" ]]; then
   echo "DOCKER_URL environment variable is not set; building image to interuss-local/dss..."


### PR DESCRIPTION
We recently created a script to produce a standard git-informed version string.  This PR uses that script in build.sh for naming docker images.