### PR TITLE
Set locality value to writer field in isa obj for update ISA

### DIFF
--- a/cmds/grpc-backend/main.go
+++ b/cmds/grpc-backend/main.go
@@ -131,7 +131,7 @@ func ConnectTo(dbName string) (*cockroach.DB, error) {
 
 // RunGRPCServer starts the example gRPC service.
 // "network" and "address" are passed to net.Listen.
-func RunGRPCServer(ctx context.Context, address string) error {
+func RunGRPCServer(ctx context.Context, address string, locality string) error {
 	logger := logging.WithValuesFromContext(ctx, logging.Logger)
 
 	if len(*jwtAudiences) == 0 {
@@ -167,8 +167,9 @@ func RunGRPCServer(ctx context.Context, address string) error {
 	MustSupportRidSchema(ctx, ridStore)
 
 	ridServer = &rid.Server{
-		App:     application.NewFromTransactor(ridStore, logger),
-		Timeout: *timeout,
+		App:      application.NewFromTransactor(ridStore, logger),
+		Timeout:  *timeout,
+		Locality: locality,
 	}
 	scopesValidators := auth.MergeOperationsAndScopesValidators(
 		rid.AuthScopes(), auxServer.AuthScopes(),
@@ -282,10 +283,9 @@ func main() {
 		}
 	}
 
-	if err := RunGRPCServer(ctx, *address); err != nil {
+	if err := RunGRPCServer(ctx, *address, *locality); err != nil {
 		logger.Panic("Failed to execute service", zap.Error(err))
 	}
 
-	logger.Info("locality: " + *locality)
 	logger.Info("Shutting down gracefully")
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -322,7 +322,7 @@ func (a *Authorizer) AuthInterceptor(ctx context.Context, req interface{}, info 
 	}
 
 	if err := a.validateKeyClaimedScopes(ctx, info, keyClaims.Scopes); err != nil {
-		return nil, dsserr.PermissionDenied(fmt.Sprintf("missing scopes"))
+		return nil, dsserr.PermissionDenied("missing scopes")
 	}
 
 	return handler(ContextWithOwner(ctx, models.Owner(keyClaims.Subject)), req)

--- a/pkg/rid/application/subscription_test.go
+++ b/pkg/rid/application/subscription_test.go
@@ -2,7 +2,6 @@ package application
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -173,7 +172,7 @@ func TestBadOwner(t *testing.T) {
 	// Test changing owner fails
 	sub.Owner = "new bad owner"
 	_, err = app.UpdateSubscription(ctx, sub)
-	require.EqualError(t, err, fmt.Sprintf("rpc error: code = PermissionDenied desc = s is owned by orig Owner"))
+	require.EqualError(t, err, "rpc error: code = PermissionDenied desc = s is owned by orig Owner")
 }
 
 func TestSubscriptionUpdateCells(t *testing.T) {

--- a/pkg/rid/models/identification_service_area.go
+++ b/pkg/rid/models/identification_service_area.go
@@ -24,7 +24,7 @@ type IdentificationServiceArea struct {
 	Version    *dssmodels.Version
 	AltitudeHi *float32
 	AltitudeLo *float32
-	Writer	   string
+	Writer     string
 }
 
 // SetCells is a convenience function that accepts an int64 array and converts

--- a/pkg/rid/models/identification_service_area.go
+++ b/pkg/rid/models/identification_service_area.go
@@ -24,6 +24,7 @@ type IdentificationServiceArea struct {
 	Version    *dssmodels.Version
 	AltitudeHi *float32
 	AltitudeLo *float32
+	Writer	   string
 }
 
 // SetCells is a convenience function that accepts an int64 array and converts

--- a/pkg/rid/server/isa_handler.go
+++ b/pkg/rid/server/isa_handler.go
@@ -126,6 +126,7 @@ func (s *Server) UpdateIdentificationServiceArea(
 		URL:     params.FlightsUrl,
 		Owner:   owner,
 		Version: version,
+		Writer:  s.Locality,
 	}
 
 	if err := isa.SetExtents(params.Extents); err != nil {

--- a/pkg/rid/server/server.go
+++ b/pkg/rid/server/server.go
@@ -27,8 +27,9 @@ var (
 
 // Server implements ridpb.DiscoveryAndSynchronizationService.
 type Server struct {
-	App     application.App
-	Timeout time.Duration
+	App      application.App
+	Timeout  time.Duration
+	Locality string
 }
 
 // AuthScopes returns a map of endpoint to required Oauth scope.

--- a/pkg/rid/server/server_test.go
+++ b/pkg/rid/server/server_test.go
@@ -507,16 +507,16 @@ func TestUpdateISA(t *testing.T) {
 		extents    *ridpb.Volume4D
 		flightsURL string
 		wantISA    *ridmodels.IdentificationServiceArea
-		wantErr    error 
-		version   *dssmodels.Version
+		wantErr    error
+		version    *dssmodels.Version
 	}{
 		{
-			name: "success",
+			name:       "success",
 			id:         dssmodels.ID("4348c8e5-0b1c-43cf-9114-2e67a4532765"),
 			extents:    testdata.LoopVolume4D,
 			flightsURL: "https://example.com",
-			version:  version,
-			wantISA: &ridmodels.IdentificationServiceArea {
+			version:    version,
+			wantISA: &ridmodels.IdentificationServiceArea{
 				ID:         "4348c8e5-0b1c-43cf-9114-2e67a4532765",
 				URL:        "https://example.com",
 				Owner:      "foo",
@@ -525,23 +525,23 @@ func TestUpdateISA(t *testing.T) {
 				EndTime:    mustTimestamp(testdata.LoopVolume4D.GetTimeEnd()),
 				AltitudeHi: &testdata.LoopVolume3D.AltitudeHi,
 				AltitudeLo: &testdata.LoopVolume3D.AltitudeLo,
-				Writer: "locality value",
-				Version: version,
+				Writer:     "locality value",
+				Version:    version,
 			},
 		},
 		{
-			name:  "missing-flights-url",
-			id:         dssmodels.ID("4348c8e5-0b1c-43cf-9114-2e67a4532765"),
-			extents:    testdata.LoopVolume4D,
-			version:  version,
+			name:    "missing-flights-url",
+			id:      dssmodels.ID("4348c8e5-0b1c-43cf-9114-2e67a4532765"),
+			extents: testdata.LoopVolume4D,
+			version: version,
 			wantErr: dsserr.BadRequest("missing required flightsURL"),
 		},
 		{
-			name: "missing-extents",
+			name:       "missing-extents",
 			id:         dssmodels.ID("4348c8e5-0b1c-43cf-9114-2e67a4532765"),
 			flightsURL: "https://example.com",
-			version: version,
-			wantErr: dsserr.BadRequest("missing required extents"),
+			version:    version,
+			wantErr:    dsserr.BadRequest("missing required extents"),
 		},
 	} {
 		t.Run(r.name, func(t *testing.T) {
@@ -551,11 +551,11 @@ func TestUpdateISA(t *testing.T) {
 					r.wantISA, []*ridmodels.Subscription(nil), nil)
 			}
 			s := &Server{
-				App: ma,
+				App:      ma,
 				Locality: "locality value",
 			}
 			_, err := s.UpdateIdentificationServiceArea(ctx, &ridpb.UpdateIdentificationServiceAreaRequest{
-				Id: r.id.String(),
+				Id:      r.id.String(),
 				Version: r.version.String(),
 				Params: &ridpb.UpdateIdentificationServiceAreaParameters{
 					Extents:    r.extents,

--- a/pkg/rid/server/server_test.go
+++ b/pkg/rid/server/server_test.go
@@ -568,7 +568,6 @@ func TestUpdateISA(t *testing.T) {
 	}
 }
 
-
 func TestDeleteIdentificationServiceAreaRequiresOwnerInContext(t *testing.T) {
 	var (
 		id = uuid.New().String()

--- a/pkg/scd/store/cockroach/subscriptions.go
+++ b/pkg/scd/store/cockroach/subscriptions.go
@@ -394,11 +394,11 @@ func (c *repo) SearchSubscriptions(ctx context.Context, v4d *dssmodels.Volume4D)
 
 // Implements scd.repos.Subscription.IncrementNotificationIndices
 func (c *repo) IncrementNotificationIndices(ctx context.Context, subscriptionIds []scdmodels.ID) ([]int, error) {
-	var updateQuery = fmt.Sprintf(`
+	var updateQuery = `
 			UPDATE scd_subscriptions
 			SET notification_index = notification_index + 1
 			WHERE id = ANY($1)
-			RETURNING notification_index`)
+			RETURNING notification_index`
 
 	ids := make([]string, len(subscriptionIds))
 	for i, id := range subscriptionIds {


### PR DESCRIPTION
#349 
1. Adding Locality field to rid.Server
2. Adding Writer field to ISA obj
3. Adding code to set Locality value to writer field when update ISA
4. Adding unit test for updating ISA

Next:
update update sql script in store.go for rid db that version >= v3.1.0