### PR TITLE
[prober] Add API-dependence tool for prober tests

### DIFF
--- a/monitoring/monitorlib/scd.py
+++ b/monitoring/monitorlib/scd.py
@@ -7,6 +7,8 @@ import s2sphere
 TIME_FORMAT_CODE = 'RFC3339'
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 EARTH_CIRCUMFERENCE_M = 40.075e6
+
+API_0_3_5 = '0.3.5'
 SCOPE_SC = 'utm.strategic_coordination'
 SCOPE_CM = 'utm.constraint_management'
 SCOPE_CI = 'utm.constraint_consumption'

--- a/monitoring/prober/conftest.py
+++ b/monitoring/prober/conftest.py
@@ -1,7 +1,8 @@
 from typing import Optional
 
 from monitoring.monitorlib import infrastructure
-from monitoring.monitorlib import auth
+from monitoring.monitorlib import auth, scd
+from monitoring.prober.infrastructure import VersionString
 
 import pytest
 
@@ -12,6 +13,7 @@ def pytest_addoption(parser):
   parser.addoption('--rid-auth')
   parser.addoption('--scd-auth1')
   parser.addoption('--scd-auth2')
+  parser.addoption('--scd-api-version')
 
 
 def make_session(pytestconfig, endpoint_suffix: str, auth_option: Optional[str] = None) -> Optional[infrastructure.DSSTestSession]:
@@ -53,3 +55,10 @@ def scd_session2(pytestconfig):
 @pytest.fixture(scope='function')
 def no_auth_session(pytestconfig):
   return make_session(pytestconfig, '/v1/dss')
+
+@pytest.fixture(scope='session')
+def scd_api(pytestconfig):
+  api = pytestconfig.getoption('scd_api_version')
+  if api is None:
+    api = scd.API_0_3_5
+  return VersionString(api)

--- a/monitoring/prober/infrastructure.py
+++ b/monitoring/prober/infrastructure.py
@@ -1,0 +1,43 @@
+import functools
+
+import pytest
+
+
+class VersionString(str):
+  pass
+
+
+def for_api_versions(*args):
+  """Test decorator that checks if API version being tested applies to the test.
+
+  A test function decorated with this decorator must include an argument that
+  matches a fixture which takes on a VersionString value.  If that VersionString
+  value matches any of the values specified in this decorator, the test will
+  proceed normally.  If it does not match any of the values specified in this
+  decorator, the test will be skipped.
+
+  :param args: List of API versions for which the decorated test should be run.
+  """
+  def decorator_default_scope(func):
+    acceptable_versions = args
+    @functools.wraps(func)
+    def wrapper_default_scope(*args, **kwargs):
+      api_version = None
+      for arg in args:
+        if isinstance(arg, VersionString):
+          api_version = arg
+          break
+      for key, value in kwargs.items():
+        if isinstance(value, VersionString):
+          api_version = value
+          break
+
+      if api_version is None:
+        raise ValueError('A test with the @for_api_versions decorator must include, in its arguments, a fixture populated with a VersionString value (for instance: scd_api)')
+      if api_version in acceptable_versions:
+        return func(*args, **kwargs)
+      else:
+        pytest.skip('Not applicable for API version {}'.format(api_version))
+
+    return wrapper_default_scope
+  return decorator_default_scope

--- a/monitoring/prober/scd/test_operation_simple.py
+++ b/monitoring/prober/scd/test_operation_simple.py
@@ -14,13 +14,15 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC, SCOPE_CI, SCOPE_CM
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
+from monitoring.prober.infrastructure import for_api_versions
 
 
 BASE_URL = 'https://example.com/uss'
 OP_ID = '0000008c-91c8-4afc-927d-d923f5000000'
 
 
-def test_ensure_clean_workspace(scd_session):
+@for_api_versions(scd.API_0_3_5)
+def test_ensure_clean_workspace(scd_api, scd_session):
   resp = scd_session.get('/operation_references/{}'.format(OP_ID), scope=SCOPE_SC)
   if resp.status_code == 200:
     resp = scd_session.delete('/operation_references/{}'.format(OP_ID), scope=SCOPE_SC)
@@ -49,16 +51,18 @@ def _make_op1_request():
 
 # Preconditions: None
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_op_does_not_exist_get(scd_session):
+def test_op_does_not_exist_get(scd_api, scd_session):
   resp = scd_session.get('/operation_references/{}'.format(OP_ID))
   assert resp.status_code == 404, resp.content
 
 
 # Preconditions: None
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_op_does_not_exist_query(scd_session):
+def test_op_does_not_exist_query(scd_api, scd_session):
   time_now = datetime.datetime.utcnow()
   end_time = time_now + datetime.timedelta(hours=1)
   resp = scd_session.post('/operation_references/query', json={
@@ -80,8 +84,9 @@ def test_op_does_not_exist_query(scd_session):
 
 # Preconditions: None
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_create_op_single_extent(scd_session):
+def test_create_op_single_extent(scd_api, scd_session):
   req = _make_op1_request()
   req['extents'] = req['extents'][0]
   resp = scd_session.put('/operation_references/{}'.format(OP_ID), json=req)
@@ -90,8 +95,9 @@ def test_create_op_single_extent(scd_session):
 
 # Preconditions: None
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_create_op_missing_time_start(scd_session):
+def test_create_op_missing_time_start(scd_api, scd_session):
   req = _make_op1_request()
   del req['extents'][0]['time_start']
   resp = scd_session.put('/operation_references/{}'.format(OP_ID), json=req)
@@ -100,8 +106,9 @@ def test_create_op_missing_time_start(scd_session):
 
 # Preconditions: None
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_create_op_missing_time_end(scd_session):
+def test_create_op_missing_time_end(scd_api, scd_session):
   req = _make_op1_request()
   del req['extents'][0]['time_end']
   resp = scd_session.put('/operation_references/{}'.format(OP_ID), json=req)
@@ -110,7 +117,8 @@ def test_create_op_missing_time_end(scd_session):
 
 # Preconditions: None
 # Mutations: Operation OP_ID created by scd_session user
-def test_create_op(scd_session):
+@for_api_versions(scd.API_0_3_5)
+def test_create_op(scd_api, scd_session):
   req = _make_op1_request()
 
   resp = scd_session.put('/operation_references/{}'.format(OP_ID), json=req, scope=SCOPE_CI)
@@ -135,7 +143,8 @@ def test_create_op(scd_session):
 
 # Preconditions: Operation OP_ID created by scd_session user
 # Mutations: None
-def test_get_op_by_id(scd_session):
+@for_api_versions(scd.API_0_3_5)
+def test_get_op_by_id(scd_api, scd_session):
   resp = scd_session.get('/operation_references/{}'.format(OP_ID), scope=SCOPE_CI)
   assert resp.status_code == 403, resp.content
 
@@ -155,16 +164,18 @@ def test_get_op_by_id(scd_session):
 
 # Preconditions: None, though preferably Operation OP_ID created by scd_session user
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_get_op_by_search_missing_params(scd_session):
+def test_get_op_by_search_missing_params(scd_api, scd_session):
   resp = scd_session.post('/operation_references/query')
   assert resp.status_code == 400, resp.content
 
 
 # Preconditions: Operation OP_ID created by scd_session user
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_get_op_by_search(scd_session):
+def test_get_op_by_search(scd_api, scd_session):
   resp = scd_session.post('/operation_references/query', json={
     'area_of_interest': scd.make_vol4(None, None, 0, 5000, scd.make_circle(-56, 178, 300))
   })
@@ -174,8 +185,9 @@ def test_get_op_by_search(scd_session):
 
 # Preconditions: Operation OP_ID created by scd_session user
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_get_op_by_search_earliest_time_included(scd_session):
+def test_get_op_by_search_earliest_time_included(scd_api, scd_session):
   earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=59)
   resp = scd_session.post('/operation_references/query', json={
     'area_of_interest': scd.make_vol4(earliest_time, None, 0, 5000, scd.make_circle(-56, 178, 300))
@@ -186,8 +198,9 @@ def test_get_op_by_search_earliest_time_included(scd_session):
 
 # Preconditions: Operation OP_ID created by scd_session user
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_get_op_by_search_earliest_time_excluded(scd_session):
+def test_get_op_by_search_earliest_time_excluded(scd_api, scd_session):
   earliest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=81)
   resp = scd_session.post('/operation_references/query', json={
     'area_of_interest': scd.make_vol4(earliest_time, None, 0, 5000, scd.make_circle(-56, 178, 300))
@@ -198,8 +211,9 @@ def test_get_op_by_search_earliest_time_excluded(scd_session):
 
 # Preconditions: Operation OP_ID created by scd_session user
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_get_op_by_search_latest_time_included(scd_session):
+def test_get_op_by_search_latest_time_included(scd_api, scd_session):
   latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=20)
   resp = scd_session.post('/operation_references/query', json={
     'area_of_interest': scd.make_vol4(None, latest_time, 0, 5000, scd.make_circle(-56, 178, 300))
@@ -210,8 +224,9 @@ def test_get_op_by_search_latest_time_included(scd_session):
 
 # Preconditions: Operation OP_ID created by scd_session user
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_get_op_by_search_latest_time_excluded(scd_session):
+def test_get_op_by_search_latest_time_excluded(scd_api, scd_session):
   latest_time = datetime.datetime.utcnow() + datetime.timedelta(minutes=1)
   resp = scd_session.post('/operation_references/query', json={
     'area_of_interest': scd.make_vol4(None, latest_time, 0, 5000, scd.make_circle(-56, 178, 300))
@@ -222,8 +237,9 @@ def test_get_op_by_search_latest_time_excluded(scd_session):
 
 # Preconditions: Operation OP_ID created by scd_session user
 # Mutations: Operation OP_ID mutated to second version
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_mutate_op(scd_session):
+def test_mutate_op(scd_api, scd_session):
   # GET current op
   resp = scd_session.get('/operation_references/{}'.format(OP_ID))
   assert resp.status_code == 200, resp.content
@@ -260,7 +276,8 @@ def test_mutate_op(scd_session):
 
 # Preconditions: Operation OP_ID mutated to second version
 # Mutations: Operation OP_ID deleted
-def test_delete_op(scd_session):
+@for_api_versions(scd.API_0_3_5)
+def test_delete_op(scd_api, scd_session):
   resp = scd_session.delete('/operation_references/{}'.format(OP_ID), scope=SCOPE_CI)
   assert resp.status_code == 403, resp.content
 
@@ -273,19 +290,20 @@ def test_delete_op(scd_session):
 
 # Preconditions: Operation OP_ID deleted
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_get_deleted_op_by_id(scd_session):
+def test_get_deleted_op_by_id(scd_api, scd_session):
   resp = scd_session.get('/operation_references/{}'.format(OP_ID))
   assert resp.status_code == 404, resp.content
 
 
 # Preconditions: Operation OP_ID deleted
 # Mutations: None
+@for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
-def test_get_deleted_op_by_search(scd_session):
+def test_get_deleted_op_by_search(scd_api, scd_session):
   resp = scd_session.post('/operation_references/query', json={
     'area_of_interest': scd.make_vol4(None, None, 0, 5000, scd.make_circle(-56, 178, 300))
   })
   assert resp.status_code == 200, resp.content
   assert OP_ID not in [x['id'] for x in resp.json()['operation_references']]
-


### PR DESCRIPTION
To prepare for upgrading tests to support SCD DSS API version 0.3.15 (or later), this PR introduces a tool to annotate prober tests as supporting a particular set of API versions.