### PR TITLE
rid_qualifier: Add first draft of display data evaluator

### DIFF
--- a/monitoring/monitorlib/requirements.txt
+++ b/monitoring/monitorlib/requirements.txt
@@ -1,8 +1,10 @@
+arrow==1.1.0
 cryptography==3.3.2
 flask==1.1.2
 google-auth==1.6.3
 jwcrypto==0.7
 pyjwt==1.7.1
+pytimeparse==1.1.8
 pyyaml==5.4
 requests==2.25.1
 s2sphere==0.2.5

--- a/monitoring/monitorlib/rid.py
+++ b/monitoring/monitorlib/rid.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Dict, List, Optional
 import s2sphere
 
@@ -12,6 +13,9 @@ DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 SCOPE_READ = 'dss.read.identification_service_areas'
 SCOPE_WRITE = 'dss.write.identification_service_areas'
+NetMaxNearRealTimeDataPeriod = datetime.timedelta(seconds=60)
+NetMaxDisplayAreaDiagonal = 3.6  # km
+NetDetailsMaxDisplayAreaDiagonal = 1.0  # km
 
 # This scope is used only for experimentation during UPP2
 UPP2_SCOPE_ENHANCED_DETAILS = 'rid.read.enhanced_details'

--- a/monitoring/monitorlib/typing.py
+++ b/monitoring/monitorlib/typing.py
@@ -1,4 +1,7 @@
+import datetime
 from typing import get_args, get_origin, get_type_hints, Dict, Optional, Type, Union
+
+import pytimeparse
 
 
 _DICT_FIELDS = set(dir({}))
@@ -132,7 +135,7 @@ class ImplicitDict(dict):
         provided_values.add(key)
 
     # Copy default field values
-    for key in optional_fields:
+    for key in all_fields:
       if key not in provided_values:
         if hasattr(type(self), key):
           self[key] = super(ImplicitDict, self).__getattribute__(key)
@@ -184,3 +187,14 @@ def _parse_value(value, value_type: Type):
   else:
     # value is a non-generic type that is not an ImplicitDict
     return value
+
+
+class StringBasedTimeDelta(str):
+  """String that only allows values which describe a timedelta."""
+  def __new__(cls, value):
+    if isinstance(value, str):
+      str_value = str.__new__(cls, value)
+    else:
+      str_value = str.__new__(cls, str(value))
+    str_value.timedelta = datetime.timedelta(seconds=pytimeparse.parse(str_value))
+    return str_value

--- a/monitoring/rid_qualifier/.gitignore
+++ b/monitoring/rid_qualifier/.gitignore
@@ -1,1 +1,2 @@
 test_definitions/*/*/
+report.json

--- a/monitoring/rid_qualifier/display_data_evaluator.py
+++ b/monitoring/rid_qualifier/display_data_evaluator.py
@@ -1,0 +1,252 @@
+import datetime
+import json
+import time
+from typing import List, Optional, Tuple
+
+import arrow
+import s2sphere
+
+from monitoring.monitorlib import fetch, geo, rid
+from monitoring.monitorlib.infrastructure import DSSTestSession
+from monitoring.monitorlib.typing import ImplicitDict, StringBasedTimeDelta
+from monitoring.rid_qualifier import observation_api
+from monitoring.rid_qualifier.reports import Findings
+from monitoring.rid_qualifier.utils import InjectedFlight
+from monitoring.rid_qualifier.injection_api import TestFlight
+
+
+class EvaluationConfiguration(ImplicitDict):
+  min_polling_interval: Optional[StringBasedTimeDelta] = StringBasedTimeDelta(datetime.timedelta(seconds=5))
+  """Do not repeat system observations with intervals smaller than this."""
+
+  max_propagation_latency: Optional[StringBasedTimeDelta] = StringBasedTimeDelta(datetime.timedelta(seconds=10))
+  """Allow up to this much time for data to propagate through the system."""
+
+  min_query_diagonal: Optional[float] = 100
+  """Do not make queries with diagonals smaller than this many meters."""
+
+
+class RIDSystemObserver(object):
+  def __init__(self, name: str, session: DSSTestSession):
+    self.session = session
+    self.name = name
+
+  def observe_system(self, rect: s2sphere.LatLngRect) -> Tuple[Optional[observation_api.GetDisplayDataResponse], fetch.Query]:
+    initiated_at = datetime.datetime.utcnow()
+    resp = self.session.get('/display_data?view={},{},{},{}'.format(
+      rect.lo().lat().degrees, rect.lo().lng().degrees,
+      rect.hi().lat().degrees, rect.hi().lng().degrees), scope=rid.SCOPE_READ)
+    try:
+      result = (ImplicitDict.parse(resp.json(),
+                                   observation_api.GetDisplayDataResponse)
+                if resp.status_code == 200 else None)
+    except ValueError as e:
+      result = None
+    return (result, fetch.describe_query(resp, initiated_at))
+
+  def observe_flight_details(self, flight_id: str) -> Tuple[Optional[observation_api.GetDetailsResponse], fetch.Query]:
+    initiated_at = datetime.datetime.utcnow()
+    resp = self.session.get('/display_data/{}'.format(flight_id))
+    try:
+      result = ImplicitDict.parse(resp.json(), observation_api.GetDetailsResponse) if resp.status_code == 200 else None
+    except ValueError:
+      result = None
+    return (result, fetch.describe_query(resp, initiated_at))
+
+
+def _get_query_rect(injected_flights: List[TestFlight], t: datetime.datetime,
+                    config: EvaluationConfiguration) -> s2sphere.LatLngRect:
+  data_exists = False
+  lat_min = 90
+  lng_min = 360
+  lat_max = -90
+  lng_max = -360
+
+  # Find the bounds of all relevant points
+  t_min = t - rid.NetMaxNearRealTimeDataPeriod - config.max_propagation_latency.timedelta
+  t_max = t
+  for injected_flight in injected_flights:
+    for telemetry in injected_flight.telemetry:
+      t = arrow.get(telemetry.timestamp).datetime
+      if t_min <= t <= t_max:
+        data_exists = True
+        lat_min = min(lat_min, telemetry.position.lat)
+        lat_max = max(lat_max, telemetry.position.lat)
+        lng_min = min(lng_min, telemetry.position.lng)
+        lng_max = max(lng_max, telemetry.position.lng)
+
+  # If there is no flight data yet, look at the center of where the data will be
+  if not data_exists:
+    lat = 0
+    lng = 0
+    n = 0
+    for injected_flight in injected_flights:
+      for telemetry in injected_flight.telemetry:
+        lat += telemetry.position.lat
+        lng += telemetry.position.lng
+        n += 1
+    lat_min = lat_max = lat / n
+    lng_min = lng_max = lng / n
+
+  # Expand view size to meet minimum, if necessary
+  OVERSHOOT = 1.01
+  while True:
+    c1 = s2sphere.LatLng.from_degrees(lat_min, lng_min)
+    c2 = s2sphere.LatLng.from_degrees(lat_max, lng_max)
+    diagonal = c1.get_distance(c2).degrees * geo.EARTH_CIRCUMFERENCE_KM * 1000 / 360
+    if diagonal >= config.min_query_diagonal:
+      break
+    if lat_min == lat_max and lng_min == lng_max:
+      lat_min -= 1e-5
+      lat_max += 1e-5
+      lng_min -= 1e-5
+      lng_max += 1e-5
+      continue
+    lat_center = 0.5 * (lat_min + lat_max)
+    lat_span = (lat_max - lat_min) * config.min_query_diagonal / diagonal * OVERSHOOT
+    lat_min = lat_center - 0.5 * lat_span
+    lat_max = lat_center + 0.5 * lat_span
+    lng_center = 0.5 * (lng_min + lng_max)
+    lng_span = (lng_max - lng_min) * config.min_query_diagonal / diagonal * OVERSHOOT
+    lng_min = lng_center - 0.5 * lng_span
+    lng_max = lng_center + 0.5 * lng_span
+
+  p1 = s2sphere.LatLng.from_degrees(lat_min, lng_min)
+  p2 = s2sphere.LatLng.from_degrees(lat_max, lng_max)
+  return s2sphere.LatLngRect.from_point_pair(p1, p2)
+
+
+def evaluate_system(
+    injected_flights: List[InjectedFlight], observers: List[RIDSystemObserver],
+    config: EvaluationConfiguration, findings: Findings) -> None:
+  """Evaluate a system by polling system state and comparing to expectations.
+
+  This routine periodically polls each of the specified observers for the system
+  state and checks that each system state matches expectations based on the
+  provided injected flights, updating the provided report findings.
+  """
+
+  # Compute the end of all injected data
+  t_end = arrow.utcnow()
+  for injected_flight in injected_flights:
+    for telemetry in injected_flight.flight.telemetry:
+      t = arrow.get(telemetry.timestamp)
+      t_end = max(t_end, t)
+  t_end += rid.NetMaxNearRealTimeDataPeriod + config.max_propagation_latency.timedelta
+
+  if arrow.utcnow() > t_end:
+    raise RuntimeError(
+      'Cannot evaluate system: injected test flights ended at {}, which is before now ({})'.format(
+        t_end, datetime.datetime.utcnow()))
+
+  t_next = arrow.utcnow()
+  while arrow.utcnow() < t_end:
+    # Evaluate the system at an instant in time
+    _evaluate_system_instantaneously(
+      injected_flights, observers, config, findings)
+    print('After observation at {}, {}'.format(arrow.utcnow(), findings))
+    print(json.dumps(findings.issues, indent=2))
+
+    # Wait until minimum polling interval elapses
+    while t_next < arrow.utcnow():
+      t_next += config.min_polling_interval.timedelta
+    if t_next > t_end:
+      break
+    delay = t_next - arrow.utcnow()
+    if delay.total_seconds() > 0:
+      time.sleep(delay.total_seconds())
+
+
+def _evaluate_system_instantaneously(
+    injected_flights: List[InjectedFlight], observers: List[RIDSystemObserver],
+    config: EvaluationConfiguration, findings: Findings) -> None:
+  for observer in observers:
+    # Find a bounding box that should observe all aircraft currently active
+    t_now = arrow.utcnow().datetime
+    rect = _get_query_rect(
+      [injected_flight.flight for injected_flight in injected_flights],
+      t_now, config)
+
+    # Conduct an observation, then log and evaluate it
+    (observation, query) = observer.observe_system(rect)
+    findings.add_observation_query(query)
+    _evaluate_observation(injected_flights, observer, rect, observation, query,
+                          config, findings)
+
+    #TODO: If bounding rect is smaller than cluster threshold, expand slightly above cluster threshold and re-observe
+    #TODO: If bounding rect is smaller than area-too-large threshold, expand slightly above area-too-large threshold and re-observe
+
+
+def _evaluate_observation(
+    injected_flights: List[InjectedFlight], observer: RIDSystemObserver,
+    rect: s2sphere.LatLngRect,
+    observation: Optional[observation_api.GetDisplayDataResponse],
+    query: fetch.Query, config: EvaluationConfiguration,
+    findings: Findings) -> None:
+  diagonal = rect.lo().get_distance(rect.hi()).degrees * geo.EARTH_CIRCUMFERENCE_KM / 360
+  if diagonal > rid.NetMaxDisplayAreaDiagonal:
+    _evaluate_area_to_large_observation(observer, diagonal, query, findings)
+  elif diagonal > rid.NetDetailsMaxDisplayAreaDiagonal:
+    _evaluate_clusters_observation(findings)
+  else:
+    _evaluate_normal_observation(injected_flights, observer, rect,
+                                 observation, query, config, findings)
+
+
+def _evaluate_normal_observation(
+    injected_flights: List[InjectedFlight], observer: RIDSystemObserver,
+    rect: s2sphere.LatLngRect,
+    observation: Optional[observation_api.GetDisplayDataResponse],
+    query: fetch.Query, config: EvaluationConfiguration,
+    findings: Findings) -> None:
+  if observation is None:
+    findings.add_observation_failure(observer.name, rect, query)
+    return
+
+  for expected_flight in injected_flights:
+    t_initiated = query.request.timestamp
+    t_response = query.response.reported
+    timestamps = [arrow.get(t.timestamp) for t in expected_flight.flight.telemetry]
+    t_min = min(timestamps).datetime
+    t_max = max(timestamps).datetime
+
+    flight_id = expected_flight.flight.details_responses[0].details.id # TODO: Choose appropriate details rather than first
+    matching_flights = [observed_flight
+                        for observed_flight in observation.flights
+                        if observed_flight.id == flight_id]
+    if len(matching_flights) > 1:
+      findings.add_duplicate_flights(observer.name, flight_id, len(matching_flights), expected_flight.uss.name, query)
+
+    if t_response < t_min:
+      # This flight should definitely not have been observed (it starts in the future)
+      if matching_flights:
+        findings.add_premature_flight(observer.name, flight_id, t_min, t_response, expected_flight.uss.name, query)
+        continue
+    elif t_response > t_max + rid.NetMaxNearRealTimeDataPeriod + config.max_propagation_latency.timedelta:
+      # This flight should not have been observed (it was too far in the past)
+      if matching_flights:
+        findings.add_lingering_flight(observer.name, flight_id, t_max, t_initiated, expected_flight.uss.name, query)
+        continue
+    elif t_min + config.max_propagation_latency.timedelta < t_initiated < t_max + rid.NetMaxNearRealTimeDataPeriod:
+      # This flight should definitely have been observed
+      if not matching_flights:
+        findings.add_missing_flight(observer.name, expected_flight, rect, expected_flight.uss.name, query)
+        continue
+    elif t_initiated > t_min:
+      # If this flight was not observed, there may be propagation latency
+      pass #TODO: findings propagation latency
+
+    for matching_flight in matching_flights:
+      pass #TODO: Check position, altitude, flight details, etc
+
+
+def _evaluate_area_to_large_observation(
+  observer: RIDSystemObserver, diagonal: float,
+  query: fetch.Query, findings: Findings) -> None:
+  if query.status_code != 413:
+    findings.add_area_too_large_not_indicated(observer.name, diagonal, query)
+
+
+def _evaluate_clusters_observation(findings: Findings) -> None:
+  #TODO: Check cluster sizing, aircraft counts, etc
+  pass

--- a/monitoring/rid_qualifier/flight_data_generator.py
+++ b/monitoring/rid_qualifier/flight_data_generator.py
@@ -203,7 +203,7 @@ class AdjacentCircularFlightsSimulator():
         return flight_details
 
 
-    def generate_rid_state(self, duration=180):
+    def generate_rid_state(self, duration):
         '''
 
         This method generates rid_state objects that can be submitted as flight telemetry
@@ -414,7 +414,7 @@ if __name__ == '__main__':
 
     grid_tracks = my_path_generator.grid_cells_flight_tracks
 
-    my_path_generator.generate_rid_state(duration=180)
+    my_path_generator.generate_rid_state(duration=30)
     flights = my_path_generator.flights
 
     query_bboxes = my_path_generator.query_bboxes

--- a/monitoring/rid_qualifier/injection_api.py
+++ b/monitoring/rid_qualifier/injection_api.py
@@ -1,4 +1,8 @@
-from typing import List
+import datetime
+from typing import List, Optional, Tuple
+
+import arrow
+
 from monitoring.monitorlib import rid
 from monitoring.monitorlib.typing import ImplicitDict
 
@@ -25,6 +29,20 @@ class TestFlight(ImplicitDict):
     injection_id: str
     telemetry: List[rid.RIDAircraftState]
     details_responses : List[TestFlightDetails]
+
+    def get_span(self) -> Tuple[Optional[datetime.datetime], Optional[datetime.datetime]]:
+      earliest = None
+      latest = None
+      times = [arrow.get(aircraft_state.timestamp).datetime
+               for aircraft_state in self.telemetry]
+      times.extend(arrow.get(details.effective_after).datetime
+                   for details in self.details_responses)
+      for t in times:
+        if earliest is None or t < earliest:
+          earliest = t
+        if latest is None or t > latest:
+          latest = t
+      return (earliest, latest)
 
 
 class CreateTestParameters(ImplicitDict):

--- a/monitoring/rid_qualifier/observation_api.py
+++ b/monitoring/rid_qualifier/observation_api.py
@@ -1,0 +1,35 @@
+from typing import List, Optional
+
+from monitoring.monitorlib.typing import ImplicitDict
+
+
+# Mirrors of types defined in remote ID automated testing observation API
+
+class Position(ImplicitDict):
+  lat: float
+  lng: float
+
+
+class Path(ImplicitDict):
+  positions: List[Position]
+
+
+class Cluster(ImplicitDict):
+  corners: List[Position]
+  area_sqm: float
+  number_of_flights: int
+
+
+class Flight(ImplicitDict):
+  id: str
+  most_recent_position: Optional[Position] = None
+  recent_paths: List[Path] = []
+
+
+class GetDetailsResponse(ImplicitDict):
+  pass
+
+
+class GetDisplayDataResponse(ImplicitDict):
+  flights: List[Flight] = []
+  clusters: List[Cluster] = []

--- a/monitoring/rid_qualifier/reports.py
+++ b/monitoring/rid_qualifier/reports.py
@@ -1,0 +1,179 @@
+import datetime
+from typing import List, Optional
+
+import s2sphere
+
+from monitoring.monitorlib import fetch
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.rid_qualifier.utils import InjectedFlight
+
+
+class Severity(object):
+  Critical = 'Critical'
+  """The system does not function correctly on a basic level."""
+
+  High = 'High'
+  """The system may superficially function, but does not meet requirements."""
+
+  Low = 'Low'
+  """The system behaves correctly, but could be improved."""
+
+
+class Issue(ImplicitDict):
+  timestamp: Optional[str]
+  """Time the issue was discovered"""
+
+  test_code: str
+  """Code corresponding to check generating this issue"""
+
+  relevant_requirements: List[str] = []
+  """Requirements that this issue relates to"""
+
+  severity: Severity
+  """How severe the issue is"""
+
+  injection_target: str
+  """Issue is related to data injected into this target.
+
+  This is generally a Service Provider for RID.
+  """
+
+  observation_source: str
+  """Issue is related to the system state observed using this target.
+
+  This is a Display Application/Provider for RID.
+  """
+
+  subject: Optional[str]
+  """Identifier of the subject of this issue, if applicable.
+
+  This may be a flight ID, or ID of other object central to the issue.
+  """
+
+  summary: str
+  """Human-readable summary of the issue"""
+
+  details: str
+  """Human-readable description of the issue"""
+
+  queries: List[fetch.Query]
+  """Description of HTTP requests relevant to this issue"""
+
+  def __init__(self, **kwargs):
+    super(Issue, self).__init__(**kwargs)
+    if 'timestamp' not in kwargs:
+      self.timestamp = datetime.datetime.utcnow().isoformat()
+
+
+class Setup(ImplicitDict):
+  injections: List[fetch.Query] = []
+
+
+class Findings(ImplicitDict):
+  issues: List[Issue] = []
+  observation_queries: List[fetch.Query] = []
+
+  def add_observation_query(self, query: fetch.Query):
+    self.observation_queries.append(query)
+
+  def add_area_too_large_not_indicated(
+      self, observer_name: str, diagonal: float, query: fetch.Query) -> None:
+    self.issues.append(Issue(
+      test_code='AREA_TOO_LARGE_NOT_INDICATED',
+      relevant_requirements=['NET0430'],
+      severity=Severity.High,
+      injection_target='N/A',
+      observation_source=observer_name,
+      summary='Expected "Area too large" response not received',
+      details='An area with {} km diagonal was queried and {} responded with {} rather than 413'.format(
+        diagonal, observer_name, query.status_code),
+      queries=[query]))
+
+  def add_duplicate_flights(
+      self, observer_name: str, flight_id: str, flight_count: int,
+      injection_target: str, query: fetch.Query) -> None:
+    self.issues.append(Issue(
+      test_code='DUPLICATE_FLIGHTS',
+      severity=Severity.Critical,
+      injection_target=injection_target,
+      observation_source=observer_name,
+      subject=flight_id,
+      summary='Found multiple flights with same ID',
+      details='Found {} flights with ID {} when {} was queried'.format(
+        flight_count, flight_id, observer_name),
+      queries=[query]))
+
+  def add_lingering_flight(
+      self, observer_name: str, flight_id: str, t_max: datetime.datetime,
+      t_initiated: datetime.datetime, injection_target: str,
+      query: fetch.Query) -> None:
+    self.issues.append(Issue(
+      test_code='LINGERING_FLIGHT',
+      severity=Severity.High,
+      relevant_requirements=['NET0260', 'NET0270'],
+      injection_target=injection_target,
+      observation_source=observer_name,
+      subject=flight_id,
+      summary='Lingering flight still observed after completion',
+      details='Flight {} ended at {} but it was still observed when queried at {} by {}'.format(
+        flight_id, t_max, t_initiated, observer_name),
+      queries=[query]))
+
+  def add_missing_flight(
+      self, observer_name: str, injected_flight: InjectedFlight,
+      rect: s2sphere.LatLngRect, injection_target: str,
+      query: fetch.Query) -> None:
+    flight_id = injected_flight.flight.details_responses[0].details.id
+    timestamp = datetime.datetime.utcnow() #TODO: Use query timestamp instead
+    span = injected_flight.flight.get_span()
+    self.issues.append(Issue(
+      test_code='MISSING_FLIGHT',
+      relevant_requirements=['NET0610'],
+      severity=Severity.Critical,
+      injection_target=injection_target,
+      observation_source=observer_name,
+      subject=flight_id,
+      summary='Expected flight not found',
+      details='Flight {} (from {} to {}) was expected inside ({}, {})-({}, {}) when {} was queried at {}'.format(
+        flight_id, span[0], span[1], rect.lo().lat().degrees,
+        rect.lo().lng().degrees, rect.hi().lat().degrees,
+        rect.hi().lng().degrees, observer_name, timestamp),
+      queries=[query]))
+
+  def add_observation_failure(self, observer_name: str,
+                              rect: s2sphere.LatLngRect,
+                              query: fetch.Query) -> None:
+    self.issues.append(Issue(
+      test_code='OBSERVATION_FAILED',
+      severity=Severity.Critical,
+      injection_target='N/A',
+      observation_source=observer_name,
+      summary='Observation attempt failed',
+      details='When queried for flights in ({}, {})-({}, {}), observer returned an invalid response with code {}'.format(
+        rect.lo().lat().degrees, rect.lo().lng().degrees,
+        rect.hi().lat().degrees, rect.hi().lng().degrees, query.status_code),
+      queries=[query]))
+
+  def add_premature_flight(
+      self, observer_name: str, flight_id: str, t_min: datetime.datetime,
+      t_response: datetime.datetime, injection_target: str,
+      query: fetch.Query) -> None:
+    self.issues.append(Issue(
+      test_code='PREMATURE_FLIGHT',
+      severity=Severity.High,
+      injection_target=injection_target,
+      observation_source=observer_name,
+      subject=flight_id,
+      summary='Future flight visible before start time',
+      details='Flight {} has first telemetry at {}, but it was already visible by {} at {}'.format(
+        flight_id, t_min, t_response, observer_name),
+      queries=[query]))
+
+  def __repr__(self):
+    return '[{} issues in {} observations]'.format(
+      len(self.issues), len(self.observation_queries))
+
+
+class Report(ImplicitDict):
+  setup: Setup = Setup()
+  findings: Findings = Findings()

--- a/monitoring/rid_qualifier/requirements.txt
+++ b/monitoring/rid_qualifier/requirements.txt
@@ -1,6 +1,6 @@
 pyproj==3.0.0
 shapely==1.7.1
-arrow==1.0.3
+arrow==1.1.0
 faker===8.1.0
 geojson===2.5.0
 -r ../monitorlib/requirements.txt

--- a/monitoring/rid_qualifier/rid_qualifier_entry.py
+++ b/monitoring/rid_qualifier/rid_qualifier_entry.py
@@ -30,6 +30,11 @@ def parseArgs() -> argparse.Namespace:
         required = True,
         help="A USS url where the test data is to be submitted")
 
+    parser.add_argument(
+      "--observation_base_url",
+      required = True,
+      help="A USS url where the system data can be observed")
+
 
     return parser.parse_args()
 
@@ -45,7 +50,7 @@ def main() -> int:
     uss_config = test_executor.build_uss_config(injection_base_url= injection_base_url)
     test_configuration = test_executor.build_test_configuration(locale = locale, auth_spec=auth_spec,uss_config = uss_config)
 
-    test_executor.main(test_configuration=test_configuration)
+    test_executor.main(test_configuration=test_configuration, observation_base_url=args.observation_base_url)
 
     return os.EX_OK
 

--- a/monitoring/rid_qualifier/run_locally.sh
+++ b/monitoring/rid_qualifier/run_locally.sh
@@ -8,9 +8,14 @@ LOCALE='--locale=che'
 
 INJECTION_URL='--injection_base_url=http://host.docker.internal:8070/sp/uss1'
 
-RID_QUALIFIER_OPTIONS="$AUTH $LOCALE $INJECTION_URL"
+OBSERVATION_URL='--observation_base_url=http://host.docker.internal:8070/dp/uss1'
+
+RID_QUALIFIER_OPTIONS="$AUTH $LOCALE $INJECTION_URL $OBSERVATION_URL"
 
 echo Reminder: must be run from root repo folder
+
+# report.json must already exist to share correctly with the Docker container
+touch $(pwd)/monitoring/rid_qualifier/report.json
 
 docker build \
     -f monitoring/rid_qualifier/Dockerfile \
@@ -20,6 +25,9 @@ docker build \
 
 docker run --name rid_qualifier \
   --rm \
+  --tty \
   -e RID_QUALIFIER_OPTIONS="${RID_QUALIFIER_OPTIONS}" \
+  -e PYTHONBUFFERED=1 \
+  -v $(pwd)/monitoring/rid_qualifier/report.json:/app/monitoring/rid_qualifier/report.json \
   interuss/dss/rid_qualifier \
   python rid_qualifier_entry.py $RID_QUALIFIER_OPTIONS

--- a/monitoring/rid_qualifier/test_executor.py
+++ b/monitoring/rid_qualifier/test_executor.py
@@ -1,15 +1,20 @@
+import json
 import uuid
 from monitoring.rid_qualifier.aircraft_state_replayer import TestHarness, TestBuilder
 import arrow
-from monitoring.rid_qualifier.utils import RIDQualifierTestConfiguration, RIDQualifierUSSConfig
+from monitoring.rid_qualifier.utils import RIDQualifierTestConfiguration, RIDQualifierUSSConfig, InjectedFlight
+from monitoring.rid_qualifier import display_data_evaluator, reports
+from monitoring.monitorlib.infrastructure import DSSTestSession
+from monitoring.monitorlib.auth import make_auth_adapter
+
 
 def build_uss_config(injection_base_url:str) -> RIDQualifierUSSConfig:
-  return RIDQualifierUSSConfig(injection_base_url=injection_base_url)
+  return RIDQualifierUSSConfig(injection_base_url=injection_base_url, name='uss1')
 
 
 def build_test_configuration(locale: str, auth_spec:str, uss_config:RIDQualifierUSSConfig) -> RIDQualifierTestConfiguration:
     now = arrow.now()
-    test_start_time = now.shift(minutes=3) # Start the test three minutes from the time the test_exceutor is run.
+    test_start_time = now.shift(seconds=15)
 
     test_config = RIDQualifierTestConfiguration(
       locale = locale,
@@ -21,17 +26,30 @@ def build_test_configuration(locale: str, auth_spec:str, uss_config:RIDQualifier
 
     return test_config
 
-def main(test_configuration: RIDQualifierTestConfiguration):
+def main(test_configuration: RIDQualifierTestConfiguration, observation_base_url: str):
     # This is the configuration for the test.
     my_test_builder = TestBuilder(test_configuration = test_configuration)
     test_payloads = my_test_builder.build_test_payloads()
     test_id = str(uuid.uuid4())
+    report = reports.Report()
 
     # Inject flights into all USSs
+    injected_flights = []
     for i, uss in enumerate(test_configuration.usses):
       uss_injection_harness = TestHarness(
         auth_spec=test_configuration.auth_spec,
         injection_base_url=uss.injection_base_url)
-      uss_injection_harness.submit_test(test_payloads[i], test_id)
+      uss_injection_harness.submit_test(test_payloads[i], test_id, report.setup)
+      for flight in test_payloads[i].requested_flights:
+        injected_flights.append(InjectedFlight(uss=uss, flight=flight))
 
-    # TODO: call display data evaluator to read RID system state and compare to expectations
+    # Evaluate observed RID system states
+    config = display_data_evaluator.EvaluationConfiguration()
+    #TODO: Accept user input describing desired observers
+    observer = display_data_evaluator.RIDSystemObserver(
+        'uss1', DSSTestSession(
+        observation_base_url,
+        make_auth_adapter('NoAuth()')))
+    display_data_evaluator.evaluate_system(injected_flights, [observer], config, report.findings)
+    with open('report.json', 'w') as f:
+      json.dump(report, f)

--- a/monitoring/rid_qualifier/utils.py
+++ b/monitoring/rid_qualifier/utils.py
@@ -9,7 +9,7 @@ from monitoring.rid_qualifier import injection_api
 
 class RIDQualifierUSSConfig(ImplicitDict):
     ''' This object defines the data required for a uss '''
-
+    name: str
     injection_base_url: str
 
 
@@ -70,3 +70,8 @@ class FullFlightRecord(ImplicitDict):
     reference_time: str
     states: List[RIDAircraftState]
     flight_details: FlightDetails
+
+
+class InjectedFlight(ImplicitDict):
+  uss: RIDQualifierUSSConfig
+  flight: injection_api.TestFlight


### PR DESCRIPTION
This PR adds a first draft of the part of rid_qualifier that observes an RID system and evaluates whether the data observed is consistent with the injected flight data.  It is primarily located in `display_data_evaluator.py`, called from `test_executor.py`.  A simple JSON-formatted report is generated as defined in `reports.py` tracking what data was injected into the system, what observations were made, and what issues were discovered.

A few utilities are improved to support these efforts, and the delays and default durations in rid_qualifier are reduced to support quicker development iteration.