### PR TITLE
rid_qualifier: Streamline data type flow through simulation and injection

### DIFF
--- a/monitoring/rid_qualifier/aircraft_state_replayer.py
+++ b/monitoring/rid_qualifier/aircraft_state_replayer.py
@@ -3,11 +3,10 @@ from monitoring.monitorlib.infrastructure import DSSTestSession
 import json, os
 import uuid
 from pathlib import Path
-from monitoring.rid_qualifier.utils import TestPayload, DeliverablePayload, FullFlightRecord
+from monitoring.rid_qualifier.utils import FullFlightRecord
 from monitoring.rid_qualifier import injection_api
-from monitoring.rid_qualifier.injection_api import OperatorLocation, TestFlightDetails, TestFlight, CreateTestParameters
+from monitoring.rid_qualifier.injection_api import TestFlightDetails, TestFlight, CreateTestParameters
 from monitoring.monitorlib.typing import ImplicitDict
-from monitoring.monitorlib.rid import RIDFlightDetails
 import arrow
 import pathlib
 
@@ -25,15 +24,15 @@ class TestBuilder():
 
         aircraft_states_directory = Path('test_definitions', test_configuration.locale, 'aircraft_states')
         aircraft_state_files = self.get_aircraft_states(aircraft_states_directory)
-        
+
         usses = self.test_configuration.usses
 
-        self.disk_rid_state_data: List[FullFlightRecord] =[]
+        self.disk_flight_records: List[FullFlightRecord] =[]
         for uss_index, uss in enumerate(usses):
-            aircraft_states_path = Path(aircraft_state_files[uss['allocated_flight_track_number']])
+            aircraft_states_path = Path(aircraft_state_files[uss_index])
             with open(aircraft_states_path) as generated_rid_state:
-                disk_rid_state_file = ImplicitDict.parse(json.load(generated_rid_state), FullFlightRecord)
-                self.disk_rid_state_data.append(disk_rid_state_file)
+                disk_flight_record = ImplicitDict.parse(json.load(generated_rid_state), FullFlightRecord)
+                self.disk_flight_records.append(disk_flight_record)
 
 
     def get_aircraft_states (self, aircraft_states_directory: Path):
@@ -42,16 +41,14 @@ class TestBuilder():
 
         all_files = os.listdir(aircraft_states_directory)
         files = [os.path.join(aircraft_states_directory,f) for f in all_files if os.path.isfile(os.path.join(aircraft_states_directory, f))]
-        
+
         if files:
             return files
         else:
             raise ValueError("The there are no tracks in the tracks directory, create tracks first using the flight_data_generator module. ")
 
-    def build_test_payloads(self) ->List[DeliverablePayload]:
+    def build_test_payloads(self) -> List[CreateTestParameters]:
         ''' This is the main method to process the test configuration and build RID payload object, maxium of one flight is allocated to each USS. '''
-
-        usses = self.test_configuration.usses # Store the USS details
 
         all_test_payloads = [] # This holds the data that will be deilver
 
@@ -60,41 +57,28 @@ class TestBuilder():
         test_start_offset = test_start_time.shift(minutes =1)
         test_start_offset_isoformat = test_start_offset.isoformat()
 
-        requested_flights = [] # This objects holds the modified aircraft state data, aircraft state data is read from disk and timestamps are modified to have recent ones.
-        for state_data_index, current_disk_rid_state_data in enumerate(self.disk_rid_state_data):
-            test_id = str(uuid.uuid4())
-            test_injection_path = '/tests/{test_id}'.format(test_id=test_id)
-
-            disk_reference_time_raw = current_disk_rid_state_data.reference_time
+        for state_data_index, flight_record in enumerate(self.disk_flight_records):
+            disk_reference_time_raw = flight_record.reference_time
             disk_reference_time = arrow.get(disk_reference_time_raw)
 
-            current_disk_rid_state_data.reference_time = test_reference_time.isoformat()
+            flight_record.reference_time = test_reference_time.isoformat()
 
             timestamp_offset = test_start_offset - disk_reference_time
-            flight_id = current_disk_rid_state_data.flight_telemetry.id
 
-            for telemetry_id, flight_telemetry in enumerate(current_disk_rid_state_data.flight_telemetry.states):
+            for telemetry_id, flight_telemetry in enumerate(flight_record.states):
                 timestamp = arrow.get(flight_telemetry.timestamp) + timestamp_offset
                 flight_telemetry.timestamp = timestamp.isoformat()
 
-            flight_details =  current_disk_rid_state_data.flight_details
-            operator_details = current_disk_rid_state_data.operator_details
+            test_flight_details = TestFlightDetails(effective_after = test_start_offset_isoformat, details = flight_record.flight_details.rid_details)
 
-            operator_location = operator_details.location
+            test_flight = TestFlight(
+              injection_id=str(uuid.uuid4()),
+              telemetry=flight_record.states,
+              details_responses=[test_flight_details])
 
-            rid_flight_details = RIDFlightDetails(id=flight_id, operator_id = operator_details.operator_id, operator_location = operator_location, operation_description = flight_details['operation_description'] , serial_number = flight_details['serial_number'], registration_number = operator_details['registration_number'])
+            test_payload = CreateTestParameters(requested_flights=[test_flight])
 
-            test_flight_details = TestFlightDetails(effective_after = test_start_offset_isoformat, details = rid_flight_details)
-
-            test_flight = TestFlight(injection_id = str(uuid.uuid4()), telemetry = current_disk_rid_state_data.flight_telemetry.states, details_responses = [test_flight_details])
-
-            requested_flights.append(test_flight)
-
-            test_payload = TestPayload(test_id = test_id, requested_flights = requested_flights)
-
-            test_payload_data_metadata = DeliverablePayload(injection_path = test_injection_path, injection_payload = test_payload)
-
-            all_test_payloads.append(test_payload_data_metadata)
+            all_test_payloads.append(test_payload)
 
         return all_test_payloads
 
@@ -107,13 +91,10 @@ class TestHarness():
         auth_adapter = make_auth_adapter(auth_spec)
         self.uss_session = DSSTestSession(injection_base_url, auth_adapter)
 
-    def submit_test(self,uss_session:DSSTestSession, payload:DeliverablePayload) -> None:
-        test_id = payload.injection_payload.test_id
-        injection_path =  payload.injection_path
+    def submit_test(self, payload: CreateTestParameters, test_id: str) -> None:
+        injection_path = '/tests/{}'.format(test_id)
 
-        request = CreateTestParameters(requested_flights=payload.injection_payload.requested_flights)
-
-        response = uss_session.put(url=injection_path, json=request, scope=injection_api.SCOPE_RID_QUALIFIER_INJECT)
+        response = self.uss_session.put(url=injection_path, json=payload, scope=injection_api.SCOPE_RID_QUALIFIER_INJECT)
 
         if response.status_code == 200:
             print("New test with ID %s created" % test_id)
@@ -135,10 +116,3 @@ class TestHarness():
 
         else:
             raise RuntimeError("Test with ID %(test_id)s not submitted, the server returned the following HTTP error code: %(status_code)d" % {'test_id': test_id, 'status_code': response.status_code})
-
-
-    def submit_payloads(self, all_test_payloads:List[DeliverablePayload]):
-        ''' This method submits the payloads to the injection url '''
-
-        for payload in all_test_payloads:
-            self.submit_test(uss_session=self.uss_session, payload=payload)

--- a/monitoring/rid_qualifier/flight_data_generator.py
+++ b/monitoring/rid_qualifier/flight_data_generator.py
@@ -7,9 +7,8 @@ from typing import List, Optional
 import arrow
 import datetime
 from datetime import datetime, timedelta
-from monitoring.rid_qualifier.utils import QueryBoundingBox, FlightPoint, GridCellFlight, FlightTelemetryDetails, FlightOperatorDetails, GeneratedFlightDetails, GeneratedOperatorDetails, FullFlightRecord, RIDFlight
-from monitoring.rid_qualifier.injection_api import OperatorLocation
-from monitoring.monitorlib.rid import RIDHeight, RIDAircraftState, RIDAircraftPosition
+from monitoring.rid_qualifier.utils import QueryBoundingBox, FlightPoint, GridCellFlight, FlightDetails, FullFlightRecord
+from monitoring.monitorlib.rid import RIDHeight, RIDAircraftState, RIDAircraftPosition, RIDFlightDetails
 from monitoring.rid_qualifier import operator_flight_details_generator as details_generator
 import os
 import pathlib
@@ -47,7 +46,7 @@ class AdjacentCircularFlightsSimulator():
         # This object holds the name and the polygon object of the query boxes. The number of bboxes are controlled by the `box_diagonals` variable
         self.query_bboxes: List[QueryBoundingBox] = []
 
-        self.flight_telemetry: Optional[FlightTelemetryDetails] = None
+        self.flights: List[FullFlightRecord] = []
         self.bbox_center: List[shapely.geometry.Point] = []
 
         self.geod = Geod(ellps="WGS84")
@@ -182,22 +181,26 @@ class AdjacentCircularFlightsSimulator():
 
         self.grid_cells_flight_tracks = all_grid_cell_tracks
 
-    def generate_flight_operator_details(self) -> FlightOperatorDetails:
+    def generate_flight_details(self, id: str, aircraft_type: str) -> FlightDetails:
         ''' This class generates details of flights and operator details for a flight, this data is required for identifying flight, operator and operation  '''
 
         my_flight_details_generator = details_generator.OperatorFlightDataGenerator()
 
-        flight_details = GeneratedFlightDetails(serial_number = my_flight_details_generator.generate_serial_number(),  operation_description = my_flight_details_generator.generate_operation_description())
+        #TODO: Put operator_location in center of circle rather than stacking operators of all flights on top of each other
+        rid_details = RIDFlightDetails(
+            id=id,
+            serial_number=my_flight_details_generator.generate_serial_number(),
+            operation_description=my_flight_details_generator.generate_operation_description(),
+            operator_location=my_flight_details_generator.generate_operator_location(centroid= self.bbox_center[0]),
+            operator_id=my_flight_details_generator.generate_operator_id(),
+            registration_number=my_flight_details_generator.generate_registration_number())
 
+        flight_details = FlightDetails(
+            rid_details=rid_details,
+            aircraft_type=aircraft_type,
+            operator_name=my_flight_details_generator.generate_company_name())
 
-        operator_location = my_flight_details_generator.generate_operator_location(centroid= self.bbox_center[0])
-        ol = OperatorLocation(lat = operator_location['lat'], lng = operator_location['lng'])
-
-        operator_details = GeneratedOperatorDetails(operator_id = my_flight_details_generator.generate_operator_id(),name  = my_flight_details_generator.generate_company_name(), registration_number = my_flight_details_generator.generate_registration_number(), location = {"lat":ol.lat, "lng":ol.lng} )
-
-        flight_operator_details = FlightOperatorDetails(flight_details =flight_details,  operator_details = operator_details)
-
-        return flight_operator_details
+        return flight_details
 
 
     def generate_rid_state(self, duration=180):
@@ -207,7 +210,7 @@ class AdjacentCircularFlightsSimulator():
 
 
         '''
-        all_flight_telemetry = {}
+        all_flight_telemetry: List[List[RIDAircraftState]] = []
         flight_track_details = {}  # Develop a index of flight length and their index
         # Store where on the track the current index is, since the tracks are circular, once the end of the track is reached, the index is reset to 0 to indicate beginning of the track again.
         flight_current_index = {}
@@ -230,8 +233,7 @@ class AdjacentCircularFlightsSimulator():
             flight_track_details[i]['track_length'] = flight_positions_len
 
             flight_current_index[i] = 0
-            all_flight_telemetry[i]= {}
-            all_flight_telemetry[i]['states'] = []
+            all_flight_telemetry.append([])
 
         timestamp = now
         for j in range(duration):
@@ -265,29 +267,22 @@ class AdjacentCircularFlightsSimulator():
                         speed_accuracy="SA3mps",
                         vertical_speed=0.0)
 
-                    all_flight_telemetry[k]['states'].append(rid_aircraft_state)
+                    all_flight_telemetry[k].append(rid_aircraft_state)
 
                     flight_current_index[k] += 1
                 else:
                     flight_current_index[k] = 0
 
 
-        telemetry_data_list = []
+        flights = []
         for m in range(num_flights):
+            flight = FullFlightRecord(
+                reference_time=now_isoformat,
+                states=all_flight_telemetry[m],
+                flight_details=self.generate_flight_details(id=str(m), aircraft_type="Helicopter"))
+            flights.append(flight)
 
-            rid_aircraft_flight = RIDFlight(id=str(m), aircraft_type="Helicopter", states=all_flight_telemetry[m]['states'])
-
-            telemetry_data_list.append(rid_aircraft_flight)
-
-
-        flight_operator_details = self.generate_flight_operator_details()
-
-        self.flight_telemetry = FlightTelemetryDetails(
-            telemetry_data_list=telemetry_data_list,
-            reference_time=now_isoformat,
-            operator_details=flight_operator_details['operator_details'],
-            flight_details=flight_operator_details['flight_details'])
-
+        self.flights = flights
 
 
 class TrackWriter():
@@ -366,10 +361,9 @@ class RIDAircraftStateWriter():
 
     """
 
-    def __init__(self, flight_telemetry: FlightTelemetryDetails, country_code='che') -> None:
+    def __init__(self, flights: List[FullFlightRecord], country_code='che') -> None:
         """ Atleast single flight points array is necessary and a ouptut directory
         Args:
-        flight_telemetry:
         country_code: An ISO 3166-1 alpha-3 code for a country, this is used to create a sub-directory to store output.
 
         Outputs:
@@ -377,7 +371,7 @@ class RIDAircraftStateWriter():
 
         """
 
-        self.flight_telemetry = flight_telemetry
+        self.flights = flights
         self.country_code = country_code
         self.flight_telemetry_check()
 
@@ -393,7 +387,7 @@ class RIDAircraftStateWriter():
         ''' Check if atleast one track is provided, if no tracks are provided, then RIDAircraftState and Test JSON cannot be generated.'''
 
         # Empty flight points cannot be converted to a Aircraft State, check if the list has
-        if (self.flight_telemetry.telemetry_data_list):
+        if (self.flights):
             return
         else:
             raise ValueError("At least one flight track is necessary to create a AircraftState and a test JSON, please generate the tracks first using AdjacentCircularFlightsSimulator class")
@@ -401,20 +395,12 @@ class RIDAircraftStateWriter():
     def write_rid_state(self):
         ''' This method iterates over flight tracks and geneates AircraftState JSON objects and writes to disk in the test_definitions folder, these files can be used to submit the data in the test harness '''
 
-        reference_time = self.flight_telemetry.reference_time
-        flight_details = self.flight_telemetry.flight_details
-        operator_details = self.flight_telemetry.operator_details
-
-
-
-        for flight_id, single_flight_telemetry_data in enumerate(self.flight_telemetry.telemetry_data_list):
-
+        for flight_id, single_flight in enumerate(self.flights):
             rid_test_file_name = 'flight_' + str(flight_id + 1) + '_rid_aircraft_state' + '.json' # Add 1 to avoid zero based numbering
 
             rid_test_file_path = self.output_subdirectories[0] / rid_test_file_name
-            flight_telemetry_data = FullFlightRecord(reference_time=reference_time, flight_telemetry=single_flight_telemetry_data, flight_details=flight_details, operator_details=operator_details)
             with open(rid_test_file_path, 'w') as f:
-                f.write(json.dumps(flight_telemetry_data))
+                f.write(json.dumps(single_flight))
 
 
 if __name__ == '__main__':
@@ -429,7 +415,7 @@ if __name__ == '__main__':
     grid_tracks = my_path_generator.grid_cells_flight_tracks
 
     my_path_generator.generate_rid_state(duration=180)
-    flight_telemetry = my_path_generator.flight_telemetry
+    flights = my_path_generator.flights
 
     query_bboxes = my_path_generator.query_bboxes
 
@@ -441,5 +427,5 @@ if __name__ == '__main__':
     my_track_writer.write_bboxes()
     my_track_writer.write_tracks()
 
-    my_state_generator = RIDAircraftStateWriter(flight_telemetry=flight_telemetry, country_code=COUNTRY_CODE)
+    my_state_generator = RIDAircraftStateWriter(flights=flights, country_code=COUNTRY_CODE)
     my_state_generator.write_rid_state()

--- a/monitoring/rid_qualifier/operator_flight_details_generator.py
+++ b/monitoring/rid_qualifier/operator_flight_details_generator.py
@@ -3,31 +3,33 @@ import string
 import random
 import uuid
 
+from monitoring.rid_qualifier.injection_api import OperatorLocation
+
+
 class OperatorFlightDataGenerator():
-    ''' A class to generate fake data detailing operator name, operation name and operator location, it can be customized for locales and locations ''' 
-    
+    ''' A class to generate fake data detailing operator name, operation name and operator location, it can be customized for locales and locations '''
+
     def __init__(self):
         self.fake = Faker()
-        
+
     def generate_serial_number(self):
         return str(uuid.uuid4())
-    
+
     def generate_registration_number(self, prefix='CHE'):
         registration_number = prefix + ''.join(random.choices(string.ascii_lowercase + string.digits, k=13))
         return registration_number
-    
+
     def generate_operation_description(self):
         operation_description = ["Electricity Grid Inspection", "Wind farm survey", "Solar Panel Inspection", "Traffic Monitoring", "Emergency services / rescue", "Delivery operation, see more details at https://deliveryops.com/operation", "News recording, live event", "Crop spraying / Agricultural Inspection"]
         return random.choice(operation_description)
-        
-    def generate_operator_location(self, centroid):        
-        operator_location = {'lat':centroid.y, 'lng':centroid.x}
+
+    def generate_operator_location(self, centroid):
+        operator_location = OperatorLocation(lat=centroid.y, lng=centroid.x)
         return operator_location
 
     def generate_operator_id(self, prefix='OP-'):
         operator_id = prefix + ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))
         return operator_id
-        
-    
+
     def generate_company_name(self):
         return self.fake.company()

--- a/monitoring/rid_qualifier/rid_qualifier_entry.py
+++ b/monitoring/rid_qualifier/rid_qualifier_entry.py
@@ -4,7 +4,7 @@ import os
 import sys
 import argparse
 from urllib.parse import urlparse
-import monitoring.rid_qualifier.test_executor as test_executor 
+import monitoring.rid_qualifier.test_executor as test_executor
 
 def is_url(url_string):
     try:
@@ -36,17 +36,17 @@ def parseArgs() -> argparse.Namespace:
 
 def main() -> int:
     args = parseArgs()
-    
+
     auth_spec = args.auth
     locale = args.locale
-    injection_base_url = args.injection_base_url    
+    injection_base_url = args.injection_base_url
 
     is_url(injection_base_url)
-    uss_config = test_executor.build_uss_config(injection_base_url= injection_base_url, allocated_track=0)
+    uss_config = test_executor.build_uss_config(injection_base_url= injection_base_url)
     test_configuration = test_executor.build_test_configuration(locale = locale, auth_spec=auth_spec,uss_config = uss_config)
-    
+
     test_executor.main(test_configuration=test_configuration)
-    
+
     return os.EX_OK
 
 if __name__ == "__main__":

--- a/monitoring/rid_qualifier/test_executor.py
+++ b/monitoring/rid_qualifier/test_executor.py
@@ -1,15 +1,16 @@
+import uuid
 from monitoring.rid_qualifier.aircraft_state_replayer import TestHarness, TestBuilder
 import arrow
 from monitoring.rid_qualifier.utils import RIDQualifierTestConfiguration, RIDQualifierUSSConfig
 
-def build_uss_config(injection_base_url:str, allocated_track:int = 0) -> RIDQualifierUSSConfig:
-  return RIDQualifierUSSConfig(injection_base_url=injection_base_url, allocated_flight_track_number = allocated_track)
-  
+def build_uss_config(injection_base_url:str) -> RIDQualifierUSSConfig:
+  return RIDQualifierUSSConfig(injection_base_url=injection_base_url)
 
-def build_test_configuration(locale: str, auth_spec:str, uss_config:RIDQualifierUSSConfig) -> RIDQualifierTestConfiguration: 
+
+def build_test_configuration(locale: str, auth_spec:str, uss_config:RIDQualifierUSSConfig) -> RIDQualifierTestConfiguration:
     now = arrow.now()
-    test_start_time = now.shift(minutes=3) # Start the test three minutes from the time the test_exceutor is run. 
-    
+    test_start_time = now.shift(minutes=3) # Start the test three minutes from the time the test_exceutor is run.
+
     test_config = RIDQualifierTestConfiguration(
       locale = locale,
       now = now.isoformat(),
@@ -19,13 +20,18 @@ def build_test_configuration(locale: str, auth_spec:str, uss_config:RIDQualifier
     )
 
     return test_config
-    
+
 def main(test_configuration: RIDQualifierTestConfiguration):
     # This is the configuration for the test.
     my_test_builder = TestBuilder(test_configuration = test_configuration)
     test_payloads = my_test_builder.build_test_payloads()
-    
-    my_test_harness = TestHarness(auth_spec = test_configuration.auth_spec, injection_base_url = test_configuration.usses[0].injection_base_url)
-    
-    my_test_harness.submit_payloads(all_test_payloads=test_payloads)
+    test_id = str(uuid.uuid4())
+
+    # Inject flights into all USSs
+    for i, uss in enumerate(test_configuration.usses):
+      uss_injection_harness = TestHarness(
+        auth_spec=test_configuration.auth_spec,
+        injection_base_url=uss.injection_base_url)
+      uss_injection_harness.submit_test(test_payloads[i], test_id)
+
     # TODO: call display data evaluator to read RID system state and compare to expectations

--- a/monitoring/rid_qualifier/utils.py
+++ b/monitoring/rid_qualifier/utils.py
@@ -2,17 +2,15 @@ from typing import List, NamedTuple
 from shapely.geometry import Polygon
 import shapely.geometry
 from datetime import datetime
-from monitoring.monitorlib.rid import RIDAircraftState
+from monitoring.monitorlib.rid import RIDAircraftState, RIDFlightDetails
 from monitoring.monitorlib.typing import ImplicitDict
 from monitoring.rid_qualifier import injection_api
-from monitoring.rid_qualifier.injection_api import OperatorLocation
 
 
 class RIDQualifierUSSConfig(ImplicitDict):
     ''' This object defines the data required for a uss '''
 
     injection_base_url: str
-    allocated_flight_track_number: int
 
 
 class RIDQualifierTestConfiguration(ImplicitDict):
@@ -61,59 +59,14 @@ class RIDSP(NamedTuple):
     rid_state_submission_status: bool
 
 
-class GeneratedFlightDetails(ImplicitDict):
+class FlightDetails(ImplicitDict):
     ''' This object stores the metadata associated with generated flight, this data is shared as information in the remote id call '''
-    serial_number: str
-    operation_description: str
-
-
-class GeneratedOperatorDetails(ImplicitDict):
-    ''' This object stores the details of the operator that will be transmitted in the RID output. The registration number and operator id can be customized to meet local regulations, at the moment it generates a random alpha numeric string '''
-
-    operator_id: str
-    name: str
-    registration_number: str
-    location: OperatorLocation
-
-
-class FlightOperatorDetails(ImplicitDict):
-    ''' This object stores the "automatically" generated data about operator and the fight '''
-    flight_details: GeneratedFlightDetails
-    operator_details: GeneratedOperatorDetails
-
-
-class RIDFlight(ImplicitDict):
-    ''' A object to stored details of a remoteID flight '''
-    id: str  # ID of the flight for Remote ID purposes, e.g. uss1.JA6kHYCcByQ-6AfU, we for this simulation we use just numeric : https://github.com/uastech/standards/blob/36e7ea23a010ff91053f82ac4f6a9bfc698503f9/remoteid/canonical.yaml#L943
+    rid_details: RIDFlightDetails
+    operator_name: str
     aircraft_type: str  # Generic type of aircraft https://github.com/uastech/standards/blob/36e7ea23a010ff91053f82ac4f6a9bfc698503f9/remoteid/canonical.yaml#L1711
-    states : List[RIDAircraftState]  # See above for definition
-
-
-class TestPayload(ImplicitDict):
-    ''' This object defines the detail of a test object, one or more flight tracks may be assigned in a test therefore the requested flights is a list. '''
-
-    test_id: str
-    requested_flights:List[injection_api.TestFlight]
-
-
-class DeliverablePayload(ImplicitDict):
-    ''' This object defines the payload that needs will be submitted to the Test Inejection URL. The payload is a set of flight tracks, operator details and other associated objects. '''
-
-    injection_path: str
-    injection_payload: TestPayload
-
-
-#TODO: Remove this class; it doesn't make sense to associate many simultaneous flights with the same single operator and flight details
-class FlightTelemetryDetails(ImplicitDict):
-    ''' Store the Aircraft states, and other metadata before saving on disk '''
-    telemetry_data_list: List[RIDFlight]
-    reference_time: str
-    operator_details: GeneratedOperatorDetails
-    flight_details: GeneratedFlightDetails
 
 
 class FullFlightRecord(ImplicitDict):
     reference_time: str
-    flight_telemetry: RIDFlight
-    flight_details: GeneratedFlightDetails
-    operator_details: GeneratedOperatorDetails
+    states: List[RIDAircraftState]
+    flight_details: FlightDetails


### PR DESCRIPTION
This PR prepares for the introduction of display_data_evaluator by streamlining the data flow through the previous parts of rid_qualifier.  It substantially reduces the number of data types by using interface-specified types when practical.  For instance, all "payloads" are converted to injection-interface-specified `CreateTestParameters` or components thereof, and multiple details types are combined in a single `FlightDetails` which references RID-interface-specified `RIDFlightDetails`.  It also fixes the bug where all flights would be assigned the same operator.