### PR TITLE
[core-service,http-gateway] Retry recoverable errors during core-service and http-gateway startups

### DIFF
--- a/cmds/core-service/README.md
+++ b/cmds/core-service/README.md
@@ -1,0 +1,50 @@
+# core-service
+
+## Introduction
+
+This core-service executable is the main application logic of the DSS.  It requires a connection to a CockroachDB database and exposes a few gRPC services: [ASTM remote ID](../../interfaces/uastech/standards/remoteid), [auxiliary](../../pkg/api/v1/auxpb/aux_service.proto), and [ASTM strategic coordination](../../interfaces/astm-utm/Protocol) (if specified).
+
+## Usage
+
+For production deployment of this executable, see [the deployment documentation](../../build/README.md).
+
+For experimentation on a local machine, see [the standalone instance documentation](../../build/dev/standalone_instance.md).
+
+To run this executable directly on a local machine using Go rather than a Docker container, run something similar to the command below from the repo root folder:
+
+```bash
+go run ./cmds/core-service \
+  -cockroach_host localhost \
+  -public_key_files build/test-certs/auth2.pem \
+  -reflect_api \
+  -log_format console \
+  -dump_requests \
+  -accepted_jwt_audiences localhost \
+  -enable_scd \
+  -enable_http
+```
+
+### Prerequisites
+
+#### CockroachDB cluster
+
+To run correctly, core-service must be able to [access](../../pkg/cockroach/flags/flags.go) a CockroachDB cluster.  Provision of this cluster is handled automatically for a local development environment if following [the instructions for a standalone instance](../../build/dev/standalone_instance.md).  Or, a CockroachDB instance can be created manually with:
+
+```bash
+docker container run -p 26257:26257 -p 8080:8080 --rm cockroachdb/cockroach:v21.2.3 start-single-node --insecure
+```
+
+#### Database configuration
+
+Once an initialized CockroachDB cluster is available, the necessary databases within the CRDB cluster must be created/configured properly.  This can be accomplished with [migrate_local_db.sh](../../build/dev/migrate_local_db.sh), as documented in the [standalone instance documentation](../../build/dev/standalone_instance.md), when using the standard standalone development DSS instance, or it can be accomplished manually with commands similar to those below starting from the repo root folder:
+
+```bash
+go run ./cmds/db-manager \
+  --schemas_dir ./build/deploy/db_schemas/rid \
+  --db_version latest \
+  --cockroach_host localhost
+go run ./cmds/db-manager \
+  --schemas_dir ./build/deploy/db_schemas/scd \
+  --db_version latest \
+  --cockroach_host localhost
+```

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -60,6 +60,10 @@ var (
 	jwtAudiences = flag.String("accepted_jwt_audiences", "", "comma-separated acceptable JWT `aud` claims")
 )
 
+const (
+	codeRetryable = stacktrace.ErrorCode(1)
+)
+
 func getDBStats(ctx context.Context, db *cockroach.DB, databaseName string) {
 	logger := logging.WithValuesFromContext(ctx, logging.Logger)
 	statsPtr := db.Pool.Stat()
@@ -74,7 +78,7 @@ func getDBStats(ctx context.Context, db *cockroach.DB, databaseName string) {
 	stats["MaxConns"] = strconv.Itoa(int(statsPtr.MaxConns()))
 	stats["TotalConns"] = strconv.Itoa(int(statsPtr.TotalConns()))
 	if stats["TotalConns"] == "0" {
-		logger.Panic("Failed periodic DB Ping, panic to force restart", zap.String("Database", databaseName))
+		logger.Panic("Failed periodic DB Ping with TotalConns=0, panic to force restart", zap.String("Database", databaseName))
 	} else {
 		logger.Info("Successful periodic DB Ping ", zap.String("Database", databaseName))
 	}
@@ -103,23 +107,32 @@ func createKeyResolver() (auth.KeyResolver, error) {
 
 func createRIDServer(ctx context.Context, locality string, logger *zap.Logger) (*rid.Server, error) {
 	connectParameters := flags.ConnectParameters()
-	connectParameters.DBName = ridc.DatabaseName
+	connectParameters.DBName = "rid"
 	ridCrdb, err := cockroach.ConnectTo(ctx, connectParameters)
 	if err != nil {
+		// TODO: More robustly detect failure to create RID server is due to a problem that may be temporary
+		if strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to CRDB server for remote ID store")
+		}
 		return nil, stacktrace.Propagate(err, "Failed to connect to remote ID database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
 	}
 
-	ridStore, err := ridc.NewStore(ctx, ridCrdb, logger)
+	ridStore, err := ridc.NewStore(ctx, ridCrdb, connectParameters.DBName, logger)
 	if err != nil {
-		// try DatabaseName with defaultdb for older versions.
-		ridc.DatabaseName = "defaultdb"
-		connectParameters.DBName = ridc.DatabaseName
+		// try DBName of defaultdb for older versions.
+		ridCrdb.Pool.Close()
+		connectParameters.DBName = "defaultdb"
 		ridCrdb, err := cockroach.ConnectTo(ctx, connectParameters)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "Failed to connect to remote ID database for older version <defaultdb>; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
 		}
-		ridStore, err = ridc.NewStore(ctx, ridCrdb, logger)
+		ridStore, err = ridc.NewStore(ctx, ridCrdb, connectParameters.DBName, logger)
 		if err != nil {
+			// TODO: More robustly detect failure to create RID server is due to a problem that may be temporary
+			if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database has not been bootstrapped with Schema Manager") {
+				ridCrdb.Pool.Close()
+				return nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to CRDB server for remote ID store")
+			}
 			return nil, stacktrace.Propagate(err, "Failed to create remote ID store")
 		}
 	}
@@ -133,13 +146,13 @@ func createRIDServer(ctx context.Context, locality string, logger *zap.Logger) (
 	// schedule period tasks for RID Server
 	ridCron := cron.New()
 	// schedule printing of DB connection stats every minute for the underlying storage for RID Server
-	if _, err := ridCron.AddFunc("@every 1m", func() { getDBStats(ctx, ridCrdb, ridc.DatabaseName) }); err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to schedule periodic db stat check to %s", ridc.DatabaseName)
+	if _, err := ridCron.AddFunc("@every 1m", func() { getDBStats(ctx, ridCrdb, connectParameters.DBName) }); err != nil {
+		return nil, stacktrace.Propagate(err, "Failed to schedule periodic db stat check to %s", connectParameters.DBName)
 	}
 
 	cronLogger := cron.VerbosePrintfLogger(log.New(os.Stdout, "RIDGarbageCollectorJob: ", log.LstdFlags))
 	if _, err = ridCron.AddJob(*garbageCollectorSpec, cron.NewChain(cron.SkipIfStillRunning(cronLogger)).Then(RIDGarbageCollectorJob{"delete rid expired records", *gc, ctx})); err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to schedule periodic delete rid expired records to %s", ridc.DatabaseName)
+		return nil, stacktrace.Propagate(err, "Failed to schedule periodic delete rid expired records to %s", connectParameters.DBName)
 	}
 	ridCron.Start()
 
@@ -148,6 +161,7 @@ func createRIDServer(ctx context.Context, locality string, logger *zap.Logger) (
 		Timeout:    *timeout,
 		Locality:   locality,
 		EnableHTTP: *enableHTTP,
+		Cron:       ridCron,
 	}, nil
 }
 
@@ -158,6 +172,17 @@ func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, erro
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "Failed to connect to strategic conflict detection database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
 	}
+
+	scdStore, err := scdc.NewStore(ctx, scdCrdb, logger)
+	if err != nil {
+		// TODO: More robustly detect failure to create SCD server is due to a problem that may be temporary
+		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database \"scd\" does not exist") {
+			scdCrdb.Pool.Close()
+			return nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to CRDB server for strategic conflict detection store")
+		}
+		return nil, stacktrace.Propagate(err, "Failed to create strategic conflict detection store")
+	}
+
 	// schedule period tasks for SCD Server
 	scdCron := cron.New()
 	// schedule printing of DB connection stats every minute for the underlying storage for RID Server
@@ -166,11 +191,6 @@ func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, erro
 	}
 
 	scdCron.Start()
-
-	scdStore, err := scdc.NewStore(ctx, scdCrdb, logger)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to create strategic conflict detection store")
-	}
 
 	return &scd.Server{
 		Store:      scdStore,
@@ -189,13 +209,6 @@ func RunGRPCServer(ctx context.Context, ctxCanceler func(), address string, loca
 		// correctly.
 		logger.Warn("missing required --accepted_jwt_audiences")
 	}
-
-	l, err := net.Listen("tcp", address)
-	if err != nil {
-		return stacktrace.Propagate(err, "Error attempting to listen at %s", address)
-	}
-	// l does not need to be closed manually. Instead, the grpc Server instance owning
-	// l will close it on a graceful stop.
 
 	var (
 		ridServer *rid.Server
@@ -219,6 +232,7 @@ func RunGRPCServer(ctx context.Context, ctxCanceler func(), address string, loca
 	if *enableSCD {
 		server, err := createSCDServer(ctx, logger)
 		if err != nil {
+			ridServer.Cron.Stop()
 			return stacktrace.Propagate(err, "Failed to create strategic conflict detection server")
 		}
 		scdServer = server
@@ -297,6 +311,12 @@ func RunGRPCServer(ctx context.Context, ctxCanceler func(), address string, loca
 			}
 		}
 	}()
+	l, err := net.Listen("tcp", address)
+	if err != nil {
+		return stacktrace.Propagate(err, "Error attempting to listen at %s", address)
+	}
+	// l does not need to be closed manually. Instead, the grpc Server instance owning
+	// l will close it on a graceful stop.
 	return s.Serve(l)
 }
 
@@ -337,8 +357,23 @@ func main() {
 		}
 	}
 
-	if err := RunGRPCServer(ctx, cancel, *address, *locality); err != nil {
-		logger.Panic("Failed to execute service", zap.Error(err))
+	backoffs := []time.Duration{
+		5 * time.Second, 15 * time.Second, 1 * time.Minute, 1 * time.Minute,
+		1 * time.Minute, 5 * time.Minute}
+	backoff := 0
+	for {
+		if err := RunGRPCServer(ctx, cancel, *address, *locality); err != nil {
+			if stacktrace.GetCode(err) == codeRetryable {
+				logger.Info(fmt.Sprintf("Prerequisites not yet satisfied; waiting %ds to retry...", backoffs[backoff]/1000000000), zap.Error(err))
+				time.Sleep(backoffs[backoff])
+				if backoff < len(backoffs)-1 {
+					backoff++
+				}
+				continue
+			}
+			logger.Panic("Failed to execute service", zap.Error(err))
+		}
+		break
 	}
 
 	logger.Info("Shutting down gracefully")

--- a/cmds/http-gateway/README.md
+++ b/cmds/http-gateway/README.md
@@ -1,0 +1,27 @@
+# http-gateway
+
+## Introduction
+
+This http-gateway executable is a translation layer that exposes a HTTP interfaces and fulfills them by with RPCs to core-service via gRPC.  It requires a connection to a core-service instance and exposes a few HTTP services: [ASTM remote ID](../../interfaces/uastech/standards/remoteid), [auxiliary](../../pkg/api/v1/auxpb/aux_service.proto), and [ASTM strategic coordination](../../interfaces/astm-utm/Protocol) (if specified).
+
+## Usage
+
+For production deployment of this executable, see [the deployment documentation](../../build/README.md).
+
+For experimentation on a local machine, see [the standalone instance documentation](../../build/dev/standalone_instance.md).
+
+To run this executable directly on a local machine using Go rather than a Docker container, run something similar to the command below from the repo root folder:
+
+```bash
+go run ./cmds/http-gateway \
+  -core-service localhost:8081 \
+  -addr :8082 \
+  -trace-requests \
+  -enable_scd
+```
+
+### Prerequisites
+
+#### core-service
+
+To run correctly, http-gateway must be able to access a core-service instance.  See [the core-service documentation](../core-service/README.md) for instructions on how to run an instance.

--- a/pkg/cockroach/cockroach.go
+++ b/pkg/cockroach/cockroach.go
@@ -160,6 +160,9 @@ func ConnectTo(ctx context.Context, connectParameters ConnectParameters) (*DB, e
 
 // GetVersion returns the Schema Version of the requested DB Name
 func (db *DB) GetVersion(ctx context.Context, dbName string) (*semver.Version, error) {
+	if dbName == "" {
+		return nil, stacktrace.NewError("GetVersion was provided with an empty database name")
+	}
 	var (
 		checkTableQuery = fmt.Sprintf(`
       SELECT EXISTS (

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -71,7 +71,7 @@ func setUpStore(ctx context.Context, t *testing.T, logger *zap.Logger) (store.St
 	cdb := &cockroach.DB{
 		Pool: db,
 	}
-	store, err := ridcrdb.NewStore(ctx, cdb, logger)
+	store, err := ridcrdb.NewStore(ctx, cdb, "rid", logger)
 	require.NoError(t, err)
 
 	return store, func() {

--- a/pkg/rid/server/server.go
+++ b/pkg/rid/server/server.go
@@ -3,6 +3,8 @@ package server
 import (
 	"time"
 
+	"github.com/robfig/cron/v3"
+
 	"github.com/interuss/dss/pkg/auth"
 	"github.com/interuss/dss/pkg/rid/application"
 )
@@ -31,6 +33,7 @@ type Server struct {
 	Timeout    time.Duration
 	Locality   string
 	EnableHTTP bool
+	Cron       *cron.Cron
 }
 
 // AuthScopes returns a map of endpoint to required Oauth scope.

--- a/pkg/rid/store/cockroach/store.go
+++ b/pkg/rid/store/cockroach/store.go
@@ -34,9 +34,6 @@ var (
 	// TODO: use this in other function calls
 	DefaultTimeout = 10 * time.Second
 
-	// DatabaseName is the name of database storing remote ID data.
-	DatabaseName = "rid"
-
 	v400 = *semver.New("4.0.0")
 )
 
@@ -55,20 +52,24 @@ type Store struct {
 	logger  *zap.Logger
 	clock   clockwork.Clock
 	version *semver.Version
+
+	// DatabaseName is the name of database storing remote ID data.
+	DatabaseName string
 }
 
 // NewStore returns a Store instance connected to a cockroach instance via db.
-func NewStore(ctx context.Context, db *cockroach.DB, logger *zap.Logger) (*Store, error) {
-	vs, err := db.GetVersion(ctx, DatabaseName)
+func NewStore(ctx context.Context, db *cockroach.DB, dbName string, logger *zap.Logger) (*Store, error) {
+	vs, err := db.GetVersion(ctx, dbName)
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to get database schema version for remote ID for db : %s", DatabaseName)
+		return nil, stacktrace.Propagate(err, "Failed to get database schema version for remote ID for db : %s", dbName)
 	}
 
 	store := &Store{
-		db:      db,
-		logger:  logger,
-		clock:   DefaultClock,
-		version: vs,
+		db:           db,
+		logger:       logger,
+		clock:        DefaultClock,
+		version:      vs,
+		DatabaseName: dbName,
 	}
 
 	if err := store.CheckCurrentMajorSchemaVersion(ctx); err != nil {
@@ -164,7 +165,7 @@ func (s *Store) CleanUp(ctx context.Context) error {
 // If the DB was is not bootstrapped using the schema manager we throw and error
 func (s *Store) GetVersion(ctx context.Context) (*semver.Version, error) {
 	if s.version == nil {
-		vs, err := s.db.GetVersion(ctx, DatabaseName)
+		vs, err := s.db.GetVersion(ctx, s.DatabaseName)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "Failed to get database schema version for remote ID")
 		}

--- a/pkg/rid/store/cockroach/store_test.go
+++ b/pkg/rid/store/cockroach/store_test.go
@@ -65,8 +65,9 @@ func newStore(ctx context.Context) (*Store, error) {
 		db: &cockroach.DB{
 			Pool: db,
 		},
-		logger: logging.Logger,
-		clock:  fakeClock,
+		logger:       logging.Logger,
+		clock:        fakeClock,
+		DatabaseName: "rid",
 	}, nil
 }
 


### PR DESCRIPTION
Currently, core-service will fail (panic) if it cannot connect to the specified CRDB instance or if that instance has not been bootstrapped (initialized) by db-manager.  This makes the bring-up of a system more difficult because all services are generally started at the same time, and the order in which they become available is unpredictable.  There is a band aid for this problem in the tools for a standalone instance: explicit signaling between containers via a shared volume + explicit startup delays.  However, 1) this is not ideal and 2) this does not exist for production deployments, so the first thing a deployer sees is multiple container failures with fatal error messages.  A similar problem exists for http-gateway when it cannot connect to its core-service instance.

This PR addresses the issue by detecting potentially retryable errors and retrying to bring up the system after increasing amounts of delays when those errors (and just those errors) are encountered.