### PR TITLE
[scripts/release] Change remote branch used for tags to origin

### DIFF
--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -21,4 +21,5 @@ if test -z "${version}"; then
 fi
 
 git tag -a "${version}"
-git push tag "${version}"
+git push origin "${version}"
+


### PR DESCRIPTION
This PR updates the tag script to use the `origin` remote.