### PR TITLE
[crdb] Extract connectTo method to prepare for reuse

### DIFF
--- a/pkg/cockroach/cockroach.go
+++ b/pkg/cockroach/cockroach.go
@@ -122,6 +122,19 @@ func Dial(uri string) (*DB, error) {
 	}, nil
 }
 
+// Connect to a database using the specified connection parameters
+func ConnectTo(connectParameters ConnectParameters) (*DB, error) {
+	uri, err := connectParameters.BuildURI()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "Error building CockroachDB connection URI")
+	}
+	db, err := Dial(uri)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "Error dialing CockroachDB database at %s", uri)
+	}
+	return db, nil
+}
+
 // GetVersion returns the Schema Version of the requested DB Name
 func (db *DB) GetVersion(ctx context.Context, dbName string) (*semver.Version, error) {
 	const query = `


### PR DESCRIPTION
Currently, there is a private `connectTo` method in the grpc-backend that produces a CockroachDB connection, but hides the fact that the the connection parameters for that connection come from flags defined in an entirely different package.  This PR changes the `ConnectTo` method to accept only the full, explicit parameter set, makes the method public in the main `cockroach` package to prepare for reuse in other areas, and makes the origin of the rest of the connection parameters more clear in the grpc-backend.