### PR TITLE
[crdb] Upgrade cockroachdb to v21.2.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ test:
 
 .PHONY: test-cockroach
 test-cockroach: cleanup-test-cockroach
-	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v21.2.3 start-single-node --insecure > /dev/null
+	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v21.2.7 start-single-node --insecure > /dev/null
 	go run ./cmds/db-manager/main.go --schemas_dir ./build/deploy/db_schemas/rid --db_version latest --cockroach_host localhost
 	go test -count=1 -v ./pkg/rid/store/cockroach --cockroach_host localhost --cockroach_port 26257 cockroach_ssl_mode disable --cockroach_user root --cockroach_db_name rid --schemas_dir db-schemas/rid
 	go test -count=1 -v ./pkg/scd/store/cockroach --cockroach_host localhost --cockroach_port 26257 cockroach_ssl_mode disable --cockroach_user root --cockroach_db_name scd --schemas_dir db-schemas/scd

--- a/build/deploy/metadata_base.libsonnet
+++ b/build/deploy/metadata_base.libsonnet
@@ -14,7 +14,7 @@
     shouldInit: false,  // Set this to true if you are starting a new cluster.
     grpc_port: 26257,
     http_port: 8080,
-    image: 'cockroachdb/cockroach:v21.2.3',
+    image: 'cockroachdb/cockroach:v21.2.7',
     nodeIPs: error 'must supply the per-node ip addresses as an array',
     JoinExisting: [],
   },

--- a/build/dev/docker-compose_dss.yaml
+++ b/build/dev/docker-compose_dss.yaml
@@ -8,7 +8,7 @@ version: '3.8'
 services:
 
   local-dss-crdb:
-    image: cockroachdb/cockroach:v21.2.3
+    image: cockroachdb/cockroach:v21.2.7
     command: start-single-node --insecure
     expose:
       - 26257

--- a/cmds/core-service/README.md
+++ b/cmds/core-service/README.md
@@ -31,7 +31,7 @@ go run ./cmds/core-service \
 To run correctly, core-service must be able to [access](../../pkg/cockroach/flags/flags.go) a CockroachDB cluster.  Provision of this cluster is handled automatically for a local development environment if following [the instructions for a standalone instance](../../build/dev/standalone_instance.md).  Or, a CockroachDB instance can be created manually with:
 
 ```bash
-docker container run -p 26257:26257 -p 8080:8080 --rm cockroachdb/cockroach:v21.2.3 start-single-node --insecure
+docker container run -p 26257:26257 -p 8080:8080 --rm cockroachdb/cockroach:v21.2.7 start-single-node --insecure
 ```
 
 #### Database configuration

--- a/test/docker_e2e.sh
+++ b/test/docker_e2e.sh
@@ -64,7 +64,7 @@ echo "Starting cockroachdb with admin port on :8080"
 docker run -d --rm --name dss-crdb-for-debugging \
 	-p 26257:26257 \
 	-p 8080:8080 \
-	cockroachdb/cockroach:v21.2.3 start-single-node \
+	cockroachdb/cockroach:v21.2.7 start-single-node \
 	--insecure > /dev/null
 
 sleep 1

--- a/test/migrations/clear_db.sh
+++ b/test/migrations/clear_db.sh
@@ -8,5 +8,5 @@ echo "Starting CRDB container"
 docker run -d --rm --name dss-crdb-for-migration-testing \
 	-p 26257:26257 \
 	-p 8080:8080 \
-  cockroachdb/cockroach:v21.2.3 start-single-node \
+  cockroachdb/cockroach:v21.2.7 start-single-node \
   --insecure > /dev/null


### PR DESCRIPTION
This PR brings the cockroachdb image used in this repository to the latest version (v21.2.7)