### PR TITLE
[prober] Fix tests for SCD 0.3.5 API

### DIFF
--- a/build/dev/startup/grpc_backend.sh
+++ b/build/dev/startup/grpc_backend.sh
@@ -29,6 +29,7 @@ else
   -log_format console \
   -dump_requests \
   -accepted_jwt_audiences localhost,host.docker.internal,local-gateway,dss_sandbox_local-dss-http-gateway_1 \
-  -enable_scd
+  -enable_scd \
+  -enable_http
 fi
 

--- a/monitoring/prober/scd/test_constraints_with_subscriptions.py
+++ b/monitoring/prober/scd/test_constraints_with_subscriptions.py
@@ -252,7 +252,7 @@ def test_mutate_subs(ids, scd_api, scd_session2, scd_session):
   req['old_version'] = existing_sub['version']
 
   if scd_api == scd.API_0_3_5:
-    resp = scd_session2.put('/subscriptions/{}'.format(ids(SUB1_TYPE)), json=req, scope=_read_both_scope(scd_api))
+    resp = scd_session2.put('/subscriptions/{}'.format(ids(SUB3_TYPE)), json=req, scope=_read_both_scope(scd_api))
   elif scd_api == scd.API_0_3_17:
     resp = scd_session2.put('/subscriptions/{}/{}'.format(ids(SUB3_TYPE), existing_sub['version']), json=req, scope=_read_both_scope(scd_api))
   else:

--- a/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
+++ b/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
@@ -243,7 +243,7 @@ def test_get_ops_by_search_earliest_time_included_v5(ids, scd_api, scd_session):
     'area_of_interest': scd.make_vol4(earliest_time, None, 0, 5000, scd.make_circle(-56, 178, 12000))
   })
   assert resp.status_code == 200, resp.content
-  found_ids = [op['id'] for op in resp.json().get('operational_intent_references', [])]
+  found_ids = [op['id'] for op in resp.json().get('operation_references', [])]
   assert len(_intersection(map(ids, OP_TYPES), found_ids)) == len(OP_TYPES)
 
 


### PR DESCRIPTION
In the process of updating prober tests to support the 0.3.17 SCD API, a few 0.3.5 tests were accidentally broken.  This PR fixes those 0.3.5 tests.