### PR TITLE
[uss_qualifier] Add SCD entrypoint and update config schema

### DIFF
--- a/monitoring/uss_qualifier/rid/utils.py
+++ b/monitoring/uss_qualifier/rid/utils.py
@@ -34,12 +34,6 @@ class EvaluationConfiguration(ImplicitDict):
 
 
 class RIDQualifierTestConfiguration(ImplicitDict):
-    locale: str
-    """A three letter ISO 3166 country code to run the qualifier against.
-
-    This should be the same one used to simulate the flight_data in
-    the flight_data_generator.py module."""
-
     injection_targets: List[InjectionTargetConfiguration]
     """Set of Service Providers into which data should be injected"""
 

--- a/monitoring/uss_qualifier/run_locally.sh
+++ b/monitoring/uss_qualifier/run_locally.sh
@@ -24,26 +24,28 @@ AUTH='--auth NoAuth()'
 
 echo '{
   "locale": "che",
-  "injection_targets": [
-    {
-      "name": "uss1",
-      "injection_base_url": "http://host.docker.internal:8070/sp/uss1"
-    },
-    {
-      "name": "uss2",
-      "injection_base_url": "http://host.docker.internal:8070/sp/uss2"
-    }
-  ],
-  "observers": [
-    {
-      "name": "uss2",
-      "observation_base_url": "http://host.docker.internal:8070/dp/uss2"
-    },
-    {
-      "name": "uss3",
-      "observation_base_url": "http://host.docker.internal:8070/dp/uss3"
-    }
-  ]
+  "rid": {
+    "injection_targets": [
+      {
+        "name": "uss1",
+        "injection_base_url": "http://host.docker.internal:8070/sp/uss1"
+      },
+      {
+        "name": "uss2",
+        "injection_base_url": "http://host.docker.internal:8070/sp/uss2"
+      }
+    ],
+    "observers": [
+      {
+        "name": "uss2",
+        "observation_base_url": "http://host.docker.internal:8070/dp/uss2"
+      },
+      {
+        "name": "uss3",
+        "observation_base_url": "http://host.docker.internal:8070/dp/uss3"
+      }
+    ]
+  }
 }' > ${CONFIG_LOCATION}
 
 RID_QUALIFIER_OPTIONS="$AUTH $CONFIG"

--- a/monitoring/uss_qualifier/scd/test_executor.py
+++ b/monitoring/uss_qualifier/scd/test_executor.py
@@ -1,0 +1,18 @@
+from monitoring.uss_qualifier.scd.utils import SCDQualifierTestConfiguration
+from monitoring.uss_qualifier.utils import is_url
+
+
+def validate_configuration(test_configuration: SCDQualifierTestConfiguration):
+    try:
+        for injection_target in test_configuration.injection_targets:
+            is_url(injection_target.injection_base_url)
+    except ValueError:
+        raise ValueError("A valid url for injection_target must be passed")
+
+def run_scd_tests(locale: str, test_configuration: SCDQualifierTestConfiguration,
+                  auth_spec: str):
+    # TODO Replace with actual implementation
+    if locale is 'che':
+        print("[SCD] Running ASTM and U-Space tests")
+    else:
+        print("[SCD] Running ASTM tests")

--- a/monitoring/uss_qualifier/scd/utils.py
+++ b/monitoring/uss_qualifier/scd/utils.py
@@ -1,0 +1,9 @@
+from typing import List
+
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.uss_qualifier.rid.utils import InjectionTargetConfiguration
+
+
+class SCDQualifierTestConfiguration(ImplicitDict):
+  injection_targets: List[InjectionTargetConfiguration]
+  """Set of USS into which data should be injected"""

--- a/monitoring/uss_qualifier/utils.py
+++ b/monitoring/uss_qualifier/utils.py
@@ -1,0 +1,26 @@
+from typing import Optional
+from urllib.parse import urlparse
+
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.uss_qualifier.rid.utils import RIDQualifierTestConfiguration
+from monitoring.uss_qualifier.scd.utils import SCDQualifierTestConfiguration
+
+
+class USSQualifierTestConfiguration(ImplicitDict):
+  locale: str
+  """A three letter ISO 3166 country code to run the qualifier against.
+
+  This should be the same one used to simulate the flight_data in
+  the flight_data_generator.py module."""
+
+  rid: Optional[RIDQualifierTestConfiguration]
+  """Test configuration for RID"""
+
+  scd: Optional[SCDQualifierTestConfiguration]
+  """Test configuration for SCD"""
+
+def is_url(url_string):
+  try:
+    urlparse(url_string)
+  except ValueError:
+    raise ValueError("A valid url must be passed")


### PR DESCRIPTION
This PR adds a placeholder for SCD automated tests execution and proposes an update of the configuration schema to handle multiple services.

It assumes the locale will be the same for all services under test.