### PR TITLE
[dev tools] Expand and document local SCD data injection tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,18 @@ format:
 	clang-format -style=file -i pkg/api/v1/scdpb/scd.proto
 	clang-format -style=file -i pkg/api/v1/auxpb/aux_service.proto
 
-.PHONY: lint
-lint:
+lint: go_lint shell_lint
+
+.PHONY: go_lint
+go_lint:
 	docker run --rm -v $(CURDIR):/dss -w /dss golangci/golangci-lint:v1.26.0 golangci-lint run --timeout 5m --skip-dirs /dss/build/workspace -v -E gofmt,bodyclose,rowserrcheck,misspell,golint -D staticcheck,vet
 	docker run --rm -v $(CURDIR):/dss -w /dss golangci/golangci-lint:v1.26.0 golangci-lint run --timeout 5m -v --disable-all --skip-dirs /dss/build/workspace -E staticcheck --skip-dirs '^cmds/http-gateway,^pkg/logging'
+
+.PHONY: shell_lint
+shell_lint:
 	find . -name '*.sh' | grep -v '^./interfaces/astm-utm' | grep -v '^./build/workspace' | xargs docker run --rm -v $(CURDIR):/dss -w /dss koalaman/shellcheck
+
+
 
 pkg/api/v1/ridpb/rid.pb.go: pkg/api/v1/ridpb/rid.proto generator
 	docker run -v$(CURDIR):/src:delegated -w /src $(GENERATOR_TAG) protoc \

--- a/build/dev/check_scd_clear.sh
+++ b/build/dev/check_scd_clear.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# This script is to clean up after check operations on SCD database for testing.
+
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+
+cd "${BASEDIR}" || exit 1
+
+# Retrieve token from dummy OAuth server
+ACCESS_TOKEN=$(curl --silent -X POST \
+    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination%20utm.constraint_management&intended_audience=localhost&issuer=localhost&sub=check_scd" \
+| jq -r '.access_token')
+
+
+echo "DSS response to [SCD] DELETE subscription query:"
+echo "============="
+
+VERSION=$(./read_scd_subscription.sh 00000158-9aba-4026-bbef-bad6cde80000 | jq -r '.subscription.version')
+
+curl --silent -X DELETE  \
+"http://localhost:8082/dss/v1/subscriptions/00000158-9aba-4026-bbef-bad6cde80000/${VERSION}" \
+-H "Authorization: Bearer ${ACCESS_TOKEN}" -H "Content-Type: application/json"
+echo
+
+
+echo "DSS response to [SCD] DELETE constraint reference query:"
+echo "============="
+
+VERSION=$(./read_scd_constraint_reference.sh 00000159-9aba-4026-bbef-bad6cde80000 | jq -r '.constraint_reference.version')
+
+curl --silent -X DELETE  "http://localhost:8082/dss/v1/constraint_references/00000159-9aba-4026-bbef-bad6cde80000/${VERSION}"  \
+-H "Authorization: Bearer ${ACCESS_TOKEN}"  \
+-H "Content-Type: application/json"
+echo
+
+
+echo "DSS response to [SCD] DELETE operational intent reference query:"
+echo "=========="
+
+VERSION=$(./read_scd_operational_intent_reference.sh 0000015a-9aba-4026-bbef-bad6cde80000 | jq -r '.operational_intent_reference.version')
+
+curl --silent -X DELETE  "http://localhost:8082/dss/v1/operational_intent_references/0000015a-9aba-4026-bbef-bad6cde80000/${VERSION}"  \
+ -H "Authorization: Bearer ${ACCESS_TOKEN}"  \
+ -H "Content-Type: application/json"
+echo

--- a/build/dev/check_scd_read.sh
+++ b/build/dev/check_scd_read.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# This script is to perform simple read operations on SCD database for testing.
+
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+
+cd "${BASEDIR}" || exit 1
+
+echo "DSS response to [SCD] GET subscription query:"
+echo "============="
+./read_scd_subscription.sh 00000158-9aba-4026-bbef-bad6cde80000
+echo
+
+echo "DSS response to [SCD] GET constraint reference query:"
+echo "============="
+./read_scd_constraint_reference.sh 00000159-9aba-4026-bbef-bad6cde80000
+echo
+
+echo "DSS response to [SCD] GET operational intent reference query:"
+echo "============="
+./read_scd_operational_intent_reference.sh 0000015a-9aba-4026-bbef-bad6cde80000
+echo

--- a/build/dev/check_scd_write.sh
+++ b/build/dev/check_scd_write.sh
@@ -6,19 +6,18 @@ set -eo pipefail
 
 # Retrieve token from dummy OAuth server
 ACCESS_TOKEN=$(curl --silent -X POST \
-    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination&intended_audience=localhost&issuer=localhost" \
+    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination%20utm.constraint_management&intended_audience=localhost&issuer=localhost&sub=check_scd" \
 | jq -r '.access_token')
 
 
-echo "DSS response to [SCD] PUT Subscriptions query:"
+echo "DSS response to [SCD] PUT subscription query:"
 echo "============="
 TIMESTAMP_NOW=$(python -c 'from datetime import datetime; print((datetime.utcnow()).isoformat() + "Z")')
 TIMESTAMP_LATER=$(python -c 'from datetime import datetime, timedelta; print((datetime.utcnow() + timedelta(minutes=5)).isoformat() + "Z")')
-RANDOMCODE=$(openssl rand -hex 2)
 
 
 curl --silent -X PUT  \
-"http://localhost:8082/dss/v1/subscriptions/000000d8-$RANDOMCODE-40ff-a64b-a8fb8db60000" \
+"http://localhost:8082/dss/v1/subscriptions/00000158-9aba-4026-bbef-bad6cde80000" \
 -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "Content-Type: application/json"  \
 -d '{
        "notify_for_operational_intents": true,
@@ -51,16 +50,13 @@ curl --silent -X PUT  \
                 "format": "RFC3339"
             }
 }}'
+echo
 
 
-echo "Create SCD constraints"
+echo "DSS response to [SCD] PUT constraint reference query:"
 echo "============="
 
-ACCESS_TOKEN=$(curl --silent -X POST \
-    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.constraint_management&intended_audience=localhost&issuer=localhost" \
-| jq -r '.access_token')
-
-curl --silent -X PUT  "http://localhost:8082/dss/v1/constraint_references/00000002-$RANDOMCODE-40ff-a64b-a8fb8db60000"  \
+curl --silent -X PUT  "http://localhost:8082/dss/v1/constraint_references/00000159-9aba-4026-bbef-bad6cde80000"  \
 -H "Authorization: Bearer ${ACCESS_TOKEN}"  \
 -H "Content-Type: application/json"  \
 -d '{
@@ -101,16 +97,13 @@ curl --silent -X PUT  "http://localhost:8082/dss/v1/constraint_references/000000
     ],
     "old_version": 0
 }'
+echo
 
 
-echo "Create Operational intent"
+echo "DSS response to [SCD] PUT operational intent reference query:"
 echo "=========="
 
-ACCESS_TOKEN=$(curl --silent -X POST \
-    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination&intended_audience=localhost&issuer=localhost" \
-| jq -r '.access_token')
-
-curl --silent -X PUT  "http://localhost:8082/dss/v1/operational_intent_references/00000156-$RANDOMCODE-40ff-a64b-a8fb8db60000"  \
+curl --silent -X PUT  "http://localhost:8082/dss/v1/operational_intent_references/0000015a-9aba-4026-bbef-bad6cde80000"  \
  -H "Authorization: Bearer ${ACCESS_TOKEN}"  \
  -H "Content-Type: application/json"  \
  -d '{
@@ -324,3 +317,4 @@ curl --silent -X PUT  "http://localhost:8082/dss/v1/operational_intent_reference
     },
     "key": []
 }'
+echo

--- a/build/dev/read_scd_constraint_reference.sh
+++ b/build/dev/read_scd_constraint_reference.sh
@@ -2,14 +2,14 @@
 
 set -eo pipefail
 
-# Test Get SCD constraints.
+# Get named SCD constraint.
 
 constraint_id=$1
 [[ -z "$constraint_id" ]] && { echo "Error: Constraint ID not provided."; exit 1; }
 
 # Retrieve token from dummy OAuth server
 ACCESS_TOKEN=$(curl --silent -X POST \
-    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.constraint_processing&intended_audience=localhost&issuer=localhost" \
+    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.constraint_processing&intended_audience=localhost&issuer=localhost&sub=check_scd" \
 | jq -r '.access_token')
 
 curl --silent -X GET  "http://localhost:8082/dss/v1/constraint_references/$constraint_id"  \

--- a/build/dev/read_scd_operational_intent_reference.sh
+++ b/build/dev/read_scd_operational_intent_reference.sh
@@ -9,7 +9,7 @@ operation_id=$1
 
 # Retrieve token from dummy OAuth server
 ACCESS_TOKEN=$(curl --silent -X POST \
-    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination&intended_audience=localhost&issuer=localhost" \
+    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination&intended_audience=localhost&issuer=localhost&sub=check_scd" \
 | jq -r '.access_token')
 
 curl --silent -X GET  "http://localhost:8082/dss/v1/operational_intent_references/$operation_id"  \

--- a/build/dev/read_scd_subscription.sh
+++ b/build/dev/read_scd_subscription.sh
@@ -9,7 +9,7 @@ subscription_id=$1
 
 # Retrieve token from dummy OAuth server
 ACCESS_TOKEN=$(curl --silent -X POST \
-    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination&intended_audience=localhost&issuer=localhost" \
+    "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination&intended_audience=localhost&issuer=localhost&sub=check_scd" \
 | jq -r '.access_token')
 
 curl --silent -X GET  \

--- a/build/dev/standalone_instance.md
+++ b/build/dev/standalone_instance.md
@@ -128,6 +128,28 @@ docker container exec -i dss_sandbox_local-dss-crdb_1 cockroach sql --insecure <
 To just determine the current version of a database schema, simply omit the
 target version parameter to `migrate_local_db.sh`.
 
+## Data injection and verification
+
+### Prober
+
+* `probe_local_instance.sh` runs the end-to-end [prober](../../monitoring/prober)
+integration test, similar to [docker_e2e.sh](../../test/docker_e2e.sh), but using
+the DSS instance already deployed locally instead of also deploying a local
+instance as docker_e2e.sh does
+
+### RID
+
+* `check_dss.sh` lists the ISAs near Hawaii
+
+### SCD
+
+* `check_scd_write.sh` creates a Subscription, Constraint Reference, and Operational Intent
+* `check_scd_read.sh` verifies that the objects created with `check_scd_write.sh` are still present
+    * `read_scd_subscription.sh <SUBSCRIPTION_ID>` retrieves the specified subscription from the DSS as the USS "check_scd"
+    * `read_scd_constraint_reference.sh <CONSTRAINT_ID>` retrieves the specified constraint reference from the DSS as the USS "check_scd"
+    * `read_scd_operational_intent_reference.sh <OP_INTENT_ID>` retrieves the specified operational_intent_reference from the DSS as the USS "check_scd"
+* `check_scd_clear.sh` removes the objects created with `check_scd_write.sh` from the DSS
+
 ## Troubleshooting
 
 If one or more of the necessary ports are not available, identify the process

--- a/monitoring/prober/infrastructure.py
+++ b/monitoring/prober/infrastructure.py
@@ -86,7 +86,7 @@ ResourceType = int
 resource_type_code_descriptions: Dict[ResourceType, str] = {}
 
 
-# Next code: 344
+# Next code: 347
 def register_resource_type(code: int, description: str) -> ResourceType:
   """Register that the specified code refers to the described resource.
 
@@ -148,3 +148,8 @@ class IDFactory(object):
     resource_type_code = ResourceType(int(x, 16))
     owner_name = utils.decode_owner(y)
     return owner_name, resource_type_code
+
+
+check_scd_write_subscription_id = register_resource_type(344, 'Subscription created by build/dev/check_scd_write.sh')
+check_scd_write_constraint_id = register_resource_type(345, 'Constraint reference created by build/dev/check_scd_write.sh')
+check_scd_write_operational_intent_id = register_resource_type(346, 'Operational intent reference created by build/dev/check_scd_write.sh')


### PR DESCRIPTION
#696 added tools to inject data into an SCD database for the purpose of verifying database down migration behavior.  This PR simplifies the usage of those tools and generalizes them for potential other purposes as well.  It also documents the tools' purpose and usage in the README.

This PR also splits out the two types of lint (Go and shell) so that the shell lint (much quicker) can be run independently from the Go lint.