### PR TITLE
Fix 'remote error: tls: bad certificate'

### DIFF
--- a/build/deploy/prometheus_configs/istio.libsonnet
+++ b/build/deploy/prometheus_configs/istio.libsonnet
@@ -333,6 +333,13 @@
           action: 'replace',
           target_label: 'kubernetes_name',
         },
+        {
+          source_labels: [
+            '__meta_kubernetes_service_name',
+          ],
+          action: 'drop',
+          regex: 'cockroachdb',
+        },
       ],
     },
     {


### PR DESCRIPTION
for prometheus to scrape cockroachdb we need to allow insecure_skip_verify set to true to skip verifying the cert matched the url its scraping. we already enable this in 'k8s-endpoint' job and don't need to double scrape in 'kubernetes-service-endpoint'