### PR TITLE
Add Index on end_at for improved performance

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -521,19 +521,4 @@ existing clusters you will need to:
 
 1.  Run `tk apply workspace/$CLUSTER_CONTEXT_schema_manager`
 
-### Database version and server cache
-Current version: 3.1.1
-Minimum support version: 3.0.0
-
-#### Note: It is best practice to keep the Server version ahead of the Database version. Having the Server code behind should be fine but to get all the functionalities both Server and Database version should be kept up to date ####
-
-Changes in v3.1.0
-* Added a new `writer` field to identification_service_areas and subscriptions table for the purposes of automatic Garbage Collection 
-* Read the database version and cache it in memory. 
-* Marking data for automatic garbage collection introduced in dss [c789b2b](https://github.com/interuss/dss/commit/c789b2b4a9fa5fb651d202da0a3abc02a03c15d2)  on Aug 25, 2020
-
-Changes in v3.1.1
-* Add index for subscriptions table by end time.
-
-The `writer` column was added to facilitate automatic Garbage Collection, recording the instance that added the record to Database.
-The presence of the `writer` column in the Database will not cause failure in basic functionality of the DSS. When running Server v3.1.x with Database v3.0.0, the `writer` column will simply be ignored and that record will not be automatically Garbage collected. You will need to manually remove expired records either with the existing Delete API ro manual SQL commands.
+Only since commit [c789b2b](https://github.com/interuss/dss/commit/c789b2b4a9fa5fb651d202da0a3abc02a03c15d2) on Aug 25, 2020 will the DSS enable automatic garbage collection of records by tracking which DSS instance is responsible for garbage collection of the record. Expired records added with a DSS deployment running code earlier than this must be manually removed.

--- a/build/README.md
+++ b/build/README.md
@@ -522,7 +522,7 @@ existing clusters you will need to:
 1.  Run `tk apply workspace/$CLUSTER_CONTEXT_schema_manager`
 
 ### Database version and server cache
-Current version: 3.1.0
+Current version: 3.1.1
 Minimum support version: 3.0.0
 
 #### Important: Server version should NEVER be behind Database Version ####
@@ -531,5 +531,8 @@ Changes in v3.1.0
 * Added a new `writer` field to identification_service_areas and subscriptions table for the purposes of automatic Garbage Collection 
 * Read the database version and cache it in memory. 
 
+Changes in v3.1.1
+* Add index for subscriptions table by end time.
+
 The `writer` column was added to facilitate automatic Garbage Collection, recording the instance that added the record to Database.
-The presence `writer` column in the Database will not cause failure in basic functionality of the DSS, as long as you keep the version of the Server ahead of the Database version. When running Server v3.1.0 with Database v3.0.0, the `writer` column will simply be ignored and that record will not be automatically Garbage collected. You will need to manually remove expired records either with the existing Delete API ro manual SQL commands.
+The presence `writer` column in the Database will not cause failure in basic functionality of the DSS, as long as you keep the version of the Server ahead of the Database version. When running Server v3.1.x with Database v3.0.0, the `writer` column will simply be ignored and that record will not be automatically Garbage collected. You will need to manually remove expired records either with the existing Delete API ro manual SQL commands.

--- a/build/README.md
+++ b/build/README.md
@@ -525,14 +525,15 @@ existing clusters you will need to:
 Current version: 3.1.1
 Minimum support version: 3.0.0
 
-#### Important: Server version should NEVER be behind Database Version ####
+#### Note: It is best practice to keep the Server version ahead of the Database version. Having the Server code behind should be fine but to get all the functionalities both Server and Database version should be kept up to date ####
 
 Changes in v3.1.0
 * Added a new `writer` field to identification_service_areas and subscriptions table for the purposes of automatic Garbage Collection 
 * Read the database version and cache it in memory. 
+* Marking data for automatic garbage collection introduced in dss [c789b2b](https://github.com/interuss/dss/commit/c789b2b4a9fa5fb651d202da0a3abc02a03c15d2)  on Aug 25, 2020
 
 Changes in v3.1.1
 * Add index for subscriptions table by end time.
 
 The `writer` column was added to facilitate automatic Garbage Collection, recording the instance that added the record to Database.
-The presence `writer` column in the Database will not cause failure in basic functionality of the DSS, as long as you keep the version of the Server ahead of the Database version. When running Server v3.1.x with Database v3.0.0, the `writer` column will simply be ignored and that record will not be automatically Garbage collected. You will need to manually remove expired records either with the existing Delete API ro manual SQL commands.
+The presence of the `writer` column in the Database will not cause failure in basic functionality of the DSS. When running Server v3.1.x with Database v3.0.0, the `writer` column will simply be ignored and that record will not be automatically Garbage collected. You will need to manually remove expired records either with the existing Delete API ro manual SQL commands.

--- a/build/deploy/db_schemas/defaultdb/000007_add_index_by_time_subscriptions.down.sql
+++ b/build/deploy/db_schemas/defaultdb/000007_add_index_by_time_subscriptions.down.sql
@@ -1,2 +1,2 @@
 DROP INDEX IF EXISTS subscriptions@subs_by_time_with_owner;
-UPDATE schema_versions set schema_version = 'v3.1.1' WHERE onerow_enforcer = TRUE;
+UPDATE schema_versions set schema_version = 'v3.1.0' WHERE onerow_enforcer = TRUE;

--- a/build/deploy/db_schemas/defaultdb/000007_add_index_by_time_subscriptions.down.sql
+++ b/build/deploy/db_schemas/defaultdb/000007_add_index_by_time_subscriptions.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS subscriptions@subs_by_time_with_owner;
+UPDATE schema_versions set schema_version = 'v3.1.1' WHERE onerow_enforcer = TRUE;

--- a/build/deploy/db_schemas/defaultdb/000007_add_index_by_time_subscriptions.up.sql
+++ b/build/deploy/db_schemas/defaultdb/000007_add_index_by_time_subscriptions.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX subs_by_time_with_owner ON subscriptions (ends_at) STORING (owner, cells);
+UPDATE schema_versions set schema_version = 'v3.1.1' WHERE onerow_enforcer = TRUE;

--- a/build/deploy/db_schemas/defaultdb/000007_add_index_by_time_subscriptions.up.sql
+++ b/build/deploy/db_schemas/defaultdb/000007_add_index_by_time_subscriptions.up.sql
@@ -1,2 +1,2 @@
-CREATE INDEX subs_by_time_with_owner ON subscriptions (ends_at) STORING (owner, cells);
+CREATE INDEX subs_by_time_with_owner ON subscriptions (ends_at) STORING (owner);
 UPDATE schema_versions set schema_version = 'v3.1.1' WHERE onerow_enforcer = TRUE;

--- a/build/deploy/examples/minimum/main.jsonnet
+++ b/build/deploy/examples/minimum/main.jsonnet
@@ -31,7 +31,7 @@ local metadata = metadataBase {
   },
   schema_manager+: {
     image: 'VAR_SCHEMA_MANAGER_IMAGE_NAME',
-    desired_rid_db_version: '3.1.0',
+    desired_rid_db_version: '3.1.1',
     desired_scd_db_version: '1.0.0',
   },
 };

--- a/build/deploy/examples/prod/main.jsonnet
+++ b/build/deploy/examples/prod/main.jsonnet
@@ -16,7 +16,7 @@ local metadata = prod.metadata {
   },
   schema_manager+: {
     image: 'your_schema_manager_image_name',
-    desired_rid_db_version: '3.1.0',
+    desired_rid_db_version: '3.1.1',
   },
 };
 

--- a/build/deploy/examples/schema_manager/main.jsonnet
+++ b/build/deploy/examples/schema_manager/main.jsonnet
@@ -14,7 +14,7 @@ local metadata = metadataBase {
   },
   schema_manager+: {
     image: 'VAR_SCHEMA_MANAGER_IMAGE_NAME',
-    desired_rid_db_version: '3.1.0',
+    desired_rid_db_version: '3.1.1',
     desired_scd_db_version: '1.0.0',
   },
 };

--- a/build/dev/startup/rid_bootstrapper.sh
+++ b/build/dev/startup/rid_bootstrapper.sh
@@ -13,7 +13,7 @@ else
   echo "Bootstrapping RID DB..."
   /usr/bin/db-manager \
     --schemas_dir /db-schemas/defaultdb \
-    --db_version 3.1.0 \
+    --db_version "latest" \
     --cockroach_host local-dss-crdb
 
   echo "RID DB bootstrapping complete; notifying other containers..."

--- a/pkg/rid/application/isa_test.go
+++ b/pkg/rid/application/isa_test.go
@@ -69,7 +69,7 @@ func (store *isaStore) UpdateISA(ctx context.Context, isa *ridmodels.Identificat
 }
 
 func (store *isaStore) GetVersion(ctx context.Context) (*semver.Version, error) {
-	return semver.NewVersion("v3.1.0")
+	return semver.NewVersion("v3.1.1")
 }
 
 // Implements repos.ISA.SearchISA

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -76,7 +76,7 @@ docker run --rm --name rid-db-manager \
 	-v "$(pwd)/build/deploy/db_schemas/defaultdb:/db-schemas/defaultdb" \
 	local-db-manager \
 	--schemas_dir db-schemas/defaultdb \
-	--db_version 3.1.0 \
+	--db_version "latest" \
 	--cockroach_host crdb
 
 sleep 1


### PR DESCRIPTION
Querying number of subscriptions is the bottle neck for inserting Subscriptions. Adding an index here making removes the full scan in the query. 
Ideally we want to index on cells however it is not supported in CRDB yet, They anticipate that v20.2 will support creating forward index on array