### PR TITLE
[prober] Fix, simplify, and improve workspace cleaning actions

### DIFF
--- a/monitoring/monitorlib/infrastructure.py
+++ b/monitoring/monitorlib/infrastructure.py
@@ -128,6 +128,10 @@ class AsyncUTMTestSession:
 
   async def build_session(self):
     self._client = ClientSession()
+
+  def close(self):
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(self._client.close())
   
   def adjust_request_kwargs(self, url, method, kwargs):
     if self.auth_adapter:

--- a/monitoring/prober/conftest.py
+++ b/monitoring/prober/conftest.py
@@ -122,7 +122,9 @@ def session(pytestconfig) -> DSSTestSession:
 
 @pytest.fixture(scope='session')
 def session_async(pytestconfig):
-  return make_session_async(pytestconfig, BASE_URL_RID, OPT_RID_AUTH)
+  session = make_session_async(pytestconfig, BASE_URL_RID, OPT_RID_AUTH)
+  yield session
+  session.close()
 
 
 @pytest.fixture(scope='session')
@@ -136,7 +138,9 @@ def scd_session(pytestconfig) -> DSSTestSession:
 
 @pytest.fixture(scope='session')
 def scd_session_async(pytestconfig):
-  return make_session_async(pytestconfig, '/dss/v1', 'scd_auth1')
+  session = make_session_async(pytestconfig, '/dss/v1', 'scd_auth1')
+  yield session
+  session.close()
 
 
 @pytest.fixture(scope='session')

--- a/monitoring/prober/scd/actions.py
+++ b/monitoring/prober/scd/actions.py
@@ -1,0 +1,70 @@
+from monitoring.monitorlib.infrastructure import DSSTestSession
+from monitoring.monitorlib import scd
+from monitoring.monitorlib.scd import SCOPE_CM, SCOPE_SC, SCOPE_CI, SCOPE_CP
+
+
+def _read_both_scope(scd_api: str) -> str:
+    if scd_api == scd.API_0_3_5:
+        return '{} {}'.format(SCOPE_SC, SCOPE_CI)
+    elif scd_api == scd.API_0_3_17:
+        return '{} {}'.format(SCOPE_SC, SCOPE_CP)
+    else:
+        raise NotImplementedError('Unsupported API version {}'.format(scd_api))
+
+
+def delete_constraint_reference_if_exists(id: str, scd_session: DSSTestSession, scd_api: str):
+    resp = scd_session.get('/constraint_references/{}'.format(id), scope=SCOPE_CM)
+    if resp.status_code == 200:
+        if scd_api == scd.API_0_3_5:
+            resp = scd_session.delete('/constraint_references/{}'.format(id), scope=SCOPE_CM)
+        elif scd_api == scd.API_0_3_17:
+            existing_constraint = resp.json().get('constraint_reference', None)
+            resp = scd_session.delete('/constraint_references/{}/{}'.format(id, existing_constraint['ovn']), scope=SCOPE_CM)
+        else:
+            raise NotImplementedError('Unsupported API version {}'.format(scd_api))
+        assert resp.status_code == 200, '{}: {}'.format(resp.url, resp.content)
+    elif resp.status_code == 404:
+        # As expected.
+        pass
+    else:
+        assert False, resp.content
+
+
+def delete_subscription_if_exists(sub_id: str, scd_session: DSSTestSession, scd_api: str):
+    resp = scd_session.get('/subscriptions/{}'.format(sub_id), scope=SCOPE_SC)
+    if resp.status_code == 200:
+        if scd_api == scd.API_0_3_5:
+            resp = scd_session.delete('/subscriptions/{}'.format(sub_id), scope=SCOPE_CI)
+        elif scd_api == scd.API_0_3_17:
+            sub = resp.json().get('subscription', None)
+            resp = scd_session.delete('/subscriptions/{}/{}'.format(sub_id, sub['version']), scope=_read_both_scope(scd_api))
+        else:
+            raise NotImplementedError('Unsupported API version {}'.format(scd_api))
+        assert resp.status_code == 200, resp.content
+    elif resp.status_code == 404:
+        # As expected.
+        pass
+    else:
+        assert False, resp.content
+
+
+def delete_operation_if_exists(id: str, scd_session: DSSTestSession, scd_api: str):
+    if scd_api == scd.API_0_3_5:
+        url = '/operation_references/{}'
+    elif scd_api == scd.API_0_3_17:
+        url = '/operational_intent_references/{}'
+    else:
+        assert False, 'Unsupported API {}'.format(scd_api)
+    resp = scd_session.get(url.format(id), scope=SCOPE_SC)
+    if resp.status_code == 200:
+        if scd_api == scd.API_0_3_5:
+            resp = scd_session.delete('/operation_references/{}'.format(id), scope=SCOPE_SC)
+        elif scd_api == scd.API_0_3_17:
+            ovn = resp.json()['operational_intent_reference']['ovn']
+            resp = scd_session.delete('/operational_intent_references/{}/{}'.format(id, ovn))
+        assert resp.status_code == 200, resp.content
+    elif resp.status_code == 404:
+        # As expected.
+        pass
+    else:
+        assert False, 'Unsupported API {}'.format(scd_api)

--- a/monitoring/prober/scd/test_constraint_simple.py
+++ b/monitoring/prober/scd/test_constraint_simple.py
@@ -15,6 +15,7 @@ from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC, SCOPE_CI, SCOPE_CM, SCOPE_CP, SCOPE_CM_SA, SCOPE_AA
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
 from monitoring.prober.infrastructure import depends_on, for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 import pytest
 
@@ -37,15 +38,7 @@ def _make_c1_request():
 def test_ensure_clean_workspace(ids, scd_api, scd_session, scd_session_cm):
   if not scd_session_cm:
     pytest.skip('SCD auth1 not enabled for constraint management')
-  resp = scd_session.get('/constraint_references/{}'.format(ids(CONSTRAINT_TYPE)), scope=SCOPE_CM)
-  if resp.status_code == 200:
-    resp = scd_session.delete('/constraint_references/{}'.format(ids(CONSTRAINT_TYPE)), scope=SCOPE_CM)
-    assert resp.status_code == 200, resp.content
-  elif resp.status_code == 404:
-    # As expected.
-    pass
-  else:
-    assert False, resp.content
+  actions.delete_constraint_reference_if_exists(ids(CONSTRAINT_TYPE), scd_session, scd_api)
 
 
 @for_api_versions(scd.API_0_3_5, scd.API_0_3_17)

--- a/monitoring/prober/scd/test_constraint_simple.py
+++ b/monitoring/prober/scd/test_constraint_simple.py
@@ -348,3 +348,8 @@ def test_get_deleted_constraint_by_search(ids, scd_api, scd_session):
   })
   assert resp.status_code == 200, resp.content
   assert ids(CONSTRAINT_TYPE) not in [x['id'] for x in resp.json()['constraint_references']]
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session, scd_session_cm):
+    test_ensure_clean_workspace(ids, scd_api, scd_session, scd_session_cm)

--- a/monitoring/prober/scd/test_constraints_with_subscriptions.py
+++ b/monitoring/prober/scd/test_constraints_with_subscriptions.py
@@ -15,6 +15,7 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_CI, SCOPE_CM, SCOPE_SC, SCOPE_CP
 from monitoring.prober.infrastructure import for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 CONSTRAINT_BASE_URL_1 = 'https://example.com/con1/uss'
@@ -79,26 +80,10 @@ def _read_constraints_scope(scd_api: str) -> str:
 
 @for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
 def test_ensure_clean_workspace(ids, scd_api, scd_session, scd_session2):
-  resp = scd_session.get('/constraint_references/{}'.format(ids(CONSTRAINT_TYPE)), scope=SCOPE_CM)
-  if resp.status_code == 200:
-    resp = scd_session.delete('/constraint_references/{}'.format(ids(CONSTRAINT_TYPE)), scope=SCOPE_CM)
-    assert resp.status_code == 200, resp.content
-  elif resp.status_code == 404:
-    # As expected.
-    pass
-  else:
-    assert False, resp.content
+  actions.delete_constraint_reference_if_exists(ids(CONSTRAINT_TYPE), scd_session, scd_api)
 
   for sub_id in (ids(SUB1_TYPE), ids(SUB2_TYPE), ids(SUB3_TYPE)):
-    resp = scd_session2.get('/subscriptions/{}'.format(sub_id), scope=SCOPE_SC)
-    if resp.status_code == 200:
-      resp = scd_session2.delete('/subscriptions/{}'.format(sub_id), scope=SCOPE_SC)
-      assert resp.status_code == 200, resp.content
-    elif resp.status_code == 404:
-      # As expected.
-      pass
-    else:
-      assert False, resp.content
+    actions.delete_subscription_if_exists(sub_id, scd_session2, scd_api)
 
 
 # Preconditions: None

--- a/monitoring/prober/scd/test_constraints_with_subscriptions.py
+++ b/monitoring/prober/scd/test_constraints_with_subscriptions.py
@@ -344,3 +344,8 @@ def test_delete_subs(ids, scd_api, scd_session2, scd_session):
     else:
       raise NotImplementedError('Unsupported API version {}'.format(scd_api))
     assert resp.status_code == 200, resp.content
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session, scd_session2):
+    test_ensure_clean_workspace(ids, scd_api, scd_session, scd_session2)

--- a/monitoring/prober/scd/test_operation_references_error_cases_v0_3_17.py
+++ b/monitoring/prober/scd/test_operation_references_error_cases_v0_3_17.py
@@ -11,6 +11,7 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.prober.infrastructure import for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 OP_TYPE = register_resource_type(342, 'Primary operational intent')
@@ -20,15 +21,7 @@ OP_TYPE2 = register_resource_type(343, 'Conflicting operational intent')
 @for_api_versions(scd.API_0_3_17)
 def test_ensure_clean_workspace(ids, scd_api, scd_session):
   for op_id in (ids(OP_TYPE), ids(OP_TYPE2)):
-    resp = scd_session.get('/operational_intent_references/{}'.format(op_id), scope=SCOPE_SC)
-    if resp.status_code == 200:
-      resp = scd_session.delete('/operational_intent_references/{}'.format(op_id), scope=SCOPE_SC)
-      assert resp.status_code == 200, resp.content
-    elif resp.status_code == 404:
-      # As expected.
-      pass
-    else:
-      assert False, resp.content
+      actions.delete_operation_if_exists(op_id, scd_session, scd_api)
 
 
 @for_api_versions(scd.API_0_3_17)

--- a/monitoring/prober/scd/test_operation_references_error_cases_v0_3_17.py
+++ b/monitoring/prober/scd/test_operation_references_error_cases_v0_3_17.py
@@ -295,3 +295,8 @@ def test_clean_up(ids, scd_api, scd_session):
       pass
     else:
       assert False, resp.content
+
+
+@for_api_versions(scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)

--- a/monitoring/prober/scd/test_operation_references_error_cases_v0_3_5.py
+++ b/monitoring/prober/scd/test_operation_references_error_cases_v0_3_5.py
@@ -11,6 +11,7 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.prober.infrastructure import for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 OP_TYPE = register_resource_type(6, 'Primary operational intent')
@@ -20,15 +21,7 @@ OP_TYPE2 = register_resource_type(7, 'Conflicting operational intent')
 @for_api_versions(scd.API_0_3_5)
 def test_ensure_clean_workspace(ids, scd_api, scd_session):
   for op_id in (ids(OP_TYPE), ids(OP_TYPE2)):
-    resp = scd_session.get('/operation_references/{}'.format(op_id), scope=SCOPE_SC)
-    if resp.status_code == 200:
-      resp = scd_session.delete('/operation_references/{}'.format(op_id), scope=SCOPE_SC)
-      assert resp.status_code == 200, resp.content
-    elif resp.status_code == 404:
-      # As expected.
-      pass
-    else:
-      assert False, resp.content
+      actions.delete_operation_if_exists(op_id, scd_session, scd_api)
 
 
 @for_api_versions(scd.API_0_3_5)

--- a/monitoring/prober/scd/test_operation_references_error_cases_v0_3_5.py
+++ b/monitoring/prober/scd/test_operation_references_error_cases_v0_3_5.py
@@ -279,3 +279,8 @@ def test_clean_up(ids, scd_api, scd_session):
       pass
     else:
       assert False, resp.content
+
+
+@for_api_versions(scd.API_0_3_5)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)

--- a/monitoring/prober/scd/test_operation_references_state_transition.py
+++ b/monitoring/prober/scd/test_operation_references_state_transition.py
@@ -142,3 +142,8 @@ def test_op_bad_state_transition_v17(ids, scd_api, scd_session):
     req['state'] = 'Ended'
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req)
   assert resp.status_code == 400, resp.content
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)

--- a/monitoring/prober/scd/test_operation_references_state_transition.py
+++ b/monitoring/prober/scd/test_operation_references_state_transition.py
@@ -7,37 +7,15 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.prober.infrastructure import for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 OP_TYPE = register_resource_type(8, 'Operational intent')
 
 
-@for_api_versions(scd.API_0_3_5)
-@default_scope(SCOPE_SC)
-def test_ensure_clean_workspace_v5(ids, scd_api, scd_session):
-  resp = scd_session.get('/operation_references/{}'.format(ids(OP_TYPE)), scope=SCOPE_SC)
-  if resp.status_code == 200:
-    resp = scd_session.delete('/operation_references/{}'.format(ids(OP_TYPE)), scope=SCOPE_SC)
-    assert resp.status_code == 200, resp.content
-  elif resp.status_code == 404:
-    # As expected.
-    pass
-  else:
-    assert False, resp.content
-
-
-@for_api_versions(scd.API_0_3_17)
-@default_scope(SCOPE_SC)
-def test_ensure_clean_workspace_v15(ids, scd_api, scd_session):
-  resp = scd_session.get('/operational_intent_references/{}'.format(ids(OP_TYPE)), scope=SCOPE_SC)
-  if resp.status_code == 200:
-    resp = scd_session.delete('/operational_intent_references/{}'.format(ids(OP_TYPE)), scope=SCOPE_SC)
-    assert resp.status_code == 200, resp.content
-  elif resp.status_code == 404:
-    # As expected.
-    pass
-  else:
-    assert False, resp.content
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_ensure_clean_workspace(ids, scd_api, scd_session):
+    actions.delete_operation_if_exists(ids(OP_TYPE), scd_session, scd_api)
 
 
 @for_api_versions(scd.API_0_3_5)

--- a/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
+++ b/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
@@ -47,7 +47,7 @@ def _intersection(list1, list2):
   return list(set(list1) & set(list2))
 
 
-@for_api_versions(scd.API_0_3_5)
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
 def test_ensure_clean_workspace(ids, scd_api, scd_session):
     for op_id in map(ids, OP_TYPES):
         actions.delete_operation_if_exists(op_id, scd_session, scd_api)
@@ -465,3 +465,8 @@ def test_get_deleted_ops_by_search_v15(ids, scd_api, scd_session):
     assert resp.status_code == 200, resp.content
     found_ids = [op['id'] for op in resp.json().get('operational_intent_reference', [])]
     assert not _intersection(map(ids, OP_TYPES), found_ids)
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)

--- a/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
+++ b/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
@@ -16,6 +16,7 @@ from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
 from monitoring.prober.infrastructure import depends_on, for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 BASE_URL = 'https://example.com/uss'
@@ -47,31 +48,9 @@ def _intersection(list1, list2):
 
 
 @for_api_versions(scd.API_0_3_5)
-def test_ensure_clean_workspace_v5(ids, scd_api, scd_session):
-  for op_id in map(ids, OP_TYPES):
-    resp = scd_session.get('/operation_references/{}'.format(op_id), scope=SCOPE_SC)
-    if resp.status_code == 200:
-      resp = scd_session.delete('/operation_references/{}'.format(op_id), scope=SCOPE_SC)
-      assert resp.status_code == 200, resp.content
-    elif resp.status_code == 404:
-      # As expected.
-      pass
-    else:
-      assert False, resp.content
-
-
-@for_api_versions(scd.API_0_3_17)
-def test_ensure_clean_workspace_v15(ids, scd_api, scd_session):
-  for op_id in map(ids, OP_TYPES):
-    resp = scd_session.get('/operational_intent_references/{}'.format(op_id), scope=SCOPE_SC)
-    if resp.status_code == 200:
-      resp = scd_session.delete('/operational_intent_references/{}'.format(op_id), scope=SCOPE_SC)
-      assert resp.status_code == 200, resp.content
-    elif resp.status_code == 404:
-      # As expected.
-      pass
-    else:
-      assert False, resp.content
+def test_ensure_clean_workspace(ids, scd_api, scd_session):
+    for op_id in map(ids, OP_TYPES):
+        actions.delete_operation_if_exists(op_id, scd_session, scd_api)
 
 
 # Preconditions: None

--- a/monitoring/prober/scd/test_operation_simple_heavy_traffic_concurrent.py
+++ b/monitoring/prober/scd/test_operation_simple_heavy_traffic_concurrent.py
@@ -20,6 +20,7 @@ from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
 from monitoring.prober.infrastructure import depends_on, for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 # TODO: verify if following issues are fixed with this PR.
@@ -197,34 +198,10 @@ async def _delete_operation_async(op_id, scd_session_async, scd_api):
   return result
 
 
-@for_api_versions(scd.API_0_3_5)
-@default_scope(SCOPE_SC)
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
 def test_ensure_clean_workspace_v5(ids, scd_api, scd_session):
     for op_id in map(ids, OP_TYPES):
-      resp = scd_session.get('/operation_references/{}'.format(op_id), scope=SCOPE_SC)
-      if resp.status_code == 200:
-        resp = scd_session.delete('/operation_references/{}'.format(op_id), scope=SCOPE_SC)
-        assert resp.status_code == 200, resp.content
-      elif resp.status_code == 404:
-        # As expected.
-        pass
-      else:
-        assert False, resp.content
-
-
-@for_api_versions(scd.API_0_3_17)
-@default_scope(SCOPE_SC)
-def test_ensure_clean_workspace_v15(ids, scd_api, scd_session):
-    for op_id in map(ids, OP_TYPES):
-      resp = scd_session.get('/operational_intent_references/{}'.format(op_id), scope=SCOPE_SC)
-      if resp.status_code == 200:
-        resp = scd_session.delete('/operational_intent_references/{}/{}'.format(op_id, resp.json()['operational_intent_reference']['ovn']), scope=SCOPE_SC)
-        assert resp.status_code == 200, resp.content
-      elif resp.status_code == 404:
-        # As expected.
-        pass
-      else:
-        assert False, resp.content
+        actions.delete_operation_if_exists(op_id, scd_session, scd_api)
 
 
 # Preconditions: None

--- a/monitoring/prober/scd/test_operation_simple_heavy_traffic_concurrent.py
+++ b/monitoring/prober/scd/test_operation_simple_heavy_traffic_concurrent.py
@@ -199,7 +199,7 @@ async def _delete_operation_async(op_id, scd_session_async, scd_api):
 
 
 @for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
-def test_ensure_clean_workspace_v5(ids, scd_api, scd_session):
+def test_ensure_clean_workspace(ids, scd_api, scd_session):
     for op_id in map(ids, OP_TYPES):
         actions.delete_operation_if_exists(op_id, scd_session, scd_api)
 
@@ -379,3 +379,8 @@ def test_delete_op_concurrent(ids, scd_api, scd_session_async):
   for resp in op_resp_map.values():
     assert resp['status_code'] == 200, resp['content']
   print(f'\n{inspect.stack()[0][3]} time_taken: {datetime.datetime.utcnow() - start_time}')
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)

--- a/monitoring/prober/scd/test_operation_simple_v0_3_17.py
+++ b/monitoring/prober/scd/test_operation_simple_v0_3_17.py
@@ -328,3 +328,8 @@ def test_get_deleted_op_by_search(ids, scd_api, scd_session):
   })
   assert resp.status_code == 200, resp.content
   assert ids(OP_TYPE) not in [x['id'] for x in resp.json()['operational_intent_references']]
+
+
+@for_api_versions(scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)

--- a/monitoring/prober/scd/test_operation_simple_v0_3_17.py
+++ b/monitoring/prober/scd/test_operation_simple_v0_3_17.py
@@ -16,6 +16,7 @@ from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC, SCOPE_CM, SCOPE_CP
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
 from monitoring.prober.infrastructure import depends_on, for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 BASE_URL = 'https://example.com/uss'
@@ -24,15 +25,7 @@ OP_TYPE = register_resource_type(341, 'Operational intent')
 
 @for_api_versions(scd.API_0_3_17)
 def test_ensure_clean_workspace(ids, scd_api, scd_session):
-  resp = scd_session.get('/operational_intent_references/{}'.format(ids(OP_TYPE)), scope=SCOPE_SC)
-  if resp.status_code == 200:
-    resp = scd_session.delete('/operational_intent_references/{}'.format(ids(OP_TYPE)), scope=SCOPE_SC)
-    assert resp.status_code == 200, resp.content
-  elif resp.status_code == 404:
-    # As expected.
-    pass
-  else:
-    assert False, resp.content
+    actions.delete_operation_if_exists(ids(OP_TYPE), scd_session, scd_api)
 
 
 def _make_op1_request():

--- a/monitoring/prober/scd/test_operation_simple_v0_3_5.py
+++ b/monitoring/prober/scd/test_operation_simple_v0_3_5.py
@@ -266,3 +266,8 @@ def test_get_deleted_op_by_search(ids, scd_api, scd_session):
   })
   assert resp.status_code == 200, resp.content
   assert ids(OP_TYPE) not in [x['id'] for x in resp.json()['operation_references']]
+
+
+@for_api_versions(scd.API_0_3_5)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)

--- a/monitoring/prober/scd/test_operation_simple_v0_3_5.py
+++ b/monitoring/prober/scd/test_operation_simple_v0_3_5.py
@@ -15,6 +15,7 @@ from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC, SCOPE_CI, SCOPE_CM, SCOPE_CP
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
 from monitoring.prober.infrastructure import depends_on, for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 BASE_URL = 'https://example.com/uss'
@@ -23,15 +24,7 @@ OP_TYPE = register_resource_type(9, 'Operational intent')
 
 @for_api_versions(scd.API_0_3_5)
 def test_ensure_clean_workspace(ids, scd_api, scd_session):
-  resp = scd_session.get('/operation_references/{}'.format(ids(OP_TYPE)), scope=SCOPE_SC)
-  if resp.status_code == 200:
-    resp = scd_session.delete('/operation_references/{}'.format(ids(OP_TYPE)), scope=SCOPE_SC)
-    assert resp.status_code == 200, resp.content
-  elif resp.status_code == 404:
-    # As expected.
-    pass
-  else:
-    assert False, resp.content
+    actions.delete_operation_if_exists(ids(OP_TYPE), scd_session, scd_api)
 
 
 def _make_op1_request():

--- a/monitoring/prober/scd/test_operation_special_cases.py
+++ b/monitoring/prober/scd/test_operation_special_cases.py
@@ -24,7 +24,7 @@ SUB_TYPE = register_resource_type(212, 'Subscription')
 
 
 @for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
-def test_ensure_clean_workspace_v5(ids, scd_api, scd_session):
+def test_ensure_clean_workspace(ids, scd_api, scd_session):
   for op_id in map(ids, (OP1_TYPE, OP2_TYPE)):
       actions.delete_operation_if_exists(op_id, scd_session, scd_api)
   actions.delete_subscription_if_exists(ids(SUB_TYPE), scd_session, scd_api)
@@ -178,3 +178,8 @@ def test_id_conversion_bug_v5(ids, scd_api, scd_session):
   else:
     raise NotImplementedError('Unsupported API version {}'.format(scd_api))
   assert resp.status_code == 200, resp.content
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -103,7 +103,7 @@ def _parse_conflicts_v17(conflicts: Dict) -> Tuple[Dict[str, Dict], Dict[str, Di
 
 
 @for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
-def test_ensure_clean_workspace_v5(ids, scd_api, scd_session, scd_session2):
+def test_ensure_clean_workspace(ids, scd_api, scd_session, scd_session2):
   for op_id, owner in ((ids(OP1_TYPE), scd_session), (ids(OP2_TYPE), scd_session2)):
       actions.delete_operation_if_exists(op_id, owner, scd_api)
   actions.delete_subscription_if_exists(ids(SUB2_TYPE), scd_session2, scd_api)
@@ -1033,3 +1033,8 @@ def test_delete_sub2(ids, scd_api, scd_session2):
   elif scd_api == scd.API_0_3_17:
     resp = scd_session2.delete('/subscriptions/{}/{}'.format(ids(SUB2_TYPE), sub2_version))
   assert resp.status_code == 200, resp.content
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session, scd_session2):
+    test_ensure_clean_workspace(ids, scd_api, scd_session, scd_session2)

--- a/monitoring/prober/scd/test_subscription_queries.py
+++ b/monitoring/prober/scd/test_subscription_queries.py
@@ -10,6 +10,7 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.prober.infrastructure import for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 SUB1_TYPE = register_resource_type(216, 'Subscription 1')
@@ -77,15 +78,7 @@ def _make_sub3_req(scd_api):
 @for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
 def test_ensure_clean_workspace(ids, scd_api, scd_session):
   for sub_id in (ids(SUB1_TYPE), ids(SUB2_TYPE), ids(SUB3_TYPE)):
-    resp = scd_session.get('/subscriptions/{}'.format(sub_id), scope=SCOPE_SC)
-    if resp.status_code == 200:
-      resp = scd_session.delete('/subscriptions/{}'.format(sub_id), scope=SCOPE_SC)
-      assert resp.status_code == 200, resp.content
-    elif resp.status_code == 404:
-      # As expected.
-      pass
-    else:
-      assert False, resp.content
+      actions.delete_subscription_if_exists(sub_id, scd_session, scd_api)
 
 
 # Preconditions: No named Subscriptions exist

--- a/monitoring/prober/scd/test_subscription_queries.py
+++ b/monitoring/prober/scd/test_subscription_queries.py
@@ -265,3 +265,8 @@ def test_delete_subs(ids, scd_api, scd_session):
     else:
       raise NotImplementedError('Unsupported API version {}'.format(scd_api))
     assert resp.status_code == 200, resp.content
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)

--- a/monitoring/prober/scd/test_subscription_simple.py
+++ b/monitoring/prober/scd/test_subscription_simple.py
@@ -198,3 +198,8 @@ def test_get_deleted_sub_by_search(ids, scd_api, scd_session):
     })
   assert resp.status_code == 200, resp.content
   assert ids(SUB_TYPE) not in [x['id'] for x in resp.json()['subscriptions']]
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)

--- a/monitoring/prober/scd/test_subscription_simple.py
+++ b/monitoring/prober/scd/test_subscription_simple.py
@@ -17,6 +17,7 @@ from monitoring.monitorlib import scd
 from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
 from monitoring.prober.infrastructure import for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 SUB_TYPE = register_resource_type(220, 'Subscription')
@@ -24,15 +25,7 @@ SUB_TYPE = register_resource_type(220, 'Subscription')
 
 @for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
 def test_ensure_clean_workspace(ids, scd_api, scd_session):
-  resp = scd_session.get('/subscriptions/{}'.format(ids(SUB_TYPE)), scope=SCOPE_SC)
-  if resp.status_code == 200:
-    resp = scd_session.delete('/subscriptions/{}'.format(ids(SUB_TYPE)), scope=SCOPE_SC)
-    assert resp.status_code == 200, resp.content
-  elif resp.status_code == 404:
-    # As expected.
-    pass
-  else:
-    assert False, resp.content
+    actions.delete_subscription_if_exists(ids(SUB_TYPE), scd_session, scd_api)
 
 
 def _make_sub1_req(scd_api):

--- a/monitoring/prober/scd/test_subscription_update_validation.py
+++ b/monitoring/prober/scd/test_subscription_update_validation.py
@@ -18,6 +18,7 @@ from monitoring.monitorlib.infrastructure import default_scope
 from monitoring.monitorlib.scd import SCOPE_SC
 from monitoring.monitorlib.testing import assert_datetimes_are_equal
 from monitoring.prober.infrastructure import depends_on, for_api_versions, register_resource_type
+from monitoring.prober.scd import actions
 
 
 BASE_URL = 'https://example.com/uss'
@@ -58,15 +59,7 @@ def _make_sub_req(time_start, time_end, alt_start, alt_end, radius, scd_api):
 @for_api_versions(scd.API_0_3_5)
 @default_scope(SCOPE_SC)
 def test_ensure_clean_workspace_v5(ids, scd_api, scd_session):
-  resp = scd_session.get('/operation_references/{}'.format(ids(OP_TYPE)))
-  if resp.status_code == 200:
-    resp = scd_session.delete('/operation_references/{}'.format(ids(OP_TYPE)))
-    assert resp.status_code == 200, resp.content
-  elif resp.status_code == 404:
-    # As expected.
-    pass
-  else:
-    assert False, resp.content
+    actions.delete_subscription_if_exists(ids(OP_TYPE), scd_session, scd_api)
 
 
 @for_api_versions(scd.API_0_3_17)

--- a/monitoring/prober/scd/test_subscription_update_validation.py
+++ b/monitoring/prober/scd/test_subscription_update_validation.py
@@ -56,25 +56,10 @@ def _make_sub_req(time_start, time_end, alt_start, alt_end, radius, scd_api):
   return req
 
 
-@for_api_versions(scd.API_0_3_5)
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
 @default_scope(SCOPE_SC)
-def test_ensure_clean_workspace_v5(ids, scd_api, scd_session):
+def test_ensure_clean_workspace(ids, scd_api, scd_session):
     actions.delete_subscription_if_exists(ids(OP_TYPE), scd_session, scd_api)
-
-
-@for_api_versions(scd.API_0_3_17)
-@default_scope(SCOPE_SC)
-def test_ensure_clean_workspace_v17(ids, scd_api, scd_session):
-  resp = scd_session.get('/operational_intent_references/{}'.format(ids(OP_TYPE)))
-  if resp.status_code == 200:
-    ovn = resp.json()['operational_intent_reference']['ovn']
-    resp = scd_session.delete('/operational_intent_references/{}/{}'.format(ids(OP_TYPE), ovn), scope=SCOPE_SC)
-    assert resp.status_code == 200, resp.content
-  elif resp.status_code == 404:
-    # As expected.
-    pass
-  else:
-    assert False, resp.content
 
 
 # Create operation normally (also creates implicit Subscription)
@@ -275,3 +260,8 @@ def test_delete_sub_v17(scd_api, scd_session):
 def test_get_deleted_sub_by_id(scd_api, scd_session):
   resp = scd_session.get('/subscriptions/{}'.format(sub_id))
   assert resp.status_code == 404, resp.content
+
+
+@for_api_versions(scd.API_0_3_5, scd.API_0_3_17)
+def test_final_cleanup(ids, scd_api, scd_session):
+    test_ensure_clean_workspace(ids, scd_api, scd_session)


### PR DESCRIPTION
Prior to this PR, cleaning of the workspace (deleting any previous instances of resources to be manipulated in the test) was unnecessarily verbose (same logic copy/pasted in many different files) and sometimes incorrect (API-dependence not respected in test_constraint_simple).  This PR creates a few generic actions in actions.py that are sensitive to API, and then calls them from all workspace cleaning pre-tests.  This fixes a 405 (method not supported) error when running test_constraint_simple on live instances under dirty conditions.