### PR TITLE
Simplify Operations repo interface and fix some Operation behavior

### DIFF
--- a/monitoring/prober/scd/test_operation_references_error_cases.py
+++ b/monitoring/prober/scd/test_operation_references_error_cases.py
@@ -35,7 +35,11 @@ def test_op_ref_start_end_times_past(scd_session):
   with open('./scd/resources/op_ref_start_end_times_past.json', 'r') as f:
     req = json.load(f)
   resp = scd_session.post('/operation_references/query', json=req)
-  assert resp.status_code == 400, resp.content
+  # It is ok (and useful) to query for past Operations that may not yet have
+  # been explicitly deleted.  This is unlike remote ID where ISAs are
+  # auto-removed from the perspective of the client immediately after their end
+  # time.
+  assert resp.status_code == 200, resp.content
 
 
 @default_scope(SCOPE_SC)
@@ -108,6 +112,10 @@ def test_op_already_exists(scd_session):
   # Delete operation
   resp = scd_session.delete('/operation_references/{}'.format(OP_ID))
   assert resp.status_code == 200, resp.content
+
+  # Verify deletion
+  resp = scd_session.get('/operation_references/{}'.format(OP_ID))
+  assert resp.status_code == 404, resp.content
 
 
 @default_scope(SCOPE_SC)

--- a/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
+++ b/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
@@ -103,8 +103,8 @@ def test_create_ops(scd_session):
     op = data['operation_reference']
     assert op['id'] == op_id
     assert op['uss_base_url'] == BASE_URL
-    assert op['time_start']['value'] == req['extents'][0]['time_start']['value']
-    assert op['time_end']['value'] == req['extents'][0]['time_end']['value']
+    assert common.iso8601_equal(op['time_start']['value'], req['extents'][0]['time_start']['value'])
+    assert common.iso8601_equal(op['time_end']['value'], req['extents'][0]['time_end']['value'])
     assert op['version'] == 1
     assert op['ovn']
     assert 'subscription_id' in op

--- a/pkg/scd/constraints_handler.go
+++ b/pkg/scd/constraints_handler.go
@@ -58,7 +58,7 @@ func (a *Server) DeleteConstraintReference(ctx context.Context, req *scdpb.Delet
 		}
 
 		// Limit Subscription notifications to only those interested in Constraints
-		var subs []*scdmodels.Subscription
+		var subs repos.Subscriptions
 		for _, sub := range allsubs {
 			if sub.NotifyForConstraints {
 				subs = append(subs, sub)
@@ -72,7 +72,7 @@ func (a *Server) DeleteConstraintReference(ctx context.Context, req *scdpb.Delet
 		}
 
 		// Increment notification indices for relevant Subscriptions
-		err = incrementNotificationIndices(ctx, r, subs)
+		err = subs.IncrementNotificationIndices(ctx, r)
 		if err != nil {
 			return stacktrace.Propagate(err, "Unable to increment notification indices")
 		}
@@ -263,7 +263,7 @@ func (a *Server) PutConstraintReference(ctx context.Context, req *scdpb.PutConst
 		}
 
 		// Limit Subscription notifications to only those interested in Constraints
-		var subs []*scdmodels.Subscription
+		var subs repos.Subscriptions
 		for _, sub := range allsubs {
 			if sub.NotifyForConstraints {
 				subs = append(subs, sub)
@@ -271,7 +271,7 @@ func (a *Server) PutConstraintReference(ctx context.Context, req *scdpb.PutConst
 		}
 
 		// Increment notification indices for relevant Subscriptions
-		err = incrementNotificationIndices(ctx, r, subs)
+		err = subs.IncrementNotificationIndices(ctx, r)
 		if err != nil {
 			return err
 		}

--- a/pkg/scd/constraints_handler.go
+++ b/pkg/scd/constraints_handler.go
@@ -14,21 +14,6 @@ import (
 	"github.com/palantir/stacktrace"
 )
 
-func incrementNotificationIndices(ctx context.Context, r repos.Repository, subs []*scdmodels.Subscription) error {
-	subIds := make([]dssmodels.ID, len(subs))
-	for i, sub := range subs {
-		subIds[i] = sub.ID
-	}
-	newIndices, err := r.IncrementNotificationIndices(ctx, subIds)
-	if err != nil {
-		return err
-	}
-	for i, newIndex := range newIndices {
-		subs[i].NotificationIndex = newIndex
-	}
-	return nil
-}
-
 // DeleteConstraintReference deletes a single constraint ref for a given ID at
 // the specified version.
 func (a *Server) DeleteConstraintReference(ctx context.Context, req *scdpb.DeleteConstraintReferenceRequest) (*scdpb.ChangeConstraintReferenceResponse, error) {
@@ -233,7 +218,6 @@ func (a *Server) PutConstraintReference(ctx context.Context, req *scdpb.PutConst
 		}
 
 		// Compute total affected Volume4D for notification purposes
-		// TODO: Fix in Operations; Subscriptions should be pulled from both old and new 4D geometries
 		var notifyVol4 *dssmodels.Volume4D
 		if old == nil {
 			notifyVol4 = uExtent

--- a/pkg/scd/errors/errors.go
+++ b/pkg/scd/errors/errors.go
@@ -18,7 +18,7 @@ var (
 // MissingOVNsErrorResponse is Used to return sufficient information for an
 // appropriate client error response when a client is missing one or more
 // OVNs for relevant Operations or Constraints.
-func MissingOVNsErrorResponse(missingOps []*dssmodels.Operation) (*spb.Status, error) {
+func MissingOVNsErrorResponse(missingOps []*dssmodels.Operation, missingConstraints []*dssmodels.Constraint) (*spb.Status, error) {
 	detail := &scdpb.AirspaceConflictResponse{
 		Message: errMessageMissingOVNs,
 	}
@@ -29,6 +29,16 @@ func MissingOVNsErrorResponse(missingOps []*dssmodels.Operation) (*spb.Status, e
 		}
 		entityRef := &scdpb.EntityReference{
 			OperationReference: opRef,
+		}
+		detail.EntityConflicts = append(detail.EntityConflicts, entityRef)
+	}
+	for _, missingConstraint := range missingConstraints {
+		constraintRef, err := missingConstraint.ToProto()
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "Error converting missing Constraint to proto")
+		}
+		entityRef := &scdpb.EntityReference{
+			ConstraintReference: constraintRef,
 		}
 		detail.EntityConflicts = append(detail.EntityConflicts, entityRef)
 	}

--- a/pkg/scd/errors/errors.go
+++ b/pkg/scd/errors/errors.go
@@ -37,10 +37,9 @@ func MissingOVNsErrorResponse(missingOps []*dssmodels.Operation, missingConstrai
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "Error converting missing Constraint to proto")
 		}
-		entityRef := &scdpb.EntityReference{
+		detail.EntityConflicts = append(detail.EntityConflicts, &scdpb.EntityReference{
 			ConstraintReference: constraintRef,
-		}
-		detail.EntityConflicts = append(detail.EntityConflicts, entityRef)
+		})
 	}
 
 	p, err := dsserrors.MakeStatusProto(codes.Code(uint16(dsserrors.MissingOVNs)), errMessageMissingOVNs, detail)

--- a/pkg/scd/models/models.go
+++ b/pkg/scd/models/models.go
@@ -55,7 +55,7 @@ func (v Version) Matches(w Version) bool {
 func ValidateUSSBaseURL(s string) error {
 	u, err := url.Parse(s)
 	if err != nil {
-		return err
+		return stacktrace.Propagate(err, "Error parsing URL")
 	}
 
 	switch u.Scheme {

--- a/pkg/scd/models/operations.go
+++ b/pkg/scd/models/operations.go
@@ -24,6 +24,34 @@ const (
 // OperationState models the state of an operation.
 type OperationState string
 
+// RequiresKey indicates whether transitioning an Operation to this
+// OperationState requires a valid key.
+func (s OperationState) RequiresKey() bool {
+	switch s {
+	case OperationStateNonConforming:
+		fallthrough
+	case OperationStateContingent:
+		return false
+	}
+	return true
+}
+
+// IsValid indicates whether an Operation may be transitioned to the specified
+// state via a DSS PUT.
+func (s OperationState) IsValidInDSS() bool {
+	switch s {
+	case OperationStateAccepted:
+		fallthrough
+	case OperationStateActivated:
+		fallthrough
+	case OperationStateNonConforming:
+		fallthrough
+	case OperationStateContingent:
+		return true
+	}
+	return false
+}
+
 // Operation models an operation.
 type Operation struct {
 	ID             dssmodels.ID

--- a/pkg/scd/models/subscriptions.go
+++ b/pkg/scd/models/subscriptions.go
@@ -37,12 +37,11 @@ type Subscription struct {
 	NotifyForOperations  bool
 	NotifyForConstraints bool
 	ImplicitSubscription bool
-	DependentOperations  []dssmodels.ID
 	Cells                s2.CellUnion
 }
 
 // ToProto converts the Subscription to its proto API format
-func (s *Subscription) ToProto() (*scdpb.Subscription, error) {
+func (s *Subscription) ToProto(dependentOperations []dssmodels.ID) (*scdpb.Subscription, error) {
 	result := &scdpb.Subscription{
 		Id:                   s.ID.String(),
 		Version:              int32(s.Version),
@@ -51,10 +50,6 @@ func (s *Subscription) ToProto() (*scdpb.Subscription, error) {
 		NotifyForOperations:  s.NotifyForOperations,
 		NotifyForConstraints: s.NotifyForConstraints,
 		ImplicitSubscription: s.ImplicitSubscription,
-	}
-
-	for i := 0; i < len(s.DependentOperations); i++ {
-		result.DependentOperations = append(result.DependentOperations, s.DependentOperations[i].String())
 	}
 
 	if s.StartTime != nil {
@@ -79,7 +74,7 @@ func (s *Subscription) ToProto() (*scdpb.Subscription, error) {
 		}
 	}
 
-	for _, op := range s.DependentOperations {
+	for _, op := range dependentOperations {
 		result.DependentOperations = append(result.DependentOperations, op.String())
 	}
 

--- a/pkg/scd/operations_handler.go
+++ b/pkg/scd/operations_handler.go
@@ -87,7 +87,7 @@ func (a *Server) DeleteOperationReference(ctx context.Context, req *scdpb.Delete
 		}
 
 		// Limit Subscription notifications to only those interested in Operations
-		var subs []*scdmodels.Subscription
+		var subs repos.Subscriptions
 		for _, s := range allsubs {
 			if s.NotifyForOperations {
 				subs = append(subs, s)
@@ -95,14 +95,12 @@ func (a *Server) DeleteOperationReference(ctx context.Context, req *scdpb.Delete
 		}
 
 		// Increment notification indices for Subscriptions to be notified
-		err = incrementNotificationIndices(ctx, r, subs)
-		if err != nil {
+		if err := subs.IncrementNotificationIndices(ctx, r); err != nil {
 			return stacktrace.Propagate(err, "Unable to increment notification indices")
 		}
 
 		// Delete Operation from repo
-		err = r.DeleteOperation(ctx, id)
-		if err != nil {
+		if err := r.DeleteOperation(ctx, id); err != nil {
 			return stacktrace.Propagate(err, "Unable to delete Operation from repo")
 		}
 
@@ -506,7 +504,7 @@ func (a *Server) PutOperationReference(ctx context.Context, req *scdpb.PutOperat
 		}
 
 		// Limit Subscription notifications to only those interested in Operations
-		var subs []*scdmodels.Subscription
+		var subs repos.Subscriptions
 		for _, sub := range allsubs {
 			if sub.NotifyForOperations {
 				subs = append(subs, sub)
@@ -514,7 +512,7 @@ func (a *Server) PutOperationReference(ctx context.Context, req *scdpb.PutOperat
 		}
 
 		// Increment notification indices for relevant Subscriptions
-		err = incrementNotificationIndices(ctx, r, subs)
+		err = subs.IncrementNotificationIndices(ctx, r)
 		if err != nil {
 			return err
 		}

--- a/pkg/scd/repos/repos.go
+++ b/pkg/scd/repos/repos.go
@@ -12,18 +12,18 @@ type Operation interface {
 	// GetOperation returns the operation identified by "id".
 	GetOperation(ctx context.Context, id dssmodels.ID) (*scdmodels.Operation, error)
 
-	// DeleteOperation deletes the operation identified by "id" and owned by "owner".
-	// Returns the deleted Operation and all Subscriptions affected by the delete.
-	DeleteOperation(ctx context.Context, id dssmodels.ID, owner dssmodels.Owner) (*scdmodels.Operation, []*scdmodels.Subscription, error)
+	// DeleteOperation deletes the operation identified by "id".
+	DeleteOperation(ctx context.Context, id dssmodels.ID) error
 
-	// UpsertOperation inserts or updates an operation using key as a fencing
-	// token. If operation does not reference an existing subscription, an
-	// implicit subscription with parameters notifySubscriptionForConstraints
-	// and subscriptionBaseURL is created.
-	UpsertOperation(ctx context.Context, operation *scdmodels.Operation, key []scdmodels.OVN) (*scdmodels.Operation, []*scdmodels.Subscription, error)
+	// UpsertOperation inserts or updates an operation into the store.
+	UpsertOperation(ctx context.Context, operation *scdmodels.Operation) (*scdmodels.Operation, error)
 
 	// SearchOperations returns all operations intersecting "v4d".
 	SearchOperations(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Operation, error)
+
+	// GetDependentOperations returns IDs of all operations dependent on
+	// subscription identified by "subscriptionID".
+	GetDependentOperations(ctx context.Context, subscriptionID dssmodels.ID) ([]dssmodels.ID, error)
 }
 
 // Subscription abstracts subscription-specific interactions with the backing repository.

--- a/pkg/scd/server.go
+++ b/pkg/scd/server.go
@@ -7,7 +7,9 @@ import (
 	"github.com/interuss/dss/pkg/api/v1/scdpb"
 	"github.com/interuss/dss/pkg/auth"
 	dsserr "github.com/interuss/dss/pkg/errors"
+	dssmodels "github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
+	"github.com/interuss/dss/pkg/scd/repos"
 	scdstore "github.com/interuss/dss/pkg/scd/store"
 	"github.com/palantir/stacktrace"
 )
@@ -68,4 +70,19 @@ func (a *Server) AuthScopes() map[auth.Operation]auth.KeyClaimedScopesValidator 
 // MakeDssReport creates an error report about a DSS.
 func (a *Server) MakeDssReport(ctx context.Context, req *scdpb.MakeDssReportRequest) (*scdpb.ErrorReport, error) {
 	return nil, stacktrace.NewErrorWithCode(dsserr.BadRequest, "Not yet implemented")
+}
+
+func incrementNotificationIndices(ctx context.Context, r repos.Repository, subs []*scdmodels.Subscription) error {
+	subIds := make([]dssmodels.ID, len(subs))
+	for i, sub := range subs {
+		subIds[i] = sub.ID
+	}
+	newIndices, err := r.IncrementNotificationIndices(ctx, subIds)
+	if err != nil {
+		return err
+	}
+	for i, newIndex := range newIndices {
+		subs[i].NotificationIndex = newIndex
+	}
+	return nil
 }

--- a/pkg/scd/server.go
+++ b/pkg/scd/server.go
@@ -7,9 +7,7 @@ import (
 	"github.com/interuss/dss/pkg/api/v1/scdpb"
 	"github.com/interuss/dss/pkg/auth"
 	dsserr "github.com/interuss/dss/pkg/errors"
-	dssmodels "github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
-	"github.com/interuss/dss/pkg/scd/repos"
 	scdstore "github.com/interuss/dss/pkg/scd/store"
 	"github.com/palantir/stacktrace"
 )
@@ -70,19 +68,4 @@ func (a *Server) AuthScopes() map[auth.Operation]auth.KeyClaimedScopesValidator 
 // MakeDssReport creates an error report about a DSS.
 func (a *Server) MakeDssReport(ctx context.Context, req *scdpb.MakeDssReportRequest) (*scdpb.ErrorReport, error) {
 	return nil, stacktrace.NewErrorWithCode(dsserr.BadRequest, "Not yet implemented")
-}
-
-func incrementNotificationIndices(ctx context.Context, r repos.Repository, subs []*scdmodels.Subscription) error {
-	subIds := make([]dssmodels.ID, len(subs))
-	for i, sub := range subs {
-		subIds[i] = sub.ID
-	}
-	newIndices, err := r.IncrementNotificationIndices(ctx, subIds)
-	if err != nil {
-		return err
-	}
-	for i, newIndex := range newIndices {
-		subs[i].NotificationIndex = newIndex
-	}
-	return nil
 }

--- a/pkg/scd/store/cockroach/operations.go
+++ b/pkg/scd/store/cockroach/operations.go
@@ -2,7 +2,6 @@ package cockroach
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -10,7 +9,6 @@ import (
 	"github.com/golang/geo/s2"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	dssmodels "github.com/interuss/dss/pkg/models"
-	scderr "github.com/interuss/dss/pkg/scd/errors"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	dsssql "github.com/interuss/dss/pkg/sql"
 	"github.com/lib/pq"
@@ -84,6 +82,13 @@ func (s *repo) fetchOperations(ctx context.Context, q dsssql.Queryable, query st
 		return nil, stacktrace.Propagate(err, "Error in rows query result")
 	}
 
+	for _, op := range payload {
+		err = s.populateOperationCells(ctx, q, op)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "Error populating cells for Operation %s", op.ID)
+		}
+	}
+
 	return payload, nil
 }
 
@@ -96,7 +101,7 @@ func (s *repo) fetchOperation(ctx context.Context, q dsssql.Queryable, query str
 		return nil, stacktrace.NewError("Query returned %d Operations when only 0 or 1 was expected", len(operations))
 	}
 	if len(operations) == 0 {
-		return nil, sql.ErrNoRows
+		return nil, nil
 	}
 	return operations[0], nil
 }
@@ -108,87 +113,6 @@ func (s *repo) fetchOperationByID(ctx context.Context, q dsssql.Queryable, id ds
 		WHERE
 			id = $1`, operationFieldsWithoutPrefix)
 	return s.fetchOperation(ctx, q, query, id)
-}
-
-// pushOperation creates/updates the Operation identified by "id" and owned by
-// "owner", affecting "cells" in the time interval ["starts", "ends"].
-//
-// Returns the created/updated Operation and all Subscriptions
-// affected by the operation.
-func (s *repo) pushOperation(ctx context.Context, q dsssql.Queryable, operation *scdmodels.Operation) (
-	*scdmodels.Operation, []*scdmodels.Subscription, error) {
-	var (
-		upsertOperationsQuery = fmt.Sprintf(`
-			WITH v AS (
-				SELECT
-					version
-				FROM
-					scd_operations
-				WHERE
-					id = $1
-			)
-			UPSERT INTO
-				scd_operations
-				(%s)
-			VALUES
-				($1, $2, COALESCE((SELECT version from v), 0) + 1, $3, $4, $5, $6, $7, $8, transaction_timestamp())
-			RETURNING
-				%s`, operationFieldsWithoutPrefix, operationFieldsWithPrefix)
-		upsertCellsForOperationQuery = `
-			UPSERT INTO
-				scd_cells_operations
-				(cell_id, cell_level, operation_id)
-			VALUES
-				($1, $2, $3)`
-		deleteLeftOverCellsForOperationQuery = `
-			DELETE FROM
-				scd_cells_operations
-			WHERE
-				cell_id != ALL($1)
-			AND
-				operation_id = $2`
-	)
-
-	cids := make([]int64, len(operation.Cells))
-	clevels := make([]int, len(operation.Cells))
-
-	for i, cell := range operation.Cells {
-		cids[i] = int64(cell)
-		clevels[i] = cell.Level()
-	}
-
-	cells := operation.Cells
-	operation, err := s.fetchOperation(ctx, q, upsertOperationsQuery,
-		operation.ID,
-		operation.Owner,
-		operation.USSBaseURL,
-		operation.AltitudeLower,
-		operation.AltitudeUpper,
-		operation.StartTime,
-		operation.EndTime,
-		operation.SubscriptionID,
-	)
-	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Error fetching Operation")
-	}
-	operation.Cells = cells
-
-	for i := range cids {
-		if _, err := q.ExecContext(ctx, upsertCellsForOperationQuery, cids[i], clevels[i], operation.ID); err != nil {
-			return nil, nil, stacktrace.Propagate(err, "Error in query: %s", upsertCellsForOperationQuery)
-		}
-	}
-
-	if _, err := q.ExecContext(ctx, deleteLeftOverCellsForOperationQuery, pq.Array(cids), operation.ID); err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Error in query: %s", deleteLeftOverCellsForOperationQuery)
-	}
-
-	subscriptions, err := s.fetchSubscriptionsForNotification(ctx, q, cids)
-	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Error fetching Subscriptions for notification")
-	}
-
-	return operation, subscriptions, nil
 }
 
 func (s *repo) populateOperationCells(ctx context.Context, q dsssql.Queryable, o *scdmodels.Operation) error {
@@ -221,154 +145,99 @@ func (s *repo) populateOperationCells(ctx context.Context, q dsssql.Queryable, o
 	return nil
 }
 
-// GetOperation returns an operation for the given ID from CockroachDB
+// GetOperation implements repos.Operation.GetOperation.
 func (s *repo) GetOperation(ctx context.Context, id dssmodels.ID) (*scdmodels.Operation, error) {
-	sub, err := s.fetchOperationByID(ctx, s.q, id)
-	switch err {
-	case nil:
-		return sub, nil
-	case sql.ErrNoRows:
-		return nil, stacktrace.NewErrorWithCode(dsserr.NotFound, "Operation %s not found", id.String())
-	default:
-		return nil, err // No need to Propagate this error as this stack layer does not add useful information
-	}
+	return s.fetchOperationByID(ctx, s.q, id)
 }
 
-// DeleteOperation deletes an operation for the given ID from CockroachDB
-func (s *repo) DeleteOperation(ctx context.Context, id dssmodels.ID, owner dssmodels.Owner) (*scdmodels.Operation, []*scdmodels.Subscription, error) {
+// DeleteOperation implements repos.Operation.DeleteOperation.
+func (s *repo) DeleteOperation(ctx context.Context, id dssmodels.ID) error {
 	var (
-		deleteQuery = `
+		deleteOperationQuery = `
 			DELETE FROM
 				scd_operations
 			WHERE
 				id = $1
-			AND
-				owner = $2
-		`
-		deleteImplicitSubscriptionQuery = `
-			DELETE FROM
-				scd_subscriptions
-			WHERE
-				id = $1
-			AND
-				owner = $2
-			AND
-				implicit = true
-			AND
-				0 = ALL (
-					SELECT
-						COALESCE(COUNT(id),0)
-					FROM
-						scd_operations
-					WHERE
-						subscription_id = $1
-				)
 		`
 	)
 
-	// We fetch to know whether to return a concurrency error, or a not found error
-	old, err := s.fetchOperationByID(ctx, s.q, id)
-	switch {
-	case err == sql.ErrNoRows: // Return a 404 here.
-		return nil, nil, stacktrace.NewErrorWithCode(dsserr.NotFound, "Operation %s not found", id.String())
-	case err != nil:
-		return nil, nil, stacktrace.Propagate(err, "Error fetching Operation by ID")
-	case old != nil && old.Owner != owner:
-		return nil, nil, stacktrace.NewErrorWithCode(dsserr.PermissionDenied, "Operation is owned by different client")
-	}
-	if err := s.populateOperationCells(ctx, s.q, old); err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Error populating Operation cells")
-	}
-
-	cids := make([]int64, len(old.Cells))
-	for i, cell := range old.Cells {
-		cids[i] = int64(cell)
-	}
-	subscriptions, err := s.fetchSubscriptionsForNotification(ctx, s.q, cids)
+	res, err := s.q.ExecContext(ctx, deleteOperationQuery, id)
 	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Error fetching Subscriptions for notification")
+		return stacktrace.Propagate(err, "Error in query: %s", deleteOperationQuery)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return stacktrace.Propagate(err, "Could not get RowsAffected")
+	}
+	if rows == 0 {
+		return stacktrace.NewError("Could not delete Operation that does not exist")
 	}
 
-	if _, err := s.q.ExecContext(ctx, deleteQuery, id, owner); err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Error in query: %s", deleteQuery)
-	}
-	if _, err := s.q.ExecContext(ctx, deleteImplicitSubscriptionQuery, old.SubscriptionID, owner); err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Error in query: %s", deleteImplicitSubscriptionQuery)
-	}
-
-	return old, subscriptions, nil
+	return nil
 }
 
-// UpsertOperation inserts or updates an operation in CockroachDB
-func (s *repo) UpsertOperation(ctx context.Context, operation *scdmodels.Operation, key []scdmodels.OVN) (*scdmodels.Operation, []*scdmodels.Subscription, error) {
-	old, err := s.fetchOperationByID(ctx, s.q, operation.ID)
-	switch {
-	case err == sql.ErrNoRows:
-		break
-	case err != nil:
-		return nil, nil, stacktrace.Propagate(err, "Error fetching Operation by ID")
+// UpsertOperation implements repos.Operation.UpsertOperation.
+func (s *repo) UpsertOperation(ctx context.Context, operation *scdmodels.Operation) (*scdmodels.Operation, error) {
+	var (
+		upsertOperationsQuery = fmt.Sprintf(`
+			UPSERT INTO
+				scd_operations
+				(%s)
+			VALUES
+				($1, $2, $3, $4, $5, $6, $7, $8, $9, transaction_timestamp())
+			RETURNING
+				%s`, operationFieldsWithoutPrefix, operationFieldsWithPrefix)
+		upsertCellsForOperationQuery = `
+			UPSERT INTO
+				scd_cells_operations
+				(cell_id, cell_level, operation_id)
+			VALUES
+				($1, $2, $3)`
+		deleteLeftOverCellsForOperationQuery = `
+			DELETE FROM
+				scd_cells_operations
+			WHERE
+				cell_id != ALL($1)
+			AND
+				operation_id = $2`
+	)
+
+	cids := make([]int64, len(operation.Cells))
+	clevels := make([]int, len(operation.Cells))
+
+	for i, cell := range operation.Cells {
+		cids[i] = int64(cell)
+		clevels[i] = cell.Level()
 	}
 
-	switch {
-	case old == nil && !operation.Version.Empty():
-		// The user wants to update an existing Operation, but one wasn't found.
-		return nil, nil, stacktrace.NewErrorWithCode(dsserr.NotFound, "Operation %s not found", operation.ID.String())
-	case old != nil && operation.Version.Empty():
-		// The user wants to create a new Operation but it already exists.
-		return nil, nil, stacktrace.NewErrorWithCode(dsserr.AlreadyExists, "Operation %s already exists", operation.ID.String())
-	case old != nil && !operation.Version.Matches(old.Version):
-		// The user wants to update an Operation but the version doesn't match.
-		return nil, nil, stacktrace.NewErrorWithCode(dsserr.VersionMismatch, "Old version")
-	case old != nil && old.Owner != operation.Owner:
-		return nil, nil, stacktrace.NewErrorWithCode(dsserr.PermissionDenied, "Operation is owned by different client")
-	}
-
-	// Validate and perhaps correct StartTime and EndTime.
-	if err := operation.ValidateTimeRange(); err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Error validating time range")
-	}
-
-	// TODO(tvoss): Investigate whether we can fold the check for OVNs into the
-	// the upsert query by means of a CTE and a coalescing condition testing
-	// whether all affected OVNs are matched.
-	switch operation.State {
-	case scdmodels.OperationStateAccepted, scdmodels.OperationStateActivated:
-		operations, err := s.searchOperations(ctx, s.q, &dssmodels.Volume4D{
-			StartTime: operation.StartTime,
-			EndTime:   operation.EndTime,
-			SpatialVolume: &dssmodels.Volume3D{
-				AltitudeHi: operation.AltitudeUpper,
-				AltitudeLo: operation.AltitudeLower,
-				Footprint: dssmodels.GeometryFunc(func() (s2.CellUnion, error) {
-					return operation.Cells, nil
-				}),
-			},
-		})
-		if err != nil {
-			return nil, nil, stacktrace.Propagate(err, "Error searching Operations")
-		}
-
-		keyIdx := map[scdmodels.OVN]struct{}{}
-		for _, ovn := range key {
-			keyIdx[ovn] = struct{}{}
-		}
-
-		for _, op := range operations {
-			if _, match := keyIdx[op.OVN]; !match {
-				return nil, nil, stacktrace.Propagate(scderr.ErrMissingOVNs, "Missing OVN for Operation %s", op.ID)
-			}
-			delete(keyIdx, op.OVN)
-		}
-	default:
-		// Do not check the OVNs for any other operation states.
-	}
-
-	area, subscribers, err := s.pushOperation(ctx, s.q, operation)
+	cells := operation.Cells
+	operation, err := s.fetchOperation(ctx, s.q, upsertOperationsQuery,
+		operation.ID,
+		operation.Owner,
+		operation.Version,
+		operation.USSBaseURL,
+		operation.AltitudeLower,
+		operation.AltitudeUpper,
+		operation.StartTime,
+		operation.EndTime,
+		operation.SubscriptionID,
+	)
 	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Error pushing Operation")
+		return nil, stacktrace.Propagate(err, "Error fetching Operation")
+	}
+	operation.Cells = cells
+
+	for i := range cids {
+		if _, err := s.q.ExecContext(ctx, upsertCellsForOperationQuery, cids[i], clevels[i], operation.ID); err != nil {
+			return nil, stacktrace.Propagate(err, "Error in query: %s", upsertCellsForOperationQuery)
+		}
 	}
 
-	return area, subscribers, nil
+	if _, err := s.q.ExecContext(ctx, deleteLeftOverCellsForOperationQuery, pq.Array(cids), operation.ID); err != nil {
+		return nil, stacktrace.Propagate(err, "Error in query: %s", deleteLeftOverCellsForOperationQuery)
+	}
+
+	return operation, nil
 }
 
 func (s *repo) searchOperations(ctx context.Context, q dsssql.Queryable, v4d *dssmodels.Volume4D) ([]*scdmodels.Operation, error) {
@@ -431,12 +300,35 @@ func (s *repo) searchOperations(ctx context.Context, q dsssql.Queryable, v4d *ds
 	return result, nil
 }
 
-// SearchOperations returns operations within the 4D volume from CockroachDB
+// SearchOperations implements repos.Operation.SearchOperations.
 func (s *repo) SearchOperations(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Operation, error) {
-	result, err := s.searchOperations(ctx, s.q, v4d)
+	return s.searchOperations(ctx, s.q, v4d)
+}
+
+// GetDependentOperations implements repos.Operation.GetDependentOperations.
+func (s *repo) GetDependentOperations(ctx context.Context, subscriptionID dssmodels.ID) ([]dssmodels.ID, error) {
+	var dependentOperationsQuery = `
+      SELECT
+        id
+      FROM
+        scd_operations
+      WHERE
+        subscription_id = $1`
+
+	rows, err := s.q.QueryContext(ctx, dependentOperationsQuery, subscriptionID)
 	if err != nil {
-		return nil, err // No need to Propagate this error as this stack layer does not add useful information
+		return nil, stacktrace.Propagate(err, "Error in query: %s", dependentOperationsQuery)
+	}
+	defer rows.Close()
+	var opID dssmodels.ID
+	var dependentOps []dssmodels.ID
+	for rows.Next() {
+		err = rows.Scan(&opID)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "Error scanning dependent Operation ID")
+		}
+		dependentOps = append(dependentOps, opID)
 	}
 
-	return result, nil
+	return dependentOps, nil
 }

--- a/pkg/scd/store/cockroach/operations.go
+++ b/pkg/scd/store/cockroach/operations.go
@@ -83,8 +83,7 @@ func (s *repo) fetchOperations(ctx context.Context, q dsssql.Queryable, query st
 	}
 
 	for _, op := range payload {
-		err = s.populateOperationCells(ctx, q, op)
-		if err != nil {
+		if err := s.populateOperationCells(ctx, q, op); err != nil {
 			return nil, stacktrace.Propagate(err, "Error populating cells for Operation %s", op.ID)
 		}
 	}

--- a/test/README.md
+++ b/test/README.md
@@ -8,7 +8,7 @@ Source code is often accompanied by `*_test.go` files which define unit tests
 for the associated code.  All unit tests for the repo may be run with the
 following command from the root folder of the repo:
 ```shell script
-go test -count=1 -v ./...
+make test
 ```
 The above command skips the CockroachDB tests because a `store-uri` argument is
  not provided.  To perform the CockroachDB tests, run the following command
@@ -40,7 +40,7 @@ One of the continuous integration presubmit checks on this repository checks Go
 style with a linter.  To run this check yourself, run the following command in
 the root folder of this repo:
 ```shell script
-docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.26.0 golangci-lint run --timeout 5m -v -E gofmt,bodyclose,rowserrcheck,misspell,golint -D staticcheck,vet
+make lint
 ```
 
 ## Interoperability tests


### PR DESCRIPTION
This PR primarily simplifies the internal store/repo interface for Operations per #277, and, in the process, incidentally fixes #344, #385, and #391, and partially addresses #386.  An additional adjustment regarding Operations is that DependentSubscriptions is removed from the Subscription model since it was not consistently populated -- instead, this information can be obtained via a separate repo call when needed.  A few tests are augmented, and the validity of end times in the past is clarified in a few cases (ok to query Operations in the past, not ok to create/update an Operation to have its end time in the past).