### PR TITLE
Fix Istio deployment + Db-manager errors

### DIFF
--- a/build/deploy/base.libsonnet
+++ b/build/deploy/base.libsonnet
@@ -190,6 +190,9 @@ local util = import 'util.libsonnet';
       template: {
         metadata+: {
           labels: job.metadata.labels,
+          annotations+: {
+            'sidecar.istio.io/inject': 'false'
+          },
         },
         spec: $.PodSpec {
           restartPolicy: 'OnFailure',

--- a/build/deploy/istio/base.libsonnet
+++ b/build/deploy/istio/base.libsonnet
@@ -2540,25 +2540,6 @@
       }
     }
   },
-  "istio-obj-66": {
-    "apiVersion": "authentication.istio.io/v1alpha1",
-    "kind": "MeshPolicy",
-    "metadata": {
-      "name": "default",
-      "labels": {
-        "release": "istio"
-      }
-    },
-    "spec": {
-      "peers": [
-        {
-          "mtls": {
-            "mode": "PERMISSIVE"
-          }
-        }
-      ]
-    }
-  },
   "istio-obj-67": {
     "apiVersion": "policy/v1beta1",
     "kind": "PodDisruptionBudget",


### PR DESCRIPTION
Istio no support Mesh Policy in v1alpha1 and there doesn't seem to be a replacement so its removed.

DB Manager job was failing to complete due to a bug in K8s when there is a side car injected. We don't need sidecar for this job and the current suggested work around is to remove it until K8s implements a fix #372 