### PR TITLE
[dss/crdb] upgrade github.com/cockroachdb/cockroach-go/v2 to v2.2.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.14
 
 require (
 	cloud.google.com/go v0.64.0
-	github.com/cockroachdb/cockroach-go/v2 v2.2.0
+	github.com/cockroachdb/cockroach-go/v2 v2.2.8
 	github.com/coreos/go-semver v0.3.0
 	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go/v2 v2.2.0 h1:/5znzg5n373N/3ESjHF5SMLxiW4RKB05Ql//KWfeTFs=
 github.com/cockroachdb/cockroach-go/v2 v2.2.0/go.mod h1:u3MiKYGupPPjkn3ozknpMUpxPaNLTFWAya419/zv6eI=
+github.com/cockroachdb/cockroach-go/v2 v2.2.8/go.mod h1:q4ZRgO6CQpwNyEvEwSxwNrOSVchsmzrBnAv3HuZ3Abc=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/pkg/cockroach/cockroach.go
+++ b/pkg/cockroach/cockroach.go
@@ -40,6 +40,7 @@ type (
 		SSL                SSL
 		MaxOpenConns       int
 		MaxConnIdleSeconds int
+		MaxRetries         int
 	}
 )
 

--- a/pkg/cockroach/flags/flags.go
+++ b/pkg/cockroach/flags/flags.go
@@ -25,4 +25,5 @@ func init() {
 	flag.StringVar(&connectParameters.Credentials.Username, "cockroach_user", "root", "cockroach user to authenticate as")
 	flag.IntVar(&connectParameters.MaxOpenConns, "max_open_conns", 4, "maximum number of open connections to the database, default is 4")
 	flag.IntVar(&connectParameters.MaxConnIdleSeconds, "max_conn_idle_secs", 30, "maximum amount of time in seconds a connection may be idle, default is 30 seconds")
+	flag.IntVar(&connectParameters.MaxRetries, "cockroach_max_retries", 100, "maximum number of attempts to retry a query in case of contention, default is 100")
 }

--- a/pkg/rid/store/cockroach/store.go
+++ b/pkg/rid/store/cockroach/store.go
@@ -2,6 +2,8 @@ package cockroach
 
 import (
 	"context"
+	"github.com/cockroachdb/cockroach-go/v2/crdb"
+	"github.com/interuss/dss/pkg/cockroach/flags"
 	"time"
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgx"
@@ -120,6 +122,8 @@ func (s *Store) Transact(ctx context.Context, f func(repo repos.Repository) erro
 	// "store" for everything
 	ctx, cancel := context.WithTimeout(ctx, DefaultTimeout)
 	defer cancel()
+
+	ctx = crdb.WithMaxRetries(ctx, flags.ConnectParameters().MaxRetries)
 
 	storeVersion, err := s.GetVersion(ctx)
 	if err != nil {

--- a/pkg/scd/store/cockroach/store.go
+++ b/pkg/scd/store/cockroach/store.go
@@ -2,10 +2,11 @@ package cockroach
 
 import (
 	"context"
-
+	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgx"
 	"github.com/coreos/go-semver/semver"
 	"github.com/interuss/dss/pkg/cockroach"
+	"github.com/interuss/dss/pkg/cockroach/flags"
 	"github.com/interuss/dss/pkg/scd/repos"
 	dsssql "github.com/interuss/dss/pkg/sql"
 	"github.com/interuss/stacktrace"
@@ -86,6 +87,7 @@ func (s *Store) Interact(_ context.Context) (repos.Repository, error) {
 
 // Transact implements store.Transactor interface.
 func (s *Store) Transact(ctx context.Context, f func(context.Context, repos.Repository) error) error {
+	ctx = crdb.WithMaxRetries(ctx, flags.ConnectParameters().MaxRetries)
 	return crdbpgx.ExecuteTx(ctx, s.db.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
 		return f(ctx, &repo{
 			q:      tx,


### PR DESCRIPTION
This PR upgrades github.com/cockroachdb/cockroach-go/v2 dependency to v2.2.8 in order to leverage better logging when a query fails after too many retry attempts.