### PR TITLE
[uss_qualifier] Add dss_base_url to config example

### DIFF
--- a/monitoring/uss_qualifier/config_run.json.dist
+++ b/monitoring/uss_qualifier/config_run.json.dist
@@ -10,6 +10,7 @@
                 "name": "uss2",
                 "injection_base_url": "http://host.docker.internal:8074/scdsc"
             }
-        ]
+        ],
+        "dss_base_url": "http://host.docker.internal:8082"
     }
 }


### PR DESCRIPTION
Fix config example to include dss_base_url introduced in #731 