### PR TITLE
[prober] Always print response upon status code assertion failure

### DIFF
--- a/monitoring/prober/rid/test_isa_expiry.py
+++ b/monitoring/prober/rid/test_isa_expiry.py
@@ -45,14 +45,14 @@ def test_create(session):
           },
           'flights_url': 'https://example.com/dss',
       })
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
 
 @default_scope(SCOPE_READ)
 def test_valid_immediately(session):
   # The ISA is still valid immediately after we create it.
   resp = session.get('/identification_service_areas/{}'.format(ISA_ID))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
 
 def test_sleep_5_seconds():
@@ -64,7 +64,7 @@ def test_sleep_5_seconds():
 def test_returned_by_id(session):
   # We can get it explicitly by ID
   resp = session.get('/identification_service_areas/{}'.format(ISA_ID))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
 
 @default_scope(SCOPE_READ)
@@ -72,7 +72,7 @@ def test_not_returned_by_search(session):
   # ...but it's not included in a search.
   resp = session.get('/identification_service_areas?area={}'.format(
       common.GEO_POLYGON_STRING))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   assert ISA_ID not in [x['id'] for x in resp.json()['service_areas']]
 
 

--- a/monitoring/prober/rid/test_isa_simple.py
+++ b/monitoring/prober/rid/test_isa_simple.py
@@ -53,7 +53,7 @@ def test_create_isa(session):
           },
           'flights_url': 'https://example.com/dss',
       })
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
   data = resp.json()
   assert data['service_area']['id'] == ISA_ID
@@ -69,7 +69,7 @@ def test_create_isa(session):
 @default_scope(SCOPE_READ)
 def test_get_isa_by_id(session):
   resp = session.get('/identification_service_areas/{}'.format(ISA_ID))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
   data = resp.json()
   assert data['service_area']['id'] == ISA_ID
@@ -86,7 +86,7 @@ def test_get_isa_by_search_missing_params(session):
 def test_get_isa_by_search(session):
   resp = session.get('/identification_service_areas?area={}'.format(
       common.GEO_POLYGON_STRING))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   assert ISA_ID in [x['id'] for x in resp.json()['service_areas']]
 
 
@@ -97,7 +97,7 @@ def test_get_isa_by_search_earliest_time_included(session):
                      '?area={}&earliest_time={}'.format(
                          common.GEO_POLYGON_STRING,
                          earliest_time.strftime(rid.DATE_FORMAT)))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   assert ISA_ID in [x['id'] for x in resp.json()['service_areas']]
 
 
@@ -108,7 +108,7 @@ def test_get_isa_by_search_earliest_time_excluded(session):
                      '?area={}&earliest_time={}'.format(
                          common.GEO_POLYGON_STRING,
                          earliest_time.strftime(rid.DATE_FORMAT)))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   assert ISA_ID not in [x['id'] for x in resp.json()['service_areas']]
 
 
@@ -119,7 +119,7 @@ def test_get_isa_by_search_latest_time_included(session):
                      '?area={}&latest_time={}'.format(
                          common.GEO_POLYGON_STRING,
                          latest_time.strftime(rid.DATE_FORMAT)))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   assert ISA_ID in [x['id'] for x in resp.json()['service_areas']]
 
 
@@ -130,7 +130,7 @@ def test_get_isa_by_search_latest_time_excluded(session):
                      '?area={}&latest_time={}'.format(
                          common.GEO_POLYGON_STRING,
                          latest_time.strftime(rid.DATE_FORMAT)))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   assert ISA_ID not in [x['id'] for x in resp.json()['service_areas']]
 
 
@@ -138,7 +138,7 @@ def test_get_isa_by_search_latest_time_excluded(session):
 def test_get_isa_by_search_area_only(session):
   resp = session.get('/identification_service_areas'
                      '?area={}'.format(common.GEO_POLYGON_STRING))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   assert ISA_ID in [x['id'] for x in resp.json()['service_areas']]
 
 
@@ -146,7 +146,7 @@ def test_get_isa_by_search_area_only(session):
 def test_get_isa_by_search_huge_area(session):
   resp = session.get('/identification_service_areas'
                      '?area={}'.format(common.HUGE_GEO_POLYGON_STRING))
-  assert resp.status_code == 413
+  assert resp.status_code == 413, resp.content
 
 
 @default_scope(SCOPE_WRITE)
@@ -165,23 +165,23 @@ def test_delete_isa(session):
   """ASTM Compliance Test: DSS0030_B_DELETE_ISA."""
   # GET the ISA first to find its version.
   resp = session.get('/identification_service_areas/{}'.format(ISA_ID), scope=SCOPE_READ)
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   version = resp.json()['service_area']['version']
 
   # Then delete it.
   resp = session.delete('/identification_service_areas/{}/{}'.format(ISA_ID, version), scope=SCOPE_WRITE)
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
 
 @default_scope(SCOPE_READ)
 def test_get_deleted_isa_by_id(session):
   resp = session.get('/identification_service_areas/{}'.format(ISA_ID))
-  assert resp.status_code == 404
+  assert resp.status_code == 404, resp.content
 
 
 @default_scope(SCOPE_READ)
 def test_get_deleted_isa_by_search(session):
   resp = session.get('/identification_service_areas?area={}'.format(
       common.GEO_POLYGON_STRING))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   assert ISA_ID not in [x['id'] for x in resp.json()['service_areas']]

--- a/monitoring/prober/rid/test_isa_validation.py
+++ b/monitoring/prober/rid/test_isa_validation.py
@@ -50,7 +50,7 @@ def test_isa_huge_area(session):
           },
           'flights_url': 'https://example.com/uss/flights',
       })
-  assert resp.status_code == 400
+  assert resp.status_code == 400, resp.content
   assert 'too large' in resp.json()['message']
 
 
@@ -75,7 +75,7 @@ def test_isa_empty_vertices(session):
           },
           'flights_url': 'https://example.com/uss/flights',
       })
-  assert resp.status_code == 400
+  assert resp.status_code == 400, resp.content
   assert 'Not enough points in polygon' in resp.json()['message']
 
 
@@ -97,7 +97,7 @@ def test_isa_missing_footprint(session):
           },
           'flights_url': 'https://example.com/uss/flights',
       })
-  assert resp.status_code == 400
+  assert resp.status_code == 400, resp.content
   assert 'missing required footprint' in resp.json()['message']
 
 
@@ -126,7 +126,7 @@ def test_isa_missing_extents(session):
       json={
           'flights_url': 'https://example.com/uss/flights',
       })
-  assert resp.status_code == 400
+  assert resp.status_code == 400, resp.content
   assert resp.json()['message'] == 'Missing required extents'
 
 

--- a/monitoring/prober/rid/test_subscription_isa_interactions.py
+++ b/monitoring/prober/rid/test_subscription_isa_interactions.py
@@ -63,7 +63,7 @@ def test_create_isa(session):
           },
           'flights_url': 'https://example.com/dss',
       })
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
 
 @default_scope(SCOPE_READ)
@@ -89,7 +89,7 @@ def test_create_subscription(session):
               'identification_service_area_url': 'https://example.com/foo'
           },
       })
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
   # The response should include our ISA.
   data = resp.json()
@@ -100,7 +100,7 @@ def test_create_subscription(session):
 def test_modify_isa(session):
   # GET the ISA first to find its version.
   resp = session.get('/identification_service_areas/{}'.format(ISA_ID), scope=SCOPE_READ)
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   version = resp.json()['service_area']['version']
 
   # Then modify it.
@@ -121,7 +121,7 @@ def test_modify_isa(session):
           },
           'flights_url': 'https://example.com/dss',
       }, scope=SCOPE_WRITE)
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
   # The response should include our subscription.
   data = resp.json()
@@ -138,13 +138,13 @@ def test_modify_isa(session):
 def test_delete_isa(session):
   # GET the ISA first to find its version.
   resp = session.get('/identification_service_areas/{}'.format(ISA_ID), scope=SCOPE_READ)
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   version = resp.json()['service_area']['version']
 
   # Then delete it.
   resp = session.delete('/identification_service_areas/{}/{}'.format(
       ISA_ID, version), scope=SCOPE_WRITE)
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
   # The response should include our subscription.
   data = resp.json()
@@ -162,7 +162,7 @@ def test_delete_isa(session):
 def test_delete_subscription(session):
   # GET the sub first to find its version.
   resp = session.get('/subscriptions/{}'.format(SUB_ID))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
   data = resp.json()
   version = data['subscription']['version']
@@ -170,4 +170,4 @@ def test_delete_subscription(session):
 
   # Then delete it.
   resp = session.delete('/subscriptions/{}/{}'.format(SUB_ID, version))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content

--- a/monitoring/prober/rid/test_subscription_simple.py
+++ b/monitoring/prober/rid/test_subscription_simple.py
@@ -33,7 +33,7 @@ def test_ensure_clean_workspace(session):
 @default_scope(SCOPE_READ)
 def test_sub_does_not_exist(session):
   resp = session.get('/subscriptions/{}'.format(SUB_ID))
-  assert resp.status_code == 404
+  assert resp.status_code == 404, resp.content
   assert 'Subscription {} not found'.format(SUB_ID) in resp.json()['message']
 
 
@@ -61,7 +61,7 @@ def test_create_sub(session):
               'identification_service_area_url': 'https://example.com/foo'
           },
       })
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
   data = resp.json()
   assert data['subscription']['id'] == SUB_ID
@@ -81,7 +81,7 @@ def test_create_sub(session):
 def test_get_sub_by_id(session):
   """ASTM Compliance Test: DSS0030_E_GET_SUB_BY_ID."""
   resp = session.get('/subscriptions/{}'.format(SUB_ID))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
   data = resp.json()
   assert data['subscription']['id'] == SUB_ID
@@ -95,26 +95,26 @@ def test_get_sub_by_id(session):
 def test_get_sub_by_search(session):
   """ASTM Compliance Test: DSS0030_F_GET_SUBS_BY_AREA."""
   resp = session.get('/subscriptions?area={}'.format(common.GEO_POLYGON_STRING))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   assert SUB_ID in [x['id'] for x in resp.json()['subscriptions']]
 
 
 @default_scope(SCOPE_READ)
 def test_get_sub_by_searching_huge_area(session):
   resp = session.get('/subscriptions?area={}'.format(common.HUGE_GEO_POLYGON_STRING))
-  assert resp.status_code == 413
+  assert resp.status_code == 413, resp.content
 
 
 @default_scope(SCOPE_READ)
 def test_delete_sub_empty_version(session):
   resp = session.delete('/subscriptions/{}/'.format(SUB_ID))
-  assert resp.status_code == 400
+  assert resp.status_code == 400, resp.content
 
 
 @default_scope(SCOPE_READ)
 def test_delete_sub_wrong_version(session):
   resp = session.delete('/subscriptions/{}/fake_version'.format(SUB_ID))
-  assert resp.status_code == 400
+  assert resp.status_code == 400, resp.content
 
 
 @default_scope(SCOPE_READ)
@@ -122,22 +122,22 @@ def test_delete_sub(session):
   """ASTM Compliance Test: DSS0030_D_DELETE_SUB."""
   # GET the sub first to find its version.
   resp = session.get('/subscriptions/{}'.format(SUB_ID))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   version = resp.json()['subscription']['version']
 
   # Then delete it.
   resp = session.delete('/subscriptions/{}/{}'.format(SUB_ID, version))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
 
 @default_scope(SCOPE_READ)
 def test_get_deleted_sub_by_id(session):
   resp = session.get('/subscriptions/{}'.format(SUB_ID))
-  assert resp.status_code == 404
+  assert resp.status_code == 404, resp.content
 
 
 @default_scope(SCOPE_READ)
 def test_get_deleted_sub_by_search(session):
   resp = session.get('/subscriptions?area={}'.format(common.GEO_POLYGON_STRING))
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
   assert SUB_ID not in [x['id'] for x in resp.json()['subscriptions']]

--- a/monitoring/prober/rid/test_subscription_validation.py
+++ b/monitoring/prober/rid/test_subscription_validation.py
@@ -53,7 +53,7 @@ def test_create_sub_empty_vertices(session):
               'identification_service_area_url': 'https://example.com/foo'
           },
       })
-  assert resp.status_code == 400
+  assert resp.status_code == 400, resp.content
 
 
 @default_scope(SCOPE_READ)
@@ -76,7 +76,7 @@ def test_create_sub_missing_footprint(session):
               'identification_service_area_url': 'https://example.com/foo'
           },
       })
-  assert resp.status_code == 400
+  assert resp.status_code == 400, resp.content
 
 
 @default_scope(SCOPE_READ)
@@ -102,7 +102,7 @@ def test_create_sub_with_huge_area(session):
               'identification_service_area_url': 'https://example.com/foo'
           },
       })
-  assert resp.status_code == 400
+  assert resp.status_code == 400, resp.content
 
 
 @default_scope(SCOPE_READ)
@@ -176,7 +176,7 @@ def test_create_sub_with_too_long_end_time(session):
             "callbacks": {"identification_service_area_url": "https://example.com/foo"},
         },
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 400, resp.content
 
 
 @default_scope(SCOPE_READ)
@@ -200,7 +200,7 @@ def test_update_sub_with_too_long_end_time(session):
             "callbacks": {"identification_service_area_url": "https://example.com/foo"},
         },
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
     time_end = time_start + datetime.timedelta(hours=(rid.MAX_SUB_TIME_HRS + 1))
     resp = session.put(
@@ -218,4 +218,4 @@ def test_update_sub_with_too_long_end_time(session):
             "callbacks": {"identification_service_area_url": "https://example.com/foo"},
         },
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 400, resp.content

--- a/monitoring/prober/rid/test_token_validation.py
+++ b/monitoring/prober/rid/test_token_validation.py
@@ -53,7 +53,7 @@ def test_put_isa_with_read_only_scope_token(session):
           },
           'flights_url': 'https://example.com/dss',
       }, scope=SCOPE_READ)
-  assert resp.status_code == 403
+  assert resp.status_code == 403, resp.content
 
 
 def test_create_isa(session):
@@ -76,19 +76,19 @@ def test_create_isa(session):
           },
           'flights_url': 'https://example.com/dss',
       }, scope=SCOPE_WRITE)
-  assert resp.status_code == 200
+  assert resp.status_code == 200, resp.content
 
 
 def test_get_isa_without_token(no_auth_session):
   resp = no_auth_session.get('/identification_service_areas/{}'.format(ISA_ID))
-  assert resp.status_code == 401
+  assert resp.status_code == 401, resp.content
   assert resp.json()['message'] == 'Missing access token'
 
 
 def test_get_isa_with_fake_token(no_auth_session):
   no_auth_session.headers['Authorization'] = 'Bearer fake_token'
   resp = no_auth_session.get('/identification_service_areas/{}'.format(ISA_ID))
-  assert resp.status_code == 401
+  assert resp.status_code == 401, resp.content
   assert resp.json()['message'] == 'token contains an invalid number of segments'
 
 
@@ -96,4 +96,4 @@ def test_get_isa_without_scope(session):
   if not isinstance(session.auth_adapter, DummyOAuth):
     pytest.skip('General auth providers will not usually grant tokens without any scopes')
   resp = session.get('/identification_service_areas/{}'.format(ISA_ID), scope='')
-  assert resp.status_code == 403
+  assert resp.status_code == 403, resp.content

--- a/monitoring/prober/scd/test_operation_special_cases.py
+++ b/monitoring/prober/scd/test_operation_special_cases.py
@@ -26,7 +26,7 @@ def test_ensure_clean_workspace(scd_session):
       resp = scd_session.delete('/operation_references/{}'.format(op_id), scope=SCOPE_SC)
       assert resp.status_code == 200, resp.content
       resp = scd_session.get('/operation_references/{}'.format(op_id), scope=SCOPE_SC)
-      assert resp.status_code == 404
+      assert resp.status_code == 404, resp.content
     elif resp.status_code == 404:
       # As expected.
       pass


### PR DESCRIPTION
The PR ensures that the prober prints the server response whenever an unexpected status code is received -- this enables more rapid and effective debugging when a prober test fails.