### PR TITLE
[uss_qualifier/scd] Track uss version

### DIFF
--- a/interfaces/automated-testing/scd/scd.yaml
+++ b/interfaces/automated-testing/scd/scd.yaml
@@ -35,6 +35,11 @@ components:
           type: string
           enum: [Starting, Ready]
           example: Ready
+        version:
+          description: |-
+            Arbitrary string representing the version of the USS system to be tested.
+          type: string
+          example: v0.0.1-445ad3
     ################################################################################
     #################### Start of ASTM-standard definitions    #####################
     #################### interfaces/astm-utm/Protocol/utm.yaml #####################

--- a/monitoring/mock_uss/config.py
+++ b/monitoring/mock_uss/config.py
@@ -22,6 +22,7 @@ KEY_SERVICES = 'SERVICES'
 KEY_DSS_URL = 'DSS_URL'
 KEY_BEHAVIOR_LOCALITY = 'BEHAVIOR_LOCALITY'
 
+KEY_CODE_VERSION = 'CODE_VERSION'
 
 workspace_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'workspace')
 
@@ -35,3 +36,4 @@ class Config(object):
   SERVICES = set(svc.strip().lower() for svc in os.environ.get(ENV_KEY_SERVICES, '').split(','))
   DSS_URL = os.environ[ENV_KEY_DSS]
   BEHAVIOR_LOCALITY = Locality(os.environ.get(ENV_KEY_BEHAVIOR_LOCALITY, 'CHE'))
+  CODE_VERSION = os.environ.get(KEY_CODE_VERSION, 'Unknown')

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -45,7 +45,7 @@ def query_operational_intents(area_of_interest: scd.Volume4D) -> List[scd.Operat
 @requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
 def scdsc_injection_status() -> Tuple[str, int]:
     """Implements USS status in SCD automated testing injection API."""
-    return flask.jsonify({'status': 'Ready'})
+    return flask.jsonify({'status': 'Ready', 'version': config.Config.CODE_VERSION})
 
 
 @webapp.route('/scdsc/v1/capabilities', methods=['GET'])

--- a/monitoring/monitorlib/clients/scd_automated_testing.py
+++ b/monitoring/monitorlib/clients/scd_automated_testing.py
@@ -7,7 +7,7 @@ from monitoring.monitorlib import fetch
 from monitoring.monitorlib.clients.scd import OperationError
 from monitoring.monitorlib.infrastructure import DSSTestSession
 from monitoring.monitorlib.scd_automated_testing.scd_injection_api import InjectFlightRequest, InjectFlightResponse, \
-    SCOPE_SCD_QUALIFIER_INJECT, InjectFlightResult, DeleteFlightResponse, DeleteFlightResult
+    SCOPE_SCD_QUALIFIER_INJECT, InjectFlightResult, DeleteFlightResponse, DeleteFlightResult, CapabilitiesResponse, StatusResponse
 from monitoring.monitorlib.typing import ImplicitDict
 
 
@@ -42,3 +42,25 @@ def delete_flight(utm_client: DSSTestSession, uss_base_url: str, flight_id: str)
     return ImplicitDict.parse(resp.json(), DeleteFlightResponse), fetch.describe_query(resp, initiated_at)
 
 
+def get_capabilities(utm_client: DSSTestSession, uss_base_url: str) -> Tuple[CapabilitiesResponse, fetch.Query]:
+    url = '{}/v1/capabilities'.format(uss_base_url)
+    print("[SCD] GET {}".format(url))
+
+    initiated_at = datetime.utcnow()
+    resp = utm_client.get(url, scope=SCOPE_SCD_QUALIFIER_INJECT)
+    if resp.status_code != 200:
+            raise QueryError('Unexpected response code for get_capabilities {}. Response: {}'.format(resp.status_code, resp.content.decode('utf-8')), fetch.describe_query(resp, initiated_at))
+
+    return ImplicitDict.parse(resp.json(), CapabilitiesResponse), fetch.describe_query(resp, initiated_at)
+
+
+def get_version(utm_client: DSSTestSession, uss_base_url: str) -> Tuple[StatusResponse, fetch.Query]:
+    url = '{}/v1/status'.format(uss_base_url)
+    print("[SCD] GET {}".format(url))
+
+    initiated_at = datetime.utcnow()
+    resp = utm_client.get(url, scope=SCOPE_SCD_QUALIFIER_INJECT)
+    if resp.status_code != 200:
+            raise QueryError('Unexpected response code for get_version {}. Response: {}'.format(resp.status_code, resp.content.decode('utf-8')), fetch.describe_query(resp, initiated_at))
+
+    return ImplicitDict.parse(resp.json(), StatusResponse), fetch.describe_query(resp, initiated_at)

--- a/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
+++ b/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
@@ -114,3 +114,13 @@ class Capability(str, Enum):
 
 class CapabilitiesResponse(ImplicitDict):
     capabilities: Optional[List[Capability]]
+
+
+class Status(str, Enum):
+    Starting = 'Starting'
+    Ready = 'Ready'
+
+
+class StatusResponse(ImplicitDict):
+    status: str
+    version: str

--- a/monitoring/uss_qualifier/scd/executor/executor.py
+++ b/monitoring/uss_qualifier/scd/executor/executor.py
@@ -82,6 +82,9 @@ def format_combination(combination: Dict[str, TestTarget]) -> List[str]:
     return list(map(lambda t: "{}: {}".format(t[0], t[1].name), combination.items()))
 
 
+def targets_information(targets: List[TestTarget]):
+    return dict(map(lambda target: (target.name, target.get_target_information()), targets))
+
 def run_scd_tests(locale: Locality, test_configuration: SCDQualifierTestConfiguration,
                   auth_spec: str) -> bool:
     automated_tests = load_scd_test_definitions(locale)
@@ -94,6 +97,7 @@ def run_scd_tests(locale: Locality, test_configuration: SCDQualifierTestConfigur
     report = Report(
             qualifier_version=os.environ.get("USS_QUALIFIER_VERSION", "unknown"),
             configuration=test_configuration,
+            targets_information=targets_information(configured_targets)
     )
 
     should_exit = False

--- a/monitoring/uss_qualifier/scd/executor/target.py
+++ b/monitoring/uss_qualifier/scd/executor/target.py
@@ -2,7 +2,8 @@
 from typing import Dict, Tuple
 
 from monitoring.monitorlib import infrastructure, auth, fetch
-from monitoring.monitorlib.clients.scd_automated_testing import create_flight, delete_flight, QueryError
+from monitoring.monitorlib.clients.scd_automated_testing import create_flight, delete_flight, QueryError, get_version, \
+    get_capabilities
 from monitoring.monitorlib.scd_automated_testing.scd_injection_api import InjectFlightResult, \
     DeleteFlightResult, InjectFlightResponse, DeleteFlightResponse
 from monitoring.uss_qualifier.rid.utils import InjectionTargetConfiguration
@@ -58,3 +59,14 @@ class TestTarget:
 
     def is_managing_flight(self, flight_name: str) -> bool:
         return flight_name in self.created_flight_ids.keys()
+
+
+    def get_target_information(self):
+        resp, _ = get_version(self.client, self.config.injection_base_url)
+        version = resp.version if resp.version is not None else "Unknown"
+        resp, _ = get_capabilities(self.client, self.config.injection_base_url)
+
+        return {
+            "version": version,
+            "capabilities": resp.capabilities
+        }

--- a/monitoring/uss_qualifier/scd/reports.py
+++ b/monitoring/uss_qualifier/scd/reports.py
@@ -1,6 +1,6 @@
 import datetime, json
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from monitoring.monitorlib import fetch
 from monitoring.monitorlib.typing import ImplicitDict
@@ -107,9 +107,14 @@ class Findings(ImplicitDict):
         return '[{} issues in {} interactions]'.format(
             len(self.issues), len(self.interactions))
 
+class TargetInformation(ImplicitDict):
+    status: str
+    version: str
+
 class Report(ImplicitDict):
     qualifier_version: str
     configuration: SCDQualifierTestConfiguration
+    targets_information: Dict[str, TargetInformation]
     findings: Findings = Findings()
 
     def save(self):


### PR DESCRIPTION
The objective of this PR is to add to the report of SCD USS qualification the versions of the USS which were tested.

Therefore, this PR :
1. adds a version field to the status endpoint injection OpenAPI specification.
2. updates the mock uss accordingly
3. updates the SCD executor to load USS version and capabilities. This information is added to the report under the `targets_information` field.