### PR TITLE
Fix scd/test_operations_simple (v17)

### DIFF
--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -351,7 +351,7 @@ def test_delete_op1_by_uss2_v5(ids, scd_api, scd_session, scd_session2):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_delete_op1_by_uss2_v15(ids, scd_api, scd_session, scd_session2):
-  resp = scd_session2.delete('/operational_intent_references/{}'.format(ids(OP1_TYPE)))
+  resp = scd_session2.delete('/operational_intent_references/{}/{}'.format(ids(OP1_TYPE), op1_ovn))
   assert resp.status_code == 403, resp.content
 
 

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -589,7 +589,7 @@ def test_read_ops_from_uss1_v15(ids, scd_api, scd_session, scd_session2):
   })
   assert resp.status_code == 200, resp.content
 
-  ops = {op['id']: op for op in resp.json().get('operational_intent_reference', [])}
+  ops = {op['id']: op for op in resp.json().get('operational_intent_references', [])}
   assert ids(OP1_TYPE) in ops
   assert ids(OP2_TYPE) in ops
 

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -519,19 +519,19 @@ def test_create_op2_v15(ids, scd_api, scd_session, scd_session2):
   assert resp.status_code == 200, resp.content
 
   data = resp.json()
-  op = data['operation_reference']
+  op = data['operational_intent_reference']
   assert op['id'] == ids(OP2_TYPE)
   assert op['uss_base_url'] == URL_OP2
   assert_datetimes_are_equal(op['time_start']['value'], req['extents'][0]['time_start']['value'])
   assert_datetimes_are_equal(op['time_end']['value'], req['extents'][0]['time_end']['value'])
   assert op['version'] == 1
   assert 'subscription_id' in op
-  assert 'state' not in op
+  assert op['state'] == 'Accepted'
   assert op.get('ovn', '')
 
   resp = scd_session2.get('/operational_intent_references/{}'.format(ids(OP1_TYPE)))
   assert resp.status_code == 200, resp.content
-  implicit_sub_id = resp.json()['operation_reference']['subscription_id']
+  implicit_sub_id = resp.json()['operational_intent_reference']['subscription_id']
 
   # USS2 should definitely be instructed to notify USS1's implicit Subscription of the new Operation
   subscribers = _parse_subscribers(data.get('subscribers', []))

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -114,7 +114,8 @@ def test_ensure_clean_workspace_v15(ids, scd_api, scd_session, scd_session2):
   for op_id, owner in ((ids(OP1_TYPE), scd_session), (ids(OP2_TYPE), scd_session2)):
     resp = owner.get('/operational_intent_references/{}'.format(op_id), scope=SCOPE_SC)
     if resp.status_code == 200:
-      resp = owner.delete('/operational_intent_references/{}'.format(op_id), scope=SCOPE_SC)
+      ovn = resp.json()['operational_intent_reference']['ovn']
+      resp = owner.delete('/operational_intent_references/{}/{}'.format(op_id, ovn), scope=SCOPE_SC)
       assert resp.status_code == 200, resp.content
     elif resp.status_code == 404:
       # As expected.
@@ -124,7 +125,8 @@ def test_ensure_clean_workspace_v15(ids, scd_api, scd_session, scd_session2):
 
   resp = scd_session2.get('/subscriptions/{}'.format(ids(SUB2_TYPE)), scope=SCOPE_SC)
   if resp.status_code == 200:
-    resp = scd_session2.delete('/subscriptions/{}'.format(ids(SUB2_TYPE)), scope=SCOPE_SC)
+    version = resp.json()['subscription']['version']
+    resp = scd_session2.delete('/subscriptions/{}/{}'.format(ids(SUB2_TYPE), version), scope=SCOPE_SC)
     assert resp.status_code == 200, resp.content
   elif resp.status_code == 404:
     # As expected.

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -283,14 +283,14 @@ def test_create_op1_v15(ids, scd_api, scd_session, scd_session2):
   assert resp.status_code == 200, resp.content
 
   data = resp.json()
-  op = data['operation_reference']
+  op = data['operational_intent_reference']
   assert op['id'] == ids(OP1_TYPE)
   assert op['uss_base_url'] == URL_OP1
   assert_datetimes_are_equal(op['time_start']['value'], req['extents'][0]['time_start']['value'])
   assert_datetimes_are_equal(op['time_end']['value'], req['extents'][0]['time_end']['value'])
   assert op['version'] == 1
   assert 'subscription_id' in op
-  assert 'state' not in op
+  assert op['state'] == 'Accepted'
   assert op.get('ovn', '')
 
   # Make sure the implicit Subscription exists when queried separately

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -327,9 +327,11 @@ def test_delete_implicit_sub_v15(ids, scd_api, scd_session, scd_session2):
     return
   resp = scd_session.get('/operational_intent_references/{}'.format(ids(OP1_TYPE)))
   assert resp.status_code == 200, resp.content
-  implicit_sub_id = resp.json()['operational_intent_reference']['subscription_id']
+  operational_intent_reference = resp.json()['operational_intent_reference']
+  implicit_sub_id = operational_intent_reference['subscription_id']
+  implicit_sub_version = operational_intent_reference['version']
 
-  resp = scd_session.delete('/subscriptions/{}'.format(implicit_sub_id))
+  resp = scd_session.delete('/subscriptions/{}/{}'.format(implicit_sub_id, implicit_sub_version))
   assert resp.status_code == 400, resp.content
 
 

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -930,7 +930,10 @@ def test_mutate_sub2(ids, scd_api, scd_session, scd_session2):
   # Attempt mutation without notifying for Operations
 
   # Perform a valid mutation
-  resp = scd_session2.put('/subscriptions/{}'.format(ids(SUB2_TYPE)), json=req)
+  if scd_api == scd.API_0_3_5:
+    resp = scd_session2.put('/subscriptions/{}'.format(ids(SUB2_TYPE)), json=req)
+  elif scd_api == scd.API_0_3_17:
+    resp = scd_session2.put('/subscriptions/{}/{}'.format(ids(SUB2_TYPE), sub2_version), json=req)
   assert resp.status_code == 200, resp.content
 
   # The Subscription response should mention Op1 and Op2, but not include Op1's OVN

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -986,7 +986,7 @@ def test_delete_op1_v5(ids, scd_api, scd_session, scd_session2):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_delete_op1_v15(ids, scd_api, scd_session, scd_session2):
-  resp = scd_session.delete('/operational_intent_references/{}'.format(ids(OP1_TYPE)))
+  resp = scd_session.delete('/operational_intent_references/{}/{}'.format(ids(OP1_TYPE), op1_ovn))
   assert resp.status_code == 200, resp.content
 
   data = resp.json()

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -126,7 +126,7 @@ def test_ensure_clean_workspace_v5(ids, scd_api, scd_session, scd_session2):
 
 
 @for_api_versions(scd.API_0_3_17)
-def test_ensure_clean_workspace_v15(ids, scd_api, scd_session, scd_session2):
+def test_ensure_clean_workspace_v17(ids, scd_api, scd_session, scd_session2):
   for op_id, owner in ((ids(OP1_TYPE), scd_session), (ids(OP2_TYPE), scd_session2)):
     resp = owner.get('/operational_intent_references/{}'.format(op_id), scope=SCOPE_SC)
     if resp.status_code == 200:
@@ -166,7 +166,7 @@ def test_op1_does_not_exist_get_1_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_op1_does_not_exist_get_1_v15(ids, scd_api, scd_session, scd_session2):
+def test_op1_does_not_exist_get_1_v17(ids, scd_api, scd_session, scd_session2):
   resp = scd_session.get('/operational_intent_references/{}'.format(ids(OP1_TYPE)))
   assert resp.status_code == 404, resp.content
 
@@ -186,7 +186,7 @@ def test_op1_does_not_exist_get_2_v5(ids, scd_api, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_op1_does_not_exist_get_2_v15(ids, scd_api, scd_session2):
+def test_op1_does_not_exist_get_2_v17(ids, scd_api, scd_session2):
   resp = scd_session2.get('/operational_intent_references/{}'.format(ids(OP1_TYPE)))
   assert resp.status_code == 404, resp.content
 
@@ -213,7 +213,7 @@ def test_op1_does_not_exist_query_1_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_op1_does_not_exist_query_1_v15(ids, scd_api, scd_session, scd_session2):
+def test_op1_does_not_exist_query_1_v17(ids, scd_api, scd_session, scd_session2):
   if scd_session is None:
     return
   time_now = datetime.datetime.utcnow()
@@ -247,7 +247,7 @@ def test_op1_does_not_exist_query_2_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_op1_does_not_exist_query_2_v15(ids, scd_api, scd_session, scd_session2):
+def test_op1_does_not_exist_query_2_v17(ids, scd_api, scd_session, scd_session2):
   if scd_session2 is None:
     return
   time_now = datetime.datetime.utcnow()
@@ -293,7 +293,7 @@ def test_create_op1_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: Operation Op1 created by scd_session user
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_create_op1_v15(ids, scd_api, scd_session, scd_session2):
+def test_create_op1_v17(ids, scd_api, scd_session, scd_session2):
   req = _make_op1_request()
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP1_TYPE)), json=req)
   assert resp.status_code == 200, resp.content
@@ -338,7 +338,7 @@ def test_delete_implicit_sub_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_delete_implicit_sub_v15(ids, scd_api, scd_session, scd_session2):
+def test_delete_implicit_sub_v17(ids, scd_api, scd_session, scd_session2):
   if scd_session is None:
     return
   resp = scd_session.get('/operational_intent_references/{}'.format(ids(OP1_TYPE)))
@@ -366,7 +366,7 @@ def test_delete_op1_by_uss2_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_delete_op1_by_uss2_v15(ids, scd_api, scd_session, scd_session2):
+def test_delete_op1_by_uss2_v17(ids, scd_api, scd_session, scd_session2):
   resp = scd_session2.delete('/operational_intent_references/{}/{}'.format(ids(OP1_TYPE), op1_ovn))
   assert resp.status_code == 403, resp.content
 
@@ -387,7 +387,7 @@ def test_create_op2_no_sub_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_create_op2_no_sub_v15(ids, scd_api, scd_session, scd_session2):
+def test_create_op2_no_sub_v17(ids, scd_api, scd_session, scd_session2):
   req = _make_op2_request()
   resp = scd_session2.put('/operational_intent_references/{}'.format(ids(OP2_TYPE)), json=req)
   assert resp.status_code == 400, resp.content
@@ -461,7 +461,7 @@ def test_create_op2_no_key_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_create_op2_no_key_v15(ids, scd_api, scd_session, scd_session2):
+def test_create_op2_no_key_v17(ids, scd_api, scd_session, scd_session2):
   req = _make_op2_request()
   req['subscription_id'] = ids(SUB2_TYPE)
   resp = scd_session2.put('/operational_intent_references/{}'.format(ids(OP2_TYPE)), json=req)
@@ -522,7 +522,7 @@ def test_create_op2_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: Operation Op2 created by scd_session2 user
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_create_op2_v15(ids, scd_api, scd_session, scd_session2):
+def test_create_op2_v17(ids, scd_api, scd_session, scd_session2):
   req = _make_op2_request()
   req['subscription_id'] = ids(SUB2_TYPE)
   req['key'] = [op1_ovn]
@@ -590,7 +590,7 @@ def test_read_ops_from_uss1_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_read_ops_from_uss1_v15(ids, scd_api, scd_session, scd_session2):
+def test_read_ops_from_uss1_v17(ids, scd_api, scd_session, scd_session2):
   if scd_session is None:
     return
   time_now = datetime.datetime.utcnow()
@@ -640,7 +640,7 @@ def test_read_ops_from_uss2_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_read_ops_from_uss2_v15(ids, scd_api, scd_session, scd_session2):
+def test_read_ops_from_uss2_v17(ids, scd_api, scd_session, scd_session2):
   if scd_session2 is None:
     return
   time_now = datetime.datetime.utcnow()
@@ -708,7 +708,7 @@ def test_mutate_op1_bad_key_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: None
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_mutate_op1_bad_key_v15(ids, scd_api, scd_session, scd_session2):
+def test_mutate_op1_bad_key_v17(ids, scd_api, scd_session, scd_session2):
   resp = scd_session.get('/operational_intent_references/{}'.format(ids(OP1_TYPE)))
   assert resp.status_code == 200, resp.content
   existing_op = resp.json().get('operational_intent_reference', None)
@@ -798,7 +798,7 @@ def test_mutate_op1_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: Operation Op1 mutated to second version
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_mutate_op1_v15(ids, scd_api, scd_session, scd_session2):
+def test_mutate_op1_v17(ids, scd_api, scd_session, scd_session2):
   resp = scd_session.get('/operational_intent_references/{}'.format(ids(OP1_TYPE)))
   assert resp.status_code == 200, resp.content
   existing_op = resp.json().get('operational_intent_reference', None)
@@ -985,7 +985,7 @@ def test_delete_op1_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: Operation Op1 deleted
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_delete_op1_v15(ids, scd_api, scd_session, scd_session2):
+def test_delete_op1_v17(ids, scd_api, scd_session, scd_session2):
   resp = scd_session.delete('/operational_intent_references/{}/{}'.format(ids(OP1_TYPE), op1_ovn))
   assert resp.status_code == 200, resp.content
 
@@ -1037,7 +1037,7 @@ def test_delete_op2_v5(ids, scd_api, scd_session, scd_session2):
 # Mutations: Operation Op2 deleted
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_delete_op2_v15(ids, scd_api, scd_session, scd_session2):
+def test_delete_op2_v17(ids, scd_api, scd_session, scd_session2):
   resp = scd_session2.delete('/operational_intent_references/{}/{}'.format(ids(OP2_TYPE), op2_ovn))
   assert resp.status_code == 200, resp.content
 

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -88,9 +88,9 @@ def _parse_conflicts(entities: Dict) -> Tuple[Dict[str, Dict], Dict[str, Dict], 
 # Dict[Constraint ID, Constraint Reference]
 def _parse_conflicts_v17(conflicts: Dict) -> Tuple[Dict[str, Dict], set]:
   missing_operational_intents = conflicts.get('missing_operational_intents', [])
-  ops = dict((op['id'], op) for op in missing_operational_intents)
+  ops = {op['id']: op for op in missing_operational_intents}
   missing_constraints = conflicts.get('missing_constraints', [])
-  constraints = dict((constraint['id'], constraint) for constraint in missing_constraints)
+  constraints = {constraint['id']: constraint for constraint in missing_constraints}
   return ops, constraints
 
 

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -1038,7 +1038,7 @@ def test_delete_op2_v5(ids, scd_api, scd_session, scd_session2):
 @for_api_versions(scd.API_0_3_17)
 @default_scope(SCOPE_SC)
 def test_delete_op2_v15(ids, scd_api, scd_session, scd_session2):
-  resp = scd_session2.delete('/operational_intent_references/{}'.format(ids(OP2_TYPE)))
+  resp = scd_session2.delete('/operational_intent_references/{}/{}'.format(ids(OP2_TYPE), op2_ovn))
   assert resp.status_code == 200, resp.content
 
   data = resp.json()

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -1066,5 +1066,8 @@ def test_delete_op2_v15(ids, scd_api, scd_session, scd_session2):
 def test_delete_sub2(ids, scd_api, scd_session2):
   if scd_session2 is None:
     return
-  resp = scd_session2.delete('/subscriptions/{}'.format(ids(SUB2_TYPE)))
+  if scd_api == scd.API_0_3_5:
+    resp = scd_session2.delete('/subscriptions/{}'.format(ids(SUB2_TYPE)))
+  elif scd_api == scd.API_0_3_17:
+    resp = scd_session2.delete('/subscriptions/{}/{}'.format(ids(SUB2_TYPE), sub2_version))
   assert resp.status_code == 200, resp.content


### PR DESCRIPTION
This PR fixes the prober v17 tests of `scd/test_operations_simple.py`.

Test command: `test/docker_e2e.sh scd/test_operations_simple.py`

