### PR TITLE
[ci] Clear image cache and print logs in case of failure

### DIFF
--- a/monitoring/uss_qualifier/scripts/test_docker.sh
+++ b/monitoring/uss_qualifier/scripts/test_docker.sh
@@ -10,6 +10,8 @@ echo "Ensure the environment is clean"
 echo "============="
 docker-compose -f docker-compose_qualifier_mocks.yaml -p $project_name down
 
+echo "Rebuild images without cache"
+docker-compose -f docker-compose_qualifier_mocks.yaml -p $project_name build --no-cache
 
 echo "Start mocks"
 echo "============="
@@ -25,6 +27,8 @@ for service_name in "${services[@]}"; do
     max_retry=3
     until [ "$(docker inspect -f \{\{.State.Health.Status\}\} "${container_name}")" == "healthy" ]; do
         if [ "$retry" -gt "$max_retry" ]; then
+            echo "$container_name logs:"
+            docker logs "$container_name"
             echo "$container_name didn't properly start. Exit." && exit 1
         fi
         sleep 1

--- a/monitoring/uss_qualifier/scripts/test_docker.sh
+++ b/monitoring/uss_qualifier/scripts/test_docker.sh
@@ -10,8 +10,10 @@ echo "Ensure the environment is clean"
 echo "============="
 docker-compose -f docker-compose_qualifier_mocks.yaml -p $project_name down
 
-echo "Rebuild images without cache"
-docker-compose -f docker-compose_qualifier_mocks.yaml -p $project_name build --no-cache
+if [ "$CI" = "true" ]; then
+    echo "Rebuild images without cache"
+    docker-compose -f docker-compose_qualifier_mocks.yaml -p $project_name build --no-cache
+fi
 
 echo "Start mocks"
 echo "============="


### PR DESCRIPTION
This PR improves the script used to test the scd qualifier by forcing the images of the mocks to be built without cache and it prints the container logs in case of starting failure.

Note: USS Qualifier Tests check is failing because of the issue addressed by PR #716.