### PR TITLE
[uss_qualifier/scd] Add flight deletion capability to SCD automated testing

### DIFF
--- a/interfaces/automated-testing/scd/scd.yaml
+++ b/interfaces/automated-testing/scd/scd.yaml
@@ -439,7 +439,7 @@ components:
 
           type: string
           enum: [Planned, Rejected, ConflictWithFlight, Failed]
-          example: Planned
+          example: ConflictWithFlight
         notes:
           description: >-
             Human-readable explanation of the observed result.  This explanation
@@ -454,6 +454,26 @@ components:
           description: The id of the operational intent communicated to the DSS. This value is only required when the result of the flight submission is `Planned`.
           anyOf:
             - $ref: '#/components/schemas/EntityID'
+    DeleteFlightResponse:
+      type: object
+      required:
+      - result
+      properties:
+        result:
+          description: >-
+            The result of attempted flight cancellation/closure
+
+              - `Closed`: The flight was closed successfully by the USS and is now out of the UTM system.
+
+              - `Failed`: The flight could not be closed successfully by the USS.
+
+          enum: [Closed, Failed]
+          example: Failed
+        notes:
+          description: >-
+            Human-readable explanation of the observed result.
+          type: string
+          example: DSS was unreachable when attempting to delete operational intent reference
 
 paths:
   /v1/status:
@@ -479,17 +499,18 @@ paths:
       description: Get the status of the USS automated testing interface
 
   /v1/flights/{flight_id}:
+    parameters:
+    - name: flight_id
+      in: path
+      required: true
+      description: A UUID string identifying the injected flight.
+      schema:
+        $ref: '#/components/schemas/UUIDv4Format'
+
     put:
       security:
         - Authority:
             - utm.inject_test_data
-      parameters:
-        - name: flight_id
-          in: path
-          required: true
-          description: A UUID string identifying the injected flight.
-          schema:
-            $ref: '#/components/schemas/UUIDv4Format'
 
       requestBody:
         content:
@@ -509,6 +530,29 @@ paths:
         '403':
           description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
 
-      summary: Inject test flight
+      summary: Inject flight
+      operationId: injectFlight
       description: >-
         This endpoint simulates the operator intention to submit a flight operation / flight request.
+
+    delete:
+      security:
+      - Authority:
+        - utm.inject_test_data
+
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteFlightResponse'
+          description: Flight was deleted from the system successfully
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+
+      summary: Delete flight
+      operationId: deleteFlight
+      description: >-
+        This endpoint simulates the operator intention to cancel or end a flight operation.

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -5,7 +5,7 @@ import flask
 
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.clients import scd as scd_client
-from monitoring.monitorlib.scd_automated_testing.scd_injection_api import InjectFlightRequest, InjectFlightResponse, SCOPE_SCD_QUALIFIER_INJECT, InjectFlightResult
+from monitoring.monitorlib.scd_automated_testing.scd_injection_api import InjectFlightRequest, InjectFlightResponse, SCOPE_SCD_QUALIFIER_INJECT, InjectFlightResult, DeleteFlightResponse, DeleteFlightResult
 from monitoring.monitorlib.typing import ImplicitDict
 from monitoring.mock_uss import config, resources, webapp
 from monitoring.mock_uss.auth import requires_scope
@@ -123,3 +123,33 @@ def inject_flight(flight_id: str) -> Tuple[str, int]:
         db.flights[flight_id] = record
 
     return flask.jsonify(InjectFlightResponse(result=InjectFlightResult.Planned, operational_intent_id=id))
+
+
+@webapp.route('/scdsc/v1/flights/<flight_id>', methods=['DELETE'])
+@requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
+def delete_flight(flight_id: str) -> Tuple[str, int]:
+    """Implements flight deletion in SCD automated testing injection API."""
+
+    with db.lock:
+        flight = db.flights.pop(flight_id, None)
+
+    if flight is None:
+        return flask.jsonify(DeleteFlightResponse(
+            result=DeleteFlightResult.Failed,
+            notes='Flight {} does not exist'.format(flight_id))), 200
+
+    # Delete operational intent from DSS
+    try:
+        result = scd_client.delete_operational_intent_reference(
+            resources.utm_client,
+            flight.op_intent_reference.id,
+            flight.op_intent_reference.ovn)
+    except (ValueError, scd_client.OperationError) as e:
+        notes = 'Error deleting operational intent: {}'.format(e)
+        return flask.jsonify(DeleteFlightResponse(
+            result=DeleteFlightResult.Failed, notes=notes)), 200
+    scd_client.notify_subscribers(
+        resources.utm_client, result.operational_intent_reference.id,
+        None, result.subscribers)
+
+    return flask.jsonify(DeleteFlightResponse(result=DeleteFlightResult.Closed))

--- a/monitoring/monitorlib/clients/scd.py
+++ b/monitoring/monitorlib/clients/scd.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import List, Optional
 
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.infrastructure import DSSTestSession
@@ -57,10 +57,13 @@ def notify_operational_intent_details_changed(utm_client: DSSTestSession, uss_ba
 # === Custom actions ===
 
 
-def notify_subscribers(utm_client: DSSTestSession, id: str, operational_intent: scd.OperationalIntent, subscribers: List[scd.SubscriberToNotify]):
+def notify_subscribers(utm_client: DSSTestSession, id: str, operational_intent: Optional[scd.OperationalIntent], subscribers: List[scd.SubscriberToNotify]):
     for subscriber in subscribers:
-        update = scd.PutOperationalIntentDetailsParameters(
-            operational_intent_id=id,
-            operational_intent=operational_intent,
-            subscriptions=subscriber.subscriptions)
+        kwargs = {
+            'operational_intent_id': id,
+            'subscriptions': subscriber.subscriptions,
+        }
+        if operational_intent is not None:
+            kwargs['operational_intent'] = operational_intent
+        update = scd.PutOperationalIntentDetailsParameters(**kwargs)
         notify_operational_intent_details_changed(utm_client, subscriber.uss_base_url, update)

--- a/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
+++ b/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
@@ -53,3 +53,13 @@ class InjectFlightResponse(ImplicitDict):
     result: InjectFlightResult
     notes: Optional[str]
     operational_intent_id: Optional[str]
+
+
+class DeleteFlightResult(str, Enum):
+    Closed = 'Closed'
+    Failed = 'Failed'
+
+
+class DeleteFlightResponse(ImplicitDict):
+    result: DeleteFlightResult
+    notes: Optional[str]

--- a/monitoring/uss_qualifier/scd/data_interfaces.py
+++ b/monitoring/uss_qualifier/scd/data_interfaces.py
@@ -42,6 +42,9 @@ class InjectionTarget(ImplicitDict):
 
 class FlightInjectionAttempt(ImplicitDict):
     """All information necessary to attempt to create a flight in a USS and to evaluate the outcome of that attempt"""
+    name: str
+    """Name of this flight, used to refer to the flight later in the automated test"""
+
     test_injection: InjectFlightRequest
     """Definition of the flight to be injected"""
 
@@ -52,10 +55,28 @@ class FlightInjectionAttempt(ImplicitDict):
     """The particular USS to which the flight injection attempt should be directed"""
 
 
+class FlightDeletionAttempt(ImplicitDict):
+    """All information necessary to attempt to close a flight previously injected into a USS"""
+    flight_name: str
+    """Name of the flight previously injected into the USS to delete"""
+
+
+class TestStep(ImplicitDict):
+    """The action taken in one step of a sequence of steps constituting an automated test"""
+    name: str
+    """Human-readable name/summary of this step"""
+
+    inject_flight: FlightInjectionAttempt
+    """If populated, the test driver should attempt to inject a flight for this step"""
+
+    delete_flight: FlightDeletionAttempt
+    """If populated, the test driver should attempt to delete the specified flight for this step"""
+
+
 class AutomatedTest(ImplicitDict):
     """Definition of a complete automated test involving some subset of USSs under test"""
     name: str
     """Human-readable name of this test (e.g., 'Nominal strategic coordination')"""
 
-    injection_attempts: List[FlightInjectionAttempt]
-    """Details of flight injections into USSs that should be attempted"""
+    steps: List[TestStep]
+    """Actions to be performed for this test"""


### PR DESCRIPTION
Currently, there is no way to instruct a USS to delete a flight created for an automated test.  This means that the system cannot be effectively cleared following the completion of a test.  This PR fixes that problem by adding a "delete flight" operation in the SCD automated testing API.

This PR also adjusts the definition of an AutomatedTest to specify generic "test steps" (rather than requiring every step to be a flight injection attempt) and includes the deletion of a flight as an action that can be defined within an automated test.  This would be useful to, e.g., check the caching behavior of a USS by injecting flight 1 into USS1, injecting flight 2 which is nearby but not conflicting into USS2, deleting flight 1 from USS1, then injecting flight 3 which conflicts with now-absent flight 1 into USS2.

My expectation is that the test driver should always clean up after its tests -- that is, the test driver should call "delete flight" on every flight injection request that resulted in Planned in the course of the test.  So, the AutomatedTest definitions would not need to specify deletion of a created flight at the end of the test in general -- this capability of prescribing flight deletions would only be used in special cases like the paragraph above.

Finally, mock USS is updated to support this new deletion operation.