### PR TITLE
[version] Append commit hash to default version 0.0.0

### DIFF
--- a/scripts/git/version.sh
+++ b/scripts/git/version.sh
@@ -43,10 +43,8 @@ COMMIT=$(git rev-parse --short HEAD)
 # If no version was found, use default v0.0.0.
 if [[ -z "$LAST_VERSION" ]]; then
   LAST_VERSION="v0.0.0-$COMMIT"
-fi
-
 # Check if there are some commits on top of the tag by checking if an abbrev part is present.
-if [[ "$LAST_VERSION" == *"-"* ]]; then
+elif [[ "$LAST_VERSION" == *"-"* ]]; then
   # Remove abbrev part
   LAST_VERSION=${LAST_VERSION%%-*}
   # Append the commit hash

--- a/scripts/git/version.sh
+++ b/scripts/git/version.sh
@@ -37,13 +37,13 @@ LAST_VERSION_TAG=$(git describe --abbrev=1 --tags --match="${UPSTREAM_ORG}/${COM
 LAST_VERSION=${LAST_VERSION_TAG##*/}
 #echo "LAST_VERSION: $LAST_VERSION"
 
-# If no version was found, use default v0.0.0.
-if [[ -z "$LAST_VERSION" ]]; then
-  LAST_VERSION="v0.0.0"
-fi
-
 # Current commit
 COMMIT=$(git rev-parse --short HEAD)
+
+# If no version was found, use default v0.0.0.
+if [[ -z "$LAST_VERSION" ]]; then
+  LAST_VERSION="v0.0.0-$COMMIT"
+fi
 
 # Check if there are some commits on top of the tag by checking if an abbrev part is present.
 if [[ "$LAST_VERSION" == *"-"* ]]; then


### PR DESCRIPTION
We identified that if a module was never released, the version generated defaults to v0.0.0. To make itmeaningful, this PR adds the commit hash to the fallback version name. That will generate useful version name for unreleased projects such as the `uss_qualifier`.