### PR TITLE
[dummy-oauth] Add API definition for Dummy OAuth

### DIFF
--- a/cmds/dummy-oauth/README.md
+++ b/cmds/dummy-oauth/README.md
@@ -1,0 +1,36 @@
+# Dummy OAuth
+
+## Contents
+
+This folder contains a development utility that generates OAuth access tokens compatible with ASTM APIs with the specified fields (and no security).
+
+## Usage
+
+The API for Dummy OAuth may be found [here](../../interfaces/dummy-oauth)
+
+Dummy OAuth can be run directly on a development system with Go installed by starting in the repo root folder and:
+
+```bash
+go run ./cmds/dummy-oauth
+```
+
+To use the [Docker image](Dockerfile) for Dummy OAuth, leverage [build/dev/run_locally.sh](../../build/dev/run_locally.sh) starting from the root folder of the repo:
+
+```bash
+build/dev/run_locally.sh build local-dss-dummy-oauth
+build/dev/run_locally.sh up -d local-dss-dummy-oauth
+```
+
+Get a token using an approach similar to this:
+
+```bash
+curl "http://localhost:8085/token?sub=uss1&intended_audience=uss2&scope=dss.read.identification_service_areas&issuer=dummy_oauth"
+```
+
+Token contents can be verified at [jwt.io](https://jwt.io), and the signature can be validated with the [auth2.pem public key](../../build/test-certs/auth2.pem).
+
+Take down the Dummy OAuth instance like this:
+
+```bash
+build/dev/run_locally.sh down
+```

--- a/cmds/dummy-oauth/README.md
+++ b/cmds/dummy-oauth/README.md
@@ -27,7 +27,7 @@ Get a token using an approach similar to this:
 curl "http://localhost:8085/token?sub=uss1&intended_audience=uss2&scope=dss.read.identification_service_areas&issuer=dummy_oauth"
 ```
 
-Token contents can be verified at [jwt.io](https://jwt.io), and the signature can be validated with the [auth2.pem public key](../../build/test-certs/auth2.pem).
+Token contents can be verified at https://dinochiesa.github.io/jwt/, and the signature can be validated with the [auth2.pem public key](../../build/test-certs/auth2.pem) by default.
 
 Take down the Dummy OAuth instance like this:
 

--- a/cmds/dummy-oauth/main.go
+++ b/cmds/dummy-oauth/main.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	address = flag.String("addr", ":8085", "address")
-	keyFile = flag.String("private_key_file", "build/test-certs/oauth.key", "oauth private key file")
+	keyFile = flag.String("private_key_file", "build/test-certs/auth2.key", "oauth private key file")
 )
 
 // TODO(steeling): add other parameters so we can test expired tokens, invalid tokens, etc.

--- a/interfaces/dummy-oauth/dummy-oauth.yaml
+++ b/interfaces/dummy-oauth/dummy-oauth.yaml
@@ -27,18 +27,21 @@ paths:
         description: Fully-qualified domain name where the service for which this access token will be used is hosted.  The `aud` claim will be populated with this value.
         schema:
           type: string
+        example: uss.example.com
       - name: scope
         in: query
         required: true
         description: Scope or scopes that should be granted in the access token.  Multiple scopes can be delimited by spaces (%20) in a single value.  The `scope` claim will be populated with all requested scopes.
         schema:
           type: string
+        example: dss.read.identification_service_areas
       - name: issuer
         in: query
         required: true
         description: Identity of the issuer of the token.  The `iss` claim will be populated with this value.
         schema:
           type: string
+        example: dummy_oauth
       - name: expire
         in: query
         required: false
@@ -46,12 +49,14 @@ paths:
         schema:
           type: integer
           format: int64
+        example: 1532714469
       - name: sub
         in: query
         required: true
         description: Identity of client/subscriber requesting access token.  The `sub` claim will be populated with this value.
         schema:
           type: string
+        example: uss1
       responses:
         '200':
           content:

--- a/interfaces/dummy-oauth/dummy-oauth.yaml
+++ b/interfaces/dummy-oauth/dummy-oauth.yaml
@@ -61,4 +61,3 @@ paths:
           description: >-
             The requested token was generated successfully
       summary: Generate an access token
-      description: Get the status of the USS automated testing interface

--- a/interfaces/dummy-oauth/dummy-oauth.yaml
+++ b/interfaces/dummy-oauth/dummy-oauth.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.2
+info:
+  title: Dummy OAuth Provider
+  version: 1.0.0
+  description: >-
+    This interface exposes the ability to generate OAuth tokens usable by the
+    DSS according to parameters specified by the client.
+
+components:
+  schemas:
+    TokenResponse:
+      type: object
+      required:
+      - access_token
+      properties:
+        access_token:
+          description: JWT that may be used as a Bearer token to authorize operations on an appropriately-configured DSS instance
+          type: string
+
+paths:
+  /token:
+    get:
+      parameters:
+      - name: intended_audience
+        in: query
+        required: true
+        description: Fully-qualified domain name where the service for which this access token will be used is hosted.  The `aud` claim will be populated with this value.
+        schema:
+          type: string
+      - name: scope
+        in: query
+        required: true
+        description: Scope or scopes that should be granted in the access token.  Multiple scopes can be delimited by spaces (%20) in a single value.  The `scope` claim will be populated with all requested scopes.
+        schema:
+          type: string
+      - name: issuer
+        in: query
+        required: true
+        description: Identity of the issuer of the token.  The `iss` claim will be populated with this value.
+        schema:
+          type: string
+      - name: expire
+        in: query
+        required: false
+        description: Unix timestamp (seconds since epoch) of the time this access token should expire.  If not specified, defaults to an hour from time of token creation.
+        schema:
+          type: integer
+          format: int64
+      - name: sub
+        in: query
+        required: true
+        description: Identity of client/subscriber requesting access token.  The `sub` claim will be populated with this value.
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+          description: >-
+            The requested token was generated successfully
+      summary: Generate an access token
+      description: Get the status of the USS automated testing interface


### PR DESCRIPTION
We currently have a webserver in cmds/dummy-oauth that generates DSS-consumable access tokens for development purposes.  Its API is currently implicit in the Go code implementing the handler.  This PR makes the API explicit and also adds a README explaining the tool and intended usage.  Not only will this make the tool more usable and approachable by new users, but it also prepares for using the new interfaces/openapi-to-go-server tool to autogenerate the webserver part of Dummy OAuth.