### PR TITLE
Add mock RID system to test rid_qualifier

### DIFF
--- a/monitoring/interoperability/Dockerfile
+++ b/monitoring/interoperability/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 # Not -alpine because: https://stackoverflow.com/a/58028091/651139
 # `docker build` should be run from `monitoring` (the parent folder of this folder)
 RUN mkdir -p /app/monitoring/interoperability

--- a/monitoring/loadtest/Dockerfile
+++ b/monitoring/loadtest/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 # Not -alpine because: https://stackoverflow.com/a/58028091/651139
 # The context for this image should be the repo's root directory
 RUN mkdir /monitoring

--- a/monitoring/monitorlib/rid.py
+++ b/monitoring/monitorlib/rid.py
@@ -2,6 +2,8 @@ from typing import Dict, List, Optional
 
 import s2sphere
 
+from monitoring.monitorlib.typing import ImplicitDict
+
 
 MAX_SUB_PER_AREA = 10
 
@@ -76,3 +78,56 @@ class Subscription(dict):
   @property
   def version(self) -> Optional[str]:
     return self.get('version', None)
+
+
+# === Mirrors of types defined in ASTM remote ID standard ===
+
+class ErrorResponse(ImplicitDict):
+  message: Optional[str]
+
+
+class LatLngPoint(ImplicitDict):
+  lat: float
+  lng: float
+
+
+class RIDAuthData(ImplicitDict):
+  format: str
+  data: str
+
+
+class RIDFlightDetails(ImplicitDict):
+  id: str
+  operator_id: Optional[str]
+  operator_location: Optional[LatLngPoint]
+  operation_description: Optional[str]
+  auth_data: Optional[RIDAuthData]
+  serial_number: Optional[str]
+  registration_number: Optional[str]
+
+
+class RIDAircraftPosition(ImplicitDict):
+  lat: float
+  lng: float
+  alt: float
+  accuracy_h: str
+  accuracy_v: str
+  extrapolated: Optional[bool]
+  pressure_altitude: Optional[float]
+
+
+class RIDHeight(ImplicitDict):
+  distance: float
+  reference: str
+
+
+class RIDAircraftState(ImplicitDict):
+  timestamp: str
+  timestamp_accuracy: float
+  operational_status: Optional[str]
+  position: RIDAircraftPosition
+  track: float
+  speed: float
+  speed_accuracy: str
+  vertical_speed: float
+  height: Optional[RIDHeight]

--- a/monitoring/monitorlib/typing.py
+++ b/monitoring/monitorlib/typing.py
@@ -1,0 +1,179 @@
+from typing import get_args, get_origin, get_type_hints, Dict, Optional, Type, Union
+
+
+_DICT_FIELDS = set(dir({}))
+_KEY_ALL_FIELDS = '_all_fields'
+_KEY_OPTIONAL_FIELDS = '_optional_fields'
+
+
+class ImplicitDict(dict):
+  """Base class that turns a subclass into a dict indexing attributes.
+
+  The expected usage of this class is to declare a subclass with typed
+  attributes:
+
+    class MySubclass1(ImplicitDict):
+      a: float
+      b: int = 2
+      c: Optional[str]
+      d = 4
+
+  All non-optional attributes must be specified when constructing an instance of
+  the subclass.  Untyped attributes with a default value are considered
+  optional.  In the above example, an instance of MySubclass can only be
+  constructed when the values for `a` and `b` are specified in the constructor:
+
+    MySubclass1()
+      >> ValueError
+
+    MySubclass1(a=1)
+      >> ValueError
+
+    MySubclass1(a=1, b=2)
+
+  But, more values can be specified:
+
+    MySubclass1(a=1, b=2, c='3', d='foo')
+
+  The subclass allows access to all the declared attributes, but stores and
+  retrieves the attributes' values in and from the underlying dict.  This means
+  that the subclass will always present itself as a dict with appropriate
+  entries for all declared attributes that are present.  As a result, subclasses
+  are JSON-serializable by the default encoder.  Example:
+
+    x = MySubclass1(a=1, b=2)
+    x.d = 'foo'
+    import json
+    json.dumps(x)
+      >> '{"b": 2, "d": "foo", "a": 1}'
+
+  To deserialize JSON into an ImplicitDict subclass, use ImplicitDict.parse:
+
+    y: MySubclass1 = ImplicitDict.parse({'b': 2, 'd': 'foo', 'a': 1}, MySubclass1)
+    print(y.d)
+      >> foo
+
+  If __init__ is overridden, ImplicitDict.__init__ should be called with
+  **kwargs.  For example:
+
+    class MySubclass2(ImplicitDict):
+      a: float
+      b: int = 2
+      c: Optional[str]
+      d = 4
+
+      def __init__(self, **kwargs):
+        self.e = 5
+        super(ImplicitDict, self).__init__(**kwargs)
+  """
+
+  @classmethod
+  def parse(cls, source: Dict, type: Type):
+    kwargs = {}
+    hints = get_type_hints(type)
+    for key, value in source.items():
+      if key in hints:
+        # This entry has an explicit type
+        kwargs[key] = _parse_value(value, hints[key])
+      else:
+        # This entry's type isn't specified
+        kwargs[key] = value
+    return type(**kwargs)
+
+  def __init__(self, previous_instance: Optional[dict]=None, **kwargs):
+    super(ImplicitDict, self).__init__()
+    subtype = type(self)
+
+    if not hasattr(subtype, _KEY_ALL_FIELDS):
+      # Enumerate all fields and default values defined for the subclass
+      all_fields = set()
+      annotations = type(self).__annotations__ if hasattr(type(self), '__annotations__') else {}
+      for key in annotations:
+        all_fields.add(key)
+
+      attributes = set()
+      for key in dir(self):
+        if key not in _DICT_FIELDS and key[0:2] != '__' and not callable(getattr(self, key)):
+          all_fields.add(key)
+          attributes.add(key)
+          self[key] = getattr(self, key)
+
+      # Identify which fields are Optional
+      optional_fields = set()
+      for key, field_type in annotations.items():
+        generic_type = get_origin(field_type)
+        if generic_type is Optional:
+          optional_fields.add(key)
+        elif generic_type is Union:
+          generic_args = get_args(field_type)
+          if len(generic_args) == 2 and generic_args[1] is type(None):
+            optional_fields.add(key)
+      for key in attributes:
+        if key not in annotations:
+          optional_fields.add(key)
+
+      setattr(subtype, _KEY_ALL_FIELDS, all_fields)
+      setattr(subtype, _KEY_OPTIONAL_FIELDS, optional_fields)
+    else:
+      all_fields = getattr(subtype, _KEY_ALL_FIELDS)
+      optional_fields = getattr(subtype, _KEY_OPTIONAL_FIELDS)
+
+    # Copy explicit field values passed to the constructor
+    provided_values = set()
+    if previous_instance:
+      for key, value in previous_instance.items():
+        if key in all_fields:
+          self[key] = value
+          provided_values.add(key)
+    for key, value in kwargs.items():
+      if key in all_fields:
+        self[key] = value
+        provided_values.add(key)
+
+    # Make sure all fields without a default and not labeled Optional were provided
+    for key in all_fields:
+      if key not in provided_values and key not in optional_fields:
+        raise ValueError('Required field "{}" not specified in {}'.format(key, type(self).__name__))
+
+  def __getattribute__(self, item):
+    if hasattr(type(self), _KEY_ALL_FIELDS) and item in getattr(type(self), _KEY_ALL_FIELDS):
+      return self[item]
+    return super(ImplicitDict, self).__getattribute__(item)
+
+  def __setattr__(self, key, value):
+    if hasattr(type(self), _KEY_ALL_FIELDS):
+      if key in getattr(type(self), _KEY_ALL_FIELDS):
+        self[key] = value
+      else:
+        raise KeyError('Attribute "{}" is not defined for "{}" object'.format(key, type(self).__name__))
+    else:
+      super(ImplicitDict, self).__setattr__(key, value)
+
+
+def _parse_value(value, value_type: Type):
+  generic_type = get_origin(value_type)
+  if generic_type:
+    # Type is generic
+    arg_types = get_args(value_type)
+    if generic_type is list:
+      if issubclass(arg_types[0], ImplicitDict):
+        # value is a list of some kind of ImplicitDict values
+        return [ImplicitDict.parse(item, arg_types[0]) for item in value]
+      else:
+        # value is a list of non-ImplicitDict values
+        return value
+
+    elif generic_type is Union and len(arg_types) == 2 and arg_types[1] is type(None):
+      # Type is an Optional declaration
+      return _parse_value(value, arg_types[0])
+
+    else:
+      raise NotImplementedError('Automatic parsing of {} type is not yet implemented'.format(value_type))
+
+  elif issubclass(value_type, ImplicitDict):
+    # value is an ImplicitDict
+    return ImplicitDict.parse(value, value_type)
+
+  else:
+    # value is a non-generic type that is not an ImplicitDict
+    return value

--- a/monitoring/prober/Dockerfile
+++ b/monitoring/prober/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 # Not -alpine because: https://stackoverflow.com/a/58028091/651139
 # The context for this image should be monitoring
 RUN mkdir /monitoring

--- a/monitoring/rid_qualifier/mock/Dockerfile
+++ b/monitoring/rid_qualifier/mock/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.8
+# Not -alpine because: https://stackoverflow.com/a/58028091/651139
+# `docker build` should be run from `monitoring` (the parent folder of this folder)
+RUN apt-get update && apt-get install openssl && apt-get install ca-certificates
+RUN mkdir -p /app/monitoring/monitorlib
+RUN mkdir -p /app/monitoring/rid_qualifier/mock
+COPY monitorlib/requirements.txt /app/monitoring/monitorlib/requirements.txt
+COPY rid_qualifier/mock/requirements.txt /app/monitoring/rid_qualifier/mock/requirements.txt
+WORKDIR /app/monitoring/rid_qualifier/mock
+RUN pip install -r requirements.txt
+RUN rm -rf __pycache__
+ADD . /app/monitoring
+ENV PYTHONPATH /app
+ARG version
+ENV CODE_VERSION=$version
+EXPOSE 5000
+
+CMD ["gunicorn", "--preload", "--workers=1", "--bind=0.0.0.0:5000", "monitoring.rid_qualifier.mock:webapp"]

--- a/monitoring/rid_qualifier/mock/Postman_rid_qualifier_mock_test.json
+++ b/monitoring/rid_qualifier/mock/Postman_rid_qualifier_mock_test.json
@@ -1,0 +1,212 @@
+{
+	"info": {
+		"_postman_id": "3ae3a1a8-073a-4e36-bf32-c97e0fba0d9c",
+		"name": "RID Qualifier",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Mock",
+			"item": [
+				{
+					"name": "Injection",
+					"item": [
+						{
+							"name": "Create test",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const moment = require('moment');",
+											"pm.globals.set(\"t_1\", moment().add(5, 'seconds').toISOString());",
+											"pm.globals.set(\"t_2\", moment().add(1, 'minutes').toISOString());",
+											"pm.globals.set(\"t_3\", moment().add(2, 'minutes').toISOString());",
+											"pm.globals.set(\"t_4\", moment().add(2, 'minutes').toISOString());",
+											"pm.globals.set(\"t_5\", moment().add(2, 'minutes').toISOString());",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"requested_flights\": [\n    {\n      \"injection_id\": \"edb7695f-8737-4b9f-91f8-e2afbb333f41\",\n      \"telemetry\": [\n        {\n          \"timestamp\": \"{{t_1}}\",\n          \"timestamp_accuracy\": 5,\n          \"operational_status\": \"Airborne\",\n          \"position\": {\n            \"lat\": 34.123,\n            \"lng\": -118.456,\n            \"alt\": 1321.2,\n            \"accuracy_h\": \"HA3m\",\n            \"accuracy_v\": \"VA10m\",\n            \"extrapolated\": false\n          },\n          \"track\": 90,\n          \"speed\": 1.9,\n          \"speed_accuracy\": \"SA10mpsPlus\",\n          \"vertical_speed\": 0\n        },\n        {\n          \"timestamp\": \"{{t_2}}\",\n          \"timestamp_accuracy\": 5,\n          \"operational_status\": \"Airborne\",\n          \"position\": {\n            \"lat\": 34.123,\n            \"lng\": -118.455,\n            \"alt\": 1321.2,\n            \"accuracy_h\": \"HA3m\",\n            \"accuracy_v\": \"VA10m\",\n            \"extrapolated\": false\n          },\n          \"track\": 180,\n          \"speed\": 2.0,\n          \"speed_accuracy\": \"SA10mpsPlus\",\n          \"vertical_speed\": 0\n        },\n        {\n          \"timestamp\": \"{{t_3}}\",\n          \"timestamp_accuracy\": 5,\n          \"operational_status\": \"Airborne\",\n          \"position\": {\n            \"lat\": 34.122,\n            \"lng\": -118.455,\n            \"alt\": 1321.2,\n            \"accuracy_h\": \"HA3m\",\n            \"accuracy_v\": \"VA10m\",\n            \"extrapolated\": false\n          },\n          \"track\": 270,\n          \"speed\": 2.1,\n          \"speed_accuracy\": \"SA10mpsPlus\",\n          \"vertical_speed\": 0\n        },\n        {\n          \"timestamp\": \"{{t_4}}\",\n          \"timestamp_accuracy\": 5,\n          \"operational_status\": \"Airborne\",\n          \"position\": {\n            \"lat\": 34.122,\n            \"lng\": -118.456,\n            \"alt\": 1321.2,\n            \"accuracy_h\": \"HA3m\",\n            \"accuracy_v\": \"VA10m\",\n            \"extrapolated\": false\n          },\n          \"track\": 270,\n          \"speed\": 2.2,\n          \"speed_accuracy\": \"SA10mpsPlus\",\n          \"vertical_speed\": 0\n        },\n        {\n          \"timestamp\": \"{{t_5}}\",\n          \"timestamp_accuracy\": 5,\n          \"operational_status\": \"Airborne\",\n          \"position\": {\n            \"lat\": 34.122,\n            \"lng\": -118.457,\n            \"alt\": 1321.2,\n            \"accuracy_h\": \"HA3m\",\n            \"accuracy_v\": \"VA10m\",\n            \"extrapolated\": false\n          },\n          \"track\": 45,\n          \"speed\": 2.3,\n          \"speed_accuracy\": \"SA10mpsPlus\",\n          \"vertical_speed\": 0\n        }\n      ],\n      \"details_responses\": [\n        {\n          \"effective_after\": \"string\",\n          \"details\": {\n            \"id\": \"a3423b-213401-0023\",\n            \"operator_id\": \"operator1\",\n            \"operator_location\": {\n              \"lng\": -118.456,\n              \"lat\": 34.123\n            },\n            \"operation_description\": \"SafeFlightDrone company doing survey with DJI Inspire 2. See my privacy policy www.example.com/privacy.\",\n            \"serial_number\": \"INTCJ123-4567-890\",\n            \"registration_number\": \"FA12345897\"\n          }\n        }\n      ]\n    }\n  ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8070/sp/uss1/tests/9a20678b-fad4-49e6-9009-b4891aa77cb7",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8070",
+									"path": [
+										"sp",
+										"uss1",
+										"tests",
+										"9a20678b-fad4-49e6-9009-b4891aa77cb7"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete test",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8070/sp/uss1/tests/9a20678b-fad4-49e6-9009-b4891aa77cb7",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8070",
+									"path": [
+										"sp",
+										"uss1",
+										"tests",
+										"9a20678b-fad4-49e6-9009-b4891aa77cb7"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Ingestion",
+					"item": [
+						{
+							"name": "Get display data (tight)",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8070/dp/display_data?view=34.122,-118.453,34.125,-118.458",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8070",
+									"path": [
+										"dp",
+										"display_data"
+									],
+									"query": [
+										{
+											"key": "view",
+											"value": "34.122,-118.453,34.125,-118.458"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get display data (loose)",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8070/dp/display_data?view=34.1,-118.4,34.2,-118.5",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8070",
+									"path": [
+										"dp",
+										"display_data"
+									],
+									"query": [
+										{
+											"key": "view",
+											"value": "34.1,-118.4,34.2,-118.5"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get display data (clusters)",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8070/dp/display_data?view=34.12,-118.45,34.13,-118.46",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8070",
+									"path": [
+										"dp",
+										"display_data"
+									],
+									"query": [
+										{
+											"key": "view",
+											"value": "34.12,-118.45,34.13,-118.46"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get flight details",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8070/dp/display_data/a3423b-213401-0023",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8070",
+									"path": [
+										"dp",
+										"display_data",
+										"a3423b-213401-0023"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Get status",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8070/status",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8070",
+							"path": [
+								"status"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	]
+}

--- a/monitoring/rid_qualifier/mock/README.md
+++ b/monitoring/rid_qualifier/mock/README.md
@@ -1,0 +1,57 @@
+# RID Qualifier System Mock
+
+## Overview
+This folder containers a tool to simulate an entire remote ID ecosystem,
+consisting of one or more USSs acting as Remote ID Service Providers, an
+implicit DSS, and a USS acting as a Remote ID Display Provider, for the purpose
+of testing `rid_qualifier`.  Once this system is running, `rid_qualifier` can
+inject data into one or more virtual RID Service Providers supporting the
+injection API and then observe the instantaneous state of the RID system via a
+virtual RID Display Provider supporting the ingestion API. 
+
+## Execution
+
+As long as the host system has Docker installed, simply run
+[`run_locally.sh`](run_locally.sh) to start the rid_qualifier system mock
+listening at localhost:8070.  Press CTRL/CMD-C to stop the system mock.
+
+## Endpoints
+
+### RID Service Providers
+This mock supports any number of RID Service Providers, and they do not need to
+be declared before use.  The RID Service Provider named `<RIDSP>` implements the
+[injection API](../../../interfaces/automated-testing/rid/README.md) at
+http://hostname/sp/<RIDSP>.  So, for instance, if an instance of this RID system
+mock is accessible at localhost:8070, then data can be injected into the `uss1`
+virtual RID Service Provider by making a PUT call to, e.g.,
+http://localhost:8070/sp/uss1/tests/9a20678b-fad4-49e6-9009-b4891aa77cb7.
+
+### RID Display Provider
+This mock implements a single virtual RID Display Provider.  This Display
+Provider implements the
+[ingestion API](../../../interfaces/automated-testing/rid/README.md) at
+http://hostname/dp.  So, for instance, if an instance of this RID system mock is
+accessible at localhost:8070, then the current flights visible to the virtual
+Display Provider can be queried by making a GET call to
+http://localhost:8070/dp/display_data.
+
+## Debugging
+
+To run the rid_qualifier system mock locally (without the Docker environment),
+install the packages specified by [requirements.txt](requirements.txt) and then
+run [`./debug_mock.py`](debug_mock.py), or the `gunicorn` command specified in
+the `CMD` of the [`Dockerfile`](Dockerfile).
+
+### Testing
+
+To send test messages, open
+[the provided collection](Postman_rid_qualifier_mock_test.json) in Postman and
+send requests.  "Get status" indicates whether the system is running and
+properly handling basic requests.  The "Injection" folder enables the injection
+of a test with one simple ~5-minute flight with telemetry approximately once a
+minute (and the deletion of that test).  After that test has been injected, the
+"Ingestion" folder enables querying the apparent state of the virtual RID system
+provided by the mock.  "Get display data (tight)" returns flights visible in a
+small area.  "Get display data (loose)" intentionally requests a view that is
+too large.  "Get display data (clusters)" requests a view larger than a detailed
+view but small enough to be valid.

--- a/monitoring/rid_qualifier/mock/__init__.py
+++ b/monitoring/rid_qualifier/mock/__init__.py
@@ -1,0 +1,5 @@
+import flask
+
+webapp = flask.Flask(__name__)
+
+from . import routes

--- a/monitoring/rid_qualifier/mock/api.py
+++ b/monitoring/rid_qualifier/mock/api.py
@@ -1,0 +1,87 @@
+import datetime
+from typing import List, Optional
+
+import iso8601
+
+from monitoring.monitorlib import rid
+from monitoring.monitorlib.typing import ImplicitDict
+
+
+# === Mirrors of types defined in remote ID automated testing injection API ===
+
+
+class TestFlightDetails(ImplicitDict):
+  effective_after: str
+  details: rid.RIDFlightDetails
+
+  def __init__(self, **kwargs):
+    super(TestFlightDetails, self).__init__(**kwargs)
+    try:
+      iso8601.parse_date(self.effective_after)
+    except iso8601.ParseError:
+      raise ValueError('TestFlightDetails.effective_after value "{}" could not be parsed as date-time'.format(self.effective_after))
+
+
+class TestFlight(ImplicitDict):
+  injection_id: str
+  telemetry: List[rid.RIDAircraftState]
+  details_responses: List[TestFlightDetails]
+
+  def get_details(self, t_now: datetime.datetime) -> Optional[TestFlightDetails]:
+    latest_after: Optional[datetime.datetime] = None
+    tf_details = None
+    for response in self.details_responses:
+      t_response = iso8601.parse_date(response.effective_after)
+      if t_now >= t_response:
+        if latest_after is None or t_response > latest_after:
+          latest_after = t_response
+          tf_details = response.details
+    return tf_details
+
+  def get_id(self, t_now: datetime.datetime) -> Optional[str]:
+    details = self.get_details(t_now)
+    return details.id if details else None
+
+  def order_telemetry(self):
+    self.telemetry = sorted(self.telemetry,
+                            key=lambda telemetry: iso8601.parse_date(telemetry.timestamp))
+
+
+class CreateTestParameters(ImplicitDict):
+  requested_flights: List[TestFlight]
+
+
+class ChangeTestResponse(ImplicitDict):
+  injected_flights: List[TestFlight]
+  version: str
+
+
+class Position(ImplicitDict):
+  lat: float
+  lng: float
+  alt: Optional[float]
+
+
+class Path(ImplicitDict):
+  positions: List[Position]
+
+
+class Flight(ImplicitDict):
+  id: str
+  most_recent_position: Optional[Position]
+  recent_paths: Optional[List[Path]]
+
+
+class Cluster(ImplicitDict):
+  corners: List[Position]
+  area_sqm: float
+  number_of_flights: int
+
+
+class GetDisplayDataResponse(ImplicitDict):
+  flights: Optional[List[Flight]]
+  clusters: Optional[List[Cluster]]
+
+
+class GetDetailsResponse(ImplicitDict):
+  pass

--- a/monitoring/rid_qualifier/mock/clustering.py
+++ b/monitoring/rid_qualifier/mock/clustering.py
@@ -1,0 +1,64 @@
+import random
+from typing import List
+
+import s2sphere
+
+from monitoring.monitorlib import geo
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.rid_qualifier.mock import api
+
+
+class Point(object):
+  x: float
+  y: float
+
+  def __init__(self, x: float, y: float):
+    self.x = x
+    self.y = y
+
+
+class Cluster(ImplicitDict):
+  x_min: float
+  x_max: float
+  y_min: float
+  y_max: float
+  points: List[Point]
+
+  def randomize(self):
+    u_min = min(p.x for p in self.points)
+    v_min = min(p.y for p in self.points)
+    u_max = max(p.x for p in self.points)
+    v_max = max(p.y for p in self.points)
+    return Cluster(
+      x_min=self.x_min + (u_min - self.x_min) * random.random(),
+      y_min=self.y_min + (v_min - self.y_min) * random.random(),
+      x_max=u_max + (self.x_max - u_max) * random.random(),
+      y_max=v_max + (self.y_max - v_max) * random.random(),
+      points=self.points)
+
+
+def make_clusters(flights: List[api.Flight], view_min: s2sphere.LatLng, view_max: s2sphere.LatLng) -> List[api.Cluster]:
+  if not flights:
+    return []
+
+  # Make the initial cluster
+  points: List[Point] = [
+    Point(*geo.flatten(view_min, s2sphere.LatLng.from_degrees(flight.most_recent_position.lat, flight.most_recent_position.lng)))
+    for flight in flights]
+  x_max, y_max = geo.flatten(view_min, view_max)
+  clusters: List[Cluster] = [Cluster(x_min=0, y_min=0, x_max=x_max, y_max=y_max, points=points)]
+
+  # TODO: subdivide cluster into many clusters
+
+  result: List[api.Cluster] = []
+  for cluster in clusters:
+    cluster = cluster.randomize()
+    p1 = geo.unflatten(view_min, (cluster.x_min, cluster.y_min))
+    p2 = geo.unflatten(view_min, (cluster.x_max, cluster.y_max))
+    result.append(api.Cluster(
+      corners=[api.Position(lat=p1.lat().degrees, lng=p1.lng().degrees), api.Position(lat=p2.lat().degrees, lng=p2.lng().degrees)],
+      area_sqm=geo.area_of_latlngrect(s2sphere.LatLngRect(p1, p2)),
+      number_of_flights=len(cluster.points)
+    ))
+
+  return result

--- a/monitoring/rid_qualifier/mock/database.py
+++ b/monitoring/rid_qualifier/mock/database.py
@@ -1,0 +1,31 @@
+from typing import Dict, List
+
+from monitoring.rid_qualifier.mock import api
+
+
+class TestRecord(object):
+  """Representation of RID SP's record of a set of injected test flights"""
+  version: str
+  flights: List[api.TestFlight]
+
+  def __init__(self, version: str, flights: List[api.TestFlight]):
+    flights = [api.TestFlight(**flight) for flight in flights]
+    for flight in flights:
+      flight.order_telemetry()
+    self.version = version
+    self.flights = flights
+
+
+class RIDSP(object):
+  tests: Dict[str, TestRecord] = {}
+
+
+class Database(object):
+  """Simple in-memory pseudo-database tracking the state of the mock system"""
+  sps: Dict[str, RIDSP] = {}
+
+  def __init__(self):
+    self.sps = {}
+
+
+db = Database()

--- a/monitoring/rid_qualifier/mock/debug_mock.py
+++ b/monitoring/rid_qualifier/mock/debug_mock.py
@@ -1,0 +1,7 @@
+#!env/bin/python3
+
+from monitoring.rid_qualifier.mock import webapp
+
+
+if __name__ == "__main__":
+  webapp.run('localhost', 8070)

--- a/monitoring/rid_qualifier/mock/requirements.txt
+++ b/monitoring/rid_qualifier/mock/requirements.txt
@@ -1,0 +1,5 @@
+Flask==1.1.2
+iso8601==0.1.14
+s2sphere==0.2.5
+gunicorn==20.0.4
+-r ../../monitorlib/requirements.txt

--- a/monitoring/rid_qualifier/mock/routes.py
+++ b/monitoring/rid_qualifier/mock/routes.py
@@ -1,0 +1,184 @@
+import datetime
+from typing import List, Optional, Tuple
+import uuid
+
+import flask
+import iso8601
+import s2sphere
+
+from monitoring.monitorlib import geo, rid
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.rid_qualifier.mock import database
+from monitoring.rid_qualifier.mock.database import db
+from . import api, clustering, webapp
+
+
+FLIGHT_ACCESSIBLE_DURATION = datetime.timedelta(seconds=65) # after last telemetry
+
+
+@webapp.route('/status')
+def status():
+  return 'RID system mock for rid_qualifier is Ok', 200
+
+
+@webapp.route('/sp/<sp_id>/tests/<test_id>', methods=['PUT'])
+def create_test(sp_id: str, test_id: str) -> Tuple[str, int]:
+  """Implements test creation in RID automated testing injection API."""
+
+  # TODO: Validate token signature & scope
+
+  try:
+    json = flask.request.json
+    req_body: api.CreateTestParameters = ImplicitDict.parse(json, api.CreateTestParameters)
+    record = database.TestRecord(version=str(uuid.uuid4()), flights=req_body.requested_flights)
+    if sp_id not in db.sps:
+      db.sps[sp_id] = database.RIDSP()
+    db.sps[sp_id].tests[test_id] = record
+
+    return flask.jsonify(api.ChangeTestResponse(version=record.version, injected_flights=record.flights))
+  except ValueError as e:
+    msg = 'Create test {} for Service Provider {} unable to parse JSON: {}'.format(test_id, sp_id, e)
+    return msg, 400
+
+
+@webapp.route('/sp/<sp_id>/tests/<test_id>', methods=['DELETE'])
+def delete_test(sp_id: str, test_id: str) -> Tuple[str, int]:
+  """Implements test deletion in RID automated testing injection API."""
+
+  # TODO: Validate token signature & scope
+
+  if sp_id not in db.sps:
+    return 'RID Service Provider "{}" not found'.format(sp_id), 404
+  if test_id not in db.sps[sp_id].tests:
+    return 'Test "{}" not found for RID Service Provider "{}"'.format(test_id, sp_id), 404
+
+  record = db.sps[sp_id].tests[test_id]
+  del db.sps[sp_id].tests[test_id]
+  return flask.jsonify(api.ChangeTestResponse(version=record.version, injected_flights=record.flights))
+
+
+def _make_api_flight(flight: api.TestFlight,
+                     t_earliest: datetime.datetime, t_now: datetime.datetime,
+                     lat_min: float, lng_min: float, lat_max: float, lng_max: float) -> api.Flight:
+  """Extract the currently-relevant information from a TestFlight.
+
+  :param flight: TestFlight with telemetry for all time
+  :param t_earliest: The time before which telemetry should be ignored
+  :param t_now: The time after which telemetry should be ignored
+  :return: Flight information currently visible in the remote ID system
+  """
+  paths: List[List[api.Position]] = []
+  current_path: List[api.Position] = []
+  previous_position: Optional[api.Position] = None
+  most_recent_position: Optional[Tuple[datetime.datetime, api.Position]] = None
+
+  for telemetry in flight.telemetry:
+    t = iso8601.parse_date(telemetry.timestamp)
+    if t < t_earliest:
+      # Not relevant; telemetry more than 60s in the past
+      continue
+    if t > t_now:
+      # Not yet relevant; will occur in the future
+      continue
+
+    if (lat_min <= telemetry.position.lat and telemetry.position.lat <= lat_max and
+        lng_min <= telemetry.position.lng and telemetry.position.lng <= lng_max):
+      # This is a relevant point inside the view
+      if not current_path and previous_position:
+        # Positions were previously outside the view but this one is in
+        current_path.append(previous_position)
+      current_path.append(telemetry.position)
+      if most_recent_position is None or most_recent_position[0] < t:
+        most_recent_position = (t, api.Position(lat=telemetry.position.lat,
+                                                lng=telemetry.position.lng,
+                                                alt=telemetry.position.alt))
+    else:
+      # This point is in the relevant time range but outside the view
+      if current_path:
+        # Positions were previously inside the view but this one is out
+        current_path.append(telemetry.position)
+        paths.append(current_path)
+        current_path = []
+    previous_position = api.Position(lat=telemetry.position.lat,
+                                     lng=telemetry.position.lng,
+                                     alt=telemetry.position.alt)
+  if current_path:
+    paths.append(current_path)
+
+  kwargs = {'id': flight.get_id(t_now)}
+  if paths:
+    kwargs['recent_paths'] = [api.Path(positions=p) for p in paths]
+  if most_recent_position:
+    kwargs['most_recent_position'] = most_recent_position[1]
+  return api.Flight(**kwargs)
+
+
+@webapp.route('/dp/display_data', methods=['GET'])
+def poll_display_data() -> Tuple[str, int]:
+  """Implements display data polling in RID automated testing ingestion API."""
+
+  # TODO: Validate token signature & scope
+
+  # Retrieve view parameters
+  if 'view' not in flask.request.args:
+    return 'Missing "view" argument in request', 400
+
+  try:
+    coords = [float(v) for v in flask.request.args['view'].split(',')]
+  except ValueError as e:
+    return '"view" argument not properly formatted: {}'.format(e), 400
+
+  if len(coords) != 4:
+    return '"view" argument contains the wrong number of coordinates (expected 4, found {})'.format(len(coords)), 400
+
+  lat_min = min(coords[0], coords[2])
+  lat_max = max(coords[0], coords[2])
+  lng_min = min(coords[1], coords[3])
+  lng_max = max(coords[1], coords[3])
+
+  if (lat_min < -90 or lat_min >= 90 or lat_max <= -90 or lat_max > 90 or
+      lng_min < -180 or lng_min >= 360 or lng_max <= -180 or lng_max > 360):
+    return '"view" coordinates do not fall within the valid range of -90 <= lat <= 90 and -180 <= lng <= 360', 400
+
+  # Check view size
+  view_min = s2sphere.LatLng.from_degrees(lat_min, lng_min)
+  view_max = s2sphere.LatLng.from_degrees(lat_max, lng_max)
+  diagonal = view_min.get_distance(view_max).degrees * geo.EARTH_CIRCUMFERENCE_KM / 360
+  if diagonal > 3.6:
+    return flask.jsonify(rid.ErrorResponse(message='Requested diagonal was too large')), 413
+
+  # Find flights to report
+  t_now = datetime.datetime.now(datetime.timezone.utc)
+  t_earliest = t_now - datetime.timedelta(seconds=60)
+  flights: List[api.Flight] = []
+  for sp_id, sp in db.sps.items():
+    for test_id, test in sp.tests.items():
+      for flight in test.flights:
+        flights.append(_make_api_flight(flight, t_earliest, t_now, lat_min, lng_min, lat_max, lng_max))
+  flights = [flight for flight in flights if 'recent_paths' in flight]
+
+  if diagonal <= 1:
+    return flask.jsonify(api.GetDisplayDataResponse(flights=flights))
+  else:
+    return flask.jsonify(api.GetDisplayDataResponse(clusters=clustering.make_clusters(flights, view_min, view_max)))
+
+
+@webapp.route('/dp/display_data/<id>', methods=['GET'])
+def display_data_details(id: str) -> Tuple[str, int]:
+  """Implements display data details in RID automated testing ingestion API."""
+
+  # TODO: Validate token signature & scope
+
+  t_now = datetime.datetime.now(datetime.timezone.utc)
+  for sp_id, sp in db.sps.items():
+    for test_id, test in sp.tests.items():
+      for flight in test.flights:
+        tf_details = flight.get_details(t_now)
+        if tf_details and tf_details.id == id:
+          t_max = max(iso8601.parse_date(telemetry.timestamp) for telemetry in flight.telemetry)
+          if t_now <= t_max + FLIGHT_ACCESSIBLE_DURATION:
+            return flask.jsonify(api.GetDetailsResponse())
+          else:
+            return 'Flight no longer exists', 404
+
+  return 'Could not find flight with ID of {} at current time'.format(id), 404

--- a/monitoring/rid_qualifier/mock/run_locally.sh
+++ b/monitoring/rid_qualifier/mock/run_locally.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+PORT=8070
+
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+
+# Always start from the repo folder root
+cd "${BASEDIR}/../../.." || exit 1
+
+echo Building rid_qualifier mock...
+docker build \
+    -f monitoring/rid_qualifier/mock/Dockerfile \
+    -t interuss/automated-testing/rid-qualifier/mock \
+    --build-arg version=`scripts/git/commit.sh` \
+    monitoring \
+    || exit 1
+
+echo Running rid_qualifier mock...
+docker run --name rid_qualifier_mock \
+  --rm \
+  -p ${PORT}:5000 \
+  interuss/automated-testing/rid-qualifier/mock

--- a/monitoring/tracer/Dockerfile
+++ b/monitoring/tracer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 # Not -alpine because: https://stackoverflow.com/a/58028091/651139
 # `docker build` should be run from `monitoring` (the parent folder of this folder)
 RUN apt-get update && apt-get install openssl && apt-get install ca-certificates


### PR DESCRIPTION
This PR adds a tool that simulates an entire remote ID ecosystem for the purpose of testing rid_qualifier; see more information in [the README added in this PR](https://github.com/BenjaminPelletier/dss/blob/rid_qualifier/mock/monitoring/rid_qualifier/mock/README.md).  Simply having this tool running (with run_locally.sh) should enable full testing of rid_qualifier without the need for any other RID Service Providers, RID Display Providers, or a DSS.

A moderate amount of this PR is dedicated to adding `ImplicitDict` (in monitoring.monitorlib.typing), a base class that should make management of schema-defined objects easier, especially with regard to JSON serialization and deserialization.