### PR TITLE
[uss_qualifier/scd] Local instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ services such as Remote ID (ASTM F3411-19) and Strategic Conflict Detection defi
 Management (UTM) UAS Service Supplier (USS) Interoperability Specification.
 
 - [Introduction to monitoring, conformance and interoperability testing](./monitoring/README.md)<br>Modules:
-  - [USS Remote ID qualifier](./monitoring/uss_qualifier/rid)
-  <!-- - [USS SCD qualifier](./monitoring/scd_qualifier) -->
+  - [USS qualifier](./monitoring/uss_qualifier)
+    - [Remote ID qualification](./monitoring/uss_qualifier/rid)
+    - [Strategic Coordination and UAS Flight Authorisation qualification](./monitoring/uss_qualifier/scd)
   - [DSSs interoperability tests](./monitoring/interoperability)
   - [DSS integration test: prober](./monitoring/prober)
   - [DSS load test](./monitoring/loadtest)

--- a/monitoring/uss_qualifier/README.md
+++ b/monitoring/uss_qualifier/README.md
@@ -6,3 +6,4 @@ The USS Qualifier automates testing standards compliance and interoperability of
 service providers. It currently includes the following components:
 
 - [Remote ID](./rid/README.md): ASTM F3411-19 - Remote ID and Tracking
+- [ASTM strategic coordination and UAS Flight Authorisation](./scd/README.md): ASTM WK63418 and U-Space Regulation

--- a/monitoring/uss_qualifier/bin/build.sh
+++ b/monitoring/uss_qualifier/bin/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# This script builds and executes the uss qualifier.
+
+set -eo pipefail
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../../.." || exit 1
+
+docker build \
+    -f monitoring/uss_qualifier/Dockerfile \
+    -t interuss/uss_qualifier \
+    --build-arg version="$(scripts/git/commit.sh)" \
+    --build-arg qualifier_scd_version="$(scripts/git/version.sh uss_qualifier --long)" \
+    monitoring

--- a/monitoring/uss_qualifier/bin/run.sh
+++ b/monitoring/uss_qualifier/bin/run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# This script builds and executes the uss qualifier.
+
+set -eo pipefail
+
+if [[ $# == 0 ]]; then
+  echo "Usage: $0 <CONFIG_LOCATION> [AUTH]"
+  echo "Builds and executes the uss qualifier"
+  echo "<CONFIG_LOCATION>: Location of the configuration file."
+  echo "[AUTH]: Location of the configuration file."
+  exit 1
+fi
+# Get absolute path of the config file provided
+CONFIG_LOCATION="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../../.." || exit 1
+
+CONFIG_CONTAINER_LOCATION='/app/monitoring/uss_qualifier/config.json' # Path of the file in the container
+AUTH="${2:-NoAuth()}"
+
+QUALIFIER_OPTIONS="--auth $AUTH --config $CONFIG_CONTAINER_LOCATION"
+
+REPORT_RID_FILE="$(pwd)/monitoring/uss_qualifier/report_rid.json"
+REPORT_SCD_FILE="$(pwd)/monitoring/uss_qualifier/report_scd.json"
+# files must already exist to share correctly with the Docker container
+touch "${REPORT_RID_FILE}"
+touch "${REPORT_SCD_FILE}"
+
+$(pwd)/monitoring/uss_qualifier/bin/build.sh
+
+if [ "$CI" == "true" ]; then
+  docker_args="--add-host host.docker.internal:host-gateway" # Required to reach other containers in Ubuntu (used for Github Actions)
+else
+  docker_args="-it"
+fi
+
+docker run ${docker_args} --name uss_qualifier \
+  --rm \
+  -e QUALIFIER_OPTIONS="${QUALIFIER_OPTIONS}" \
+  -e PYTHONBUFFERED=1 \
+  -v "${REPORT_RID_FILE}:/app/monitoring/uss_qualifier/report.json" \
+  -v "${REPORT_SCD_FILE}:/app/monitoring/uss_qualifier/report_scd.json" \
+  -v "${CONFIG_LOCATION}:$CONFIG_CONTAINER_LOCATION" \
+  interuss/uss_qualifier \
+  python main.py $QUALIFIER_OPTIONS

--- a/monitoring/uss_qualifier/bin/run.sh
+++ b/monitoring/uss_qualifier/bin/run.sh
@@ -34,7 +34,7 @@ REPORT_SCD_FILE="$(pwd)/monitoring/uss_qualifier/report_scd.json"
 touch "${REPORT_RID_FILE}"
 touch "${REPORT_SCD_FILE}"
 
-$(pwd)/monitoring/uss_qualifier/bin/build.sh
+"$(pwd)"/monitoring/uss_qualifier/bin/build.sh
 
 if [ "$CI" == "true" ]; then
   docker_args="--add-host host.docker.internal:host-gateway" # Required to reach other containers in Ubuntu (used for Github Actions)
@@ -42,6 +42,7 @@ else
   docker_args="-it"
 fi
 
+# shellcheck disable=SC2086
 docker run ${docker_args} --name uss_qualifier \
   --rm \
   -e QUALIFIER_OPTIONS="${QUALIFIER_OPTIONS}" \

--- a/monitoring/uss_qualifier/config_run.json.dist
+++ b/monitoring/uss_qualifier/config_run.json.dist
@@ -1,0 +1,15 @@
+{
+    "locale": "CHE",
+    "scd": {
+        "injection_targets": [
+            {
+                "name": "uss1",
+                "injection_base_url": "http://host.docker.internal:8074/scdsc"
+            },
+            {
+                "name": "uss2",
+                "injection_base_url": "http://host.docker.internal:8074/scdsc"
+            }
+        ]
+    }
+}

--- a/monitoring/uss_qualifier/run_locally_scd.sh
+++ b/monitoring/uss_qualifier/run_locally_scd.sh
@@ -12,11 +12,11 @@ else
 fi
 cd "${BASEDIR}/../.." || exit 1
 
-echo '#########################################################################'
-echo '## NOTE: A prerequisite for running this command locally is to have    ##'
-echo '## a running instance of the uss_qualifier SCD system mock             ##'
-echo '## (../mock_uss/run_locally_scdsc.sh) including related dependencies.  ##'
-echo '#########################################################################'
+echo '####################################################################################'
+echo '## NOTE: Prerequisites to run this command are:                                   ##'
+echo '## 1. Local DSS instance + Dummy OAuth server (/build/dev/run_locally.sh)         ##'
+echo '## 2. Local mock SCD service provider (/monitoring/mock_uss/run_locally_scdsc.sh) ##'
+echo '####################################################################################'
 
 CONFIG_LOCATION="monitoring/uss_qualifier/config_run_locally.json"
 CONFIG='--config config_run_locally.json'
@@ -41,15 +41,15 @@ echo '{
 
 SCD_QUALIFIER_OPTIONS="$AUTH $CONFIG"
 
-REPORT_FILE="$(pwd)/monitoring/uss_qualifier/report.json"
+REPORT_SCD_FILE="$(pwd)/monitoring/uss_qualifier/report_scd.json"
 # report.json must already exist to share correctly with the Docker container
-touch "${REPORT_FILE}"
+touch "${REPORT_SCD_FILE}"
 
 docker build \
     -f monitoring/uss_qualifier/Dockerfile \
     -t interuss/uss_qualifier \
     --build-arg version="$(scripts/git/commit.sh)" \
-    --build-arg qualifier_scd_version="$(scripts/git/version.sh uss_qualifier_scd --long)" \
+    --build-arg qualifier_scd_version="$(scripts/git/version.sh uss_qualifier --long)" \
     monitoring
 
 if [ "$CI" == "true" ]; then

--- a/monitoring/uss_qualifier/run_locally_scd.sh
+++ b/monitoring/uss_qualifier/run_locally_scd.sh
@@ -12,11 +12,11 @@ else
 fi
 cd "${BASEDIR}/../.." || exit 1
 
-echo '####################################################################################'
-echo '## NOTE: Prerequisites to run this command are:                                   ##'
-echo '## 1. Local DSS instance + Dummy OAuth server (/build/dev/run_locally.sh)         ##'
-echo '## 2. Local mock SCD service provider (/monitoring/mock_uss/run_locally_scdsc.sh) ##'
-echo '####################################################################################'
+echo '#########################################################################'
+echo '## NOTE: A prerequisite for running this command locally is to have    ##'
+echo '## a running instance of the uss_qualifier SCD system mock             ##'
+echo '## (../mock_uss/run_locally_scdsc.sh) including related dependencies.  ##'
+echo '#########################################################################'
 
 CONFIG_LOCATION="monitoring/uss_qualifier/config_run_locally.json"
 CONFIG='--config config_run_locally.json'

--- a/monitoring/uss_qualifier/run_locally_scd.sh
+++ b/monitoring/uss_qualifier/run_locally_scd.sh
@@ -42,7 +42,7 @@ echo '{
 SCD_QUALIFIER_OPTIONS="$AUTH $CONFIG"
 
 REPORT_SCD_FILE="$(pwd)/monitoring/uss_qualifier/report_scd.json"
-# report.json must already exist to share correctly with the Docker container
+# report_scd.json must already exist to share correctly with the Docker container
 touch "${REPORT_SCD_FILE}"
 
 docker build \
@@ -64,7 +64,6 @@ docker run ${docker_args} --name uss_qualifier \
   --rm \
   -e SCD_QUALIFIER_OPTIONS="${SCD_QUALIFIER_OPTIONS}" \
   -e PYTHONBUFFERED=1 \
-  -v "${REPORT_FILE}:/app/monitoring/uss_qualifier/report.json" \
   -v "${REPORT_SCD_FILE}:/app/monitoring/uss_qualifier/report_scd.json" \
   -v "$(pwd):/app" \
   interuss/uss_qualifier \

--- a/monitoring/uss_qualifier/scd/README.md
+++ b/monitoring/uss_qualifier/scd/README.md
@@ -1,0 +1,15 @@
+# Strategic Coordination and UAS Flight Authorisation
+
+## Local qualification
+1. Copy `config_run.json.dist` to `config_run.json`.
+2. Edit the `injection_base_url` fields to the required target urls of the service providers to test.
+3. Setup the dependencies:
+    1. Start the local DSS instance and the Dummy OAuth server using [/build/dev/run_locally.sh](/build/dev/run_locally.sh)
+4. Ensure that the service provider to be tested implements the [injection interfaces](/interfaces/automated-testing/scd).
+5. Configure the service provider to connect to the local DSS instance and the Dummy OAuth server:
+   1. Local DSS server url: `http://host.docker.internal:8082`
+   2. Dummy OAuth server url: `http://host.docker.internal:8085/token`
+   3. Dummy OAuth server public key: [`/build/test-certs/auth2.pem`](/build/test-certs/auth2.pem)
+   4. Audience should correspond to the base url of the service provider to be tested.
+6. Run the automated test: `bin/run.sh config_run.json`
+7. Consult the report: [`report_scd.json`](../report_scd.json)


### PR DESCRIPTION
This PR adds instructions and helper scripts to run configurable automated tests locally  from a service provider point of view. Additionally it changes the module version to uss_qualifier instead of uss_qualifier_scd.