### PR TITLE
Increase ImplicitDict robustness and improve rid_qualifier mock responses

### DIFF
--- a/monitoring/monitorlib/typing.py
+++ b/monitoring/monitorlib/typing.py
@@ -68,9 +68,11 @@ class ImplicitDict(dict):
   """
 
   @classmethod
-  def parse(cls, source: Dict, type: Type):
+  def parse(cls, source: Dict, parse_type: Type):
+    if not isinstance(source, dict):
+      raise ValueError('Expected to find dictionary data to populate {} object but instead found {} type'.format(parse_type.__name__, type(source).__name__))
     kwargs = {}
-    hints = get_type_hints(type)
+    hints = get_type_hints(parse_type)
     for key, value in source.items():
       if key in hints:
         # This entry has an explicit type
@@ -78,7 +80,7 @@ class ImplicitDict(dict):
       else:
         # This entry's type isn't specified
         kwargs[key] = value
-    return type(**kwargs)
+    return parse_type(**kwargs)
 
   def __init__(self, previous_instance: Optional[dict]=None, **kwargs):
     super(ImplicitDict, self).__init__()

--- a/monitoring/rid_qualifier/mock/routes.py
+++ b/monitoring/rid_qualifier/mock/routes.py
@@ -29,6 +29,8 @@ def create_test(sp_id: str, test_id: str) -> Tuple[str, int]:
 
   try:
     json = flask.request.json
+    if json is None:
+      raise ValueError('Request did not contain a JSON payload')
     req_body: api.CreateTestParameters = ImplicitDict.parse(json, api.CreateTestParameters)
     record = database.TestRecord(version=str(uuid.uuid4()), flights=req_body.requested_flights)
     if sp_id not in db.sps:


### PR DESCRIPTION
This PR improves rid_qualifier mock's responses when various types of invalid requests are submitted.  This includes an explicit error when attempting to parse dictionary data with ImplicitDict.parse and instead finding data of a different type (like a str or NoneType), and explicitly indicating that a JSON payload was not included when it is not present.