### PR TITLE
Add ability for tracer to incorporate KMLs generated by external server

### DIFF
--- a/build/dev/startup/grpc_backend.sh
+++ b/build/dev/startup/grpc_backend.sh
@@ -16,7 +16,7 @@ if [[ $DEBUG_ON == 1 ]]; then
   -reflect_api \
   -log_format console \
   -dump_requests \
-  -accepted_jwt_audiences localhost \
+  -accepted_jwt_audiences localhost,host.docker.internal \
   -enable_scd
 else
   echo "Debug Mode: off"
@@ -27,6 +27,6 @@ else
   -reflect_api \
   -log_format console \
   -dump_requests \
-  -accepted_jwt_audiences localhost \
+  -accepted_jwt_audiences localhost,host.docker.internal \
   -enable_scd
 fi

--- a/monitoring/monitorlib/auth.py
+++ b/monitoring/monitorlib/auth.py
@@ -35,7 +35,7 @@ class DummyOAuth(AuthAdapter):
       urllib.parse.quote(intended_audience), self._sub)
     response = self._oauth_session.post(url)
     if response.status_code != 200:
-      raise AccessTokenError('Request to get access token returned {} {}'.format(response.status_code, response.content.decode('utf-8')))
+      raise AccessTokenError('Request to get DummyOAuth access token returned {} "{}" at {}'.format(response.status_code, response.content.decode('utf-8'), response.url))
     return response.json()['access_token']
 
 
@@ -59,7 +59,7 @@ class ServiceAccount(AuthAdapter):
       urllib.parse.quote(intended_audience))
     response = self._oauth_session.post(url)
     if response.status_code != 200:
-      raise AccessTokenError('Request to get access token returned {} {}'.format(response.status_code, response.content.decode('utf-8')))
+      raise AccessTokenError('Request to get ServiceAccount access token returned {} "{}" at {}'.format(response.status_code, response.content.decode('utf-8'), response.url))
     return response.json()['access_token']
 
 
@@ -85,7 +85,7 @@ class UsernamePassword(AuthAdapter):
       'scope': ' '.join(scopes),
     })
     if response.status_code != 200:
-      raise AccessTokenError('Request to get access token returned {} {}'.format(response.status_code, response.content.decode('utf-8')))
+      raise AccessTokenError('Request to get UsernamePassword access token returned {} "{}" at {}'.format(response.status_code, response.content.decode('utf-8'), response.url))
     return response.json()['access_token']
 
 
@@ -193,7 +193,7 @@ class SignedRequest(AuthAdapter):
     }
     response = requests.post(self._token_endpoint, data=payload, headers=request_headers)
     if response.status_code != 200:
-      raise AccessTokenError('Unable to retrieve access token:\n' + response.content.decode('utf-8'))
+      raise AccessTokenError('Request to get SignedRequest access token returned {} "{}" at {}'.format(response.status_code, response.content.decode('utf-8'), response.url))
     return response.json()['access_token']
 
 

--- a/monitoring/monitorlib/infrastructure.py
+++ b/monitoring/monitorlib/infrastructure.py
@@ -171,3 +171,24 @@ def get_token_claims(headers: Dict) -> Dict:
     return {'error': 'ValueError: ' + str(e)}
   except jwt.exceptions.DecodeError as e:
     return {'error': 'DecodeError: ' + str(e)}
+
+
+class KMLGenerationSession(requests.Session):
+  """
+  Requests session that provides additional functionality for generating KMLs:
+    * Adds a prefix to URLs that start with a '/'.
+  """
+
+  def __init__(self, prefix_url: str, kml_folder: str):
+    super().__init__()
+
+    self._prefix_url = prefix_url[0:-1] if prefix_url[-1] == '/' else prefix_url
+    self.kml_folder = kml_folder
+
+  # Overrides method on requests.Session
+  def prepare_request(self, request, **kwargs):
+    # Automatically prefix any unprefixed URLs
+    if request.url.startswith('/'):
+      request.url = self._prefix_url + request.url
+
+    return super().prepare_request(request, **kwargs)

--- a/monitoring/tracer/Dockerfile
+++ b/monitoring/tracer/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.7
 # Not -alpine because: https://stackoverflow.com/a/58028091/651139
 # `docker build` should be run from `monitoring` (the parent folder of this folder)
+RUN apt-get update && apt-get install openssl && apt-get install ca-certificates
 RUN mkdir -p /app/monitoring/monitorlib
 RUN mkdir /app/monitoring/tracer
 COPY monitorlib/requirements.txt /app/monitoring/monitorlib/requirements.txt

--- a/monitoring/tracer/requirements.txt
+++ b/monitoring/tracer/requirements.txt
@@ -1,2 +1,3 @@
 gunicorn==20.0.4
+pyopenssl
 -r ../monitorlib/requirements.txt

--- a/monitoring/tracer/resources.py
+++ b/monitoring/tracer/resources.py
@@ -32,6 +32,8 @@ class ResourceSet(object):
     parser.add_argument('--start-time', default=datetime.datetime.utcnow().isoformat(), help='ISO8601 UTC datetime at which to start polling')
     parser.add_argument('--trace-hours', type=float, default=18, help='Number of hours to trace for')
     parser.add_argument('--output-folder', help='Path of folder in which to write logs')
+    parser.add_argument('--kml-server', help='Base URL of KML-generating server', type=str, default=None)
+    parser.add_argument('--kml-folder', help='Name of path on KML server', type=str, default=None)
 
   @classmethod
   def from_arguments(cls, args: argparse.Namespace):
@@ -40,5 +42,8 @@ class ResourceSet(object):
     area: s2sphere.LatLngRect = geo.make_latlng_rect(args.area)
     start_time = datetime.datetime.fromisoformat(args.start_time)
     end_time = start_time + datetime.timedelta(hours=args.trace_hours)
-    logger = tracerlog.Logger(args.output_folder) if args.output_folder else None
+    if args.kml_server and args.kml_folder is None:
+      raise ValueError('If --kml-server is specified, --kml-folder must also be specified')
+    kml_session = infrastructure.KMLGenerationSession(args.kml_server, args.kml_folder) if args.kml_server else None
+    logger = tracerlog.Logger(args.output_folder, kml_session) if args.output_folder else None
     return ResourceSet(dss_client, area, logger, start_time, end_time)

--- a/monitoring/tracer/run_poll_locally.sh
+++ b/monitoring/tracer/run_poll_locally.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+AUTH='--auth=DummyOAuth(http://host.docker.internal:8085/token,uss1)'
+DSS='--dss=http://host.docker.internal:8082'
+AREA='--area=34.1234,-123.4567,34.4567,-123.1234'
+LOGS='--output-folder=/logs'
+KML_SERVER='--kml-server=https://example.com/kmlgeneration'
+KML_FOLDER='--kml-folder=test/localmock'
+MONITOR='--rid-isa-poll-interval=15 --scd-operation-poll-interval=15 --scd-constraint-poll-interval=15'
+PORT=5000
+
+TRACER_OPTIONS="$AUTH $DSS $AREA $LOGS $KML_SERVER $KML_FOLDER $MONITOR"
+
+echo Reminder: must be run from root repo folder
+
+docker build \
+    -f monitoring/tracer/Dockerfile \
+    -t interuss/dss/tracer \
+    --build-arg version=`scripts/git/commit.sh` \
+    monitoring
+
+docker run --name tracer_poll \
+  --rm \
+  -e TRACER_OPTIONS="${TRACER_OPTIONS}" \
+  -v /Users/pelletierb/Documents/test/localmock:/logs \
+  interuss/dss/tracer \
+  python tracer_poll.py $TRACER_OPTIONS

--- a/monitoring/tracer/run_poll_locally.sh
+++ b/monitoring/tracer/run_poll_locally.sh
@@ -22,6 +22,6 @@ docker build \
 docker run --name tracer_poll \
   --rm \
   -e TRACER_OPTIONS="${TRACER_OPTIONS}" \
-  -v /Users/pelletierb/Documents/test/localmock:/logs \
+  -v `pwd`/logs:/logs \
   interuss/dss/tracer \
   python tracer_poll.py $TRACER_OPTIONS

--- a/monitoring/tracer/run_subscribe_locally.sh
+++ b/monitoring/tracer/run_subscribe_locally.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+AUTH='--auth=DummyOAuth(http://host.docker.internal:8085/token,uss1)'
+DSS='--dss=http://host.docker.internal:8082'
+AREA='--area=34.1234,-123.4567,34.4567,-123.1234'
+LOGS='--output-folder=/logs'
+BASE_URL='--base-url=http://host.docker.internal:5000'
+KML_SERVER='--kml-server=https://example.com/kmlgeneration'
+KML_FOLDER='--kml-folder=test/localmock'
+MONITOR='--monitor-rid --monitor-scd'
+PORT=5000
+
+TRACER_OPTIONS="$AUTH $DSS $AREA $LOGS $BASE_URL $KML_SERVER $KML_FOLDER $MONITOR"
+
+echo Reminder: must be run from root repo folder
+
+docker build \
+    -f monitoring/tracer/Dockerfile \
+    -t interuss/dss/tracer \
+    --build-arg version=`scripts/git/commit.sh` \
+    monitoring
+
+docker run --name tracer_subscribe \
+  --rm \
+  -e TRACER_OPTIONS="${TRACER_OPTIONS}" \
+  -p ${PORT}:5000 \
+  -v /Users/pelletierb/Documents/test/localmock:/logs \
+  interuss/dss/tracer \
+  gunicorn \
+    --preload \
+    --workers=2 \
+    --bind=0.0.0.0:5000 \
+    monitoring.tracer.uss_receiver:webapp

--- a/monitoring/tracer/run_subscribe_locally.sh
+++ b/monitoring/tracer/run_subscribe_locally.sh
@@ -24,7 +24,7 @@ docker run --name tracer_subscribe \
   --rm \
   -e TRACER_OPTIONS="${TRACER_OPTIONS}" \
   -p ${PORT}:5000 \
-  -v /Users/pelletierb/Documents/test/localmock:/logs \
+  -v `pwd`/logs:/logs \
   interuss/dss/tracer \
   gunicorn \
     --preload \

--- a/monitoring/tracer/tracerlog.py
+++ b/monitoring/tracer/tracerlog.py
@@ -6,6 +6,8 @@ from typing import Dict
 
 import yaml
 
+from monitoring.monitorlib import infrastructure
+
 
 logging.basicConfig()
 _logger = logging.getLogger('tracer.logging')
@@ -13,10 +15,11 @@ _logger.setLevel(logging.DEBUG)
 
 
 class Logger(object):
-  def __init__(self, log_path: str):
+  def __init__(self, log_path: str, kml_session: infrastructure.KMLGenerationSession = None):
     self.log_path = log_path
     _logger.info('Log path: {}'.format(self.log_path))
     os.makedirs(self.log_path, exist_ok=True)
+    self.kml_session = kml_session
 
   def log_same(self, t0: datetime.datetime, t1: datetime.datetime, code: str) -> None:
     with open(os.path.join(self.log_path, '000000_nochange_queries.yaml'), 'a') as f:
@@ -29,12 +32,28 @@ class Logger(object):
 
   def log_new(self, code: str, content: Dict) -> str:
     n = len(os.listdir(self.log_path))
-    logname = '{:06d}_{}_{}.yaml'.format(n, datetime.datetime.now().strftime('%H%M%S_%f'), code)
+    basename = '{:06d}_{}_{}'.format(n, datetime.datetime.now().strftime('%H%M%S_%f'), code)
+    logname = '{}.yaml'.format(basename)
     fullname = os.path.join(self.log_path, logname)
 
     dump = copy.deepcopy(content)
     dump['object_type'] = type(content).__name__
     with open(fullname, 'w') as f:
       f.write(yaml.dump(dump, indent=2))
+
+    if self.kml_session:
+      kml_server_filename = os.path.join(self.kml_session.kml_folder, logname)
+      try:
+        with open(fullname, 'r') as f:
+          resp = self.kml_session.post('/realtime_kml',
+                                       data={'path': self.kml_session.kml_folder},
+                                       files=[('files[]', f)])
+        resp.raise_for_status()
+        kml_path = os.path.join(self.log_path, 'kml')
+        os.makedirs(kml_path, exist_ok=True)
+        with open(os.path.join(kml_path, '{}.kml'.format(basename)), 'w') as f:
+          f.write(resp.content.decode('utf-8'))
+      except IOError as e:
+        print('Error posting {} to KML server: {}'.format(kml_server_filename, e))
 
     return logname

--- a/monitoring/tracer/uss_receiver/routes.py
+++ b/monitoring/tracer/uss_receiver/routes.py
@@ -1,4 +1,5 @@
 import datetime
+import glob
 import logging
 import os
 from typing import Dict, Tuple
@@ -161,8 +162,13 @@ def status():
 @webapp.route('/logs')
 @webapp.route('/')
 def list_logs():
-  logs = list(reversed(sorted(os.listdir(context.resources.logger.log_path))))
-  response = flask.make_response(flask.render_template('logs.html', logs=logs))
+  logs = [log for log in reversed(sorted(os.listdir(context.resources.logger.log_path))) if log.endswith('.yaml')]
+  kmls = {}
+  for log in logs:
+    kml = os.path.join('kml', log[0:-5] + '.kml')
+    if os.path.exists(os.path.join(context.resources.logger.log_path, kml)):
+      kmls[log] = kml
+  response = flask.make_response(flask.render_template('logs.html', logs=logs, kmls=kmls))
   response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
   response.headers['Pragma'] = 'no-cache'
   return response
@@ -218,6 +224,29 @@ def logs(log):
     }
 
   return flask.render_template('log.html', log=_redact_and_augment_log(obj), title=logfile)
+
+
+@webapp.route('/kml/now.kml')
+def kml_now():
+  all_kmls = glob.glob(os.path.join(context.resources.logger.log_path, 'kml', '*.kml'))
+  if not all_kmls:
+    flask.abort(404, 'No KMLs exist')
+  latest_kml = max(all_kmls, key=os.path.getctime)
+  return flask.send_file(latest_kml,
+                         mimetype='application/vnd.google-earth.kml+xml',
+                         attachment_filename='now.kml',
+                         as_attachment=True)
+
+
+@webapp.route('/kml/<kml>')
+def kmls(kml):
+  kmlfile = os.path.join(context.resources.logger.log_path, 'kml', kml)
+  if not os.path.exists(kmlfile):
+    flask.abort(404)
+  return flask.send_file(kmlfile,
+                         mimetype='application/vnd.google-earth.kml+xml',
+                         attachment_filename=kml,
+                         as_attachment=True)
 
 
 @webapp.route('/rid_poll', methods=['GET'])

--- a/monitoring/tracer/uss_receiver/templates/logs.html
+++ b/monitoring/tracer/uss_receiver/templates/logs.html
@@ -8,6 +8,7 @@
   {% for log in logs %}
     <li>
       <a href="{{ url_for('logs', log=log) }}">{{ log }}</a>
+      {% if log in kmls %}[<a href="{{ kmls[log] }}">kml</a>]{% endif %}
     </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
This PR adds a `KML_SERVER` flag to the `tracer` tool which `tracer` will send new logs to in order to generate KMLs representing the state of the system.  Those KMLs are cached by `tracer` and then served to clients when requested.  If the new flag is not specified, `tracer` behaves as before.