### PR TITLE
Bug/remove deprecated k8s apis

### DIFF
--- a/build/deploy/base.libsonnet
+++ b/build/deploy/base.libsonnet
@@ -80,10 +80,15 @@ local util = import 'util.libsonnet';
 
   },
 
-  Deployment(metadata, name): $._Object('apps/v1beta1', 'Deployment', metadata, name) {
+  Deployment(metadata, name): $._Object('apps/v1', 'Deployment', metadata, name) {
     local deployment = self,
 
     spec: {
+      selector: {
+        matchLabels: {
+          app: name,
+        },
+      },
       template: {
         metadata+: {
           labels+: {

--- a/build/deploy/base.libsonnet
+++ b/build/deploy/base.libsonnet
@@ -76,7 +76,7 @@ local util = import 'util.libsonnet';
 
   },
 
-  Ingress(metadata, name): $._Object('extensions/v1beta1', 'Ingress', metadata, name) {
+  Ingress(metadata, name): $._Object('networking.k8s.io/v1beta1', 'Ingress', metadata, name) {
 
   },
 

--- a/build/deploy/grpc-backend.libsonnet
+++ b/build/deploy/grpc-backend.libsonnet
@@ -10,7 +10,7 @@ local volumes = import 'volumes.libsonnet';
     },
 
     deployment: base.Deployment(metadata, 'grpc-backend') {
-      apiVersion: 'apps/v1beta1',
+      apiVersion: 'apps/v1',
       kind: 'Deployment',
       metadata+: {
         namespace: metadata.namespace,


### PR DESCRIPTION
As per k8s blog https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ several APIs have been deprecated. We should have kept up to date but we only realized this when we were forced to go with k8s 1.16