### PR TITLE
[mock_ridsp] Implement ISA insertion into DSS

### DIFF
--- a/monitoring/mock_ridsp/database.py
+++ b/monitoring/mock_ridsp/database.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from monitoring.monitorlib.rid_automated_testing import injection_api
 
@@ -7,6 +7,7 @@ class TestRecord(object):
   """Representation of RID SP's record of a set of injected test flights"""
   version: str
   flights: List[injection_api.TestFlight]
+  isa_version: Optional[str] = None
 
   def __init__(self, version: str, flights: List[injection_api.TestFlight]):
     flights = [injection_api.TestFlight(**flight) for flight in flights]

--- a/monitoring/mock_ridsp/resources.py
+++ b/monitoring/mock_ridsp/resources.py
@@ -1,0 +1,8 @@
+from monitoring.monitorlib import auth, infrastructure
+from monitoring.mock_ridsp import webapp
+from . import config
+
+
+dss_client = infrastructure.DSSTestSession(
+  webapp.config.get(config.KEY_DSS_URL),
+  auth.make_auth_adapter(webapp.config.get(config.KEY_AUTH_SPEC)))

--- a/monitoring/mock_ridsp/routes_injection.py
+++ b/monitoring/mock_ridsp/routes_injection.py
@@ -3,11 +3,13 @@ import uuid
 
 import flask
 
+from monitoring.monitorlib import rid
+from monitoring.monitorlib.mutate import rid as mutate
 from monitoring.monitorlib.rid_automated_testing import injection_api
 from monitoring.monitorlib.typing import ImplicitDict
 from monitoring.mock_ridsp import webapp
 from monitoring.mock_ridsp.auth import requires_scope
-from . import database
+from . import config, database, resources
 from .database import db
 
 
@@ -22,13 +24,27 @@ def create_test(test_id: str) -> Tuple[str, int]:
       raise ValueError('Request did not contain a JSON payload')
     req_body: injection_api.CreateTestParameters = ImplicitDict.parse(json, injection_api.CreateTestParameters)
     record = database.TestRecord(version=str(uuid.uuid4()), flights=req_body.requested_flights)
-    #TODO: Create ISA in DSS
-    db.tests[test_id] = record
-
-    return flask.jsonify(injection_api.ChangeTestResponse(version=record.version, injected_flights=record.flights))
   except ValueError as e:
     msg = 'Create test {} unable to parse JSON: {}'.format(test_id, e)
     return msg, 400
+
+  # Create ISA in DSS
+  (t0, t1) = req_body.get_span()
+  rect = req_body.get_rect()
+  flights_url = '{}/v1/uss/flights'.format(webapp.config.get(config.KEY_BASE_URL))
+  mutated_isa = mutate.put_isa(resources.dss_client, rect, t0, t1, flights_url, record.version)
+  if not mutated_isa.dss_response.success:
+    response = rid.ErrorResponse(message='Unable to create ISA in DSS')
+    response['errors'] = mutated_isa.dss_response.errors
+    return flask.jsonify(response), 412
+  record.isa_version = mutated_isa.dss_response.isa.version
+  for (url, notification) in mutated_isa.notifications.items():
+    code = notification.response.status_code
+    if code != 204 and code != 200:
+      pass #TODO: Log notification failures (maybe also log incorrect 200s)
+
+  db.tests[test_id] = record
+  return flask.jsonify(injection_api.ChangeTestResponse(version=record.version, injected_flights=record.flights))
 
 
 @webapp.route('/injection/tests/<test_id>', methods=['DELETE'])
@@ -40,6 +56,17 @@ def delete_test(test_id: str) -> Tuple[str, int]:
     return 'Test "{}" not found'.format(test_id), 404
 
   record = db.tests[test_id]
-  #TODO: Delete ISA in DSS
+
+  # Delete ISA from DSS
+  deleted_isa = mutate.delete_isa(resources.dss_client, record.version, record.isa_version)
+  if not deleted_isa.dss_response.success:
+    response = rid.ErrorResponse(message='Unable to delete ISA from DSS')
+    response['errors'] = deleted_isa.dss_response.errors
+    return flask.jsonify(response), 412
+  for (url, notification) in deleted_isa.notifications.items():
+    code = notification.response.status_code
+    if code != 204 and code != 200:
+      pass #TODO: Log notification failures (maybe also log incorrect 200s)
+
   del db.tests[test_id]
   return flask.jsonify(injection_api.ChangeTestResponse(version=record.version, injected_flights=record.flights))

--- a/monitoring/monitorlib/geo.py
+++ b/monitoring/monitorlib/geo.py
@@ -1,5 +1,5 @@
 import math
-from typing import Tuple
+from typing import List, Tuple
 import s2sphere
 
 
@@ -54,3 +54,18 @@ def unflatten(reference: s2sphere.LatLng, point: Tuple[float, float]) -> s2spher
 def area_of_latlngrect(rect: s2sphere.LatLngRect) -> float:
   """Compute the approximate surface area within a lat-lng rectangle."""
   return EARTH_AREA_M2 * rect.area() / (4 * math.pi)
+
+
+def bounding_rect(latlngs: List[Tuple[float, float]]) -> s2sphere.LatLngRect:
+  lat_min = 90
+  lat_max = -90
+  lng_min = 360
+  lng_max = -360
+  for (lat, lng) in latlngs:
+    lat_min = min(lat_min, lat)
+    lat_max = max(lat_max, lat)
+    lng_min = min(lng_min, lng)
+    lng_max = max(lng_max, lng)
+  return s2sphere.LatLngRect.from_point_pair(
+    s2sphere.LatLng.from_degrees(lat_min, lng_min),
+    s2sphere.LatLng.from_degrees(lat_max, lng_max))

--- a/monitoring/monitorlib/mutate/rid.py
+++ b/monitoring/monitorlib/mutate/rid.py
@@ -1,12 +1,12 @@
 import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import s2sphere
 import yaml
 from yaml.representer import Representer
 
-from monitoring.monitorlib import infrastructure, rid
-from monitoring.monitorlib import fetch
+from monitoring.monitorlib import fetch, infrastructure, rid
+from monitoring.monitorlib.typing import ImplicitDict
 
 
 class MutatedSubscription(fetch.Query):
@@ -80,3 +80,126 @@ def delete_subscription(utm_client: infrastructure.DSSTestSession,
     utm_client, 'DELETE', url, scope=rid.SCOPE_READ))
   result['mutation'] = 'delete'
   return result
+
+
+class MutatedISAResponse(fetch.Query):
+  """Response to a call to the DSS to mutate an ISA"""
+  @property
+  def success(self) -> bool:
+    return not self.errors
+
+  @property
+  def errors(self) -> List[str]:
+    if self.status_code != 200:
+      return ['Failed to {} RID ISA ({})'.format(self.mutation, self.status_code)]
+    if self.json_result is None:
+      return ['Response did not contain valid JSON']
+    try:
+      _ = self.isa
+    except ValueError as e:
+      return ['Response returned an invalid ISA: {}'.format(e)]
+
+  @property
+  def isa(self) -> rid.IdentificationServiceArea:
+    if self.json_result is None:
+      raise ValueError('No JSON result present in response from DSS')
+    isa_dict = self.json_result.get('service_area', None)
+    if not isa_dict:
+      raise ValueError('No `service_area` field present in response from DSS')
+    return rid.IdentificationServiceArea(isa_dict)
+
+  @property
+  def subscribers(self) -> List[rid.SubscriberToNotify]:
+    if self.json_result is None:
+      raise ValueError('No JSON result present in response from DSS')
+    subs = self.json_result.get('subscribers', None)
+    if not subs:
+      return []
+    return [rid.SubscriberToNotify(sub) for sub in subs]
+
+  @property
+  def mutation(self) -> str:
+    return self['mutation']
+yaml.add_representer(MutatedISAResponse, Representer.represent_dict)
+
+
+class MutatedISA(ImplicitDict):
+  """Result of an attempt to mutate an ISA (including DSS & notifications)"""
+  dss_response: MutatedISAResponse
+  notifications: Dict[str, fetch.Query]
+
+
+def put_isa(utm_client: infrastructure.DSSTestSession,
+            area: s2sphere.LatLngRect,
+            start_time: datetime.datetime,
+            end_time: datetime.datetime,
+            flights_url: str,
+            entity_id: str,
+            isa_version: Optional[str]=None) -> MutatedISA:
+  extents = {
+    'spatial_volume': {
+      'footprint': {
+        'vertices': rid.vertices_from_latlng_rect(area)
+      },
+      'altitude_lo': 0,
+      'altitude_hi': 3048,
+    },
+    'time_start': start_time.strftime(rid.DATE_FORMAT),
+    'time_end': end_time.strftime(rid.DATE_FORMAT),
+  }
+  body = {
+    'extents': extents,
+    'flights_url': flights_url,
+  }
+  if isa_version is None:
+    url = '/v1/dss/identification_service_areas/{}'.format(entity_id)
+  else:
+    url = '/v1/dss/identification_service_areas/{}/{}'.format(entity_id, isa_version)
+  dss_response = MutatedISAResponse(fetch.query_and_describe(
+    utm_client, 'PUT', url, json=body, scope=rid.SCOPE_WRITE))
+  dss_response['mutation'] = 'create' if isa_version is None else 'update'
+
+  # Notify subscribers
+  notifications: Dict[str, fetch.Query] = {}
+  try:
+    subscribers = dss_response.subscribers
+    isa = dss_response.isa
+  except ValueError:
+    subscribers = []
+    isa = None
+  for subscriber in subscribers:
+    body = {
+      'service_area': isa,
+      'subscriptions': subscriber.subscriptions,
+      'extents': extents
+    }
+    url = '{}/{}'.format(subscriber.url, entity_id)
+    notifications[subscriber.url] = fetch.query_and_describe(
+      utm_client, 'POST', url, json=body, scope=rid.SCOPE_WRITE)
+
+  return MutatedISA(dss_response=dss_response, notifications=notifications)
+
+
+def delete_isa(utm_client: infrastructure.DSSTestSession,
+               entity_id: str,
+               isa_version: str) -> MutatedISA:
+  url = '/v1/dss/identification_service_areas/{}/{}'.format(entity_id, isa_version)
+  dss_response = MutatedISAResponse(fetch.query_and_describe(
+    utm_client, 'DELETE', url, scope=rid.SCOPE_WRITE))
+  dss_response['mutation'] = 'delete'
+
+  # Notify subscribers
+  notifications: Dict[str, fetch.Query] = {}
+  try:
+    subscribers = dss_response.subscribers
+  except ValueError:
+    subscribers = []
+  for subscriber in subscribers:
+    body = {
+      'subscriptions': subscriber.subscriptions
+    }
+    url = '{}/{}'.format(subscriber.url, entity_id)
+    notifications[subscriber.url] = fetch.query_and_describe(
+      utm_client, 'POST', url, json=body, scope=rid.SCOPE_WRITE)
+
+  return MutatedISA(dss_response=dss_response, notifications=notifications)

--- a/monitoring/monitorlib/rid.py
+++ b/monitoring/monitorlib/rid.py
@@ -157,3 +157,22 @@ class GetFlightDetailsResponse(ImplicitDict):
 class GetFlightsResponse(ImplicitDict):
   timestamp: StringBasedDateTime
   flights: List[RIDFlight]
+
+
+class IdentificationServiceArea(ImplicitDict):
+  flights_url: str
+  owner: str
+  time_start: StringBasedDateTime
+  time_end: StringBasedDateTime
+  version: str
+  id: str
+
+
+class SubscriptionState(ImplicitDict):
+  subscription_id: str
+  notification_index: int = 0
+
+
+class SubscriberToNotify(ImplicitDict):
+  subscriptions: List[SubscriptionState] = []
+  url: str


### PR DESCRIPTION
This PR improves mock_ridsp to insert an ISA into the DSS for each injected test, and then delete that ISA when the test is deleted.

After this PR is submitted, mock_ridsp should behave as a complete RID Service Provider, capable of interacting with a standard RID Display Provider.