### PR TITLE
[mock_ridsp] Add skeleton mock RID SP

### DIFF
--- a/monitoring/mock_ridsp/Dockerfile
+++ b/monitoring/mock_ridsp/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.8
+# Not -alpine because: https://stackoverflow.com/a/58028091/651139
+# `docker build` should be run from `monitoring` (the parent folder of this folder)
+RUN apt-get update && apt-get install openssl && apt-get install ca-certificates
+RUN mkdir -p /app/monitoring/monitorlib
+RUN mkdir /app/monitoring/mock_ridsp
+COPY monitorlib/requirements.txt /app/monitoring/monitorlib/requirements.txt
+COPY mock_ridsp/requirements.txt /app/monitoring/mock_ridsp/requirements.txt
+WORKDIR /app/monitoring/mock_ridsp
+RUN pip install -r requirements.txt
+RUN rm -rf __pycache__
+ADD . /app/monitoring
+ENV PYTHONPATH /app
+ARG version
+ENV CODE_VERSION=$version
+
+ENTRYPOINT []

--- a/monitoring/mock_ridsp/README.md
+++ b/monitoring/mock_ridsp/README.md
@@ -1,0 +1,7 @@
+`mock_ridsp` is a mock Remote ID Service Provider implementation.  It provides a
+development-level web server that responds to requests to the USS endpoints
+defined in the ASTM remote ID standard in a standards-compliant manner.
+
+While responses for flights are currently no-ops, future development will add
+the ability to inject flight data using the
+[RID automated testing injection interface](../../interfaces/automated-testing/rid/README.md).

--- a/monitoring/mock_ridsp/__init__.py
+++ b/monitoring/mock_ridsp/__init__.py
@@ -1,0 +1,9 @@
+import flask
+
+from .config import Config
+
+webapp = flask.Flask(__name__)
+
+webapp.config.from_object(Config)
+
+from monitoring.mock_ridsp import routes

--- a/monitoring/mock_ridsp/auth.py
+++ b/monitoring/mock_ridsp/auth.py
@@ -1,0 +1,8 @@
+from monitoring.monitorlib import auth_validation
+from monitoring.mock_ridsp import webapp
+from . import config
+
+
+requires_scope = auth_validation.requires_scope_decorator(
+  webapp.config.get(config.KEY_TOKEN_PUBLIC_KEY),
+  webapp.config.get(config.KEY_TOKEN_AUDIENCE))

--- a/monitoring/mock_ridsp/config.py
+++ b/monitoring/mock_ridsp/config.py
@@ -1,0 +1,30 @@
+import os
+
+from monitoring.monitorlib import auth_validation
+
+
+ENV_KEY_PREFIX = 'MOCK_RIDSP'
+ENV_KEY_PUBLIC_KEY = '{}_PUBLIC_KEY'.format(ENV_KEY_PREFIX)
+ENV_KEY_TOKEN_AUDIENCE = '{}_TOKEN_AUDIENCE'.format(ENV_KEY_PREFIX)
+ENV_KEY_BASE_URL = '{}_BASE_URL'.format(ENV_KEY_PREFIX)
+ENV_KEY_AUTH = '{}_AUTH_SPEC'.format(ENV_KEY_PREFIX)
+ENV_KEY_DSS = '{}_DSS_URL'.format(ENV_KEY_PREFIX)
+
+# These keys map to entries in the Config class
+KEY_TOKEN_PUBLIC_KEY = 'TOKEN_PUBLIC_KEY'
+KEY_TOKEN_AUDIENCE = 'TOKEN_AUDIENCE'
+KEY_BASE_URL = 'USS_BASE_URL'
+KEY_AUTH_SPEC = 'AUTH_SPEC'
+KEY_DSS_URL = 'DSS_URL'
+
+
+workspace_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'workspace')
+
+
+class Config(object):
+  TOKEN_PUBLIC_KEY = auth_validation.fix_key(
+    os.environ.get(ENV_KEY_PUBLIC_KEY, '')).encode('utf-8')
+  TOKEN_AUDIENCE = os.environ.get(ENV_KEY_TOKEN_AUDIENCE, '')
+  USS_BASE_URL = os.environ[ENV_KEY_BASE_URL]
+  AUTH_SPEC = os.environ[ENV_KEY_AUTH]
+  DSS_URL = os.environ[ENV_KEY_DSS]

--- a/monitoring/mock_ridsp/mockuss.py
+++ b/monitoring/mock_ridsp/mockuss.py
@@ -1,0 +1,12 @@
+import sys
+
+from monitoring.mock_ridsp import webapp
+
+
+def main(argv):
+  del argv
+  webapp.run(host='localhost', port=8071)
+
+
+if __name__ == '__main__':
+  main(sys.argv)

--- a/monitoring/mock_ridsp/requirements.txt
+++ b/monitoring/mock_ridsp/requirements.txt
@@ -1,0 +1,4 @@
+flask==1.1.2
+gunicorn==20.0.4
+pyopenssl
+-r ../monitorlib/requirements.txt

--- a/monitoring/mock_ridsp/routes.py
+++ b/monitoring/mock_ridsp/routes.py
@@ -1,0 +1,31 @@
+import flask
+from werkzeug.exceptions import HTTPException
+
+from monitoring.monitorlib import versioning, auth_validation
+from monitoring.mock_ridsp import webapp
+
+
+@webapp.route('/status')
+def status():
+  return 'Mock RID Service Provider ok {}'.format(versioning.get_code_version())
+
+
+@webapp.errorhandler(Exception)
+def handle_exception(e):
+  if isinstance(e, HTTPException):
+    return e
+  elif isinstance(e, auth_validation.InvalidScopeError):
+    return flask.jsonify({
+      'message': 'Invalid scope; expected one of {%s}, but received only {%s}' % (' '.join(e.permitted_scopes),
+                                                                                  ' '.join(e.provided_scopes))}), 403
+  elif isinstance(e, auth_validation.InvalidAccessTokenError):
+    return flask.jsonify({'message': e.message}), 401
+  elif isinstance(e, auth_validation.ConfigurationError):
+    return flask.jsonify({'message': e.message}), 500
+  elif isinstance(e, ValueError):
+    return flask.jsonify({'message': str(e)}), 400
+
+  return flask.jsonify({'message': str(e)}), 500
+
+
+from . import routes_ridsp

--- a/monitoring/mock_ridsp/routes_ridsp.py
+++ b/monitoring/mock_ridsp/routes_ridsp.py
@@ -1,0 +1,30 @@
+import datetime
+
+import flask
+
+from monitoring.monitorlib import rid
+from monitoring.mock_ridsp import webapp
+from monitoring.mock_ridsp.auth import requires_scope
+
+
+@webapp.route('/v1/uss/identification_service_areas/<id>', methods=['POST'])
+@requires_scope([rid.SCOPE_WRITE])
+def notify_isa(id: str):
+  return 'Notification acknowledged', 204
+
+
+@webapp.route('/v1/uss/flights', methods=['GET'])
+@requires_scope([rid.SCOPE_READ])
+def flights():
+  return flask.jsonify({
+    'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
+    'flights': []
+  })
+
+
+@webapp.route('/v1/uss/flights/<id>/details', methods=['GET'])
+@requires_scope([rid.SCOPE_READ])
+def flight_details(id: str):
+  return flask.jsonify({
+    'message': 'Flight {} not found'.format(id),
+  }), 404

--- a/monitoring/mock_ridsp/run_locally.sh
+++ b/monitoring/mock_ridsp/run_locally.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../.." || exit 1
+
+# This sample assumes that a local DSS instance is available similar to the one
+# produced with /build/dev/run_locally.sh
+AUTH="DummyOAuth(http://host.docker.internal:8085/token,uss1)"
+DSS="http://host.docker.internal:8082"
+PUBLIC_KEY="/var/test-certs/auth2.pem"
+AUD="host.docker.internal"
+BASE_URL="http://host.docker.internal:8071"
+PORT=8071
+
+docker build \
+  -t local-interuss/mock_ridsp \
+  -f monitoring/mock_ridsp/Dockerfile \
+  --build-arg version=`scripts/git/commit.sh` \
+  monitoring \
+  || exit 1
+
+docker run --name mock_ridsp \
+  --rm \
+  -e MOCK_RIDSP_AUTH_SPEC="${AUTH}" \
+  -e MOCK_RIDSP_DSS_URL="${DSS}" \
+  -e MOCK_RIDSP_PUBLIC_KEY="${PUBLIC_KEY}" \
+  -e MOCK_RIDSP_TOKEN_AUDIENCE="${AUD}" \
+  -e MOCK_RIDSP_BASE_URL="${BASE_URL}" \
+  -p ${PORT}:5000 \
+  -v `pwd`/build/test-certs:/var/test-certs:ro \
+  local-interuss/mock_ridsp \
+  gunicorn \
+    --preload \
+    --workers=2 \
+    --bind=0.0.0.0:5000 \
+    monitoring.mock_ridsp:webapp

--- a/monitoring/monitorlib/auth_validation.py
+++ b/monitoring/monitorlib/auth_validation.py
@@ -1,0 +1,114 @@
+import json
+from typing import List, NamedTuple
+from functools import wraps
+
+import flask
+import jwcrypto.jwk
+import jwt
+import requests
+
+
+class Authorization(NamedTuple):
+  client_id: str
+  scopes: List[str]
+  issuer: str
+
+
+class InvalidScopeError(Exception):
+  def __init__(self, permitted_scopes, provided_scopes):
+    self.permitted_scopes = permitted_scopes
+    self.provided_scopes = provided_scopes
+
+
+class InvalidAccessTokenError(Exception):
+  def __init__(self, message):
+    self.message = message
+
+
+class ConfigurationError(Exception):
+  def __init__(self, message):
+    self.message = message
+
+
+def requires_scope_decorator(public_key: str, audience: str):
+  """Function that produces a decorator to protect a Flask endpoint.
+
+  If you decorate an endpoint with a decorator produced by this function, it
+  will ensure that the requester has a valid access token with the required
+  scope before allowing the endpoint to be called.
+  """
+  def decorator(permitted_scopes):
+    def outer_wrapper(fn):
+      @wraps(fn)
+      def wrapper(*args, **kwargs):
+        if hasattr(flask.request, 'jwt'):
+          # Token has already been processed; check additional scope
+          has_scope = False
+          for scope in permitted_scopes:
+            if scope in flask.request.jwt.scopes:
+              has_scope = True
+              break
+          if not has_scope:
+            raise InvalidScopeError(permitted_scopes, flask.request.jwt.scopes)
+        else:
+          # Token has not yet been processed; process it
+          token = flask.request.headers.get('Authorization', None)
+          if token is None:
+            raise InvalidAccessTokenError('Missing Authorization header')
+          token = token.replace('Bearer ', '')
+          try:
+            if not public_key:
+              raise ConfigurationError('Public key for access tokens is not configured on server')
+            if not audience:
+              raise ConfigurationError('Audience for access tokens is not configured on server')
+            r = jwt.decode(token, public_key, algorithms='RS256', audience=audience)
+            provided_scopes = r['scope'].split(' ')
+            has_scope = False
+            for scope in permitted_scopes:
+              if scope in provided_scopes:
+                has_scope = True
+                break
+            if not has_scope:
+              raise InvalidScopeError(permitted_scopes, provided_scopes)
+            client_id = r['client_id'] if 'client_id' in r else r.get('sub', None)
+          except jwt.ImmatureSignatureError:
+            raise InvalidAccessTokenError('Access token is immature.')
+          except jwt.ExpiredSignatureError:
+            raise InvalidAccessTokenError('Access token has expired.')
+          except jwt.InvalidSignatureError:
+            raise InvalidAccessTokenError('Access token signature is invalid.')
+          except jwt.DecodeError:
+            raise InvalidAccessTokenError('Access token cannot be decoded.')
+          except jwt.InvalidTokenError as e:
+            raise InvalidAccessTokenError('Unexpected InvalidTokenError: %s' % str(e))
+          issuer = r.get('iss', None)
+          flask.request.jwt = Authorization(client_id, provided_scopes, issuer)
+
+        return fn(*args, **kwargs)
+      return wrapper
+    return outer_wrapper
+  return decorator
+
+
+def fix_key(public_key: str) -> str:
+  """Convert a user-specified public key into a properly-formatted PEM string"""
+
+  if public_key.startswith('http://') or public_key.startswith('https://'):
+    resp = requests.get(public_key)
+    if public_key.endswith('.json'):
+      key = resp.json()
+      if 'keys' in key:
+        key = key['keys'][0]
+      jwk = jwcrypto.jwk.JWK.from_json(json.dumps(key))
+      public_key = jwk.export_to_pem().decode('utf-8')
+    else:
+      public_key = resp.content.decode('utf-8')
+  elif public_key.startswith('/') or public_key.endswith(('.pem')):
+    with open(public_key, 'r') as f:
+      public_key = f.read()
+  # ENV variables sometimes don't pass newlines, spec says white space
+  # doesn't matter, but pyjwt cares about it, so fix it
+  public_key = public_key.replace(' PUBLIC ', '_PLACEHOLDER_')
+  public_key = public_key.replace(' ', '\n')
+  public_key = public_key.replace('_PLACEHOLDER_', ' PUBLIC ')
+  return public_key


### PR DESCRIPTION
This PR adds the start of a mock remote ID service provider.  While it currently only responds to endpoints with trivial hard-coded responses, the intent is to enhance it in later PRs to accept injected test data and properly report that data (including interacting with the DSS when appropriate).