### PR TITLE
[rid_qualifier]Accept JSON configuration as input

### DIFF
--- a/monitoring/rid_qualifier/aircraft_state_replayer.py
+++ b/monitoring/rid_qualifier/aircraft_state_replayer.py
@@ -27,7 +27,7 @@ class TestBuilder():
         aircraft_states_directory = Path('test_definitions', test_configuration.locale, 'aircraft_states')
         aircraft_state_files = self.get_aircraft_states(aircraft_states_directory)
 
-        usses = self.test_configuration.usses
+        usses = self.test_configuration.injection_targets
 
         self.disk_flight_records: List[FullFlightRecord] =[]
         for uss_index, uss in enumerate(usses):
@@ -54,8 +54,8 @@ class TestBuilder():
 
         all_test_payloads = [] # This holds the data that will be deilver
 
-        test_reference_time = arrow.get(self.test_configuration.now)
-        test_start_time = arrow.get(self.test_configuration.test_start_time)
+        test_reference_time = arrow.now()
+        test_start_time = test_reference_time + self.test_configuration.flight_start_delay.timedelta
         test_start_isoformat = test_start_time.isoformat()
 
         for state_data_index, flight_record in enumerate(self.disk_flight_records):

--- a/monitoring/rid_qualifier/display_data_evaluator.py
+++ b/monitoring/rid_qualifier/display_data_evaluator.py
@@ -8,22 +8,11 @@ import s2sphere
 
 from monitoring.monitorlib import fetch, geo, rid
 from monitoring.monitorlib.infrastructure import DSSTestSession
-from monitoring.monitorlib.typing import ImplicitDict, StringBasedTimeDelta
+from monitoring.monitorlib.typing import ImplicitDict
 from monitoring.rid_qualifier import observation_api
 from monitoring.rid_qualifier.reports import Findings
-from monitoring.rid_qualifier.utils import InjectedFlight
+from monitoring.rid_qualifier.utils import EvaluationConfiguration, InjectedFlight
 from monitoring.rid_qualifier.injection_api import TestFlight
-
-
-class EvaluationConfiguration(ImplicitDict):
-  min_polling_interval: Optional[StringBasedTimeDelta] = StringBasedTimeDelta(datetime.timedelta(seconds=5))
-  """Do not repeat system observations with intervals smaller than this."""
-
-  max_propagation_latency: Optional[StringBasedTimeDelta] = StringBasedTimeDelta(datetime.timedelta(seconds=10))
-  """Allow up to this much time for data to propagate through the system."""
-
-  min_query_diagonal: Optional[float] = 100
-  """Do not make queries with diagonals smaller than this many meters."""
 
 
 class RIDSystemObserver(object):

--- a/monitoring/rid_qualifier/reports.py
+++ b/monitoring/rid_qualifier/reports.py
@@ -5,7 +5,7 @@ import s2sphere
 
 from monitoring.monitorlib import fetch
 from monitoring.monitorlib.typing import ImplicitDict
-from monitoring.rid_qualifier.utils import InjectedFlight
+from monitoring.rid_qualifier.utils import InjectedFlight, RIDQualifierTestConfiguration
 
 
 class Severity(object):
@@ -66,6 +66,7 @@ class Issue(ImplicitDict):
 
 
 class Setup(ImplicitDict):
+  configuration: RIDQualifierTestConfiguration
   injections: List[fetch.Query] = []
 
 
@@ -175,5 +176,5 @@ class Findings(ImplicitDict):
 
 
 class Report(ImplicitDict):
-  setup: Setup = Setup()
+  setup: Setup
   findings: Findings = Findings()

--- a/monitoring/rid_qualifier/run_locally.sh
+++ b/monitoring/rid_qualifier/run_locally.sh
@@ -1,18 +1,47 @@
-
 #!/usr/bin/env bash
 
-AUTH='--auth=NoAuth()'
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../.." || exit 1
+
+CONFIG_LOCATION="monitoring/rid_qualifier/config.json"
+
+AUTH='--auth NoAuth()'
 # NB: A prerequisite to run this command locally is to have a running instance of the rid_qualifier/mock (/monitoring/rid_qualifier/mock/run_locally.sh)
 
-LOCALE='--locale=che'
+echo '{
+  "locale": "che",
+  "injection_targets": [
+    {
+      "name": "uss1",
+      "injection_base_url": "http://host.docker.internal:8070/sp/uss1"
+    },
+    {
+      "name": "uss2",
+      "injection_base_url": "http://host.docker.internal:8070/sp/uss2"
+    }
+  ],
+  "observers": [
+    {
+      "name": "uss2",
+      "observation_base_url": "http://host.docker.internal:8070/dp/uss2"
+    },
+    {
+      "name": "uss3",
+      "observation_base_url": "http://host.docker.internal:8070/dp/uss3"
+    }
+  ]
+}' > ${CONFIG_LOCATION}
 
-INJECTION_URL='--injection_base_url=http://host.docker.internal:8070/sp/uss1'
+CONFIG='--config config.json'
 
-OBSERVATION_URL='--observation_base_url=http://host.docker.internal:8070/dp/uss1'
-
-RID_QUALIFIER_OPTIONS="$AUTH $LOCALE $INJECTION_URL $OBSERVATION_URL"
-
-echo Reminder: must be run from root repo folder
+RID_QUALIFIER_OPTIONS="$AUTH $CONFIG"
 
 # report.json must already exist to share correctly with the Docker container
 touch $(pwd)/monitoring/rid_qualifier/report.json
@@ -29,5 +58,8 @@ docker run --name rid_qualifier \
   -e RID_QUALIFIER_OPTIONS="${RID_QUALIFIER_OPTIONS}" \
   -e PYTHONBUFFERED=1 \
   -v $(pwd)/monitoring/rid_qualifier/report.json:/app/monitoring/rid_qualifier/report.json \
+  -v $(pwd)/${CONFIG_LOCATION}:/app/${CONFIG_LOCATION} \
   interuss/dss/rid_qualifier \
   python rid_qualifier_entry.py $RID_QUALIFIER_OPTIONS
+
+rm ${CONFIG_LOCATION}

--- a/monitoring/rid_qualifier/test_executor.py
+++ b/monitoring/rid_qualifier/test_executor.py
@@ -1,55 +1,43 @@
 import json
 import uuid
+from typing import List
 from monitoring.rid_qualifier.aircraft_state_replayer import TestHarness, TestBuilder
 import arrow
-from monitoring.rid_qualifier.utils import RIDQualifierTestConfiguration, RIDQualifierUSSConfig, InjectedFlight
+from monitoring.rid_qualifier.utils import RIDQualifierTestConfiguration, InjectedFlight
 from monitoring.rid_qualifier import display_data_evaluator, reports
 from monitoring.monitorlib.infrastructure import DSSTestSession
 from monitoring.monitorlib.auth import make_auth_adapter
 
 
-def build_uss_config(injection_base_url:str) -> RIDQualifierUSSConfig:
-  return RIDQualifierUSSConfig(injection_base_url=injection_base_url, name='uss1')
-
-
-def build_test_configuration(locale: str, auth_spec:str, uss_config:RIDQualifierUSSConfig) -> RIDQualifierTestConfiguration:
-    now = arrow.now()
-    test_start_time = now.shift(seconds=15)
-
-    test_config = RIDQualifierTestConfiguration(
-      locale = locale,
-      now = now.isoformat(),
-      test_start_time = test_start_time.isoformat(),
-      auth_spec = auth_spec,
-      usses = [uss_config]
-    )
-
-    return test_config
-
-def main(test_configuration: RIDQualifierTestConfiguration, observation_base_url: str):
+def main(test_configuration: RIDQualifierTestConfiguration, auth_spec: str):
     # This is the configuration for the test.
     my_test_builder = TestBuilder(test_configuration = test_configuration)
     test_payloads = my_test_builder.build_test_payloads()
     test_id = str(uuid.uuid4())
-    report = reports.Report()
+    report = reports.Report(setup=reports.Setup(configuration=test_configuration))
 
     # Inject flights into all USSs
     injected_flights = []
-    for i, uss in enumerate(test_configuration.usses):
+    for i, target in enumerate(test_configuration.injection_targets):
       uss_injection_harness = TestHarness(
-        auth_spec=test_configuration.auth_spec,
-        injection_base_url=uss.injection_base_url)
+        auth_spec=auth_spec,
+        injection_base_url=target.injection_base_url)
       uss_injection_harness.submit_test(test_payloads[i], test_id, report.setup)
       for flight in test_payloads[i].requested_flights:
-        injected_flights.append(InjectedFlight(uss=uss, flight=flight))
+        injected_flights.append(InjectedFlight(uss=target, flight=flight))
+
+    # Create observers
+    observers: List[display_data_evaluator.RIDSystemObserver] = []
+    for observer_config in test_configuration.observers:
+        observer = display_data_evaluator.RIDSystemObserver(
+            observer_config.name, DSSTestSession(
+                observer_config.observation_base_url,
+                make_auth_adapter(auth_spec)))
+        observers.append(observer)
 
     # Evaluate observed RID system states
-    config = display_data_evaluator.EvaluationConfiguration()
-    #TODO: Accept user input describing desired observers
-    observer = display_data_evaluator.RIDSystemObserver(
-        'uss1', DSSTestSession(
-        observation_base_url,
-        make_auth_adapter('NoAuth()')))
-    display_data_evaluator.evaluate_system(injected_flights, [observer], config, report.findings)
+    display_data_evaluator.evaluate_system(
+        injected_flights, observers, test_configuration.evaluation,
+        report.findings)
     with open('report.json', 'w') as f:
-      json.dump(report, f)
+        json.dump(report, f)

--- a/monitoring/rid_qualifier/test_executor.py
+++ b/monitoring/rid_qualifier/test_executor.py
@@ -2,7 +2,6 @@ import json
 import uuid
 from typing import List
 from monitoring.rid_qualifier.aircraft_state_replayer import TestHarness, TestBuilder
-import arrow
 from monitoring.rid_qualifier.utils import RIDQualifierTestConfiguration, InjectedFlight
 from monitoring.rid_qualifier import display_data_evaluator, reports
 from monitoring.monitorlib.infrastructure import DSSTestSession

--- a/monitoring/rid_qualifier/utils.py
+++ b/monitoring/rid_qualifier/utils.py
@@ -3,24 +3,50 @@ from shapely.geometry import Polygon
 import shapely.geometry
 from datetime import datetime
 from monitoring.monitorlib.rid import RIDAircraftState, RIDFlightDetails
-from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.monitorlib.typing import ImplicitDict, StringBasedTimeDelta
 from monitoring.rid_qualifier import injection_api
 
 
-class RIDQualifierUSSConfig(ImplicitDict):
+class InjectionTargetConfiguration(ImplicitDict):
     ''' This object defines the data required for a uss '''
     name: str
     injection_base_url: str
 
 
-class RIDQualifierTestConfiguration(ImplicitDict):
-    ''' This is the object that defines the test configuration for a RID Qualifier '''
+class ObserverConfiguration(ImplicitDict):
+    name: str
+    observation_base_url: str
 
-    locale: str  # The locale here is indicating the geographical location in ISO3166 3-letter country code and also a folder within the test definitions directory. The aircraft_state_replayer reads flight track information from the locale/aircraft_states directory.  The locale directory also contains information about the query_bboxes that the rid display provider will use to query and retrieve the flight information.
-    now: str
-    test_start_time: str
-    auth_spec: str
-    usses: List[RIDQualifierUSSConfig]
+
+class EvaluationConfiguration(ImplicitDict):
+    min_polling_interval: StringBasedTimeDelta = StringBasedTimeDelta('5s')
+    """Do not repeat system observations with intervals smaller than this."""
+
+    max_propagation_latency: StringBasedTimeDelta = StringBasedTimeDelta('10s')
+    """Allow up to this much time for data to propagate through the system."""
+
+    min_query_diagonal: float = 100
+    """Do not make queries with diagonals smaller than this many meters."""
+
+
+class RIDQualifierTestConfiguration(ImplicitDict):
+    locale: str
+    """A three letter ISO 3166 country code to run the qualifier against.
+
+    This should be the same one used to simulate the flight_data in
+    the flight_data_generator.py module."""
+
+    injection_targets: List[InjectionTargetConfiguration]
+    """Set of Service Providers into which data should be injected"""
+
+    observers: List[ObserverConfiguration]
+    """Set of Display Providers through with the system should be observed"""
+
+    flight_start_delay: StringBasedTimeDelta = StringBasedTimeDelta('15s')
+    """Amount of time between starting the test and commencement of flights"""
+
+    evaluation: EvaluationConfiguration = EvaluationConfiguration()
+    """Settings to control behavior when evaluating observed system data"""
 
 
 class QueryBoundingBox(NamedTuple):
@@ -48,17 +74,6 @@ class GridCellFlight(NamedTuple):
     track: List[FlightPoint]
 
 
-class RIDSP(NamedTuple):
-
-    ''' This is the object that stores details of a USS, mainly it will hold the injection endpoint and details of the flights allocated to the USS and their submissiion status '''
-
-    test_id: str
-    name: str
-    flight_id: int
-    rid_state_injection_url: str
-    rid_state_submission_status: bool
-
-
 class FlightDetails(ImplicitDict):
     ''' This object stores the metadata associated with generated flight, this data is shared as information in the remote id call '''
     rid_details: RIDFlightDetails
@@ -73,5 +88,5 @@ class FullFlightRecord(ImplicitDict):
 
 
 class InjectedFlight(ImplicitDict):
-  uss: RIDQualifierUSSConfig
-  flight: injection_api.TestFlight
+    uss: InjectionTargetConfiguration
+    flight: injection_api.TestFlight


### PR DESCRIPTION
This PR enables rid_qualifier to accept a single JSON-based configuration description (`RIDQualifierTestConfiguration`) for its test(s), which fills in the gaps of allowing the user to specify various parameters that were previously hard-coded.

`run_locally.sh` is updated to demonstrate how this configuration is provided, and also includes a multi-injection-target, multi-observer test, and is also adjusted so that it no longer needs to be run from a specific working directory.

The `auth_spec` is kept separate from the configuration because it often contains sensitive data (e.g., passwords) that would be insecure to store along side other configuration data.