### PR TITLE
[uss_qualifier/scd] Load automated tests files

### DIFF
--- a/monitoring/mock_uss/config.py
+++ b/monitoring/mock_uss/config.py
@@ -2,7 +2,7 @@ from enum import Enum
 import os
 
 from monitoring.monitorlib import auth_validation
-
+from monitoring.monitorlib.locality import Locality
 
 ENV_KEY_PREFIX = 'MOCK_USS'
 ENV_KEY_PUBLIC_KEY = '{}_PUBLIC_KEY'.format(ENV_KEY_PREFIX)
@@ -26,20 +26,6 @@ KEY_BEHAVIOR_LOCALITY = 'BEHAVIOR_LOCALITY'
 workspace_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'workspace')
 
 
-class BehaviorLocality(str, Enum):
-    """The mock USS should behave as if it were operating in this locality."""
-    CHE = 'CHE'
-    """Switzerland"""
-
-    @property
-    def is_uspace_applicable(self) -> bool:
-        return self in {BehaviorLocality.CHE}
-
-    @property
-    def allow_same_priority_intersections(self) -> bool:
-        return self in set()
-
-
 class Config(object):
   TOKEN_PUBLIC_KEY = auth_validation.fix_key(
     os.environ.get(ENV_KEY_PUBLIC_KEY, '')).encode('utf-8')
@@ -48,4 +34,4 @@ class Config(object):
   AUTH_SPEC = os.environ[ENV_KEY_AUTH]
   SERVICES = set(svc.strip().lower() for svc in os.environ.get(ENV_KEY_SERVICES, '').split(','))
   DSS_URL = os.environ[ENV_KEY_DSS]
-  BEHAVIOR_LOCALITY = BehaviorLocality(os.environ.get(ENV_KEY_BEHAVIOR_LOCALITY, 'CHE'))
+  BEHAVIOR_LOCALITY = Locality(os.environ.get(ENV_KEY_BEHAVIOR_LOCALITY, 'CHE'))

--- a/monitoring/monitorlib/locality.py
+++ b/monitoring/monitorlib/locality.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 
 class Locality(str, Enum):
-    """The mock USS should behave as if it were operating in this locality."""
+    """Operating locations and their respective regulation and technical variations."""
     CHE = 'CHE'
     """Switzerland"""
 

--- a/monitoring/monitorlib/locality.py
+++ b/monitoring/monitorlib/locality.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class Locality(str, Enum):
+    """The mock USS should behave as if it were operating in this locality."""
+    CHE = 'CHE'
+    """Switzerland"""
+
+    @property
+    def is_uspace_applicable(self) -> bool:
+        return self in {Locality.CHE}
+
+    @property
+    def allow_same_priority_intersections(self) -> bool:
+        return self in set()

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -55,6 +55,7 @@ def main() -> int:
         print(f"[SCD] Configuration provided with {len(config.scd.injection_targets)} injection targets.")
         scd_test_executor.validate_configuration(config.scd)
         locale = Locality(config.locale.upper())
+        print(f"[SCD] Locale: {locale.value} (is_uspace_applicable:{locale.is_uspace_applicable}, allow_same_priority_intersections:{locale.allow_same_priority_intersections})")
         scd_test_executor.run_scd_tests(locale=locale, test_configuration=config.scd, auth_spec=auth_spec)
     else:
         print("[SCD] No configuration provided.")

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 
+from monitoring.monitorlib.locality import Locality
 from monitoring.monitorlib.typing import ImplicitDict
 from monitoring.uss_qualifier.rid import test_executor as rid_test_executor
 from monitoring.uss_qualifier.scd import test_executor as scd_test_executor
@@ -53,7 +54,8 @@ def main() -> int:
     if "scd" in config:
         print(f"[SCD] Configuration provided with {len(config.scd.injection_targets)} injection targets.")
         scd_test_executor.validate_configuration(config.scd)
-        scd_test_executor.run_scd_tests(locale=config.locale, test_configuration=config.scd, auth_spec=auth_spec)
+        locale = Locality(config.locale.upper())
+        scd_test_executor.run_scd_tests(locale=locale, test_configuration=config.scd, auth_spec=auth_spec)
     else:
         print("[SCD] No configuration provided.")
 

--- a/monitoring/uss_qualifier/scd/test_executor.py
+++ b/monitoring/uss_qualifier/scd/test_executor.py
@@ -1,6 +1,42 @@
+import json
+import os
+from pathlib import Path
+from typing import List
+
+from monitoring.monitorlib.locality import Locality
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.uss_qualifier.scd.data_interfaces import AutomatedTest
 from monitoring.uss_qualifier.scd.utils import SCDQualifierTestConfiguration
 from monitoring.uss_qualifier.utils import is_url
 
+
+def get_automated_tests(automated_tests_dir: Path) -> List[AutomatedTest]:
+    """Gets automated tests from the specified directory if they exist"""
+
+    if not os.path.exists(automated_tests_dir):
+        raise ValueError('The automated tests directory does not exist: {}'.format(automated_tests_dir))
+
+    all_files = os.listdir(automated_tests_dir)
+    files = [os.path.join(automated_tests_dir, f) for f in all_files if os.path.isfile(os.path.join(automated_tests_dir, f))]
+    if not files:
+        raise ValueError('There are no automated tests in the directory, create automated tests first using the simulator module.')
+
+    automated_tests = []
+    for file in files:
+        with open(file, 'r') as f:
+            automated_tests.append(ImplicitDict.parse(json.load(f), AutomatedTest))
+
+    return automated_tests
+
+def load_scd_test_definitions(locale: str) -> List[AutomatedTest]:
+    automated_tests_dir = Path(os.getcwd(), 'scd/test_definitions', locale.value, 'automated_test')
+    try:
+        automated_tests = get_automated_tests(automated_tests_dir)
+    except ValueError:
+        print('[SCD] No automated tests files found; generating them via simulator now')
+        # TODO: Call the simulator
+        raise NotImplementedError()
+    return automated_tests
 
 def validate_configuration(test_configuration: SCDQualifierTestConfiguration):
     try:
@@ -9,10 +45,14 @@ def validate_configuration(test_configuration: SCDQualifierTestConfiguration):
     except ValueError:
         raise ValueError("A valid url for injection_target must be passed")
 
-def run_scd_tests(locale: str, test_configuration: SCDQualifierTestConfiguration,
+def run_scd_tests(locale: Locality, test_configuration: SCDQualifierTestConfiguration,
                   auth_spec: str):
+
+    automated_tests = load_scd_test_definitions(locale)
+
+    # TODO: Move to simulator
+    if locale.is_uspace_applicable():
+        print("[SCD] U-Space tests")
+
+    print("[SCD] Running ASTM tests")
     # TODO Replace with actual implementation
-    if locale == 'che':
-        print("[SCD] Running ASTM and U-Space tests")
-    else:
-        print("[SCD] Running ASTM tests")


### PR DESCRIPTION
This PR adds to the USS qualifier the ability to load automated tests files generated in #685.

`BehaviorLocality` defined in uss_mock config was moved to monitoringlib to leverage locality definition in the uss_qualifier simulator and test-executor.