### PR TITLE
[monitoring] Enforce itsdangerous package version to 2.0.1

### DIFF
--- a/monitoring/monitorlib/requirements.txt
+++ b/monitoring/monitorlib/requirements.txt
@@ -1,6 +1,7 @@
 arrow==1.1.0
 cryptography==3.3.2
 flask==1.1.2
+itsdangerous==2.0.1 # Version 2.1.0 is not compatible with flask 1.1.2.
 google-auth==1.6.3
 jwcrypto==0.7
 lxml==4.6.5

--- a/monitoring/uss_qualifier/rid/mock/requirements.txt
+++ b/monitoring/uss_qualifier/rid/mock/requirements.txt
@@ -1,5 +1,4 @@
-Flask==1.1.2
+-r ../../../monitorlib/requirements.txt
 iso8601==0.1.14
 s2sphere==0.2.5
 gunicorn==20.0.4
--r ../../../monitorlib/requirements.txt


### PR DESCRIPTION
Since February 17, 2022, itsdangerous requirement is matching version 2.1.0 which is not supported by flask 1.1.2.
Stack trace of the issue:
```
Traceback (most recent call last):
  File "/usr/local/bin/gunicorn", line 8, in <module>
    sys.exit(run())
  File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 58, in run
    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
  File "/usr/local/lib/python3.8/site-packages/gunicorn/app/base.py", line 228, in run
    super().run()
  File "/usr/local/lib/python3.8/site-packages/gunicorn/app/base.py", line 72, in run
    Arbiter(self).run()
  File "/usr/local/lib/python3.8/site-packages/gunicorn/arbiter.py", line 58, in __init__
    self.setup(app)
  File "/usr/local/lib/python3.8/site-packages/gunicorn/arbiter.py", line 118, in setup
    self.app.wsgi()
  File "/usr/local/lib/python3.8/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 49, in load
    return self.load_wsgiapp()
  File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 39, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/local/lib/python3.8/site-packages/gunicorn/util.py", line 358, in import_app
    mod = importlib.import_module(module)
qualifier_sandbox_mock_1 didn't properly start. Exit.
  File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/app/monitoring/uss_qualifier/rid/mock/__init__.py", line 1, in <module>
    import flask
  File "/usr/local/lib/python3.8/site-packages/flask/__init__.py", line 19, in <module>
    from . import json
  File "/usr/local/lib/python3.8/site-packages/flask/json/__init__.py", line 15, in <module>
    from itsdangerous import json as _json
ImportError: cannot import name 'json' from 'itsdangerous' (/usr/local/lib/python3.8/site-packages/itsdangerous/__init__.py)
```

This PR forces version 2.0.1 of the itsdangerous package.