### PR TITLE
[scd] Prep for test fixes

### DIFF
--- a/build/dev/probe_local_instance.sh
+++ b/build/dev/probe_local_instance.sh
@@ -46,5 +46,5 @@ docker run --network dss_sandbox_default \
 	--dss-endpoint http://local-gateway:8082 \
 	--rid-auth "DummyOAuth(http://oauth:8085/token,sub=fake_uss)" \
 	--scd-auth1 "DummyOAuth(http://oauth:8085/token,sub=fake_uss)" \
-	--scd-auth2 "DummyOAuth(http://oauth:8085/token,sub=fake_uss2)"
-
+	--scd-auth2 "DummyOAuth(http://oauth:8085/token,sub=fake_uss2)"	\
+	--test-owner "unknown"

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/interuss/stacktrace v1.0.0
 	github.com/jonboulle/clockwork v0.2.2
 	github.com/lib/pq v1.9.0
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.16.0

--- a/monitoring/prober/README.md
+++ b/monitoring/prober/README.md
@@ -27,6 +27,8 @@ the tests that depend on that authorization will be skipped.
 Example: `--rid-auth "UsernamePassword(https://example.com/token, username=uss1,
 password=uss1, client_id=uss1)"`
 
+`--test-owner` flag should be set to uniquely identify a prober test owner. Supported characters for an owner name are letters, numbers and _.  
+
 ## Running pytest via Docker
 This approach takes slightly longer to execute due to building the prober image,
 but it requires no setup and generally obtains more reproducible results than
@@ -35,6 +37,7 @@ running locally.  From the root of this repo:
 ```shell script
 docker run --rm $(docker build -q -f monitoring/prober/Dockerfile monitoring) \
     --dss-endpoint <URL> \
+    --test-owner <owner-name> \
     [--rid-auth <SPEC>] \
     [--scd-auth1 <SPEC>] \
     [--scd-auth2 <SPEC>]
@@ -52,6 +55,7 @@ docker build -f prober/Dockerfile . -t local-prober
 ```shell script
 docker run --rm local-prober \
     --dss-endpoint <URL> \
+    --test-owner <owner-name> \
     [--rid-auth <SPEC>] \
     [--scd-auth1 <SPEC>] \
     [--scd-auth2 <SPEC>]
@@ -75,6 +79,7 @@ pip install -r requirements.txt
 . ./env/bin/activate
 pytest \
     --dss-endpoint <URL> \
+    --test-owner <owner-name> \
     [--rid-auth <SPEC>] \
     [--scd-auth1 <SPEC>] \
     [--scd-auth2 <SPEC>] \

--- a/monitoring/prober/conftest.py
+++ b/monitoring/prober/conftest.py
@@ -13,6 +13,7 @@ def pytest_addoption(parser):
   parser.addoption('--rid-auth')
   parser.addoption('--scd-auth1')
   parser.addoption('--scd-auth2')
+  parser.addoption('--test-owner')
   parser.addoption('--scd-api-version')
 
 
@@ -50,6 +51,17 @@ def scd_session(pytestconfig):
 @pytest.fixture(scope='session')
 def scd_session2(pytestconfig):
   return make_session(pytestconfig, '/dss/v1', 'scd_auth2')
+
+
+@pytest.fixture()
+def test_owner(pytestconfig):
+  if pytestconfig.getoption('test_owner'):
+    return pytestconfig.getoption('test_owner')
+  else:
+    pytest.exit(
+      ValueError("""
+      test-owner required.
+      Please follow the instructions in monitoring/prober/README.md to set the value"""))
 
 
 @pytest.fixture(scope='function')

--- a/monitoring/prober/rid/common.py
+++ b/monitoring/prober/rid/common.py
@@ -42,3 +42,28 @@ HUGE_VERTICES = [
 ]
 
 HUGE_GEO_POLYGON_STRING = rid.geo_polygon_string(HUGE_VERTICES)
+
+LOOP_VERTICES = [
+    {
+        'lat': -80.75088500976562,
+        'lng': 37.045312802603355
+    },
+    {
+        'lat': -80.2496337890625,
+        'lng': 37.045312802603355
+    },
+    {
+        'lat': -80.2496337890625,
+        'lng': 37.35487607348372
+    },
+    {
+        'lat': -80.75088500976562,
+        'lng': 37.35487607348372
+    },
+    {
+        'lat': -80.75088500976562,
+        'lng': 37.045312802603355
+    }
+]
+
+LOOP_GEO_POLYGON_STRING = rid.geo_polygon_string(LOOP_VERTICES)

--- a/monitoring/prober/rid/test_isa_simple.py
+++ b/monitoring/prober/rid/test_isa_simple.py
@@ -223,3 +223,10 @@ def test_get_deleted_isa_by_search(session):
       common.GEO_POLYGON_STRING))
   assert resp.status_code == 200, resp.content
   assert ISA_ID not in [x['id'] for x in resp.json()['service_areas']]
+
+
+@default_scope(SCOPE_READ)
+def test_get_isa_search_area_with_loop(session):
+  resp = session.get('/identification_service_areas'
+                     '?area={}'.format(common.LOOP_GEO_POLYGON_STRING))
+  assert resp.status_code == 400, resp.content

--- a/monitoring/prober/rid/test_subscription_simple.py
+++ b/monitoring/prober/rid/test_subscription_simple.py
@@ -141,3 +141,9 @@ def test_get_deleted_sub_by_search(session):
   resp = session.get('/subscriptions?area={}'.format(common.GEO_POLYGON_STRING))
   assert resp.status_code == 200, resp.content
   assert SUB_ID not in [x['id'] for x in resp.json()['subscriptions']]
+
+
+@default_scope(SCOPE_READ)
+def test_get_sub_with_loop_area(session):
+  resp = session.get('/subscriptions?area={}'.format(common.LOOP_GEO_POLYGON_STRING))
+  assert resp.status_code == 400, resp.content

--- a/monitoring/prober/scd/test_constraint_simple.py
+++ b/monitoring/prober/scd/test_constraint_simple.py
@@ -14,11 +14,17 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC, SCOPE_CI, SCOPE_CM
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
+from monitoring.prober import utils
 from monitoring.prober.infrastructure import for_api_versions
 
 
 BASE_URL = 'https://example.com/uss'
-CONSTRAINT_ID = '0000006f-5a03-482a-a7e1-23c29c000000'
+CONSTRAINT_ID = ''
+
+
+def test_set_test_owner_ids(test_owner):
+  global CONSTRAINT_ID
+  CONSTRAINT_ID = utils.encode_owner(test_owner, '0000006f-5a03-482a-a7e1-23c29c000000')
 
 
 def _make_c1_request():

--- a/monitoring/prober/scd/test_constraints_with_subscriptions.py
+++ b/monitoring/prober/scd/test_constraints_with_subscriptions.py
@@ -14,6 +14,7 @@ from typing import Dict
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_CI, SCOPE_CM, SCOPE_SC
+from monitoring.prober import utils
 from monitoring.prober.infrastructure import for_api_versions
 
 
@@ -22,10 +23,22 @@ CONSTRAINT_BASE_URL_2 = 'https://example.com/con2/uss'
 CONSTRAINT_BASE_URL_3 = 'https://example.com/con3/uss'
 SUB_BASE_URL_A = 'https://example.com/sub1/uss'
 SUB_BASE_URL_B = 'https://example.com/sub2/uss'
-CONSTRAINT_ID = '000000a2-2629-49c9-a688-23afb3000000'
-SUB1_ID = '00000007-e548-48bb-b9f2-68e0e0000000'
-SUB2_ID = '00000068-6289-46cc-a402-fbc0f7000000'
-SUB3_ID = '00000089-b954-4d3f-8afa-2c4e3b000000'
+
+CONSTRAINT_ID = ''
+SUB1_ID = ''
+SUB2_ID = ''
+SUB3_ID = ''
+
+
+def test_set_test_owner_ids(test_owner):
+  global CONSTRAINT_ID
+  global SUB1_ID
+  global SUB2_ID
+  global SUB3_ID
+  CONSTRAINT_ID = utils.encode_owner(test_owner, '000000a2-2629-49c9-a688-23afb3000000')
+  SUB1_ID = utils.encode_owner(test_owner, '00000007-e548-48bb-b9f2-68e0e0000000')
+  SUB2_ID = utils.encode_owner(test_owner, '00000068-6289-46cc-a402-fbc0f7000000')
+  SUB3_ID = utils.encode_owner(test_owner, '00000089-b954-4d3f-8afa-2c4e3b000000')
 
 
 def _make_c1_request():

--- a/monitoring/prober/scd/test_operation_references_error_cases.py
+++ b/monitoring/prober/scd/test_operation_references_error_cases.py
@@ -10,11 +10,19 @@ import yaml
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
+from monitoring.prober import utils
 from monitoring.prober.infrastructure import for_api_versions
 
 
-OP_ID = '00000028-728d-40c4-8eb2-20d19c000000'
-OP_ID2 = '0000006e-b4ec-48a3-ae38-426042000000'
+OP_ID = ''
+OP_ID2 = ''
+
+
+def test_set_test_owner_ids(test_owner):
+  global OP_ID
+  global OP_ID2
+  OP_ID = utils.encode_owner(test_owner, '00000028-728d-40c4-8eb2-20d19c000000')
+  OP_ID2 = utils.encode_owner(test_owner, '0000006e-b4ec-48a3-ae38-426042000000')
 
 
 @for_api_versions(scd.API_0_3_5)

--- a/monitoring/prober/scd/test_operation_references_state_transition.py
+++ b/monitoring/prober/scd/test_operation_references_state_transition.py
@@ -6,10 +6,16 @@ import json
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
+from monitoring.prober import utils
 from monitoring.prober.infrastructure import for_api_versions
 
 
-OP_ID = '00000067-cb83-4880-a7e7-1fee85000000'
+OP_ID = ''
+
+
+def test_set_test_owner_ids(test_owner):
+  global OP_ID
+  OP_ID = utils.encode_owner(test_owner, '00000067-cb83-4880-a7e7-1fee85000000')
 
 
 @for_api_versions(scd.API_0_3_5)

--- a/monitoring/prober/scd/test_operation_simple.py
+++ b/monitoring/prober/scd/test_operation_simple.py
@@ -14,11 +14,17 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC, SCOPE_CI, SCOPE_CM
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
+from monitoring.prober import utils
 from monitoring.prober.infrastructure import for_api_versions
 
 
 BASE_URL = 'https://example.com/uss'
-OP_ID = '0000008c-91c8-4afc-927d-d923f5000000'
+OP_ID = ''
+
+
+def test_set_test_owner_ids(test_owner):
+  global OP_ID
+  OP_ID = utils.encode_owner(test_owner, '0000008c-91c8-4afc-927d-d923f5000000')
 
 
 @for_api_versions(scd.API_0_3_5)

--- a/monitoring/prober/scd/test_operation_special_cases.py
+++ b/monitoring/prober/scd/test_operation_special_cases.py
@@ -15,11 +15,19 @@ import uuid
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
+from monitoring.prober import utils
 from monitoring.prober.infrastructure import for_api_versions
 
 
-OP1_ID = '00000020-b6ee-4082-b6e7-75eb4f000000'
-OP2_ID = '00000000-ee51-4700-873d-e10911000000'
+OP1_ID = ''
+OP2_ID = ''
+
+
+def test_set_test_owner_ids(test_owner):
+  global OP1_ID
+  global OP2_ID
+  OP1_ID = utils.encode_owner(test_owner, '00000020-b6ee-4082-b6e7-75eb4f000000')
+  OP2_ID = utils.encode_owner(test_owner, '00000000-ee51-4700-873d-e10911000000')
 
 
 @for_api_versions(scd.API_0_3_5)

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -16,6 +16,7 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
+from monitoring.prober import utils
 from monitoring.prober.infrastructure import for_api_versions
 
 
@@ -24,9 +25,18 @@ URL_SUB1 = 'https://example.com/subs1/dss'
 URL_OP2 = 'https://example.com/op2/dss'
 URL_SUB2 = 'https://example.com/subs2/dss'
 
-OP1_ID = '0000007d-312e-47f5-b51c-dc5744000000'
-OP2_ID = '0000007a-be5e-4503-b8cf-40a6b4000000'
-SUB2_ID = '00000059-193c-4910-8f36-bde224000000'
+OP1_ID = ''
+OP2_ID = ''
+SUB2_ID = ''
+
+
+def test_set_test_owner_ids(test_owner):
+  global OP1_ID
+  global OP2_ID
+  global SUB2_ID
+  OP1_ID = utils.encode_owner(test_owner, '0000007d-312e-47f5-b51c-dc5744000000')
+  OP2_ID = utils.encode_owner(test_owner, '0000007a-be5e-4503-b8cf-40a6b4000000')
+  SUB2_ID = utils.encode_owner(test_owner, '00000059-193c-4910-8f36-bde224000000')
 
 
 op1_ovn = None

--- a/monitoring/prober/scd/test_subscription_queries.py
+++ b/monitoring/prober/scd/test_subscription_queries.py
@@ -9,12 +9,22 @@ import datetime
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
+from monitoring.prober import utils
 from monitoring.prober.infrastructure import for_api_versions
 
 
-SUB1_ID = '00000088-b268-481c-a32d-6be442000000'
-SUB2_ID = '00000017-a3fe-42d6-9f3b-83dec2000000'
-SUB3_ID = '0000001b-9c8a-475e-a82d-d81922000000'
+SUB1_ID = ''
+SUB2_ID = ''
+SUB3_ID = ''
+
+
+def test_set_test_owner_ids(test_owner):
+  global SUB1_ID
+  global SUB2_ID
+  global SUB3_ID
+  SUB1_ID = utils.encode_owner(test_owner, '00000088-b268-481c-a32d-6be442000000')
+  SUB2_ID = utils.encode_owner(test_owner, '00000017-a3fe-42d6-9f3b-83dec2000000')
+  SUB3_ID = utils.encode_owner(test_owner, '0000001b-9c8a-475e-a82d-d81922000000')
 
 
 LAT0 = 23
@@ -255,7 +265,6 @@ def test_search_time_footprint(scd_api, scd_session):
   assert SUB1_ID not in result_ids
   assert SUB2_ID in result_ids
   assert SUB3_ID not in result_ids
-
 
 
 # Preconditions: Subscriptions 1, 2, and 3 created

--- a/monitoring/prober/scd/test_subscription_query_time.py
+++ b/monitoring/prober/scd/test_subscription_query_time.py
@@ -1,0 +1,44 @@
+"""Strategic conflict detection Subscription put query tests:
+
+  - query with different time formats.
+"""
+
+import datetime
+
+from monitoring.monitorlib.infrastructure import default_scope
+from monitoring.monitorlib import scd
+from monitoring.monitorlib.scd import SCOPE_SC
+from monitoring.prober.infrastructure import for_api_versions
+
+
+BASE_URL = 'https://example.com/uss'
+
+SUB_ID = '00000088-b268-481c-a32d-6be442000000'
+def _make_sub_req(time_start, time_end, alt_start, alt_end, radius, scd_api):
+  req = {
+    "extents": scd.make_vol4(time_start, time_end, alt_start, alt_end, scd.make_circle(-56, 178, radius)),
+    "old_version": 0,
+    "uss_base_url": BASE_URL,
+    
+    "notify_for_constraints": False
+  }
+  if scd_api == scd.API_0_3_5:
+    req["notify_for_operations"] = True
+  elif scd_api == scd.API_0_3_15:
+    req["notify_for_operational_intents"] = True
+  return req
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_15)
+@default_scope(SCOPE_SC)
+def test_subscription_with_invalid_start_time(scd_api, scd_session):
+  if scd_session is None:
+    return
+
+  time_start = datetime.datetime.utcnow()
+  time_end = time_start + datetime.timedelta(hours=2.5)
+  req = _make_sub_req(time_start, time_end, 200, 1000, 500, scd_api)
+  req['extents']['time_start']['value'] = 'something-invalid'
+
+  resp = scd_session.put('/subscriptions/{}'.format(SUB_ID), json=req)
+  assert resp.status_code == 400, resp.content

--- a/monitoring/prober/scd/test_subscription_simple.py
+++ b/monitoring/prober/scd/test_subscription_simple.py
@@ -16,10 +16,16 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
+from monitoring.prober import utils
 from monitoring.prober.infrastructure import for_api_versions
 
 
-SUB_ID = '000000b7-cf7e-4d9a-af00-6963ca000000'
+SUB_ID = ''
+
+
+def test_set_test_owner_ids(test_owner):
+  global SUB_ID
+  SUB_ID = utils.encode_owner(test_owner, '000000b7-cf7e-4d9a-af00-6963ca000000')
 
 
 @for_api_versions(scd.API_0_3_5, scd.API_0_3_15)

--- a/monitoring/prober/scd/test_subscription_update_validation.py
+++ b/monitoring/prober/scd/test_subscription_update_validation.py
@@ -17,13 +17,19 @@ from monitoring.monitorlib import scd
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
+from monitoring.prober import utils
 from monitoring.prober.infrastructure import for_api_versions
 
 
 BASE_URL = 'https://example.com/uss'
-OP_ID = '00000073-ff83-443b-aa56-36671e000000'
+OP_ID = ''
 
 sub_id = ''
+
+
+def test_set_test_owner_ids(test_owner):
+  global OP_ID
+  OP_ID = utils.encode_owner(test_owner, '00000073-ff83-443b-aa56-36671e000000')
 
 
 def _make_op_req():

--- a/monitoring/prober/utils.py
+++ b/monitoring/prober/utils.py
@@ -1,0 +1,84 @@
+
+def bin_to_hex(bin_string):
+  return format(int(bin_string,2), "02x")
+
+
+def bin_to_dec(bin_string):
+  return int(bin_string, 2)
+
+
+def hex_to_bin(hex_string):
+  return format(int(hex_string,16), "08b")
+
+
+def dec_to_bin(num):
+  return format(num, "06b")
+
+
+def split_by(string_val, num=8):
+  """Splits a string into substrings with a length of given number."""
+  return [string_val[i:i+num] for i in range(0, len(string_val), num)]
+
+
+def get_ord_val(letter):
+  """Encodes new ord value for ascii letters."""
+  ord_val = ord(letter)
+  if ord_val >= 48 and ord_val <= 57: # decimal numbers
+    return ord_val - 48
+  if ord_val >= 65 and ord_val <= 90: # capitals
+    return ord_val - 65 + 10
+  if ord_val >= 97 and ord_val <= 122: # small letters.
+    return ord_val - 97 + 10 + 26
+  if ord_val == 95:
+    return 63
+
+
+def get_ascii_val_from_bit_value(num):
+  """Decodes new ord value to ascii letters."""
+  if num >=0 and num <= 9:
+    return chr(num + 48)
+  if num >= 10 and num <= 35:
+    return chr(num + 65 - 10)
+  if num >= 36 and num <= 62:
+    return chr(num + 97 - 10 - 26)
+  if num == 63:
+    return '_'
+
+
+def encode_owner(owner_name, fixed_id):
+  bits = ''
+  if len(owner_name) > 8:
+    string_val = owner_name[:4] + owner_name[-4:]
+  else:
+    string_val = owner_name
+  for letter in string_val:
+    ord_val = get_ord_val(letter)
+    bits += dec_to_bin(ord_val)
+  hex_codes = ''.join((bin_to_hex(s) for s in split_by(bits)[:6]))
+  fixed_code = list(fixed_id)
+  curr_pos = 16
+  hex_ptr = 0
+  while curr_pos <= 30 and hex_ptr < len(hex_codes):
+    if fixed_code[curr_pos] == '-':
+      curr_pos += 1
+    fixed_code[curr_pos] = hex_codes[hex_ptr]
+    curr_pos += 1
+    hex_ptr += 1
+  return ''.join(fixed_code)
+
+
+def decode_owner(owner_id):
+  if len(owner_id) < 30:
+    raise ValueError('Invalid owner id.')
+  owner_hex_code = (owner_id[16:30]).replace('-', '')
+  hex_splits = split_by(owner_hex_code, num=2)
+  bits = ''
+  for h in hex_splits:
+    bits += hex_to_bin(h)
+  test_owner = ''
+  for seq in split_by(bits, 6):
+    num = bin_to_dec(seq)
+    test_owner += get_ascii_val_from_bit_value(num)
+  if len(test_owner) == 8:
+      return test_owner[:4] + '.. ' + test_owner[-4:]
+  return test_owner

--- a/pkg/rid/server/isa_handler.go
+++ b/pkg/rid/server/isa_handler.go
@@ -9,9 +9,11 @@ import (
 	"github.com/interuss/dss/pkg/auth"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/geo"
+	geoerr "github.com/interuss/dss/pkg/geo"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
 	"github.com/interuss/stacktrace"
+	"github.com/pkg/errors"
 )
 
 // GetIdentificationServiceArea returns a single ISA for a given ID.
@@ -221,7 +223,10 @@ func (s *Server) SearchIdentificationServiceAreas(
 
 	cu, err := geo.AreaToCellIDs(req.GetArea())
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "Invalid area")
+		if errors.Is(err, geoerr.ErrAreaTooLarge) {
+			return nil, stacktrace.Propagate(err, "Invalid area")
+		}
+		return nil, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Invalid area")
 	}
 
 	var (

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -153,6 +153,7 @@ docker run --link dummy-oauth-for-testing:oauth \
 	--rid-auth "DummyOAuth(http://oauth:8085/token,sub=fake_uss)" \
 	--scd-auth1 "DummyOAuth(http://oauth:8085/token,sub=fake_uss)" \
 	--scd-auth2 "DummyOAuth(http://oauth:8085/token,sub=fake_uss2)"	\
+	--scd-api-version 0.3.15 \
 	--test-owner "unknown"
 
 echo "Cleaning up http-gateway container"

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -152,7 +152,8 @@ docker run --link dummy-oauth-for-testing:oauth \
 	--dss-endpoint http://local-gateway:8082 \
 	--rid-auth "DummyOAuth(http://oauth:8085/token,sub=fake_uss)" \
 	--scd-auth1 "DummyOAuth(http://oauth:8085/token,sub=fake_uss)" \
-	--scd-auth2 "DummyOAuth(http://oauth:8085/token,sub=fake_uss2)"
+	--scd-auth2 "DummyOAuth(http://oauth:8085/token,sub=fake_uss2)"	\
+	--test-owner "unknown"
 
 echo "Cleaning up http-gateway container"
 docker stop http-gateway-for-testing > /dev/null


### PR DESCRIPTION
This PR prepares for the effort of fixing tests on the [path to updated SCD API support](https://github.com/interuss/dss/wiki/Updating-SCD-API) by targeting automated tests to API version 0.3.15 and pulling #549 into the scd_api_update branch.

The only change in this PR beyond #549 is the addition of `--scd-api-version 0.3.15` in docker_e2e.sh.