### PR TITLE
[monitorlib/typing] Fix AutomatedTest parsing for ImplicitDict

### DIFF
--- a/monitoring/monitorlib/typing.py
+++ b/monitoring/monitorlib/typing.py
@@ -179,6 +179,11 @@ def _parse_value(value, value_type: Type):
         # value is a list of non-ImplicitDict values
         return value
 
+    elif generic_type is dict:
+        # value is a dict of some kind
+        return {k if arg_types[0] is str else _parse_value(k, arg_types[0]): _parse_value(v, arg_types[1])
+                for k, v in value.items()}
+
     elif generic_type is Union and len(arg_types) == 2 and arg_types[1] is type(None):
       # Type is an Optional declaration
       if value is None:

--- a/monitoring/uss_qualifier/common_data_definitions.py
+++ b/monitoring/uss_qualifier/common_data_definitions.py
@@ -1,4 +1,7 @@
-class Severity(object):
+from enum import Enum
+
+
+class Severity(str, Enum):
   Critical = 'Critical'
   """The system does not function correctly on a basic level."""
 


### PR DESCRIPTION
This PR enables ImplicitDict parsing of AutomatedTest objects.  The primary change is implementing ImplicitDict parsing of generic Dict objects, but the type of Severity is also updated to be a string Enum as well.