### PR TITLE
[scd] Fix #569: second part

### DIFF
--- a/monitoring/prober/scd/test_operation_references_error_cases.py
+++ b/monitoring/prober/scd/test_operation_references_error_cases.py
@@ -457,7 +457,7 @@ def test_missing_conflicted_operation_v15(ids, scd_api, scd_session):
     req = yaml.full_load(f)
   dt = datetime.datetime.utcnow() - scd.start_of(req['extents'])
   req['extents'] = scd.offset_time(req['extents'], dt)
-  resp = scd_session.put('/operational_intent_reference/{}'.format(ids(OP_TYPE)), json=req)
+  resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req)
   assert resp.status_code == 200, resp.content
   ovn1a = resp.json()['operational_intent_reference']['ovn']
   sub_id = resp.json()['operational_intent_reference']['subscription_id']
@@ -467,7 +467,7 @@ def test_missing_conflicted_operation_v15(ids, scd_api, scd_session):
     req = yaml.full_load(f)
   req['extents'] = scd.offset_time(req['extents'], dt)
   req['key'] = [ovn1a]
-  resp = scd_session.put('/operational_intent_reference/{}'.format(ids(OP_TYPE2)), json=req)
+  resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE2)), json=req)
   assert resp.status_code == 200, resp.content
 
   # Attempt to update Operation 1 without OVN for the pre-existing Operation
@@ -476,8 +476,8 @@ def test_missing_conflicted_operation_v15(ids, scd_api, scd_session):
   req['extents'] = scd.offset_time(req['extents'], dt)
   req['key'] = [ovn1a]
   req['subscription_id'] = sub_id
-  resp = scd_session.put('/operational_intent_reference/{}'.format(ids(OP_TYPE)), json=req)
-  assert resp.status_code == 409, resp.content
+  resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req)
+  assert resp.status_code == 400, resp.content
   # TODO: entity_conflicts is not there in v15 response. What is the replacement key?
   # conflicts = []
   # for conflict in resp.json()['entity_conflicts']:
@@ -489,9 +489,9 @@ def test_missing_conflicted_operation_v15(ids, scd_api, scd_session):
   with open('./scd/resources/op_missing_query.json', 'r') as f:
     req = json.load(f)
   req['area_of_interest'] = scd.offset_time([req['area_of_interest']], dt)[0]
-  resp = scd_session.post('/operational_intent_reference/query', json=req)
+  resp = scd_session.post('/operational_intent_references/query', json=req)
   assert  resp.status_code == 200, resp.content
-  ops = [op['id'] for op in resp.json()['operational_intent_reference']]
+  ops = [op['id'] for op in resp.json()['operational_intent_references']]
   assert ids(OP_TYPE) in ops, resp.content
 
   # ids(OP_ID2) not expected here because its ceiling is <575m whereas query floor is

--- a/monitoring/prober/scd/test_operation_references_error_cases.py
+++ b/monitoring/prober/scd/test_operation_references_error_cases.py
@@ -369,16 +369,17 @@ def test_op_repeated_requests_v5(ids, scd_api, scd_session):
 def test_op_repeated_requests_v15(ids, scd_api, scd_session):
   with open('./scd/resources/op_request_1_v15.json', 'r') as f:
     req = json.load(f)
-  resp = scd_session.put('/operational_intent_reference/{}'.format(ids(OP_TYPE)), json=req)
+  resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req)
   assert resp.status_code == 200, resp.content
+  ovn = resp.json()['operational_intent_reference']['ovn']
 
   with open('./scd/resources/op_request_1.json', 'r') as f:
     req = json.load(f)
-  resp = scd_session.put('/operational_intent_reference/{}'.format(ids(OP_TYPE)), json=req)
+  resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req)
   assert resp.status_code == 409, resp.content
 
   # Delete operation
-  resp = scd_session.delete('/operational_intent_reference/{}'.format(ids(OP_TYPE)))
+  resp = scd_session.delete('/operational_intent_references/{}/{}'.format(ids(OP_TYPE), ovn))
   assert resp.status_code == 200, resp.content
 
 

--- a/monitoring/prober/scd/test_operation_simple.py
+++ b/monitoring/prober/scd/test_operation_simple.py
@@ -236,14 +236,14 @@ def test_create_op_v15(ids, scd_api, scd_session):
   assert resp.status_code == 200, resp.content
 
   data = resp.json()
-  op = data['operation_reference']
+  op = data['operational_intent_reference']
   assert op['id'] == ids(OP_TYPE)
   assert op['uss_base_url'] == BASE_URL
   assert_datetimes_are_equal(op['time_start']['value'], req['extents'][0]['time_start']['value'])
   assert_datetimes_are_equal(op['time_end']['value'], req['extents'][0]['time_end']['value'])
   assert op['version'] == 1
   assert 'subscription_id' in op
-  assert 'state' not in op
+  assert op['state'] == 'Accepted'
 
 
 # Preconditions: Operation ids(OP_ID) created by scd_session user

--- a/pkg/scd/models/operational_intents.go
+++ b/pkg/scd/models/operational_intents.go
@@ -68,6 +68,10 @@ type OperationalIntent struct {
 	Cells          s2.CellUnion
 }
 
+func (state OperationalIntentState) String() string {
+	return string(state)
+}
+
 // ToProto converts the OperationalIntent to its proto API format
 func (o *OperationalIntent) ToProto() (*scdpb.OperationalIntentReference, error) {
 	result := &scdpb.OperationalIntentReference{
@@ -77,6 +81,7 @@ func (o *OperationalIntent) ToProto() (*scdpb.OperationalIntentReference, error)
 		Version:        int32(o.Version),
 		UssBaseUrl:     o.USSBaseURL,
 		SubscriptionId: o.SubscriptionID.String(),
+		State:          o.State.String(),
 	}
 
 	if o.StartTime != nil {

--- a/pkg/scd/store/cockroach/operational_intents.go
+++ b/pkg/scd/store/cockroach/operational_intents.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	operationFieldsWithIndices   [10]string
+	operationFieldsWithIndices   [11]string
 	operationFieldsWithPrefix    string
 	operationFieldsWithoutPrefix string
 )
@@ -33,6 +33,7 @@ func init() {
 	operationFieldsWithIndices[7] = "ends_at"
 	operationFieldsWithIndices[8] = "subscription_id"
 	operationFieldsWithIndices[9] = "updated_at"
+	operationFieldsWithIndices[10] = "state"
 
 	operationFieldsWithoutPrefix = strings.Join(
 		operationFieldsWithIndices[:], ",",
@@ -72,6 +73,7 @@ func (s *repo) fetchOperationalIntents(ctx context.Context, q dsssql.Queryable, 
 			&o.EndTime,
 			&o.SubscriptionID,
 			&updatedAt,
+			&o.State,
 		)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "Error scanning Operation row")
@@ -184,7 +186,7 @@ func (s *repo) UpsertOperationalIntent(ctx context.Context, operation *scdmodels
 				scd_operations
 				(%s)
 			VALUES
-				($1, $2, $3, $4, $5, $6, $7, $8, $9, transaction_timestamp())
+				($1, $2, $3, $4, $5, $6, $7, $8, $9, transaction_timestamp(), $10)
 			RETURNING
 				%s`, operationFieldsWithoutPrefix, operationFieldsWithPrefix)
 		upsertCellsForOperationQuery = `
@@ -221,6 +223,7 @@ func (s *repo) UpsertOperationalIntent(ctx context.Context, operation *scdmodels
 		operation.StartTime,
 		operation.EndTime,
 		operation.SubscriptionID,
+		operation.State,
 	)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "Error fetching Operation")


### PR DESCRIPTION
Depends on #570 (Shall be merged first). This PR is targetting scd_api_update for readability.

Fixes : 
- `scd/test_operation_simple.py::test_create_op_v15`
- `scd/test_operation_references_error_cases.py::test_missing_conflicted_operation_v15`
- `scd/test_operation_references_error_cases.py::test_op_repeated_requests_v15`