### PR TITLE
[scd] Change Subscription version to OVN

### DIFF
--- a/build/deploy/db_schemas/scd/000002_support_api_1_0_0.up.sql
+++ b/build/deploy/db_schemas/scd/000002_support_api_1_0_0.up.sql
@@ -1,6 +1,5 @@
-/* Switch Subscription version from integer to string */
-SET enable_experimental_alter_column_type_general = true;
-ALTER TABLE scd_subscriptions ALTER COLUMN version SET DATA TYPE STRING;
+/* Note: Subscription version column is now ignored; version, like OVN for
+   operational intent, is encoded in updated_at */
 
 /* Add tracking for operational intent state */
 CREATE TYPE operational_intent_state AS ENUM ('Unknown', 'Accepted', 'Activated', 'Nonconforming', 'Contingent');

--- a/pkg/scd/models/subscriptions.go
+++ b/pkg/scd/models/subscriptions.go
@@ -24,8 +24,12 @@ const (
 
 // Subscription represents an SCD subscription
 type Subscription struct {
-	ID                          dssmodels.ID
-	Version                     *dssmodels.Version
+	ID dssmodels.ID
+
+	// Version is an OVN-like string constructed from the Subscription's
+	// updated_at field in the database; it may be unspecified when creating a new
+	// Subscription in the database.
+	Version                     OVN
 	NotificationIndex           int
 	Manager                     dssmodels.Manager
 	StartTime                   *time.Time

--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -355,7 +355,6 @@ func (a *Server) PutOperationalIntentReference(ctx context.Context, entityid str
 			sub, err = r.UpsertSubscription(ctx, &scdmodels.Subscription{
 				ID:                          dssmodels.ID(uuid.New().String()),
 				Manager:                     manager,
-				Version:                     dssmodels.VersionFromTime(time.Now()),
 				StartTime:                   uExtent.StartTime,
 				EndTime:                     uExtent.EndTime,
 				AltitudeLo:                  uExtent.SpatialVolume.AltitudeLo,


### PR DESCRIPTION
Fixes #589 by treating the Subscription version as an OVN string populated from updated_at.  This makes the version column in the database unnecessary, but it is retained for now to support ease of database downgrading.