### PR TITLE
[automated-testing/scd] Add USS capabilities

### DIFF
--- a/interfaces/automated-testing/scd/scd.yaml
+++ b/interfaces/automated-testing/scd/scd.yaml
@@ -503,7 +503,7 @@ components:
           description: >-
             True if, and only if, all flights in the specified area owned by the
             USS were canceled and removed.
-          type: bool
+          type: boolean
           default: false
         message:
           description: >-
@@ -525,6 +525,34 @@ components:
       properties:
         outcome:
           $ref: '#/components/schemas/ClearAreaOutcome'
+    Capability:
+      type: string
+      description: >-
+        Capability of a USS.
+
+          `FlightAuthorisationValidation`: USS supports EU flight authorisation
+            parameter validation.
+
+          `BasicStrategicConflictDetection`: USS supports strategic conflict
+            detection for typical flights, including future planning (Accepted
+            operational intents), activation (Accepted operational intents), and
+            closing (deleting the operational intent reference).
+
+          `HighPriorityFlights`: USS supports flights at priority levels higher
+            than typical flights.
+      enum:
+      - FlightAuthorisationValidation
+      - BasicStrategicConflictDetection
+      - HighPriorityFlights
+    CapabilitiesResponse:
+      type: object
+      properties:
+        capabilities:
+          type: array
+          description: Set of capabilities supported by this USS.
+          items:
+            $ref: '#/components/schemas/Capability'
+          default: []
 
 paths:
   /v1/status:
@@ -548,6 +576,26 @@ paths:
           description: The USS automated testing interface is not activated.
       summary: Retrieve the status of the USS automated testing interface
       description: Get the status of the USS automated testing interface
+
+  /v1/capabilities:
+    get:
+      security:
+      - Authority:
+          - utm.inject_test_data
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CapabilitiesResponse'
+          description: >-
+            The capabilities of the USS under test were retrieved successfully.
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+      summary: Retrieve the capabilities of the USS under test
+      description: Retrieve the capabilities of the USS under test
 
   /v1/flights/{flight_id}:
     parameters:

--- a/monitoring/mock_uss/postman_collection.json
+++ b/monitoring/mock_uss/postman_collection.json
@@ -380,6 +380,37 @@
 					"response": []
 				},
 				{
+					"name": "Capabilities",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{production_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8074/scdsc/v1/capabilities",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8074",
+							"path": [
+								"scdsc",
+								"v1",
+								"capabilities"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Flight 1 (nominal)",
 					"event": [
 						{
@@ -616,7 +647,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"extents\": [\n        {\n            \"volume\": {\n                \"outline_polygon\": {\n                    \"vertices\": [\n                        {\n                            \"lng\": -155.6043,\n                            \"lat\": 19.4763\n                        },\n                        {\n                            \"lng\": -155.5746,\n                            \"lat\": 19.4884\n                        },\n                        {\n                            \"lng\": -155.5941,\n                            \"lat\": 19.4516\n                        }\n                    ]\n                },\n                \"altitude_lower\": {\n                    \"value\": 0,\n                    \"units\": \"M\",\n                    \"reference\": \"W84\"\n                },\n                \"altitude_upper\": {\n                    \"value\": 122,\n                    \"units\": \"M\",\n                    \"reference\": \"W84\"\n                }\n            },\n            \"time_start\": {\n                \"value\": \"{{timestamp_start}}\",\n                \"format\": \"RFC3339\"\n            },\n            \"time_end\": {\n                \"value\": \"{{timestamp_end}}\",\n                \"format\": \"RFC3339\"\n            }\n        }\n    ]\n}",
+							"raw": "{\n    \"request_id\": \"dbd6a424-6ed8-4890-a900-54d01d9970f4\",\n    \"extent\": {\n        \"volume\": {\n            \"outline_polygon\": {\n                \"vertices\": [\n                    {\n                        \"lng\": -155.6043,\n                        \"lat\": 19.4763\n                    },\n                    {\n                        \"lng\": -155.5746,\n                        \"lat\": 19.4884\n                    },\n                    {\n                        \"lng\": -155.5941,\n                        \"lat\": 19.4516\n                    }\n                ]\n            },\n            \"altitude_lower\": {\n                \"value\": 0,\n                \"units\": \"M\",\n                \"reference\": \"W84\"\n            },\n            \"altitude_upper\": {\n                \"value\": 122,\n                \"units\": \"M\",\n                \"reference\": \"W84\"\n            }\n        },\n        \"time_start\": {\n            \"value\": \"{{timestamp_start}}\",\n            \"format\": \"RFC3339\"\n        },\n        \"time_end\": {\n            \"value\": \"{{timestamp_end}}\",\n            \"format\": \"RFC3339\"\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -624,7 +655,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8074/scdsc/clear_all_flights",
+							"raw": "http://localhost:8074/scdsc/v1/clear_area_requests",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -632,7 +663,8 @@
 							"port": "8074",
 							"path": [
 								"scdsc",
-								"clear_all_flights"
+								"v1",
+								"clear_area_requests"
 							]
 						}
 					},

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -54,7 +54,8 @@ def scd_capabilities() -> Tuple[str, int]:
     """Implements USS capabilities in SCD automated testing injection API."""
     return flask.jsonify(CapabilitiesResponse(capabilities=[
         Capability.BasicStrategicConflictDetection,
-        Capability.FlightAuthorisationValidation]))
+        Capability.FlightAuthorisationValidation,
+        Capability.HighPriorityFlights]))
 
 
 @webapp.route('/scdsc/v1/flights/<flight_id>', methods=['PUT'])

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -10,7 +10,7 @@ import yaml
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.clients import scd as scd_client
 from monitoring.monitorlib.scd_automated_testing import scd_injection_api
-from monitoring.monitorlib.scd_automated_testing.scd_injection_api import InjectFlightRequest, InjectFlightResponse, SCOPE_SCD_QUALIFIER_INJECT, InjectFlightResult, DeleteFlightResponse, DeleteFlightResult, ClearAreaRequest, ClearAreaOutcome, ClearAreaResponse
+from monitoring.monitorlib.scd_automated_testing.scd_injection_api import InjectFlightRequest, InjectFlightResponse, SCOPE_SCD_QUALIFIER_INJECT, InjectFlightResult, DeleteFlightResponse, DeleteFlightResult, ClearAreaRequest, ClearAreaOutcome, ClearAreaResponse, Capability, CapabilitiesResponse
 from monitoring.monitorlib.typing import ImplicitDict, StringBasedDateTime
 from monitoring.mock_uss import config, resources, webapp
 from monitoring.mock_uss.auth import requires_scope
@@ -46,6 +46,15 @@ def query_operational_intents(area_of_interest: scd.Volume4D) -> List[scd.Operat
 def scdsc_injection_status() -> Tuple[str, int]:
     """Implements USS status in SCD automated testing injection API."""
     return flask.jsonify({'status': 'Ready'})
+
+
+@webapp.route('/scdsc/v1/capabilities', methods=['GET'])
+@requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
+def scd_capabilities() -> Tuple[str, int]:
+    """Implements USS capabilities in SCD automated testing injection API."""
+    return flask.jsonify(CapabilitiesResponse(capabilities=[
+        Capability.BasicStrategicConflictDetection,
+        Capability.FlightAuthorisationValidation]))
 
 
 @webapp.route('/scdsc/v1/flights/<flight_id>', methods=['PUT'])

--- a/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
+++ b/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
@@ -104,3 +104,13 @@ class ClearAreaOutcome(ImplicitDict):
 class ClearAreaResponse(ImplicitDict):
     request: ClearAreaRequest
     outcome: ClearAreaOutcome
+
+
+class Capability(str, Enum):
+    FlightAuthorisationValidation = 'FlightAuthorisationValidation'
+    BasicStrategicConflictDetection = 'BasicStrategicConflictDetection'
+    HighPriorityFlights = 'HighPriorityFlights'
+
+
+class CapabilitiesResponse(ImplicitDict):
+    capabilities: Optional[List[Capability]]

--- a/monitoring/uss_qualifier/scd/data_interfaces.py
+++ b/monitoring/uss_qualifier/scd/data_interfaces.py
@@ -75,23 +75,12 @@ class TestStep(ImplicitDict):
     """If populated, the test driver should attempt to delete the specified flight for this step"""
 
 
-class AutomatedTestComponent(str, Enum):
-    AutomatedTest = 'AutomatedTest'
-    """Skip the entire AutomatedTest"""
-
-    TestStep = 'TestStep'
-    """Skip just the TestStep"""
-
-
 class RequiredUSSCapabilities(ImplicitDict):
     capabilities: List[Capability]
     """The set of capabilities a particular USS in the test must support"""
 
     injection_target: InjectionTarget
     """The USS which must support the specified capabilities"""
-
-    skip: Optional[AutomatedTestComponent] = None
-    """If specified, skip the specified test component which involves the specified injection target utilizing the specified capabilities."""
 
     generate_issue: Optional[KnownIssueFields] = None
     """If specified, generate an issue with the specified characteristics when the specified injection target does not support the specified capabilities."""

--- a/monitoring/uss_qualifier/scd/data_interfaces.py
+++ b/monitoring/uss_qualifier/scd/data_interfaces.py
@@ -1,7 +1,8 @@
+from enum import Enum
 from typing import Optional, List, Dict
 from monitoring.monitorlib.locality import Locality
 from monitoring.monitorlib.typing import ImplicitDict
-from monitoring.monitorlib.scd_automated_testing.scd_injection_api import InjectFlightRequest
+from monitoring.monitorlib.scd_automated_testing.scd_injection_api import InjectFlightRequest, Capability
 from monitoring.uss_qualifier.common_data_definitions import Severity
 
 
@@ -74,10 +75,35 @@ class TestStep(ImplicitDict):
     """If populated, the test driver should attempt to delete the specified flight for this step"""
 
 
+class AutomatedTestComponent(str, Enum):
+    AutomatedTest = 'AutomatedTest'
+    """Skip the entire AutomatedTest"""
+
+    TestStep = 'TestStep'
+    """Skip just the TestStep"""
+
+
+class RequiredUSSCapabilities(ImplicitDict):
+    capabilities: List[Capability]
+    """The set of capabilities a particular USS in the test must support"""
+
+    injection_target: InjectionTarget
+    """The USS which must support the specified capabilities"""
+
+    skip: Optional[AutomatedTestComponent] = None
+    """If specified, skip the specified test component which involves the specified injection target utilizing the specified capabilities."""
+
+    generate_issue: Optional[KnownIssueFields] = None
+    """If specified, generate an issue with the specified characteristics when the specified injection target does not support the specified capabilities."""
+
+
 class AutomatedTest(ImplicitDict):
     """Definition of a complete automated test involving some subset of USSs under test"""
     name: str
     """Human-readable name of this test (e.g., 'Nominal planning')"""
+
+    uss_capabilities: Optional[List[RequiredUSSCapabilities]] = []
+    """List of required USS capabilities for this test and what to do when they are not supported"""
 
     steps: List[TestStep]
     """Actions to be performed for this test"""

--- a/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-1.json
+++ b/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-1.json
@@ -3,6 +3,38 @@
     "steps": [
         {
             "name": "Inject flight via First-mover USS",
+            "uss_capabilities": [
+                {
+                    "capabilities": ["BasicStrategicConflictDetection"],
+                    "injection_target": {
+                        "uss_role": "First-Mover USS"
+                    },
+                    "skip": "AutomatedTest",
+                    "generate_issue": {
+                        "test_code": "FirstMoverCapabilities",
+                        "relevant_requirements": [],
+                        "severity": "High",
+                        "subject": "",
+                        "summary": "Basic strategic conflict detection not supported",
+                        "details": "USSP indicated it does not support flight authorisation validation, so it cannot perform the First-Mover USS role to test basic strategic conflict detection required by the flight authorisation service in Switzerland."
+                    }
+                },
+                {
+                    "capabilities": ["BasicStrategicConflictDetection"],
+                    "injection_target": {
+                        "uss_role": "Second USS"
+                    },
+                    "skip": "AutomatedTest",
+                    "generate_issue": {
+                        "test_code": "SecondUSSCapabilities",
+                        "relevant_requirements": [],
+                        "severity": "High",
+                        "subject": "",
+                        "summary": "Basic strategic conflict detection not supported",
+                        "details": "USSP indicated it does not support flight authorisation validation, so it cannot perform the Second USS role to test basic strategic conflict detection required by the flight authorisation service in Switzerland."
+                    }
+                }
+            ],
             "inject_flight": {
                 "reference_time": "2023-02-12T10:34:14.483425+00:00",
                 "test_injection": {

--- a/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-1.json
+++ b/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-1.json
@@ -9,7 +9,6 @@
                     "injection_target": {
                         "uss_role": "First-Mover USS"
                     },
-                    "skip": "AutomatedTest",
                     "generate_issue": {
                         "test_code": "FirstMoverCapabilities",
                         "relevant_requirements": [],
@@ -24,7 +23,6 @@
                     "injection_target": {
                         "uss_role": "Second USS"
                     },
-                    "skip": "AutomatedTest",
                     "generate_issue": {
                         "test_code": "SecondUSSCapabilities",
                         "relevant_requirements": [],

--- a/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-priority-1.json
+++ b/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-priority-1.json
@@ -8,15 +8,13 @@
                     "capabilities": ["FlightAuthorisationValidation"],
                     "injection_target": {
                         "uss_role": "First-Mover USS"
-                    },
-                    "skip": "AutomatedTest"
+                    }
                 },
                 {
                     "capabilities": ["FlightAuthorisationValidation", "HighPriorityFlights"],
                     "injection_target": {
                         "uss_role": "Second USS"
-                    },
-                    "skip": "AutomatedTest"
+                    }
                 }
             ],
             "inject_flight": {

--- a/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-priority-1.json
+++ b/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-priority-1.json
@@ -3,6 +3,22 @@
     "steps": [
         {
             "name": "Inject flight via First-mover USS",
+            "uss_capabilities": [
+                {
+                    "capabilities": ["FlightAuthorisationValidation"],
+                    "injection_target": {
+                        "uss_role": "First-Mover USS"
+                    },
+                    "skip": "AutomatedTest"
+                },
+                {
+                    "capabilities": ["FlightAuthorisationValidation", "HighPriorityFlights"],
+                    "injection_target": {
+                        "uss_role": "Second USS"
+                    },
+                    "skip": "AutomatedTest"
+                }
+            ],
             "inject_flight": {
                 "reference_time": "2023-02-12T10:34:14.483425+00:00",
                 "test_injection": {

--- a/monitoring/uss_qualifier/scd/test_definitions/CHE/u-space/flight-authorisation-validation-1.json
+++ b/monitoring/uss_qualifier/scd/test_definitions/CHE/u-space/flight-authorisation-validation-1.json
@@ -3,6 +3,23 @@
     "steps": [
         {
             "name": "Inject Fight Authorisation data",
+            "uss_capabilities": [
+                {
+                    "capabilities": ["FlightAuthorisationValidation"],
+                    "injection_target": {
+                        "uss_role": "Submitting USS"
+                    },
+                    "skip": "AutomatedTest",
+                    "generate_issue": {
+                        "test_code": "Capabilities",
+                        "relevant_requirements": [],
+                        "severity": "High",
+                        "subject": "",
+                        "summary": "Flight authorisation validation not supported",
+                        "details": "USSP indicated it does not support flight authorisation validation which is required to perform the flight authorisation U-space service in Switzerland."
+                    }
+                }
+            ],
             "inject_flight": {
                 "reference_time": "2023-02-12T10:34:14.681217+00:00",
                 "name": "8vludg44",

--- a/monitoring/uss_qualifier/scd/test_definitions/CHE/u-space/flight-authorisation-validation-1.json
+++ b/monitoring/uss_qualifier/scd/test_definitions/CHE/u-space/flight-authorisation-validation-1.json
@@ -9,7 +9,6 @@
                     "injection_target": {
                         "uss_role": "Submitting USS"
                     },
-                    "skip": "AutomatedTest",
                     "generate_issue": {
                         "test_code": "Capabilities",
                         "relevant_requirements": [],


### PR DESCRIPTION
With the addition of [the nominal-planning-priority test](https://github.com/interuss/dss/tree/master/interfaces/automated-testing/scd/design/astm-strategic-coordination/nominal-planning-priority), we have our first test where some USSs will not be able to complete the test simply because of the scope of activities that USS chooses to support, but we should expect many other situations like this in the future.  A USS may reasonably choose only to support normal-priority flights to avoid the additional design requirements involved in supporting a high-priority flight, for instance.  This PR introduces the concept of capabilities of USSs under test.

This PR makes a few changes related to this concept:
* Adds a simple /capabilities endpoint for USSs to implement
* Implements that endpoint in mock_uss
* Introduces data structures (within the AutomatedTest schema) to support implementation of this feature in uss_qualifier
* Populates the new schema elements for the currently-defined automated tests

This PR does not implement capability awareness in uss_qualifier; this is expected in a separate PR.