### PR TITLE
Update CRDB version to 20.2.0 in non-production usages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ test:
 
 .PHONY: test-cockroach
 test-cockroach: cleanup-test-cockroach
-	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v20.1.1 start --insecure > /dev/null
+	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v20.2.0 start-single-node --insecure > /dev/null
 	go run ./cmds/db-manager/main.go --schemas_dir ./build/deploy/db_schemas/defaultdb --db_version latest --cockroach_host localhost
 	go test -count=1 -v ./pkg/rid/store/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"
 	go test -count=1 -v ./pkg/scd/store/cockroach -store-uri "postgresql://root@localhost:26257?sslmode=disable"

--- a/build/dev/docker-compose_dss.yaml
+++ b/build/dev/docker-compose_dss.yaml
@@ -8,8 +8,8 @@ version: '3.8'
 services:
 
   local-dss-crdb:
-    image: cockroachdb/cockroach:v20.1.1
-    command: start --insecure
+    image: cockroachdb/cockroach:v20.2.0
+    command: start-single-node --insecure
     expose:
       - 26257
     ports:

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -66,7 +66,7 @@ echo "Starting cockroachdb with admin port on :8080"
 docker run -d --rm --name dss-crdb-for-debugging \
 	-p 26257:26257 \
 	-p 8080:8080 \
-	cockroachdb/cockroach:v20.1.1 start \
+	cockroachdb/cockroach:v20.2.0 start-single-node \
 	--insecure > /dev/null
 
 sleep 1


### PR DESCRIPTION
PR #469 upgraded CockroachDB usage to 20.2.0 in the production configuration, but did not change the references in the development and test tools to match.  This PR updates all CRDB usage in the repo, including the end-to-end test, Makefile test, and stand-along dev instance, to 20.2.0.