### PR TITLE
Add detailed error message infrastructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3
 	github.com/lib/pq v1.5.2
-	github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177 // indirect
+	github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.15.0

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3
 	github.com/lib/pq v1.5.2
+	github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177 // indirect
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,8 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
+github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177 h1:nRlQD0u1871kaznCnn1EvYiMbum36v7hw1DLPEjds4o=
+github.com/palantir/stacktrace v0.0.0-20161112013806-78658fd2d177/go.mod h1:ao5zGxj8Z4x60IOVYZUbDSmt3R8Ddo080vEgPosHpak=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/monitoring/prober/scd/test_operation_references_error_cases.py
+++ b/monitoring/prober/scd/test_operation_references_error_cases.py
@@ -43,7 +43,7 @@ def test_op_ref_incorrect_units(scd_session):
   with open('./scd/resources/op_ref_incorrect_units.json', 'r') as f:
     req = json.load(f)
   resp = scd_session.post('/operation_references/query', json=req)
-  assert resp.status_code == 500, resp.content
+  assert resp.status_code == 400, resp.content
 
 
 @default_scope(SCOPE_SC)
@@ -51,7 +51,7 @@ def test_op_ref_incorrect_altitude_ref(scd_session):
   with open('./scd/resources/op_ref_incorrect_altitude_ref.json', 'r') as f:
     req = json.load(f)
   resp = scd_session.post('/operation_references/query', json=req)
-  assert resp.status_code == 500, resp.content
+  assert resp.status_code == 400, resp.content
 
 
 @default_scope(SCOPE_SC)
@@ -76,7 +76,7 @@ def test_op_bad_subscription_id_random(scd_session):
     req = json.load(f)
     req['subscription_id'] = uuid.uuid4().hex
   resp = scd_session.put('/operation_references/{}'.format(OP_ID), json=req)
-  assert resp.status_code == 500, resp.content
+  assert resp.status_code == 400, resp.content
 
 
 @default_scope(SCOPE_SC)
@@ -84,7 +84,7 @@ def test_op_new_and_existing_subscription(scd_session):
   with open('./scd/resources/op_new_and_existing_subscription.json', 'r') as f:
     req = json.load(f)
   resp = scd_session.put('/operation_references/{}'.format(OP_ID), json=req)
-  assert resp.status_code == 500, resp.content
+  assert resp.status_code == 400, resp.content
 
 
 @default_scope(SCOPE_SC)
@@ -165,3 +165,11 @@ def test_op_repeated_requests(scd_session):
   # Delete operation
   resp = scd_session.delete('/operation_references/{}'.format(OP_ID))
   assert resp.status_code == 200, resp.content
+
+
+@default_scope(SCOPE_SC)
+def test_op_invalid_id(scd_session):
+  with open('./scd/resources/op_request_1.json', 'r') as f:
+    req = json.load(f)
+  resp = scd_session.put('/operation_references/not_uuid_format', json=req)
+  assert resp.status_code == 400, resp.content

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -36,13 +36,12 @@ func init() {
 	}
 }
 
-func makeErrId() string {
-	errUuid, err := uuid.NewRandom()
+func MakeErrID() string {
+	errUUID, err := uuid.NewRandom()
 	if err == nil {
-		return errUuid.String()
-	} else {
-		return fmt.Sprintf("<error ID could not be constructed: %s>", err)
+		return errUUID.String()
 	}
+	return fmt.Sprintf("<error ID could not be constructed: %s>", err)
 }
 
 // Interceptor returns a grpc.UnaryServerInterceptor that inspects outgoing
@@ -60,21 +59,21 @@ func Interceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
 			statusErr, ok := status.FromError(rootErr)
 			switch {
 			case !ok:
-				errId := makeErrId()
+				errID := MakeErrID()
 				logger.Error(
-					fmt.Sprintf("encountered non-Status error %s during unary server call", errId),
+					fmt.Sprintf("encountered non-Status error %s during unary server call", errID),
 					zap.String("method", info.FullMethod),
 					zap.String("stacktrace", trace),
 					zap.Error(rootErr))
 				if obfuscateInternalErrors {
-					err = status.Error(codes.Internal, fmt.Sprintf("Internal server error %s", errId))
+					err = status.Error(codes.Internal, fmt.Sprintf("Internal server error %s", errID))
 				} else {
 					err = status.Error(codes.Internal, err.Error())
 				}
 			case statusErr.Code() == codes.Internal, statusErr.Code() == codes.Unknown:
-				errId := makeErrId()
+				errID := MakeErrID()
 				logger.Error(
-					fmt.Sprintf("encountered internal Status error %s during unary server call", errId),
+					fmt.Sprintf("encountered internal Status error %s during unary server call", errID),
 					zap.String("method", info.FullMethod),
 					zap.Stringer("code", statusErr.Code()),
 					zap.String("message", statusErr.Message()),
@@ -82,7 +81,7 @@ func Interceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
 					zap.String("stacktrace", trace),
 					zap.Error(rootErr))
 				if obfuscateInternalErrors {
-					err = status.Error(codes.Internal, fmt.Sprintf("Internal server error %s", errId))
+					err = status.Error(codes.Internal, fmt.Sprintf("Internal server error %s", errID))
 				}
 			}
 		}

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -43,7 +43,7 @@ func (owner Owner) String() string {
 	return string(owner)
 }
 
-func IdFromString(s string) (ID, error) {
+func IDFromString(s string) (ID, error) {
 	id, err := uuid.Parse(s)
 	if err != nil {
 		return ID(""), err
@@ -51,12 +51,11 @@ func IdFromString(s string) (ID, error) {
 	return ID(id.String()), nil
 }
 
-func IdFromOptionalString(s string) (ID, error) {
+func IDFromOptionalString(s string) (ID, error) {
 	if s == "" {
 		return ID(""), nil
-	} else {
-		return IdFromString(s)
 	}
+	return IDFromString(s)
 }
 
 // VersionFromString converts a version, typically provided from a user, to

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -4,13 +4,17 @@ import (
 	"errors"
 	"strconv"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type (
-	// ID represents a UUID string.
+	// ID represents a UUID-formatted string.
 	ID string
+
 	// Owner is the owner taken from the oauth token.
 	Owner string
+
 	// Version represents a version, which can be supplied as a commit timestamp
 	// or a string.
 	Version struct {
@@ -31,8 +35,28 @@ func (id ID) String() string {
 	return string(id)
 }
 
+func (id ID) Empty() bool {
+	return string(id) == ""
+}
+
 func (owner Owner) String() string {
 	return string(owner)
+}
+
+func IdFromString(s string) (ID, error) {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return ID(""), err
+	}
+	return ID(id.String()), nil
+}
+
+func IdFromOptionalString(s string) (ID, error) {
+	if s == "" {
+		return ID(""), nil
+	} else {
+		return IdFromString(s)
+	}
 }
 
 // VersionFromString converts a version, typically provided from a user, to

--- a/pkg/rid/application/subscription.go
+++ b/pkg/rid/application/subscription.go
@@ -9,6 +9,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
 	"github.com/interuss/dss/pkg/rid/repos"
+	"github.com/palantir/stacktrace"
 	"go.uber.org/zap"
 )
 
@@ -75,7 +76,7 @@ func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription)
 		count, err := repo.MaxSubscriptionCountInCellsByOwner(ctx, s.Cells, s.Owner)
 		if err != nil {
 			a.logger.Error("Error fetching max subscription count", zap.Error(err))
-			return dsserr.Internal(
+			return stacktrace.Propagate(err,
 				"failed to fetch subscription count, rejecting request")
 		}
 		if count >= maxSubscriptionsPerArea {
@@ -117,7 +118,7 @@ func (a *app) UpdateSubscription(ctx context.Context, s *ridmodels.Subscription)
 		count, err := repo.MaxSubscriptionCountInCellsByOwner(ctx, s.Cells, s.Owner)
 		if err != nil {
 			a.logger.Error("Error fetching max subscription count", zap.Error(err))
-			return dsserr.Internal(
+			return stacktrace.Propagate(err,
 				"failed to fetch subscription count, rejecting request")
 		}
 		if count >= maxSubscriptionsPerArea {

--- a/pkg/rid/server/isa_handler.go
+++ b/pkg/rid/server/isa_handler.go
@@ -20,7 +20,7 @@ func (s *Server) GetIdentificationServiceArea(
 	ctx context.Context, req *ridpb.GetIdentificationServiceAreaRequest) (
 	*ridpb.GetIdentificationServiceAreaResponse, error) {
 
-	id, err := dssmodels.IdFromString(req.Id)
+	id, err := dssmodels.IDFromString(req.Id)
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -66,7 +66,7 @@ func (s *Server) CreateIdentificationServiceArea(
 	if params.Extents == nil {
 		return nil, dsserr.BadRequest("missing required extents")
 	}
-	id, err := dssmodels.IdFromString(req.Id)
+	id, err := dssmodels.IDFromString(req.Id)
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -130,7 +130,7 @@ func (s *Server) UpdateIdentificationServiceArea(
 	if params.Extents == nil {
 		return nil, dsserr.BadRequest("missing required extents")
 	}
-	id, err := dssmodels.IdFromString(req.Id)
+	id, err := dssmodels.IDFromString(req.Id)
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -180,7 +180,7 @@ func (s *Server) DeleteIdentificationServiceArea(
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}
-	id, err := dssmodels.IdFromString(req.Id)
+	id, err := dssmodels.IDFromString(req.Id)
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}

--- a/pkg/rid/server/subscription_handler.go
+++ b/pkg/rid/server/subscription_handler.go
@@ -27,7 +27,7 @@ func (s *Server) DeleteSubscription(
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}
-	id, err := dssmodels.IdFromString(req.Id)
+	id, err := dssmodels.IDFromString(req.Id)
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -91,7 +91,7 @@ func (s *Server) GetSubscription(
 	ctx context.Context, req *ridpb.GetSubscriptionRequest) (
 	*ridpb.GetSubscriptionResponse, error) {
 
-	id, err := dssmodels.IdFromString(req.Id)
+	id, err := dssmodels.IDFromString(req.Id)
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -136,7 +136,7 @@ func (s *Server) CreateSubscription(
 	if params.Extents == nil {
 		return nil, dsserr.BadRequest("missing required extents")
 	}
-	id, err := dssmodels.IdFromString(req.Id)
+	id, err := dssmodels.IDFromString(req.Id)
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -193,7 +193,7 @@ func (s *Server) UpdateSubscription(
 	if err != nil {
 		return nil, dsserr.BadRequest(fmt.Sprintf("bad version: %s", err))
 	}
-	id, err := dssmodels.IdFromString(req.Id)
+	id, err := dssmodels.IDFromString(req.Id)
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}

--- a/pkg/rid/store/cockroach/identification_service_area.go
+++ b/pkg/rid/store/cockroach/identification_service_area.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/geo/s2"
 	dssql "github.com/interuss/dss/pkg/sql"
 	"github.com/lib/pq"
+	"github.com/palantir/stacktrace"
 	"go.uber.org/zap"
 )
 
@@ -191,7 +192,7 @@ func (c *isaRepo) SearchISAs(ctx context.Context, cells s2.CellUnion, earliest *
 	}
 
 	if earliest == nil {
-		return nil, dsserr.Internal("must call with an earliest start time.")
+		return nil, stacktrace.NewError("Earliest start time is missing")
 	}
 
 	cids := make([]int64, len(cells))

--- a/pkg/scd/constraints_handler.go
+++ b/pkg/scd/constraints_handler.go
@@ -34,7 +34,7 @@ func incrementNotificationIndices(ctx context.Context, r repos.Repository, subs 
 // the specified version.
 func (a *Server) DeleteConstraintReference(ctx context.Context, req *scdpb.DeleteConstraintReferenceRequest) (*scdpb.ChangeConstraintReferenceResponse, error) {
 	// Retrieve Constraint ID
-	id, err := dssmodels.IdFromString(req.GetEntityuuid())
+	id, err := dssmodels.IDFromString(req.GetEntityuuid())
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -118,7 +118,7 @@ func (a *Server) DeleteConstraintReference(ctx context.Context, req *scdpb.Delet
 
 // GetConstraintReference returns a single constraint ref for the given ID.
 func (a *Server) GetConstraintReference(ctx context.Context, req *scdpb.GetConstraintReferenceRequest) (*scdpb.GetConstraintReferenceResponse, error) {
-	id, err := dssmodels.IdFromString(req.GetEntityuuid())
+	id, err := dssmodels.IDFromString(req.GetEntityuuid())
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -167,7 +167,7 @@ func (a *Server) GetConstraintReference(ctx context.Context, req *scdpb.GetConst
 
 // PutConstraintReference creates a single contraint ref.
 func (a *Server) PutConstraintReference(ctx context.Context, req *scdpb.PutConstraintReferenceRequest) (*scdpb.ChangeConstraintReferenceResponse, error) {
-	id, err := dssmodels.IdFromString(req.GetEntityuuid())
+	id, err := dssmodels.IDFromString(req.GetEntityuuid())
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}

--- a/pkg/scd/models/constraints.go
+++ b/pkg/scd/models/constraints.go
@@ -12,7 +12,7 @@ import (
 
 // Constraint models a constraint, as known by the DSS
 type Constraint struct {
-	ID            ID
+	ID            dssmodels.ID
 	Version       Version
 	OVN           OVN
 	Owner         dssmodels.Owner

--- a/pkg/scd/models/models.go
+++ b/pkg/scd/models/models.go
@@ -9,9 +9,6 @@ import (
 )
 
 type (
-	// ID models the id of an entity.
-	ID string
-
 	// OVN models an opaque version number.
 	OVN string
 
@@ -20,16 +17,6 @@ type (
 	// Primarily used as a fencing token in data mutations.
 	Version int32
 )
-
-// Empty returns true if id indicates an empty ID.
-func (id ID) Empty() bool {
-	return len(id) == 0
-}
-
-// String returns the string representation of id.
-func (id ID) String() string {
-	return string(id)
-}
 
 // NewOVNFromTime encodes t as an OVN.
 func NewOVNFromTime(t time.Time, salt string) OVN {

--- a/pkg/scd/models/operations.go
+++ b/pkg/scd/models/operations.go
@@ -25,7 +25,7 @@ type OperationState string
 
 // Operation models an operation.
 type Operation struct {
-	ID             ID
+	ID             dssmodels.ID
 	Version        Version
 	OVN            OVN
 	Owner          dssmodels.Owner
@@ -36,7 +36,7 @@ type Operation struct {
 	USSBaseURL     string
 	State          OperationState
 	Cells          s2.CellUnion
-	SubscriptionID ID
+	SubscriptionID dssmodels.ID
 }
 
 // ToProto converts the Operation to its proto API format

--- a/pkg/scd/models/subscriptions.go
+++ b/pkg/scd/models/subscriptions.go
@@ -23,7 +23,7 @@ const (
 
 // Subscription represents an SCD subscription
 type Subscription struct {
-	ID                ID
+	ID                dssmodels.ID
 	Version           Version
 	NotificationIndex int
 	Owner             dssmodels.Owner
@@ -36,7 +36,7 @@ type Subscription struct {
 	NotifyForOperations  bool
 	NotifyForConstraints bool
 	ImplicitSubscription bool
-	DependentOperations  []ID
+	DependentOperations  []dssmodels.ID
 	Cells                s2.CellUnion
 }
 

--- a/pkg/scd/operations_handler.go
+++ b/pkg/scd/operations_handler.go
@@ -24,7 +24,7 @@ import (
 // the specified version.
 func (a *Server) DeleteOperationReference(ctx context.Context, req *scdpb.DeleteOperationReferenceRequest) (*scdpb.ChangeOperationReferenceResponse, error) {
 	// Retrieve Operation ID
-	id, err := dssmodels.IdFromString(req.GetEntityuuid())
+	id, err := dssmodels.IDFromString(req.GetEntityuuid())
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -71,7 +71,7 @@ func (a *Server) DeleteOperationReference(ctx context.Context, req *scdpb.Delete
 
 // GetOperationReference returns a single operation ref for the given ID.
 func (a *Server) GetOperationReference(ctx context.Context, req *scdpb.GetOperationReferenceRequest) (*scdpb.GetOperationReferenceResponse, error) {
-	id, err := dssmodels.IdFromString(req.GetEntityuuid())
+	id, err := dssmodels.IDFromString(req.GetEntityuuid())
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -176,7 +176,7 @@ func (a *Server) SearchOperationReferences(ctx context.Context, req *scdpb.Searc
 
 // PutOperationReference creates a single operation ref.
 func (a *Server) PutOperationReference(ctx context.Context, req *scdpb.PutOperationReferenceRequest) (*scdpb.ChangeOperationReferenceResponse, error) {
-	id, err := dssmodels.IdFromString(req.GetEntityuuid())
+	id, err := dssmodels.IDFromString(req.GetEntityuuid())
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -238,7 +238,7 @@ func (a *Server) PutOperationReference(ctx context.Context, req *scdpb.PutOperat
 		return nil, dsserr.BadRequest("invalid state for version 0")
 	}
 
-	subscriptionID, err := dssmodels.IdFromOptionalString(params.GetSubscriptionId())
+	subscriptionID, err := dssmodels.IDFromOptionalString(params.GetSubscriptionId())
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format for Subscription ID")
 	}

--- a/pkg/scd/repos/repos.go
+++ b/pkg/scd/repos/repos.go
@@ -10,11 +10,11 @@ import (
 // Operation abstracts operation-specific interactions with the backing repository.
 type Operation interface {
 	// GetOperation returns the operation identified by "id".
-	GetOperation(ctx context.Context, id scdmodels.ID) (*scdmodels.Operation, error)
+	GetOperation(ctx context.Context, id dssmodels.ID) (*scdmodels.Operation, error)
 
 	// DeleteOperation deletes the operation identified by "id" and owned by "owner".
 	// Returns the deleted Operation and all Subscriptions affected by the delete.
-	DeleteOperation(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner) (*scdmodels.Operation, []*scdmodels.Subscription, error)
+	DeleteOperation(ctx context.Context, id dssmodels.ID, owner dssmodels.Owner) (*scdmodels.Operation, []*scdmodels.Subscription, error)
 
 	// UpsertOperation inserts or updates an operation using key as a fencing
 	// token. If operation does not reference an existing subscription, an
@@ -33,7 +33,7 @@ type Subscription interface {
 
 	// GetSubscription returns the Subscription referenced by id, or nil and no
 	// error if the Subscription doesn't exist
-	GetSubscription(ctx context.Context, id scdmodels.ID) (*scdmodels.Subscription, error)
+	GetSubscription(ctx context.Context, id dssmodels.ID) (*scdmodels.Subscription, error)
 
 	// UpsertSubscription upserts sub into the store and returns the result
 	// subscription.
@@ -42,12 +42,12 @@ type Subscription interface {
 	// DeleteSubscription deletes a Subscription from the store and returns the
 	// deleted subscription.  Returns an error if the Subscription does not
 	// exist.
-	DeleteSubscription(ctx context.Context, id scdmodels.ID) error
+	DeleteSubscription(ctx context.Context, id dssmodels.ID) error
 
 	// IncrementNotificationIndices increments the notification index of each
 	// specified Subscription and returns the resulting corresponding
 	// notification indices.
-	IncrementNotificationIndices(ctx context.Context, subscriptionIds []scdmodels.ID) ([]int, error)
+	IncrementNotificationIndices(ctx context.Context, subscriptionIds []dssmodels.ID) ([]int, error)
 }
 
 // repos.Constraint abstracts constraint-specific interactions with the backing store.
@@ -57,7 +57,7 @@ type Constraint interface {
 
 	// GetConstraint returns the Constraint referenced by id, or
 	// (nil, sql.ErrNoRows) if the Constraint doesn't exist
-	GetConstraint(ctx context.Context, id scdmodels.ID) (*scdmodels.Constraint, error)
+	GetConstraint(ctx context.Context, id dssmodels.ID) (*scdmodels.Constraint, error)
 
 	// UpsertConstraint upserts "constraint" into the store.
 	UpsertConstraint(ctx context.Context, constraint *scdmodels.Constraint) (*scdmodels.Constraint, error)
@@ -65,7 +65,7 @@ type Constraint interface {
 	// DeleteConstraint deletes a Constraint from the store and returns the
 	// deleted subscription.  Returns nil and an error if the Constraint does
 	// not exist.
-	DeleteConstraint(ctx context.Context, id scdmodels.ID) error
+	DeleteConstraint(ctx context.Context, id dssmodels.ID) error
 }
 
 // Repository aggregates all SCD-specific repo interfaces.

--- a/pkg/scd/store/cockroach/constraints.go
+++ b/pkg/scd/store/cockroach/constraints.go
@@ -106,7 +106,7 @@ func (c *repo) fetchConstraint(ctx context.Context, q dsssql.Queryable, query st
 }
 
 // Implements scd.repos.Constraint.GetConstraint
-func (c *repo) GetConstraint(ctx context.Context, id scdmodels.ID) (*scdmodels.Constraint, error) {
+func (c *repo) GetConstraint(ctx context.Context, id dssmodels.ID) (*scdmodels.Constraint, error) {
 	var (
 		query = fmt.Sprintf(`
 			SELECT
@@ -159,7 +159,7 @@ func (c *repo) UpsertConstraint(ctx context.Context, s *scdmodels.Constraint) (*
 }
 
 // Implements scd.repos.Constraint.DeleteConstraint
-func (c *repo) DeleteConstraint(ctx context.Context, id scdmodels.ID) error {
+func (c *repo) DeleteConstraint(ctx context.Context, id dssmodels.ID) error {
 	const (
 		query = `
 		DELETE FROM

--- a/pkg/scd/store/cockroach/operations.go
+++ b/pkg/scd/store/cockroach/operations.go
@@ -100,7 +100,7 @@ func (s *repo) fetchOperation(ctx context.Context, q dsssql.Queryable, query str
 	return operations[0], nil
 }
 
-func (s *repo) fetchOperationByID(ctx context.Context, q dsssql.Queryable, id scdmodels.ID) (*scdmodels.Operation, error) {
+func (s *repo) fetchOperationByID(ctx context.Context, q dsssql.Queryable, id dssmodels.ID) (*scdmodels.Operation, error) {
 	query := fmt.Sprintf(`
 		SELECT %s FROM
 			scd_operations
@@ -221,7 +221,7 @@ func (s *repo) populateOperationCells(ctx context.Context, q dsssql.Queryable, o
 }
 
 // GetOperation returns an operation for the given ID from CockroachDB
-func (s *repo) GetOperation(ctx context.Context, id scdmodels.ID) (*scdmodels.Operation, error) {
+func (s *repo) GetOperation(ctx context.Context, id dssmodels.ID) (*scdmodels.Operation, error) {
 	sub, err := s.fetchOperationByID(ctx, s.q, id)
 	switch err {
 	case nil:
@@ -234,7 +234,7 @@ func (s *repo) GetOperation(ctx context.Context, id scdmodels.ID) (*scdmodels.Op
 }
 
 // DeleteOperation deletes an operation for the given ID from CockroachDB
-func (s *repo) DeleteOperation(ctx context.Context, id scdmodels.ID, owner dssmodels.Owner) (*scdmodels.Operation, []*scdmodels.Subscription, error) {
+func (s *repo) DeleteOperation(ctx context.Context, id dssmodels.ID, owner dssmodels.Owner) (*scdmodels.Operation, []*scdmodels.Subscription, error) {
 	var (
 		deleteQuery = `
 			DELETE FROM

--- a/pkg/scd/store/cockroach/subscriptions.go
+++ b/pkg/scd/store/cockroach/subscriptions.go
@@ -50,7 +50,7 @@ func init() {
 	)
 }
 
-func (c *repo) fetchCellsForSubscription(ctx context.Context, q dsssql.Queryable, id scdmodels.ID) (s2.CellUnion, error) {
+func (c *repo) fetchCellsForSubscription(ctx context.Context, q dsssql.Queryable, id dssmodels.ID) (s2.CellUnion, error) {
 	var (
 		cellsQuery = `
 			SELECT
@@ -183,7 +183,7 @@ func (c *repo) fetchSubscription(ctx context.Context, q dsssql.Queryable, query 
 	return subs[0], nil
 }
 
-func (c *repo) fetchSubscriptionByID(ctx context.Context, q dsssql.Queryable, id scdmodels.ID) (*scdmodels.Subscription, error) {
+func (c *repo) fetchSubscriptionByID(ctx context.Context, q dsssql.Queryable, id dssmodels.ID) (*scdmodels.Subscription, error) {
 	var (
 		query = fmt.Sprintf(`
 			SELECT
@@ -276,7 +276,7 @@ func (c *repo) pushSubscription(ctx context.Context, q dsssql.Queryable, s *scdm
 }
 
 // GetSubscription returns the subscription identified by "id".
-func (c *repo) GetSubscription(ctx context.Context, id scdmodels.ID) (*scdmodels.Subscription, error) {
+func (c *repo) GetSubscription(ctx context.Context, id dssmodels.ID) (*scdmodels.Subscription, error) {
 	sub, err := c.fetchSubscriptionByID(ctx, c.q, id)
 	switch err {
 	case nil:
@@ -301,7 +301,7 @@ func (c *repo) UpsertSubscription(ctx context.Context, s *scdmodels.Subscription
 
 // DeleteSubscription deletes the subscription identified by "id" and
 // returns the deleted subscription.
-func (c *repo) DeleteSubscription(ctx context.Context, id scdmodels.ID) error {
+func (c *repo) DeleteSubscription(ctx context.Context, id dssmodels.ID) error {
 	const (
 		query = `
 		DELETE FROM
@@ -393,7 +393,7 @@ func (c *repo) SearchSubscriptions(ctx context.Context, v4d *dssmodels.Volume4D)
 }
 
 // Implements scd.repos.Subscription.IncrementNotificationIndices
-func (c *repo) IncrementNotificationIndices(ctx context.Context, subscriptionIds []scdmodels.ID) ([]int, error) {
+func (c *repo) IncrementNotificationIndices(ctx context.Context, subscriptionIds []dssmodels.ID) ([]int, error) {
 	var updateQuery = fmt.Sprintf(`
 			UPDATE scd_subscriptions
 			SET notification_index = notification_index + 1

--- a/pkg/scd/subscriptions_handler.go
+++ b/pkg/scd/subscriptions_handler.go
@@ -22,7 +22,7 @@ var (
 // PutSubscription creates a single subscription.
 func (a *Server) PutSubscription(ctx context.Context, req *scdpb.PutSubscriptionRequest) (*scdpb.PutSubscriptionResponse, error) {
 	// Retrieve Subscription ID
-	id, err := dssmodels.IdFromString(req.GetSubscriptionid())
+	id, err := dssmodels.IDFromString(req.GetSubscriptionid())
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -192,7 +192,7 @@ func (a *Server) PutSubscription(ctx context.Context, req *scdpb.PutSubscription
 // GetSubscription returns a single subscription for the given ID.
 func (a *Server) GetSubscription(ctx context.Context, req *scdpb.GetSubscriptionRequest) (*scdpb.GetSubscriptionResponse, error) {
 	// Retrieve Subscription ID
-	id, err := dssmodels.IdFromString(req.GetSubscriptionid())
+	id, err := dssmodels.IDFromString(req.GetSubscriptionid())
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}
@@ -296,7 +296,7 @@ func (a *Server) QuerySubscriptions(ctx context.Context, req *scdpb.QuerySubscri
 // specified version.
 func (a *Server) DeleteSubscription(ctx context.Context, req *scdpb.DeleteSubscriptionRequest) (*scdpb.DeleteSubscriptionResponse, error) {
 	// Retrieve Subscription ID
-	id, err := dssmodels.IdFromString(req.GetSubscriptionid())
+	id, err := dssmodels.IDFromString(req.GetSubscriptionid())
 	if err != nil {
 		return nil, dsserr.BadRequest("Invalid ID format")
 	}

--- a/pkg/scd/subscriptions_handler.go
+++ b/pkg/scd/subscriptions_handler.go
@@ -12,6 +12,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	"github.com/interuss/dss/pkg/scd/repos"
+	"github.com/palantir/stacktrace"
 )
 
 var (
@@ -21,9 +22,9 @@ var (
 // PutSubscription creates a single subscription.
 func (a *Server) PutSubscription(ctx context.Context, req *scdpb.PutSubscriptionRequest) (*scdpb.PutSubscriptionResponse, error) {
 	// Retrieve Subscription ID
-	id := scdmodels.ID(req.GetSubscriptionid())
-	if id.Empty() {
-		return nil, dsserr.BadRequest("missing Subscription ID")
+	id, err := dssmodels.IdFromString(req.GetSubscriptionid())
+	if err != nil {
+		return nil, dsserr.BadRequest("Invalid ID format")
 	}
 
 	// Retrieve ID of client making call
@@ -113,7 +114,7 @@ func (a *Server) PutSubscription(ctx context.Context, req *scdpb.PutSubscription
 			return err
 		}
 		if sub == nil {
-			return dsserr.Internal(fmt.Sprintf("UpsertSubscription returned no Subscription for ID: %s", id))
+			return stacktrace.NewError(fmt.Sprintf("UpsertSubscription returned no Subscription for ID: %s", id))
 		}
 
 		// Find relevant Operations
@@ -139,7 +140,7 @@ func (a *Server) PutSubscription(ctx context.Context, req *scdpb.PutSubscription
 		// Convert Subscription to proto
 		p, err := sub.ToProto()
 		if err != nil {
-			return dsserr.Internal(err.Error())
+			return stacktrace.Propagate(err, "Could not convert Subscription to proto")
 		}
 		result = &scdpb.PutSubscriptionResponse{
 			Subscription: p,
@@ -181,7 +182,6 @@ func (a *Server) PutSubscription(ctx context.Context, req *scdpb.PutSubscription
 
 	err = a.Store.Transact(ctx, action)
 	if err != nil {
-		// TODO: wrap err in dss.Internal?
 		return nil, err
 	}
 
@@ -192,9 +192,9 @@ func (a *Server) PutSubscription(ctx context.Context, req *scdpb.PutSubscription
 // GetSubscription returns a single subscription for the given ID.
 func (a *Server) GetSubscription(ctx context.Context, req *scdpb.GetSubscriptionRequest) (*scdpb.GetSubscriptionResponse, error) {
 	// Retrieve Subscription ID
-	id := scdmodels.ID(req.GetSubscriptionid())
-	if id.Empty() {
-		return nil, dsserr.BadRequest("missing Subscription ID")
+	id, err := dssmodels.IdFromString(req.GetSubscriptionid())
+	if err != nil {
+		return nil, dsserr.BadRequest("Invalid ID format")
 	}
 
 	// Retrieve ID of client making call
@@ -222,7 +222,7 @@ func (a *Server) GetSubscription(ctx context.Context, req *scdpb.GetSubscription
 		// Convert Subscription to proto
 		p, err := sub.ToProto()
 		if err != nil {
-			return dsserr.Internal("unable to convert Subscription to proto")
+			return stacktrace.Propagate(err, "unable to convert Subscription to proto")
 		}
 
 		// Return response to client
@@ -233,9 +233,8 @@ func (a *Server) GetSubscription(ctx context.Context, req *scdpb.GetSubscription
 		return nil
 	}
 
-	err := a.Store.Transact(ctx, action)
+	err = a.Store.Transact(ctx, action)
 	if err != nil {
-		// TODO: wrap err in dss.Internal?
 		return nil, err
 	}
 
@@ -253,7 +252,7 @@ func (a *Server) QuerySubscriptions(ctx context.Context, req *scdpb.QuerySubscri
 	// Parse area of interest to common Volume4D
 	vol4, err := dssmodels.Volume4DFromSCDProto(aoi)
 	if err != nil {
-		return nil, dsserr.Internal("failed to convert to internal geometry model")
+		return nil, stacktrace.Propagate(err, "failed to convert to internal geometry model")
 	}
 
 	// Retrieve ID of client making call
@@ -276,7 +275,7 @@ func (a *Server) QuerySubscriptions(ctx context.Context, req *scdpb.QuerySubscri
 			if sub.Owner == owner {
 				p, err := sub.ToProto()
 				if err != nil {
-					return dsserr.Internal("error converting Subscription model to proto")
+					return stacktrace.Propagate(err, "error converting Subscription model to proto")
 				}
 				response.Subscriptions = append(response.Subscriptions, p)
 			}
@@ -287,7 +286,6 @@ func (a *Server) QuerySubscriptions(ctx context.Context, req *scdpb.QuerySubscri
 
 	err = a.Store.Transact(ctx, action)
 	if err != nil {
-		// TODO: wrap err in dss.Internal?
 		return nil, err
 	}
 
@@ -298,9 +296,9 @@ func (a *Server) QuerySubscriptions(ctx context.Context, req *scdpb.QuerySubscri
 // specified version.
 func (a *Server) DeleteSubscription(ctx context.Context, req *scdpb.DeleteSubscriptionRequest) (*scdpb.DeleteSubscriptionResponse, error) {
 	// Retrieve Subscription ID
-	id := scdmodels.ID(req.GetSubscriptionid())
-	if id.Empty() {
-		return nil, dsserr.BadRequest("missing Subscription ID")
+	id, err := dssmodels.IdFromString(req.GetSubscriptionid())
+	if err != nil {
+		return nil, dsserr.BadRequest("Invalid ID format")
 	}
 
 	// Retrieve ID of client making call
@@ -331,7 +329,7 @@ func (a *Server) DeleteSubscription(ctx context.Context, req *scdpb.DeleteSubscr
 		// Convert deleted Subscription to proto
 		p, err := old.ToProto()
 		if err != nil {
-			return dsserr.Internal("error converting Subscription model to proto")
+			return stacktrace.Propagate(err, "error converting Subscription model to proto")
 		}
 
 		// Create response for client
@@ -342,9 +340,8 @@ func (a *Server) DeleteSubscription(ctx context.Context, req *scdpb.DeleteSubscr
 		return nil
 	}
 
-	err := a.Store.Transact(ctx, action)
+	err = a.Store.Transact(ctx, action)
 	if err != nil {
-		// TODO: wrap err in dss.Internal?
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR begins to address #379 by:

1. Replacing all of our explicit Internal errors with `stacktrace` messages and propagations
1. Adding an error ID so a particular client-facing error message can be connected to backend logs quickly and easily, even if error message details are obfuscated
1. Fixing a number of issues with input validation and implicit Subscriptions exposed by the work above

In future PRs, we can add more `stacktrace.Propagate` statements to improve visibility into error causes, but that will be a large task and this PR aims to be a targeted introduction to the work.