### PR TITLE
[interop] Fix scope to delete subscription during Cleanup

### DIFF
--- a/monitoring/interoperability/README.md
+++ b/monitoring/interoperability/README.md
@@ -13,8 +13,8 @@ From the [`root folder of this repo`](../..) folder:
 ```shell script
 docker run --rm $(docker build -q -f monitoring/interoperability/Dockerfile monitoring) \
     --auth <SPEC> \
-    --dss https://example.com/v1/dss \
-    --dss https://example2.com/v1/dss
+    https://example.com/v1/dss \
+    https://example2.com/v1/dss
 ```
 
 The auth SPEC defines how to obtain access tokens to access the DSS instances.

--- a/monitoring/interoperability/interop_test_suite.py
+++ b/monitoring/interoperability/interop_test_suite.py
@@ -104,7 +104,7 @@ class TestSteps:
                 dss.delete(f"/identification_service_areas/{stored_uuid}/{version}", scope=SCOPE_WRITE)
             elif entity_type == "SUB":
                 version = self.context[stored_uuid].uuid
-                dss.delete(f"/subscriptions/{stored_uuid}/{version}", scope=SCOPE_WRITE)
+                dss.delete(f"/subscriptions/{stored_uuid}/{version}", scope=SCOPE_READ)
             elif entity_type == "VERSION":
                 # do nothing
                 continue


### PR DESCRIPTION
Currently the interoperability script generates 403s during cleanup on the DSS under test. The DSS `/subscriptions` endpoint requires the scope `dss.write.identification_service_areas` to properly delete a suscription. This PR fixes that as well as an inexact command line example in the documentation.