### PR TITLE
Add script to run flight_data_generator of rid_qualifier in the docker container

### DIFF
--- a/monitoring/rid_qualifier/run_flight_data_generator.sh
+++ b/monitoring/rid_qualifier/run_flight_data_generator.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../.." || exit 1
+
+docker build \
+    -f monitoring/rid_qualifier/Dockerfile \
+    -t interuss/dss/rid_qualifier \
+    --build-arg version=`scripts/git/commit.sh` \
+    monitoring
+
+docker run -i -t --name flight_data_generator \
+  --rm \
+  --tty \
+  -e PYTHONBUFFERED=1 \
+  -v $(pwd)/monitoring/rid_qualifier/test_definitions:/app/test_definitions \
+  interuss/dss/rid_qualifier \
+  python flight_data_generator.py


### PR DESCRIPTION
This PR adds a script to run flight_data_generator.py in the docker container. It allows a developer to generate the initial test dataset without installing the python dependencies on his local host.