### PR TITLE
[uss_qualifier/scd] Complete MVP for mock_uss's scdsc module

### DIFF
--- a/interfaces/automated-testing/scd/scd.yaml
+++ b/interfaces/automated-testing/scd/scd.yaml
@@ -440,6 +440,16 @@ components:
           type: string
           enum: [Planned, Rejected, ConflictWithFlight, Failed]
           example: Planned
+        notes:
+          description: >-
+            Human-readable explanation of the observed result.  This explanation
+            should be available to a human reviewing the test results, and
+            ideally should explain why an undesirable result was obtained.  For
+            instance, if the injection attempt Failed, then these notes may
+            indicate that the attempt failed because the DSS indicated 400 to a
+            valid request (perhaps also including the valid request as proof).
+          type: string
+          example: Requested flight intersected operational intent c036326c-c97b-4926-bf9f-c60dc83d2b57
         operational_intent_id:
           description: The id of the operational intent communicated to the DSS. This value is only required when the result of the flight submission is `Planned`.
           anyOf:

--- a/monitoring/mock_uss/config.py
+++ b/monitoring/mock_uss/config.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import os
 
 from monitoring.monitorlib import auth_validation
@@ -10,6 +11,7 @@ ENV_KEY_BASE_URL = '{}_BASE_URL'.format(ENV_KEY_PREFIX)
 ENV_KEY_AUTH = '{}_AUTH_SPEC'.format(ENV_KEY_PREFIX)
 ENV_KEY_SERVICES = '{}_SERVICES'.format(ENV_KEY_PREFIX)
 ENV_KEY_DSS = '{}_DSS_URL'.format(ENV_KEY_PREFIX)
+ENV_KEY_BEHAVIOR_LOCALITY = '{}_BEHAVIOR_LOCALITY'.format(ENV_KEY_PREFIX)
 
 # These keys map to entries in the Config class
 KEY_TOKEN_PUBLIC_KEY = 'TOKEN_PUBLIC_KEY'
@@ -18,9 +20,24 @@ KEY_BASE_URL = 'USS_BASE_URL'
 KEY_AUTH_SPEC = 'AUTH_SPEC'
 KEY_SERVICES = 'SERVICES'
 KEY_DSS_URL = 'DSS_URL'
+KEY_BEHAVIOR_LOCALITY = 'BEHAVIOR_LOCALITY'
 
 
 workspace_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'workspace')
+
+
+class BehaviorLocality(str, Enum):
+    """The mock USS should behave as if it were operating in this locality."""
+    CHE = 'CHE'
+    """Switzerland"""
+
+    @property
+    def is_uspace_applicable(self) -> bool:
+        return self in {BehaviorLocality.CHE}
+
+    @property
+    def allow_same_priority_intersections(self) -> bool:
+        return self in set()
 
 
 class Config(object):
@@ -31,3 +48,4 @@ class Config(object):
   AUTH_SPEC = os.environ[ENV_KEY_AUTH]
   SERVICES = set(svc.strip().lower() for svc in os.environ.get(ENV_KEY_SERVICES, '').split(','))
   DSS_URL = os.environ[ENV_KEY_DSS]
+  BEHAVIOR_LOCALITY = BehaviorLocality(os.environ.get(ENV_KEY_BEHAVIOR_LOCALITY, 'CHE'))

--- a/monitoring/mock_uss/mockuss.py
+++ b/monitoring/mock_uss/mockuss.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from monitoring.mock_uss import webapp
@@ -5,7 +6,8 @@ from monitoring.mock_uss import webapp
 
 def main(argv):
   del argv
-  webapp.run(host='localhost', port=8071)
+  port = int(os.environ.get('MOCK_USS_PORT', '8071'))
+  webapp.run(host='localhost', port=port)
 
 
 if __name__ == '__main__':

--- a/monitoring/mock_uss/postman_collection.json
+++ b/monitoring/mock_uss/postman_collection.json
@@ -313,7 +313,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "http://localhost:8085/token?grant_type=client_credentials&sub=uss1&intended_audience=host.docker.internal&issuer=dummy&scope=utm.inject_test_data",
+							"raw": "http://localhost:8085/token?grant_type=client_credentials&sub=uss1&intended_audience=host.docker.internal&issuer=dummy&scope=utm.inject_test_data utm.strategic_coordination",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -341,7 +341,7 @@
 								},
 								{
 									"key": "scope",
-									"value": "utm.inject_test_data"
+									"value": "utm.inject_test_data utm.strategic_coordination"
 								}
 							]
 						}
@@ -393,6 +393,16 @@
 								],
 								"type": "text/javascript"
 							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var data = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"op_intent_id\", data.operational_intent_id);"
+								],
+								"type": "text/javascript"
+							}
 						}
 					],
 					"request": {
@@ -429,6 +439,102 @@
 								"v1",
 								"flights",
 								"c036326c-c97b-4926-bf9f-c60dc83d2b57"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Flight 1 details",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{production_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8074/mock/scd/uss/v1/operational_intents/{{op_intent_id}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8074",
+							"path": [
+								"mock",
+								"scd",
+								"uss",
+								"v1",
+								"operational_intents",
+								"{{op_intent_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Clear all flights",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"const moment = require('moment');",
+									"pm.globals.set(\"timestamp_start\", moment().subtract(2, 'seconds').toISOString());",
+									"pm.globals.set(\"timestamp_end\", moment().add(5, 'minutes').toISOString());",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{production_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"extents\": [\n        {\n            \"volume\": {\n                \"outline_polygon\": {\n                    \"vertices\": [\n                        {\n                            \"lng\": -155.6043,\n                            \"lat\": 19.4763\n                        },\n                        {\n                            \"lng\": -155.5746,\n                            \"lat\": 19.4884\n                        },\n                        {\n                            \"lng\": -155.5941,\n                            \"lat\": 19.4516\n                        }\n                    ]\n                },\n                \"altitude_lower\": {\n                    \"value\": 0,\n                    \"units\": \"M\",\n                    \"reference\": \"W84\"\n                },\n                \"altitude_upper\": {\n                    \"value\": 122,\n                    \"units\": \"M\",\n                    \"reference\": \"W84\"\n                }\n            },\n            \"time_start\": {\n                \"value\": \"{{timestamp_start}}\",\n                \"format\": \"RFC3339\"\n            },\n            \"time_end\": {\n                \"value\": \"{{timestamp_end}}\",\n                \"format\": \"RFC3339\"\n            }\n        }\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8074/scdsc/clear_all_flights",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8074",
+							"path": [
+								"scdsc",
+								"clear_all_flights"
 							]
 						}
 					},

--- a/monitoring/mock_uss/scdsc/database.py
+++ b/monitoring/mock_uss/scdsc/database.py
@@ -1,4 +1,5 @@
 import dataclasses
+from multiprocessing import Lock
 from typing import Dict
 
 from monitoring.monitorlib import scd
@@ -15,10 +16,12 @@ class FlightRecord(object):
 
 class Database(object):
     """Simple in-memory pseudo-database tracking the state of the mock system"""
+    lock: Lock
     flights: Dict[str, FlightRecord]
     cached_operations: Dict[str, scd.OperationalIntent]
 
     def __init__(self):
+        self.lock = Lock()
         self.flights = {}
         self.cached_operations = {}
 

--- a/monitoring/mock_uss/scdsc/routes.py
+++ b/monitoring/mock_uss/scdsc/routes.py
@@ -1,9 +1,77 @@
-from monitoring.mock_uss import webapp
+from typing import List, Tuple
+
+import flask
+
+from monitoring.monitorlib import scd
+from monitoring.monitorlib.clients import scd as scd_client
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.mock_uss import resources, webapp
+from monitoring.mock_uss.scdsc.database import db
 
 
 @webapp.route('/scdsc/status')
 def scdsc_status():
     return 'Mock SCD strategic coordinator ok'
+
+
+@webapp.route('/scdsc/clear_all_flights', methods=['POST'])
+def clear_all_flights() -> Tuple[str, int]:
+    """Clear all flights from the system that this mock USS may have been involved with.
+
+    Expected request body is a JSON form of scd.DeleteAllFlightsRequest.
+    """
+    try:
+        json = flask.request.json
+        if json is None:
+            raise ValueError('Request did not contain a JSON payload')
+        req = ImplicitDict.parse(json, scd.DeleteAllFlightsRequest)
+    except ValueError as e:
+        msg = 'Unable to parse DeleteAllFlightsRequest JSON request: {}'.format(e)
+        return msg, 400
+
+    # Find operational intents in the DSS
+    start_time = scd.start_of(req.extents)
+    end_time = scd.end_of(req.extents)
+    area = scd.rect_bounds_of(req.extents)
+    alt_lo, alt_hi = scd.meter_altitude_bounds_of(req.extents)
+    vol4 = scd.make_vol4(start_time, end_time, alt_lo, alt_hi, polygon=scd.make_polygon(latlngrect=area))
+    try:
+        op_intent_refs = scd_client.query_operational_intent_references(resources.utm_client, vol4)
+    except (ValueError, scd_client.OperationError) as e:
+        msg = 'Error querying operational intents: {}'.format(e)
+        return msg, 412
+
+    # Try to delete every operational intent found
+    dss_deletion_results = {}
+    deleted = set()
+    for op_intent_ref in op_intent_refs:
+        try:
+            scd_client.delete_operational_intent_reference(resources.utm_client, op_intent_ref.id, op_intent_ref.ovn)
+            dss_deletion_results[op_intent_ref.id] = 'Deleted from DSS'
+            deleted.add(op_intent_ref.id)
+        except scd_client.OperationError as e:
+            dss_deletion_results[op_intent_ref.id] = str(e)
+
+    # Delete corresponding flight injections and cached operational intents
+    with db.lock:
+        flights_to_delete = []
+        for flight_id, record in db.flights.items():
+            if record.op_intent_reference.id in deleted:
+                flights_to_delete.append(flight_id)
+        for flight_id in flights_to_delete:
+            del db.flights[flight_id]
+
+        cache_deletions = []
+        for op_intent_id in deleted:
+            if op_intent_id in db.cached_operations:
+                del db.cached_operations[op_intent_id]
+                cache_deletions.append(op_intent_id)
+
+    return flask.jsonify({
+        'dss_deletions': dss_deletion_results,
+        'flight_deletions': flights_to_delete,
+        'cache_deletions': cache_deletions,
+    }), 200
 
 
 from . import routes_scdsc

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -83,7 +83,7 @@ def inject_flight(flight_id: str) -> Tuple[str, int]:
         v2a = op_intent.details.volumes
         v2b = op_intent.details.off_nominal_volumes
         if scd.vol4s_intersect(v1, v2a) or scd.vol4s_intersect(v1, v2b):
-            notes = 'Requested flight intersected {} operational intent {}'.format(op_intent.reference.manager, op_intent.reference.id)
+            notes = 'Requested flight intersected {}\'s operational intent {}'.format(op_intent.reference.manager, op_intent.reference.id)
             return flask.jsonify(InjectFlightResponse(
                 result=InjectFlightResult.ConflictWithFlight, notes=notes)), 200
 

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import List, Tuple
 import uuid
 
 import flask
@@ -11,6 +11,29 @@ from monitoring.mock_uss import config, resources, webapp
 from monitoring.mock_uss.auth import requires_scope
 from monitoring.mock_uss.scdsc import database
 from monitoring.mock_uss.scdsc.database import db
+
+
+def query_operational_intents(area_of_interest: scd.Volume4D) -> List[scd.OperationalIntent]:
+    """Retrieve a complete set of operational intents in an area, including details.
+
+    :param area_of_interest: Area where intersecting operational intents must be discovered
+    :return: Full definition for every operational intent discovered
+    """
+    op_intent_refs = scd_client.query_operational_intent_references(resources.utm_client, area_of_interest)
+    with db.lock:
+        get_details_for = []
+        for op_intent_ref in op_intent_refs:
+            if op_intent_ref.id not in db.cached_operations or db.cached_operations[op_intent_ref.id].reference.version != op_intent_ref.version:
+                get_details_for.append(op_intent_ref)
+
+    updated_op_intents = []
+    for op_intent_ref in get_details_for:
+        updated_op_intents.append(scd_client.get_operational_intent_details(resources.utm_client, op_intent_ref.uss_base_url, op_intent_ref.id))
+
+    with db.lock:
+        for op_intent in updated_op_intents:
+            db.cached_operations[op_intent.reference.id] = op_intent
+        return [db.cached_operations[op_intent_ref.id] for op_intent_ref in op_intent_refs]
 
 
 @webapp.route('/scdsc/v1/status', methods=['GET'])
@@ -45,7 +68,7 @@ def inject_flight(flight_id: str) -> Tuple[str, int]:
     alt_lo, alt_hi = scd.meter_altitude_bounds_of(req_body.operational_intent.volumes)
     vol4 = scd.make_vol4(start_time, end_time, alt_lo, alt_hi, polygon=scd.make_polygon(latlngrect=area))
     try:
-        op_intents = scd_client.query_operational_intents(resources.utm_client, vol4, db.cached_operations)
+        op_intents = query_operational_intents(vol4)
     except (ValueError, scd_client.OperationError) as e:
         notes = 'Error querying operational intents: {}'.format(e)
         return flask.jsonify(InjectFlightResponse(
@@ -94,6 +117,7 @@ def inject_flight(flight_id: str) -> Tuple[str, int]:
         op_intent_reference=result.operational_intent_reference,
         op_intent_injection=req_body.operational_intent,
         flight_authorisation=req_body.flight_authorisation)
-    db.flights[flight_id] = record
+    with db.lock:
+        db.flights[flight_id] = record
 
     return flask.jsonify(InjectFlightResponse(result=InjectFlightResult.Planned, operational_intent_id=id))

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -58,8 +58,9 @@ def inject_flight(flight_id: str) -> Tuple[str, int]:
         msg = 'Create flight {} unable to parse JSON: {}'.format(flight_id, e)
         return msg, 400
 
-    # Validate flight authorisation
-    # TODO: Implement
+    if webapp.config[config.KEY_BEHAVIOR_LOCALITY].is_uspace_applicable:
+        # Validate flight authorisation
+        pass  # TODO: Implement
 
     # Check for operational intents in the DSS
     start_time = scd.start_of(req_body.operational_intent.volumes)
@@ -79,7 +80,8 @@ def inject_flight(flight_id: str) -> Tuple[str, int]:
     for op_intent in op_intents:
         if req_body.operational_intent.priority > op_intent.details.priority:
             continue
-        # TODO: Allow intersections between same-priority operations when configured to do so
+        if webapp.config[config.KEY_BEHAVIOR_LOCALITY].allow_same_priority_intersections:
+            continue
         v2a = op_intent.details.volumes
         v2b = op_intent.details.off_nominal_volumes
         if scd.vol4s_intersect(v1, v2a) or scd.vol4s_intersect(v1, v2b):

--- a/monitoring/mock_uss/scdsc/routes_scdsc.py
+++ b/monitoring/mock_uss/scdsc/routes_scdsc.py
@@ -12,11 +12,12 @@ def get_operational_intent_details(entityid: str):
     """Implements getOperationalIntentDetails in ASTM SCD API."""
 
     # Look up entityid in database
-    flight = None
-    for f in db.flights.values():
-        if f.op_intent_reference.id == entityid:
-            flight = f
-            break
+    with db.lock:
+        flight = None
+        for f in db.flights.values():
+            if f.op_intent_reference.id == entityid:
+                flight = f
+                break
 
     # If requested operational intent doesn't exist, return 404
     if flight is None:

--- a/monitoring/monitorlib/clients/scd.py
+++ b/monitoring/monitorlib/clients/scd.py
@@ -30,6 +30,13 @@ def create_operational_intent_reference(utm_client: DSSTestSession, id: str, req
     return ImplicitDict.parse(resp.json(), scd.ChangeOperationalIntentReferenceResponse)
 
 
+def delete_operational_intent_reference(utm_client: DSSTestSession, id: str, ovn: str) -> scd.ChangeOperationalIntentReferenceResponse:
+    resp = utm_client.delete('/dss/v1/operational_intent_references/{}/{}'.format(id, ovn), scope=scd.SCOPE_SC)
+    if resp.status_code != 200:
+        raise OperationError('deleteOperationalIntentReference failed {}:\n{}'.format(resp.status_code, resp.content.decode('utf-8')))
+    return ImplicitDict.parse(resp.json(), scd.ChangeOperationalIntentReferenceResponse)
+
+
 # === USS operations defined in the ASTM API ===
 
 

--- a/monitoring/monitorlib/clients/scd.py
+++ b/monitoring/monitorlib/clients/scd.py
@@ -43,7 +43,7 @@ def get_operational_intent_details(utm_client: DSSTestSession, uss_base_url: str
 
 def notify_operational_intent_details_changed(utm_client: DSSTestSession, uss_base_url: str, update: scd.PutOperationalIntentDetailsParameters) -> None:
     resp = utm_client.post('{}/uss/v1/operational_intents'.format(uss_base_url), json=update, scope=scd.SCOPE_SC)
-    if resp.status_code != 200:
+    if resp.status_code != 204 and resp.status_code != 200:
         raise OperationError('notifyOperationalIntentDetailsChanged failed {}:\n{}'.format(resp.status_code, resp.content.decode('utf-8')))
 
 

--- a/monitoring/monitorlib/clients/scd.py
+++ b/monitoring/monitorlib/clients/scd.py
@@ -50,24 +50,6 @@ def notify_operational_intent_details_changed(utm_client: DSSTestSession, uss_ba
 # === Custom actions ===
 
 
-def query_operational_intents(utm_client: DSSTestSession, area_of_interest: scd.Volume4D, cache: Dict[str, scd.OperationalIntent]=None) -> List[scd.OperationalIntent]:
-    """Retrieve a complete set of operational intents in an area, including details.
-
-    :param utm_client: Means by which to execute HTTP calls to the DSS and other USSs
-    :param area_of_interest: Area where intersecting operational intents must be discovered
-    :param cache: If specified, this cache is mutated to store the details of operational intents so that the details don't necessarily need to be retrieved next time
-    :return: Full definition for every operational intent discovered
-    """
-    if cache is None:
-        cache = dict()
-    op_intent_refs = query_operational_intent_references(utm_client, area_of_interest)
-    for op_intent_ref in op_intent_refs:
-        if op_intent_ref.id not in cache or cache[op_intent_ref.id].reference.version != op_intent_ref.version:
-            op_intent = get_operational_intent_details(utm_client, op_intent_ref.uss_base_url, op_intent_ref.id)
-            cache[op_intent.reference.id] = op_intent
-    return [cache[op_intent_ref.id] for op_intent_ref in op_intent_refs]
-
-
 def notify_subscribers(utm_client: DSSTestSession, id: str, operational_intent: scd.OperationalIntent, subscribers: List[scd.SubscriberToNotify]):
     for subscriber in subscribers:
         update = scd.PutOperationalIntentDetailsParameters(

--- a/monitoring/monitorlib/scd.py
+++ b/monitoring/monitorlib/scd.py
@@ -165,6 +165,11 @@ class OperationalIntent(ImplicitDict):
 class GetOperationalIntentDetailsResponse(ImplicitDict):
     operational_intent: OperationalIntent
 
+class PutOperationalIntentDetailsParameters(ImplicitDict):
+    operational_intent_id: str
+    operational_intent: Optional[OperationalIntent]
+    subscriptions: List[SubscriptionState]
+
 ################################################################################
 #################### End of ASTM-standard definitions    #####################
 #################### interfaces/astm-utm/Protocol/utm.yaml #####################

--- a/monitoring/monitorlib/scd.py
+++ b/monitoring/monitorlib/scd.py
@@ -176,6 +176,10 @@ class PutOperationalIntentDetailsParameters(ImplicitDict):
 ################################################################################
 
 
+class DeleteAllFlightsRequest(ImplicitDict):
+    extents: List[Volume4D]
+
+
 def make_vol4(
         t0: Optional[datetime] = None,
         t1: Optional[datetime] = None,

--- a/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
+++ b/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
@@ -51,5 +51,5 @@ class InjectFlightResult(str, Enum):
 class InjectFlightResponse(ImplicitDict):
     ''' A class to hold test flight submission response '''
     result: InjectFlightResult
-    notes: str
+    notes: Optional[str]
     operational_intent_id: Optional[str]

--- a/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
+++ b/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
@@ -51,4 +51,5 @@ class InjectFlightResult(str, Enum):
 class InjectFlightResponse(ImplicitDict):
     ''' A class to hold test flight submission response '''
     result: InjectFlightResult
+    notes: str
     operational_intent_id: Optional[str]


### PR DESCRIPTION
This PR finishes a basic mock strategic coordination SCD USS, minus validation of flight authorisation information.

First, the SCD flight injection API is updated to include a `notes` field to eventually inform the reader of the report generated by uss_qualifier why the USS behaved the way it did (e.g., why a flight injection attempt Failed).

The mock USS now also performs its subscriber notification duties following creation of an operational intent.

Because this mock implementation is naive, it will query itself for details of its own operations (currently -- this could be improved in the future).  This means that the handler for flight injection will call the handler for flight details, which means the mock USS webserver must have at least 2 workers (this was changed in the previous PR).  That now means that access to the in-memory database should be thread-safe, so this PR also makes that change.

Because the SCD automated testing API does not yet include a flight deletion operation, injection of a flight often made it impossible to inject another flight (to try again).  This PR adds an endpoint that will clear out flights created by any mock USS instance configured with the identity of the currently-running mock USS (defined by the AuthSpec), and a Postman request is added to the collection to provide easy access to this functionality.

Finally, expectations for USSs will vary somewhat between jurisdictions.  This PR introduces a behavior locality setting to mock USS which causes it to behave according to the country ruleset it is following.  The two currently-known behaviors that may vary by jurisdiction are allowing conflicts between operational intents of the same priority and complying with the U-space regulation.