### PR TITLE
[automated-testing] Migrate old rid_qualifier entrypoint to uss_qualifier

### DIFF
--- a/monitoring/mock_riddp/__init__.py
+++ b/monitoring/mock_riddp/__init__.py
@@ -5,5 +5,10 @@ from .config import Config
 webapp = flask.Flask(__name__)
 
 webapp.config.from_object(Config)
+print(
+  '################################################################################\n' + \
+  '################################ Configuration  ################################\n' + \
+  '\n'.join('## {}: {}'.format(key, webapp.config[key]) for key in webapp.config) + '\n' + \
+  '################################################################################', flush=True)
 
 from monitoring.mock_riddp import routes

--- a/monitoring/mock_riddp/routes_observation.py
+++ b/monitoring/mock_riddp/routes_observation.py
@@ -80,7 +80,7 @@ def display_data() -> Tuple[str, int]:
   isas_response: fetch.FetchedISAs = fetch.isas(resources.utm_client, view, t, t)
   if not isas_response.success:
     response = rid.ErrorResponse(message='Unable to fetch ISAs from DSS')
-    response['errors'] = [isas_response.error]
+    response['errors'] = [isas_response]
     return flask.jsonify(response), 412
 
   # Fetch flights from each unique flights URL
@@ -91,7 +91,7 @@ def display_data() -> Tuple[str, int]:
     flights_response = fetch.flights(resources.utm_client, flights_url, view, True)
     if not flights_response.success:
       response = rid.ErrorResponse(message='Error querying {}'.format(flights_url))
-      response['errors'] = flights_response.errors
+      response['errors'] = [flights_response]
       return flask.jsonify(response), 412
     for flight in flights_response.flights:
       try:

--- a/monitoring/mock_ridsp/__init__.py
+++ b/monitoring/mock_ridsp/__init__.py
@@ -5,5 +5,10 @@ from .config import Config
 webapp = flask.Flask(__name__)
 
 webapp.config.from_object(Config)
+print(
+  '################################################################################\n' + \
+  '################################ Configuration  ################################\n' + \
+  '\n'.join('## {}: {}'.format(key, webapp.config[key]) for key in webapp.config) + '\n' + \
+  '################################################################################', flush=True)
 
 from monitoring.mock_ridsp import routes

--- a/monitoring/mock_ridsp/run_locally.sh
+++ b/monitoring/mock_ridsp/run_locally.sh
@@ -15,8 +15,8 @@ cd "${BASEDIR}/../.." || exit 1
 AUTH="DummyOAuth(http://host.docker.internal:8085/token,uss1)"
 DSS="http://host.docker.internal:8082"
 PUBLIC_KEY="/var/test-certs/auth2.pem"
-AUD=${MOCK_RIDSP_TOKEN_AUDIENCE:-localhost}
-BASE_URL="http://${AUD}:8071/ridsp"
+AUD=${MOCK_RIDSP_TOKEN_AUDIENCE:-localhost,host.docker.internal}
+BASE_URL="http://${MOCK_RIDSP_TOKEN_AUDIENCE:-host.docker.internal}:8071/ridsp"
 PORT=8071
 
 docker build \

--- a/monitoring/uss_qualifier/.gitignore
+++ b/monitoring/uss_qualifier/.gitignore
@@ -1,3 +1,4 @@
-test_definitions/*/*/
+config_run_locally.json
+config_test_fully_mocked_local_system.json
 report.json
 client_secret.json

--- a/monitoring/uss_qualifier/README.md
+++ b/monitoring/uss_qualifier/README.md
@@ -3,6 +3,6 @@
 ## Introduction
 
 The USS Qualifier automates testing standards compliance and interoperability of multiple
-service providers. It currently includes the following qualifiers:
+service providers. It currently includes the following components:
 
-- [Remote ID qualifier](./rid/README.md): ASTM F3411-19 - Remote ID and Tracking 
+- [Remote ID](./rid/README.md): ASTM F3411-19 - Remote ID and Tracking

--- a/monitoring/uss_qualifier/bin/generate_rid_test_definition.sh
+++ b/monitoring/uss_qualifier/bin/generate_rid_test_definition.sh
@@ -27,6 +27,6 @@ fi
 docker run ${docker_args} --name flight_data_generator \
   --rm \
   -e PYTHONBUFFERED=1 \
-  -v "$(pwd)/monitoring/uss_qualifier/test_definitions/rid:/app/monitoring/uss_qualifier/test_definitions/rid" \
+  -v "$(pwd)/monitoring/uss_qualifier/rid/test_definitions:/app/monitoring/uss_qualifier/rid/test_definitions" \
   interuss/uss_qualifier \
   python rid/simulator/flight_state.py

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -62,8 +62,8 @@ def main() -> int:
       flight_records = aircraft_state_replayer.get_full_flight_records(aircraft_states_directory)
 
     # Run RID tests
-    test_executor.test_rid(test_configuration=config, auth_spec=auth_spec,
-                           flight_records=flight_records)
+    test_executor.run_rid_tests(test_configuration=config, auth_spec=auth_spec,
+                                flight_records=flight_records)
 
     return os.EX_OK
 

--- a/monitoring/uss_qualifier/rid/.gitignore
+++ b/monitoring/uss_qualifier/rid/.gitignore
@@ -1,0 +1,1 @@
+test_definitions

--- a/monitoring/uss_qualifier/rid/aircraft_state_replayer.py
+++ b/monitoring/uss_qualifier/rid/aircraft_state_replayer.py
@@ -25,7 +25,7 @@ def get_full_flight_records(aircraft_states_directory: Path) -> List[FullFlightR
     files = [os.path.join(aircraft_states_directory,f) for f in all_files if os.path.isfile(os.path.join(aircraft_states_directory, f))]
 
     if not files:
-        raise ValueError('The there are no states in the states directory, create states first using the flight_data_generator module.')
+        raise ValueError('There are no states in the states directory, create states first using the simulator/flight_state module.')
 
     flight_records: List[FullFlightRecord] = []
     for file in files:
@@ -88,6 +88,7 @@ class TestHarness():
     def __init__(self, auth_spec:str, injection_base_url:str):
 
         auth_adapter = make_auth_adapter(auth_spec)
+        self._base_url = injection_base_url
         self.uss_session = DSSTestSession(injection_base_url, auth_adapter)
 
     def submit_test(self, payload: CreateTestParameters, test_id: str, setup: reports.Setup) -> None:
@@ -101,4 +102,5 @@ class TestHarness():
         if response.status_code == 200:
             print("New test with ID %s created" % test_id)
         else:
-            raise RuntimeError('Error {} submitting test ID {}: {}'.format(response.status_code, test_id, response.content.decode('utf-8')))
+            raise RuntimeError('Error {} submitting test ID {} to {}: {}'.format(
+                response.status_code, test_id, self._base_url, response.content.decode('utf-8')))

--- a/monitoring/uss_qualifier/rid/test_executor.py
+++ b/monitoring/uss_qualifier/rid/test_executor.py
@@ -8,9 +8,9 @@ from monitoring.monitorlib.infrastructure import DSSTestSession
 from monitoring.monitorlib.auth import make_auth_adapter
 
 
-def test_rid(test_configuration: RIDQualifierTestConfiguration,
-             auth_spec: str,
-             flight_records: List[FullFlightRecord]) -> reports.Report:
+def run_rid_tests(test_configuration: RIDQualifierTestConfiguration,
+                  auth_spec: str,
+                  flight_records: List[FullFlightRecord]) -> reports.Report:
     my_test_builder = TestBuilder(test_configuration=test_configuration, flight_records=flight_records)
     test_payloads = my_test_builder.build_test_payloads()
     test_id = str(uuid.uuid4())

--- a/monitoring/uss_qualifier/rid/test_executor.py
+++ b/monitoring/uss_qualifier/rid/test_executor.py
@@ -1,17 +1,17 @@
 import json
 import uuid
-from typing import List, Optional
+from typing import List
 from monitoring.uss_qualifier.rid.aircraft_state_replayer import TestHarness, TestBuilder
-from monitoring.uss_qualifier.rid.utils import RIDQualifierTestConfiguration, InjectedFlight
+from monitoring.uss_qualifier.rid.utils import RIDQualifierTestConfiguration, InjectedFlight, FullFlightRecord
 from monitoring.uss_qualifier.rid import display_data_evaluator, reports
 from monitoring.monitorlib.infrastructure import DSSTestSession
 from monitoring.monitorlib.auth import make_auth_adapter
 
 
-def main(
-        test_configuration: RIDQualifierTestConfiguration,
-        auth_spec: str, aircraft_state_files: Optional[list] = None) -> reports.Report:
-    my_test_builder = TestBuilder(test_configuration=test_configuration, aircraft_state_files=aircraft_state_files)
+def test_rid(test_configuration: RIDQualifierTestConfiguration,
+             auth_spec: str,
+             flight_records: List[FullFlightRecord]) -> reports.Report:
+    my_test_builder = TestBuilder(test_configuration=test_configuration, flight_records=flight_records)
     test_payloads = my_test_builder.build_test_payloads()
     test_id = str(uuid.uuid4())
     report = reports.Report(setup=reports.Setup(configuration=test_configuration))

--- a/monitoring/uss_qualifier/run_locally.sh
+++ b/monitoring/uss_qualifier/run_locally.sh
@@ -12,10 +12,15 @@ else
 fi
 cd "${BASEDIR}/../.." || exit 1
 
-CONFIG_LOCATION="monitoring/uss_qualifier/config.json"
+echo '################################################################################'
+echo '## NOTE: A prerequisite for running this command locally is to have a running ##'
+echo '## instance of the uss_qualifier RID system mock (rid/mock/run_locally.sh)    ##'
+echo '################################################################################'
+
+CONFIG_LOCATION="monitoring/uss_qualifier/config_run_locally.json"
+CONFIG='--config config_run_locally.json'
 
 AUTH='--auth NoAuth()'
-# NB: A prerequisite to run this command locally is to have a running instance of the uss_qualifier/rid/mock (/monitoring/uss_qualifier/rid/mock/run_locally.sh)
 
 echo '{
   "locale": "che",
@@ -40,8 +45,6 @@ echo '{
     }
   ]
 }' > ${CONFIG_LOCATION}
-
-CONFIG='--config config.json'
 
 RID_QUALIFIER_OPTIONS="$AUTH $CONFIG"
 
@@ -69,6 +72,6 @@ docker run ${docker_args} --name uss_qualifier \
   -v "${REPORT_FILE}:/app/monitoring/uss_qualifier/report.json" \
   -v "$(pwd)/${CONFIG_LOCATION}:/app/${CONFIG_LOCATION}" \
   interuss/uss_qualifier \
-  python rid/main.py $RID_QUALIFIER_OPTIONS
+  python main.py $RID_QUALIFIER_OPTIONS
 
 rm ${CONFIG_LOCATION}

--- a/monitoring/uss_qualifier/test_fully_mocked_local_system.sh
+++ b/monitoring/uss_qualifier/test_fully_mocked_local_system.sh
@@ -10,7 +10,15 @@ else
 fi
 cd "${BASEDIR}/../.." || exit 1
 
-CONFIG_LOCATION="monitoring/uss_qualifier/config.json"
+echo '################################################################################'
+echo '## NOTE: Prerequisites to run this command are:                               ##'
+echo '## 1. Local DSS instance + Dummy OAuth server (/build/dev/run_locally.sh)     ##'
+echo '## 2. Local mock RID service provider (/monitoring/mock_ridsp/run_locally.sh) ##'
+echo '## 3. Local mock RID display provider (/monitoring/mock_riddp/run_locally.sh) ##'
+echo '################################################################################'
+
+CONFIG_LOCATION="monitoring/uss_qualifier/config_test_fully_mocked_local_system.json"
+CONFIG='--config config_test_fully_mocked_local_system.json'
 
 AUTH='--auth DummyOAuth(http://host.docker.internal:8085/token,sub=testing_uss)'
 
@@ -29,8 +37,6 @@ echo '{
     }
   ]
 }' > ${CONFIG_LOCATION}
-
-CONFIG='--config config.json'
 
 RID_QUALIFIER_OPTIONS="$AUTH $CONFIG"
 
@@ -52,6 +58,6 @@ docker run --name uss_qualifier \
   -v "$(pwd)/monitoring/uss_qualifier/report.json:/app/monitoring/uss_qualifier/report.json" \
   -v "$(pwd)/${CONFIG_LOCATION}:/app/${CONFIG_LOCATION}" \
   interuss/uss_qualifier \
-  python rid/main.py $RID_QUALIFIER_OPTIONS
+  python main.py $RID_QUALIFIER_OPTIONS
 
 rm ${CONFIG_LOCATION}

--- a/monitoring/uss_qualifier/webapp/tasks.py
+++ b/monitoring/uss_qualifier/webapp/tasks.py
@@ -35,7 +35,7 @@ def call_test_executor(user_config_json: str, auth_spec: str, flight_record_json
     if debug:
         report = test_report.test_data
     else:
-        report = test_executor.test_rid(user_config, auth_spec, flight_records)
+        report = test_executor.run_rid_tests(user_config, auth_spec, flight_records)
     return json.dumps(report)
 
 def call_kml_processor(kml_content, output_path):

--- a/monitoring/uss_qualifier/webapp/tasks.py
+++ b/monitoring/uss_qualifier/webapp/tasks.py
@@ -1,10 +1,11 @@
 import json
+from typing import List
 import redis
 import rq
 from . import resources
 from monitoring.monitorlib.typing import ImplicitDict
 from monitoring.uss_qualifier.rid import test_executor
-from monitoring.uss_qualifier.rid.utils import RIDQualifierTestConfiguration
+from monitoring.uss_qualifier.rid.utils import RIDQualifierTestConfiguration, FullFlightRecord
 from monitoring.uss_qualifier.rid.simulator import flight_state_from_kml
 from monitoring.uss_qualifier.test_data import test_report
 
@@ -25,13 +26,16 @@ def remove_rq_job(job_id):
     return rq_job
 
 
-def call_test_executor(user_config_json, auth_spec, input_files, debug=False):
+def call_test_executor(user_config_json: str, auth_spec: str, flight_record_jsons: List[str], debug=False):
     user_config: RIDQualifierTestConfiguration = ImplicitDict.parse(
         json.loads(user_config_json), RIDQualifierTestConfiguration)
+    flight_records: List[FullFlightRecord] = [
+        ImplicitDict.parse(json.loads(j), FullFlightRecord)
+        for j in flight_record_jsons]
     if debug:
         report = test_report.test_data
     else:
-        report = test_executor.main(user_config, auth_spec, input_files)
+        report = test_executor.test_rid(user_config, auth_spec, flight_records)
     return json.dumps(report)
 
 def call_kml_processor(kml_content, output_path):

--- a/monitoring/uss_qualifier/webapp/templates/base.html
+++ b/monitoring/uss_qualifier/webapp/templates/base.html
@@ -12,7 +12,7 @@
     <link id="favicon" rel="shortcut icon" type="image/png" href="static/images/favicon.png" />
     <nav class="navbar navbar-expand-md navbar-dark bg-steel fixed-top">
       <div class="container">
-        <a class="navbar-brand mr-4" href="/">RID Host</a>
+        <a class="navbar-brand mr-4" href="/">USS Qualifier Host</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggle" aria-controls="navbarToggle" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
@@ -34,7 +34,7 @@
     {% block head %}{% endblock %}
     </head>
     <body>
-        <title>RID Qualifier host</title>
+        <title>USS Qualifier host</title>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
         <script>
           $(window).on("load", function() {


### PR DESCRIPTION
This PR moves the main entrypoint for automated testing from the `rid` folder to the main `uss_qualifier` folder.  The tests performed and listed below revealed some issues and possible improvements which are also addressed in this PR.

## Tests performed

### Blank slate, mock RID system

After deleting test_definitions:

1. `monitoring/uss_qualifier/rid/mock/run_locally.sh`
2. `monitoring/uss_qualifier/run_locally.sh`

### Full system mock

1. `build/dev/run_locally.sh`
2. `monitoring/mock_ridsp/run_locally.sh`
3. `monitoring/mock_riddp/run_locally.sh`
4. `monitoring/uss_qualifier/test_fully_mocked_local_system.sh`

### Generate test definitions

1. `monitoring/uss_qualifier/bin/generate_rid_test_definitions.sh`

...then rerun Full system mock

### Via web app

1. `build/dev/run_locally.sh`
2. `monitoring/mock_ridsp/run_locally.sh`
3. `monitoring/mock_riddp/run_locally.sh`
4. `monitoring/uss_qualifier/webapp/run_locally.sh`
5. Add Flight Records -> select all .json files in monitoring/uss_qualifier/rid/test_definitions/che
6. Auth Spec -> content in test_fully_mocked_local_system.sh
7. User Config -> content in test_fully_mocked_local_system.sh
8. Click Run Test (and wait ~11 minutes)