### PR TITLE
Add NoAuth AuthAdapter

### DIFF
--- a/monitoring/monitorlib/README.md
+++ b/monitoring/monitorlib/README.md
@@ -21,6 +21,7 @@ AuthAdapter's `__init__` constructor.  Both ordinal (e.g.,
 
 ### Examples
 
+* `NoAuth()`
 * `UsernamePassword(https://example.com/token, username=uss1, password=uss1,
    client_id=uss1)`
 * `ServiceAccount(https://example.com/token, ~/credentials/account.json)`
@@ -28,3 +29,8 @@ AuthAdapter's `__init__` constructor.  Both ordinal (e.g.,
 * `SignedRequest(https://example.com/oauth/token, client_id=uss1.com,
    key_path=/auth/uss1.key, cert_url=https://uss1.com/uss1.der)`
 * `ClientIdClientSecret(https://example.com/token, uss1, dXNzMQ==)`
+
+### Testing
+
+Use [`get_access_token.py`](../get_access_token.py) to retrieve an access token
+using a provided auth spec.

--- a/monitoring/monitorlib/auth.py
+++ b/monitoring/monitorlib/auth.py
@@ -2,6 +2,7 @@ import datetime
 import re
 from typing import List, Optional
 import urllib.parse
+import uuid
 
 import cryptography.exceptions
 import cryptography.hazmat.backends
@@ -11,11 +12,66 @@ import cryptography.x509
 import jwcrypto.common
 import jwcrypto.jwk
 import jwcrypto.jws
+import jwcrypto.jwt
 import requests
 from google.auth.transport import requests as google_requests
 from google.oauth2 import service_account
 
 from monitoring.monitorlib.infrastructure import AuthAdapter
+
+
+_UNIX_EPOCH = datetime.datetime.utcfromtimestamp(0)
+
+
+class NoAuth(AuthAdapter):
+  """Auth adapter that generates tokens without an auth server.
+
+  While no server is used, the access tokens generated are fully valid and their
+  signatures will validate against test-certs/auth2.pem.
+  """
+
+  # This is the private key from test-certs/auth2.key.
+  dummy_private_key = jwcrypto.jwk.JWK.from_pem(
+    '-----BEGIN RSA PRIVATE KEY-----\n'
+    'MIICWwIBAAKBgHkNtpy3GB0YTCl2VCCd22i0rJwIGBSazD4QRKvH6rch0IP4igb+\n'
+    '02r7t0X//tuj0VbwtJz3cEICP8OGSqrdTSCGj5Y03Oa2gPkx/0c0V8D0eSXS/CUC\n'
+    '0qrYHnAGLqko7eW87HW0rh7nnl2bB4Lu+R8fOmQt5frCJ5eTkzwK5YczAgMBAAEC\n'
+    'gYAtSgMjGKEt6XQ9IucQmN6Iiuf1LFYOB2gYZC+88PuQblc7uJWzTk08vlXwG3l3\n'
+    'JQ/h7gY0n6JhH8RJW4m96TO8TrlHLx5aVcW8E//CtgayMn3vBgXida3wvIlAXT8G\n'
+    'WezsNsWorXLVmz5yov0glu+TIk31iWB5DMs4xXhXdH/t8QJBALQzvF+y5bZEhZin\n'
+    'qTXkiKqMsKsJbXjP1Sp/3t52VnYVfbxN3CCb7yDU9kg5QwNa3ungE3cXXNMUr067\n'
+    '9zIraekCQQCr+NSeWAXIEutWewPIykYMQilVtiJH4oFfoEpxvecVv7ulw6kM+Jsb\n'
+    'o6Pi7x86tMVkwOCzZzy/Uyo/gSHnEZq7AkEAm0hBuU2VuTzOyr8fhvtJ8X2O97QG\n'
+    'C6c8j4Tk7lqXIuZeFRga6la091vMZmxBnPB/SpX28BbHvHUEpBpBZ5AVkQJAX7Lq\n'
+    '7urg3MPafpeaNYSKkovG4NGoJgSgJgzXIJCjJfE6hTZqvrMh7bGUo9aZtFugdT74\n'
+    'TB2pKncnTYuYyDN9vQJACDVr+wvYYA2VdnA9k+/1IyGc1HHd2npQqY9EduCeOGO8\n'
+    'rXQedG6rirVOF6ypkefIayc3usipVvfadpqcS5ERhw==\n'
+    '-----END RSA PRIVATE KEY-----'.encode('UTF-8'))
+
+  EXPIRATION = 3600 # seconds
+
+  def __init__(self, sub: str = 'uss_noauth'):
+    super().__init__()
+    self.sub = sub
+
+  # Overrides method in AuthAdapter
+  def issue_token(self, intended_audience: str, scopes: List[str]) -> str:
+    timestamp = int((datetime.datetime.utcnow() - _UNIX_EPOCH).total_seconds())
+    jwt = jwcrypto.jwt.JWT(
+      header={'typ': 'JWT', 'alg': 'RS256'},
+      claims={
+        'sub': self.sub,
+        'client_id': self.sub,
+        'scope': scopes,
+        'aud': intended_audience,
+        'nbf': timestamp - 1,
+        'exp': timestamp + NoAuth.EXPIRATION,
+        'iss': 'NoAuth',
+        'jti': str(uuid.uuid4()),
+      },
+      algs=['RS256'])
+    jwt.make_signed_token(NoAuth.dummy_private_key)
+    return jwt.serialize()
 
 
 class DummyOAuth(AuthAdapter):

--- a/monitoring/monitorlib/auth.py
+++ b/monitoring/monitorlib/auth.py
@@ -62,7 +62,7 @@ class NoAuth(AuthAdapter):
       claims={
         'sub': self.sub,
         'client_id': self.sub,
-        'scope': scopes,
+        'scope': ' '.join(scopes),
         'aud': intended_audience,
         'nbf': timestamp - 1,
         'exp': timestamp + NoAuth.EXPIRATION,


### PR DESCRIPTION
This PR adds an AuthAdapter that allows the user to generate valid access tokens without referencing (or requiring) any server.  This can save the effort of setting up a Dummy OAuth server locally in certain debugging/development situations.