### PR TITLE
Fix SQL statements

### DIFF
--- a/build/deploy/db_schemas/defaultdb/000002_inverted_index.down.sql
+++ b/build/deploy/db_schemas/defaultdb/000002_inverted_index.down.sql
@@ -2,4 +2,4 @@ DROP INDEX IF EXISTS identification_service_areas@cell_idx;
 DROP INDEX IF EXISTS subscriptions@cell_idx;
 ALTER TABLE identification_service_areas DROP IF EXISTS cells;
 ALTER TABLE subscriptions DROP IF EXISTS cells;
-UPDATE schema_versions set schema_version = 'v1.0.0' WHERE onerow_enforcer = TRUE
+UPDATE schema_versions set schema_version = 'v1.0.0' WHERE onerow_enforcer = TRUE;

--- a/build/deploy/db_schemas/defaultdb/000002_inverted_index.up.sql
+++ b/build/deploy/db_schemas/defaultdb/000002_inverted_index.up.sql
@@ -1,6 +1,4 @@
-ALTER TABLE identification_service_areas ADD COLUMN IF NOT EXISTS cells INT64[] NOT NULL;
-ALTER TABLE identification_service_areas ADD CONSTRAINT cells_not_null CHECK (array_length(cells, 1) IS NOT NULL);
+ALTER TABLE identification_service_areas ADD COLUMN IF NOT EXISTS cells INT64[];
 CREATE INVERTED INDEX IF NOT EXISTS cell_idx on identification_service_areas (cells);
-ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS cells INT64[] NOT NULL;
-ALTER TABLE subscriptions ADD CONSTRAINT cells_not_null CHECK (array_length(cells, 1) IS NOT NULL);
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS cells INT64[];
 CREATE INVERTED INDEX IF NOT EXISTS cell_idx on subscriptions (cells);

--- a/build/deploy/db_schemas/defaultdb/000003_migrate_data_to_index.up.sql
+++ b/build/deploy/db_schemas/defaultdb/000003_migrate_data_to_index.up.sql
@@ -27,3 +27,10 @@ WHERE subs.id = compact_sub_cells.subscription_id
     AND cells IS NULL;
 
 COMMIT;
+
+ALTER TABLE identification_service_areas ALTER COLUMN cells SET NOT NULL;
+ALTER TABLE subscriptions ALTER COLUMN cells SET NOT NULL;
+ALTER TABLE identification_service_areas ADD CONSTRAINT isa_cells_not_null CHECK (array_length(cells, 1) IS NOT NULL);
+ALTER TABLE subscriptions ADD CONSTRAINT subs_cells_not_null CHECK (array_length(cells, 1) IS NOT NULL);
+ALTER TABLE identification_service_areas DROP CONSTRAINT IF EXISTS cells_not_null;
+ALTER TABLE subscriptions DROP CONSTRAINT IF EXISTS cells_not_null;

--- a/build/deploy/db_schemas/defaultdb/000004_drop_cells_table.up.sql
+++ b/build/deploy/db_schemas/defaultdb/000004_drop_cells_table.up.sql
@@ -1,3 +1,3 @@
 DROP TABLE IF EXISTS cells_identification_service_areas;
 DROP TABLE IF EXISTS cells_subscriptions;
-UPDATE schema_versions set schema_version = 'v2.0.0' WHERE onerow_enforcer = TRUE
+UPDATE schema_versions set schema_version = 'v2.0.0' WHERE onerow_enforcer = TRUE;

--- a/build/deploy/db_schemas/defaultdb/000005_bump_version.down.sql
+++ b/build/deploy/db_schemas/defaultdb/000005_bump_version.down.sql
@@ -1,1 +1,1 @@
-UPDATE schema_versions set schema_version = 'v2.0.0' WHERE onerow_enforcer = TRUE
+UPDATE schema_versions set schema_version = 'v2.0.0' WHERE onerow_enforcer = TRUE;

--- a/build/deploy/db_schemas/defaultdb/000005_bump_version.up.sql
+++ b/build/deploy/db_schemas/defaultdb/000005_bump_version.up.sql
@@ -1,1 +1,1 @@
-UPDATE schema_versions set schema_version = 'v3.0.0' WHERE onerow_enforcer = TRUE
+UPDATE schema_versions set schema_version = 'v3.0.0' WHERE onerow_enforcer = TRUE;

--- a/build/deploy/db_schemas/defaultdb/000006_add_writer_column.down.sql
+++ b/build/deploy/db_schemas/defaultdb/000006_add_writer_column.down.sql
@@ -1,3 +1,3 @@
 ALTER TABLE identification_service_areas DROP IF EXISTS writer;
 ALTER TABLE subscriptions DROP IF EXISTS writer;
-UPDATE schema_versions set schema_version = 'v3.0.0' WHERE onerow_enforcer = TRUE
+UPDATE schema_versions set schema_version = 'v3.0.0' WHERE onerow_enforcer = TRUE;

--- a/build/deploy/db_schemas/defaultdb/000006_add_writer_column.up.sql
+++ b/build/deploy/db_schemas/defaultdb/000006_add_writer_column.up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE identification_service_areas ADD COLUMN IF NOT EXISTS writer STRING;
 ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS writer STRING;
-UPDATE schema_versions set schema_version = 'v3.1.0' WHERE onerow_enforcer = TRUE
+UPDATE schema_versions set schema_version = 'v3.1.0' WHERE onerow_enforcer = TRUE;


### PR DESCRIPTION
Constraints name must be unique and applying the constraints to upgrade from old V2 where bootstrap scripts was in GRPC we needed to rename the constraints the make the run valid