### PR TITLE
[scd] Add missing files to scd.libsonnet

### DIFF
--- a/build/deploy/db_schemas/scd.libsonnet
+++ b/build/deploy/db_schemas/scd.libsonnet
@@ -4,5 +4,7 @@
     "000001_create_initial_version.up.sql": importstr "scd/000001_create_initial_version.up.sql",
     "000002_support_api_1_0_0.down.sql": importstr "scd/000002_support_api_1_0_0.down.sql",
     "000002_support_api_1_0_0.up.sql": importstr "scd/000002_support_api_1_0_0.up.sql",
+    "000003_scd_inverted_indices.down.sql": importstr "scd/000003_scd_inverted_indices.down.sql",
+    "000003_scd_inverted_indices.up.sql": importstr "scd/000003_scd_inverted_indices.up.sql",
   },
 }


### PR DESCRIPTION
#608 missed the instruction "The two new .sql files must be added to scd.libsonnet or defaultdb.libsonnet (for remote ID) in this folder"; this PR executes that instruction.