### PR TITLE
Fix aiohttp dependency location

### DIFF
--- a/monitoring/monitorlib/requirements.txt
+++ b/monitoring/monitorlib/requirements.txt
@@ -13,3 +13,4 @@ pyyaml==5.4
 requests==2.25.1
 s2sphere==0.2.5
 termcolor==1.1.0
+aiohttp==3.8.0

--- a/monitoring/prober/requirements.txt
+++ b/monitoring/prober/requirements.txt
@@ -1,2 +1,1 @@
 -r ../monitorlib/requirements.txt
-aiohttp


### PR DESCRIPTION
aiohttp is required in /monitoring/monitoringlib/infrastructure.py