### PR TITLE
[uss_qualifier/scd] Check for injected operational intents in UTM system

### DIFF
--- a/monitoring/mock_uss/routes.py
+++ b/monitoring/mock_uss/routes.py
@@ -22,8 +22,8 @@ def handle_exception(e):
     elif isinstance(e, auth_validation.InvalidAccessTokenError):
         return flask.jsonify({'message': e.message}), 401
     elif isinstance(e, auth_validation.ConfigurationError):
-        return flask.jsonify({'message': e.message}), 500
+        return flask.jsonify({'message': 'Auth validation configuration error: ' + e.message}), 500
     elif isinstance(e, ValueError):
         return flask.jsonify({'message': str(e)}), 400
 
-    return flask.jsonify({'message': str(e)}), 500
+    return flask.jsonify({'message': 'Unhandled {}: {}'.format(type(e).__name__, str(e))}), 500

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 import uuid
 
 import flask
+import requests.exceptions
 import yaml
 
 from monitoring.monitorlib import scd
@@ -91,7 +92,7 @@ def inject_flight(flight_id: str) -> Tuple[str, int]:
     vol4 = scd.make_vol4(start_time, end_time, alt_lo, alt_hi, polygon=scd.make_polygon(latlngrect=area))
     try:
         op_intents = query_operational_intents(vol4)
-    except (ValueError, scd_client.OperationError) as e:
+    except (ValueError, scd_client.OperationError, requests.exceptions.ConnectionError, ConnectionError) as e:
         notes = 'Error querying operational intents: {}'.format(e)
         return flask.jsonify(InjectFlightResponse(
             result=InjectFlightResult.Failed, notes=notes)), 200
@@ -124,7 +125,7 @@ def inject_flight(flight_id: str) -> Tuple[str, int]:
     id = str(uuid.uuid4())
     try:
         result = scd_client.create_operational_intent_reference(resources.utm_client, id, req)
-    except (ValueError, scd_client.OperationError) as e:
+    except (ValueError, scd_client.OperationError, requests.exceptions.ConnectionError, ConnectionError) as e:
         notes = 'Error creating operational intent: {}'.format(e)
         return flask.jsonify(InjectFlightResponse(
             result=InjectFlightResult.Failed, notes=notes)), 200
@@ -165,7 +166,7 @@ def delete_flight(flight_id: str) -> Tuple[str, int]:
             resources.utm_client,
             flight.op_intent_reference.id,
             flight.op_intent_reference.ovn)
-    except (ValueError, scd_client.OperationError) as e:
+    except (ValueError, scd_client.OperationError, requests.exceptions.ConnectionError, ConnectionError) as e:
         notes = 'Error deleting operational intent: {}'.format(e)
         return flask.jsonify(DeleteFlightResponse(
             result=DeleteFlightResult.Failed, notes=notes)), 200
@@ -196,7 +197,7 @@ def clear_area() -> Tuple[str, int]:
     vol4 = scd.make_vol4(start_time, end_time, alt_lo, alt_hi, polygon=scd.make_polygon(latlngrect=area))
     try:
         op_intent_refs = scd_client.query_operational_intent_references(resources.utm_client, vol4)
-    except (ValueError, scd_client.OperationError) as e:
+    except (ValueError, scd_client.OperationError, requests.exceptions.ConnectionError, ConnectionError) as e:
         msg = 'Error querying operational intents: {}'.format(e)
         return flask.jsonify(ClearAreaResponse(
             outcome=ClearAreaOutcome(

--- a/monitoring/monitorlib/fetch/scd.py
+++ b/monitoring/monitorlib/fetch/scd.py
@@ -29,8 +29,8 @@ class FetchedEntityReferences(fetch.Query):
     for entity_ref in self.json_result.get(self.entity_type, []):
       if 'id' not in entity_ref:
         return 'DSS response to search {} included entry without id'.format(self.entity_type)
-      if 'owner' not in entity_ref:
-        return 'DSS response to search {} included {} without owner'.format(self.entity_type, entity_ref['id'])
+      if 'manager' not in entity_ref:
+        return 'DSS response to search {} included {} without manager'.format(self.entity_type, entity_ref['id'])
       if 'uss_base_url' not in entity_ref:
         return 'DSS response to search {} included {} without uss_base_url'.format(self.entity_type, entity_ref['id'])
     return None
@@ -80,6 +80,15 @@ def _entity_references(dss_resource_name: str,
   return entity_references
 
 
+def operational_intent_references(utm_client: infrastructure.DSSTestSession,
+                                  area: s2sphere.LatLngRect,
+                                  start_time: datetime.datetime,
+                                  end_time: datetime.datetime,
+                                  alt_min_m: float=0,
+                                  alt_max_m: float=3048) -> FetchedEntityReferences:
+    return _entity_references('operational_intent_references', utm_client, area, start_time, end_time, alt_min_m, alt_max_m)
+
+
 class FetchedEntity(fetch.Query):
   @property
   def success(self) -> bool:
@@ -110,7 +119,10 @@ class FetchedEntity(fetch.Query):
     prefix = 'USS query for {} {} '.format(self.entity_type, self.id_requested)
 
     if self.status_code != 200:
-      return prefix + 'indicated failure ({})'.format(self.status_code)
+      msg = prefix + 'indicated failure ({})'.format(self.status_code)
+      if 'failure' in self.response:
+          msg += ': ' + self.response['failure']
+      return msg
     if self.json_result is None:
       return prefix + 'did not return valid JSON'
     if self.entity_type not in self.json_result:
@@ -138,7 +150,7 @@ yaml.add_representer(FetchedEntity, Representer.represent_dict)
 def _full_entity(uss_resource_name: str,
                  uss_base_url: str,
                  entity_id: str,
-                 utm_client: infrastructure.DSSTestSession):
+                 utm_client: infrastructure.DSSTestSession) -> FetchedEntity:
   uss_entity_url = uss_base_url + '/uss/v1/{}s/{}'.format(uss_resource_name, entity_id)
 
   # Query the USS for Entity details
@@ -147,6 +159,10 @@ def _full_entity(uss_resource_name: str,
   entity['id_requested'] = entity_id
   entity['entity_type'] = uss_resource_name
   return entity
+
+
+def operational_intent(uss_base_url: str, entity_id: str, utm_client: infrastructure.DSSTestSession) -> FetchedEntity:
+    return _full_entity('operational_intent', uss_base_url, entity_id, utm_client)
 
 
 class FetchedEntities(dict):

--- a/monitoring/uss_qualifier/rid/utils.py
+++ b/monitoring/uss_qualifier/rid/utils.py
@@ -7,6 +7,7 @@ from monitoring.monitorlib.rid import RIDAircraftState, RIDFlightDetails
 from monitoring.monitorlib.typing import ImplicitDict, StringBasedTimeDelta
 
 
+#TODO: This class is used in both RID and SCD; it should therefore be moved to a shared tools file rather than an RID utils file
 class InjectionTargetConfiguration(ImplicitDict):
     ''' This object defines the data required for a uss '''
     name: str

--- a/monitoring/uss_qualifier/run_locally_scd.sh
+++ b/monitoring/uss_qualifier/run_locally_scd.sh
@@ -21,7 +21,7 @@ echo '#########################################################################'
 CONFIG_LOCATION="monitoring/uss_qualifier/config_run_locally.json"
 CONFIG='--config config_run_locally.json'
 
-AUTH='--auth NoAuth()'
+AUTH='--auth DummyOAuth(http://host.docker.internal:8085/token,uss_qualifier)'
 
 echo '{
     "locale": "CHE",
@@ -35,7 +35,8 @@ echo '{
                 "name": "uss2",
                 "injection_base_url": "http://host.docker.internal:8074/scdsc"
             }
-        ]
+        ],
+        "dss_base_url": "http://host.docker.internal:8082"
     }
 }' > ${CONFIG_LOCATION}
 

--- a/monitoring/uss_qualifier/scd/configuration.py
+++ b/monitoring/uss_qualifier/scd/configuration.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from monitoring.monitorlib.typing import ImplicitDict
 from monitoring.uss_qualifier.rid.utils import InjectionTargetConfiguration
@@ -7,3 +7,7 @@ from monitoring.uss_qualifier.rid.utils import InjectionTargetConfiguration
 class SCDQualifierTestConfiguration(ImplicitDict):
     injection_targets: List[InjectionTargetConfiguration]
     """Set of USS into which data should be injected"""
+
+    dss_base_url: Optional[str]
+    """Base URL of DSS serving the above targets, or blank to not perform DSS
+    checks"""

--- a/monitoring/uss_qualifier/scd/executor/report_recorder.py
+++ b/monitoring/uss_qualifier/scd/executor/report_recorder.py
@@ -12,10 +12,11 @@ class ReportRecorder:
         self.context = context
 
 
-    def capture_interaction(self, step_ref: TestStepReference, query: fetch.Query) -> InteractionID:
+    def capture_interaction(self, step_ref: TestStepReference, query: fetch.Query, purpose: str) -> InteractionID:
         interaction_id = str(uuid.uuid4())
         interaction = Interaction(
                 interaction_id=interaction_id,
+                purpose=purpose,
                 test_step=step_ref,
                 context=self.context,
                 query=query
@@ -37,9 +38,11 @@ class ReportRecorder:
                 uss_role=attempt.injection_target.uss_role,
                 interactions=[interaction_id]
             )
-        self.report.findings.add_issue(issue)
+        self.capture_issue(issue)
         return issue
 
+    def capture_issue(self, issue: Issue):
+        self.report.findings.add_issue(issue)
 
     def capture_injection_unknown_issue(self, interaction_id: InteractionID, summary: str, details: str, target_name: str, attempt: FlightInjectionAttempt):
         issue = Issue(
@@ -54,7 +57,7 @@ class ReportRecorder:
                 uss_role=attempt.injection_target.uss_role,
                 interactions=[interaction_id]
             )
-        self.report.findings.add_issue(issue)
+        self.capture_issue(issue)
         return issue
 
 

--- a/monitoring/uss_qualifier/scd/executor/target.py
+++ b/monitoring/uss_qualifier/scd/executor/target.py
@@ -28,13 +28,13 @@ class TestTarget:
         return "TestTarget({}, {})".format(self.name, self.config.injection_base_url)
 
 
-    def inject_flight(self, flight_request: FlightInjectionAttempt) -> Tuple[InjectFlightResponse, fetch.Query]:
+    def inject_flight(self, flight_request: FlightInjectionAttempt) -> Tuple[InjectFlightResponse, fetch.Query, str]:
         flight_id, resp, query = create_flight(self.client, self.config.injection_base_url, flight_request.test_injection)
 
         if resp.result == InjectFlightResult.Planned:
             self.created_flight_ids[flight_request.name] = flight_id
 
-        return resp, query
+        return resp, query, flight_id
 
 
     def delete_flight(self, flight_name: str) -> Tuple[DeleteFlightResponse, fetch.Query]:

--- a/monitoring/uss_qualifier/scd/executor/test_steps/delete_flight.py
+++ b/monitoring/uss_qualifier/scd/executor/test_steps/delete_flight.py
@@ -1,0 +1,23 @@
+from monitoring.monitorlib.clients.scd_automated_testing import QueryError
+from monitoring.uss_qualifier.scd.data_interfaces import TestStep
+from monitoring.uss_qualifier.scd.executor.errors import TestRunnerError
+from monitoring.uss_qualifier.scd.executor.target import TestTarget
+from monitoring.uss_qualifier.scd.reports import TestStepReference
+
+
+def execute(self, step: TestStep, step_ref: TestStepReference, target: TestTarget) -> None:
+    print("[SCD]     Step: Delete flight {} in {}".format(step.delete_flight.flight_name, target.name))
+    try:
+        resp, query = target.delete_flight(step.delete_flight.flight_name)
+        self.report_recorder.capture_interaction(step_ref, query, 'Delete flight as part of test sequence')
+    except QueryError as e:
+        interaction_id = self.report_recorder.capture_interaction(step_ref, e.query, 'Delete flight as part of test sequence')
+        issue = self.report_recorder.capture_deletion_unknown_issue(
+            interaction_id=interaction_id,
+            summary="Deletion request was unsuccessful.",
+            details="Deletion attempt failed with status {}.".format(e.query.status_code),
+            flight_name=step.delete_flight.flight_name,
+            target_name=target.name,
+            uss_role=self.get_target_role(target.name)
+        )
+        raise TestRunnerError("Unsuccessful attempt to delete flight {}".format(step.inject_flight.name), issue)

--- a/monitoring/uss_qualifier/scd/executor/test_steps/inject_flight.py
+++ b/monitoring/uss_qualifier/scd/executor/test_steps/inject_flight.py
@@ -1,0 +1,160 @@
+import datetime
+
+from monitoring.monitorlib import scd
+from monitoring.monitorlib.clients.scd_automated_testing import QueryError
+from monitoring.monitorlib.fetch import scd as fetch_scd
+from monitoring.monitorlib.scd_automated_testing.scd_injection_api import InjectFlightResponse, InjectFlightResult
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.uss_qualifier.common_data_definitions import Severity, SubjectType, IssueSubject
+from monitoring.uss_qualifier.scd.data_interfaces import TestStep
+from monitoring.uss_qualifier.scd.executor.errors import TestRunnerError
+from monitoring.uss_qualifier.scd.executor.target import TestTarget
+from monitoring.uss_qualifier.scd.reports import Issue, TestStepReference
+
+
+NUMERIC_PRECISION = 0.001
+
+
+def execute(runner, step: TestStep, step_ref: TestStepReference, target: TestTarget) -> None:
+    print("[SCD]     Step: Inject flight {} to {}".format(step.inject_flight.name, target.name))
+    try:
+        resp, query, flight_id = target.inject_flight(step.inject_flight)
+    except QueryError as e:
+        interaction_id = runner.report_recorder.capture_interaction(step_ref, e.query, 'Inject flight into USS')
+        issue = runner.report_recorder.capture_injection_unknown_issue(
+            interaction_id,
+            summary="Injection request was unsuccessful",
+            details="Injection attempt failed with status {}.".format(e.query.status_code),
+            target_name=target.name,
+            attempt=step.inject_flight
+        )
+        raise TestRunnerError("Unsuccessful attempt to inject flight {}".format(step.inject_flight.name), issue)
+    interaction_id = runner.report_recorder.capture_interaction(step_ref, query, 'Inject flight into USS')
+    runner.evaluate_inject_flight_response(interaction_id, target, step.inject_flight, resp)
+
+    if (runner.dss_target and
+            resp.result == InjectFlightResult.Planned and
+            InjectFlightResult.Planned in step.inject_flight.known_responses.acceptable_results):
+        _verify_operational_intent(runner, step, step_ref, target, resp, flight_id)
+
+
+def _verify_operational_intent(runner, step: TestStep, step_ref: TestStepReference, target: TestTarget, resp: InjectFlightResponse, flight_id: str) -> None:
+    # Verify that the operation actually does exist in the system
+
+    # Check the DSS for a reference
+    op_intent = step.inject_flight.test_injection.operational_intent
+    vol4s = op_intent.volumes + op_intent.off_nominal_volumes
+    rect = scd.rect_bounds_of(vol4s)
+    t0 = scd.start_of(vol4s)
+    t1 = scd.end_of(vol4s)
+    alts = scd.meter_altitude_bounds_of(vol4s)
+    op_refs = fetch_scd.operational_intent_references(runner.dss_target.client, rect, t0, t1, alts[0], alts[1])
+    dss_interaction_id = runner.report_recorder.capture_interaction(step_ref, op_refs, 'Check if injected operational intent exists in DSS')
+    if not op_refs.success:
+        # The DSS call didn't even succeed
+        issue = Issue(
+            context=runner.context,
+            check_code='CREATED_FLIGHT_EXISTS_IN_SYSTEM',
+            uss_role=step.inject_flight.injection_target.uss_role,
+            target=target.name,
+            relevant_requirements=[],
+            severity=Severity.Critical,
+            subject=None,
+            summary='Error querying operational intent references from DSS',
+            details=op_refs.error,
+            interactions=[dss_interaction_id])
+        raise TestRunnerError(issue.summary, issue)
+    try:
+        ImplicitDict.parse(op_refs.json_result, scd.QueryOperationalIntentReferenceResponse)
+    except ValueError as e:
+        # The DSS returned an invalid result
+        issue = Issue(
+            context=runner.context,
+            check_code='CREATED_FLIGHT_EXISTS_IN_SYSTEM',
+            uss_role=step.inject_flight.injection_target.uss_role,
+            target=target.name,
+            relevant_requirements=[],
+            severity=Severity.Critical,
+            subject=None,
+            summary='Error in operational intent reference data format from DSS',
+            details=str(e),
+            interactions=[dss_interaction_id])
+        raise TestRunnerError(issue.summary, issue)
+    if resp.operational_intent_id not in op_refs.references_by_id:
+        # The expected operational intent reference wasn't present
+        issue = Issue(
+            context=runner.context,
+            check_code='CREATED_FLIGHT_EXISTS_IN_SYSTEM',
+            uss_role=step.inject_flight.injection_target.uss_role,
+            target=target.name,
+            relevant_requirements=['F3548-21 USS0005'],
+            severity=Severity.High,
+            subject=IssueSubject(subject_type=SubjectType.OperationalIntent, subject=resp.operational_intent_id),
+            summary='Operational intent not present in DSS',
+            details='When queried for the operational intent {} for flight {} in the DSS, it was not found in the Volume4D of interest'.format(resp.operational_intent_id, flight_id),
+            interactions=[dss_interaction_id])
+        raise TestRunnerError(issue.summary, issue)
+    op_ref = op_refs.references_by_id[resp.operational_intent_id]
+
+    # Check the USS for the operational intent details
+    op = fetch_scd.operational_intent(op_ref['uss_base_url'], resp.operational_intent_id, runner.dss_target.client)
+    uss_interaction_id = runner.report_recorder.capture_interaction(step_ref, op, 'Inspect operational intent details')
+    if not op.success:
+        # The USS call didn't succeed
+        issue = Issue(
+            context=runner.context,
+            check_code='CREATED_FLIGHT_EXISTS_IN_SYSTEM',
+            uss_role=step.inject_flight.injection_target.uss_role,
+            target=target.name,
+            relevant_requirements=['F3548-21 USS0105'],
+            severity=Severity.High,
+            subject=IssueSubject(subject_type=SubjectType.OperationalIntent, subject=resp.operational_intent_id),
+            summary='Error querying operational intent details from USS',
+            details=op.error,
+            interactions=[uss_interaction_id])
+        raise TestRunnerError(issue.summary, issue)
+    try:
+        op_resp: scd.GetOperationalIntentDetailsResponse = ImplicitDict.parse(op.json_result, scd.GetOperationalIntentDetailsResponse)
+    except ValueError as e:
+        # The USS returned an invalid result
+        issue = Issue(
+            context=runner.context,
+            check_code='CREATED_FLIGHT_EXISTS_IN_SYSTEM',
+            uss_role=step.inject_flight.injection_target.uss_role,
+            target=target.name,
+            relevant_requirements=['F3548-21 USS0105'],
+            severity=Severity.High,
+            subject=IssueSubject(subject_type=SubjectType.OperationalIntent, subject=resp.operational_intent_id),
+            summary='Error in operational intent data format from USS',
+            details=str(e),
+            interactions=[uss_interaction_id])
+        raise TestRunnerError(issue.summary, issue)
+
+    # Check that the USS is providing reasonable details
+    resp_vol4s = op_resp.operational_intent.details.volumes + op_resp.operational_intent.details.off_nominal_volumes
+    resp_alts = scd.meter_altitude_bounds_of(resp_vol4s)
+    resp_start = scd.start_of(resp_vol4s)
+    resp_end = scd.end_of(resp_vol4s)
+    error_text = None
+    if resp_alts[0] > alts[0] + NUMERIC_PRECISION:
+        error_text = 'Lower altitude specified by USS in operational intent details ({} m WGS84) is above the lower altitude in the injected flight ({} m WGS84)'.format(resp_alts[0], alts[0])
+    elif resp_alts[1] < alts[1] - NUMERIC_PRECISION:
+        error_text = 'Upper altitude specified by USS in operational intent details ({} m WGS84) is below the upper altitude in the injected flight ({} m WGS84)'.format(resp_alts[1], alts[1])
+    elif resp_start > t0 + datetime.timedelta(seconds=NUMERIC_PRECISION):
+        error_text = 'Start time specified by USS in operational intent details ({}) is past the start time of the injected flight ({})'.format(resp_start.isoformat(), t0.isoformat())
+    elif resp_end < t1 - datetime.timedelta(seconds=NUMERIC_PRECISION):
+        error_text = 'End time specified by USS in operational intent details ({}) is prior to the end time of the injected flight ({})'.format(resp_end.isoformat(), t1.isoformat())
+    if error_text:
+        # The USS's flight details are incorrect
+        issue = Issue(
+            context=runner.context,
+            check_code='CREATED_FLIGHT_EXISTS_IN_SYSTEM',
+            uss_role=step.inject_flight.injection_target.uss_role,
+            target=target.name,
+            relevant_requirements=[],
+            severity=Severity.High,
+            subject=IssueSubject(subject_type=SubjectType.OperationalIntent, subject=resp.operational_intent_id),
+            summary='Operational intent details does not match injected flight',
+            details=error_text,
+            interactions=[uss_interaction_id])
+        raise TestRunnerError(issue.summary, issue)

--- a/monitoring/uss_qualifier/scd/reports.py
+++ b/monitoring/uss_qualifier/scd/reports.py
@@ -77,6 +77,9 @@ class Interaction(ImplicitDict):
     interaction_id: InteractionID
     """ID of this interaction (used to refer to this interaction from an issue)"""
 
+    purpose: str
+    """Intended purpose of the interaction"""
+
     context: AutomatedTestContext
     """Context in which this interaction was performed."""
 


### PR DESCRIPTION
This PR has uss_qualifier double check with the DSS and USS (acting as a USS itself) that the operational intent a USS reported injecting actually appears properly in the UTM system whenever a USS properly indicates Planned as their response to a flight injection attempt.

As a consequence of debugging some behaviors observed during development of this change, this PR also adds some improved error messages and mock USS behaviors and fixes a problem where issues discovered through TestRunnerErrors were not added to the report.