### PR TITLE
Initial Specification of /inject/flight endpoint for SCD automated tests

### DIFF
--- a/interfaces/automated-testing/scd/scd.yaml
+++ b/interfaces/automated-testing/scd/scd.yaml
@@ -45,14 +45,16 @@ components:
           description: >-
             The result of the flight submission
 
-              - `Planned`: The flight submission data was correct and the operational intent was successfully accepted by the DSS.
+              - `Planned`: The flight submission data was valid and the flight was successfully processed by the USS and is now authorized.
 
-              - `Rejected`: The flight submission data was incorrect and / or the USS was not able to successfully submit the operational intent to the DSS.
+              - `Rejected`: The flight submission data provided was invalid and/or could not be used to attempt to authorize the flight.
 
-              - `Conflict`: The flight submission data was correct but an operational intent could not be created because of conflicting operational intent.
+              - `ConflictWithFlight`: The flight submission data was valid, but the flight could not be authorized because of a disallowed conflict with another flight.
+
+              - `Failed`: The USS was not able to successfully authorize the flight due to a problem with the USS or a downstream system
 
           type: string
-          enum: [Planned, Rejected, Conflict]
+          enum: [Planned, Rejected, ConflictWithFlight, Failed]
           example: Planned
 
 paths:

--- a/interfaces/automated-testing/scd/scd.yaml
+++ b/interfaces/automated-testing/scd/scd.yaml
@@ -78,12 +78,19 @@ paths:
       summary: Retrieve the status of the USS automated testing interface
       description: Get the status of the USS automated testing interface
 
-  /inject/flight:
-    summary: Process operator details
+  /v1/flights/{flight_id}:    
     put:      
       security:
         - Authority:
             - utm.inject_test_data
+      parameters:
+        - name: flight_id
+          in: path
+          required: true
+          description: A UUID string identifying the injected flight.
+          schema:
+            type: string
+            format: uuid
       responses:
         '200':
           content:

--- a/interfaces/automated-testing/scd/scd.yaml
+++ b/interfaces/automated-testing/scd/scd.yaml
@@ -39,7 +39,7 @@ components:
     InjectFlightResponse:
       type: object
       required:
-        - results
+        - result
       properties: 
         result: 
           description: >-

--- a/interfaces/automated-testing/scd/scd.yaml
+++ b/interfaces/automated-testing/scd/scd.yaml
@@ -36,6 +36,25 @@ components:
           enum: [Starting, Ready]
           example: Ready
 
+    InjectFlightResponse:
+      type: object
+      required:
+        - results
+      properties: 
+        result: 
+          description: >-
+            The result of the flight submission
+
+              - `Planned`: The flight submission data was correct and the operational intent was successfully accepted by the DSS.
+
+              - `Rejected`: The flight submission data was incorrect and / or the USS was not able to successfully submit the operational intent to the DSS.
+
+              - `Conflict`: The flight submission data was correct but an operational intent could not be created because of conflicting operational intent.
+
+          type: string
+          enum: [Planned, Rejected, Conflict]
+          example: Planned
+
 paths:
   /v1/status:
     get:
@@ -58,3 +77,25 @@ paths:
           description: The USS automated testing interface is not activated.
       summary: Retrieve the status of the USS automated testing interface
       description: Get the status of the USS automated testing interface
+
+  /inject/flight:
+    summary: Process operator details
+    put:      
+      security:
+        - Authority:
+            - utm.inject_test_data
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InjectFlightResponse'
+          description: Requested data was processed successfully
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+
+      summary: Inject test flight
+      description: >-
+        This endpoint simulates the operator intention to submit a flight operation / flight request.

--- a/interfaces/automated-testing/scd/scd.yaml
+++ b/interfaces/automated-testing/scd/scd.yaml
@@ -80,6 +80,7 @@ paths:
 
   /v1/flights/{flight_id}:    
     put:      
+      # TODO: Add the details of a requestBody for this endpoint
       security:
         - Authority:
             - utm.inject_test_data


### PR DESCRIPTION
This is the first PR of series which will fully specify the SCD testing interfaces. 

The payloads for the requests, have been left out for the next PRs.