### PR TITLE
[openapi-to-go-server] Improve float query parameter support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,13 @@ protos: pkg/api/v1/auxpb/aux_service.pb.gw.go pkg/api/v1/ridpb/rid.pb.gw.go pkg/
 
 # --- Targets to autogenerate Go code for OpenAPI-defined interfaces ---
 .PHONY: apis
-apis: dummy_oauth_api
+apis: example_apis dummy_oauth_api
 
 openapi-to-go-server:
 	docker image build -t interuss/openapi-to-go-server ./interfaces/openapi-to-go-server
+
+example_apis: openapi-to-go-server
+	$(CURDIR)/interfaces/openapi-to-go-server/generate_example.sh
 
 dummy_oauth_api: openapi-to-go-server
 	docker container run -it \


### PR DESCRIPTION
This PR adds a few small updates to openapi-to-go-server.  The primary one is better support for float query parameters (and some improvement in int support as well).  Also, support is added for responses with empty bodies.  Finally, the `make apis` target is extended to also regenerate the example API code.