### PR TITLE
[uss_qualifier/scd] Test Definition: Fix structure of default data

### DIFF
--- a/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-1.json
+++ b/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-1.json
@@ -1,38 +1,38 @@
 {
     "name": "Nominal Planning Test",
+    "uss_capabilities": [
+        {
+            "capabilities": ["BasicStrategicConflictDetection"],
+            "injection_target": {
+                "uss_role": "First-Mover USS"
+            },
+            "generate_issue": {
+                "test_code": "FirstMoverCapabilities",
+                "relevant_requirements": [],
+                "severity": "High",
+                "subject": "",
+                "summary": "Basic strategic conflict detection not supported",
+                "details": "USSP indicated it does not support flight authorisation validation, so it cannot perform the First-Mover USS role to test basic strategic conflict detection required by the flight authorisation service in Switzerland."
+            }
+        },
+        {
+            "capabilities": ["BasicStrategicConflictDetection"],
+            "injection_target": {
+                "uss_role": "Second USS"
+            },
+            "generate_issue": {
+                "test_code": "SecondUSSCapabilities",
+                "relevant_requirements": [],
+                "severity": "High",
+                "subject": "",
+                "summary": "Basic strategic conflict detection not supported",
+                "details": "USSP indicated it does not support flight authorisation validation, so it cannot perform the Second USS role to test basic strategic conflict detection required by the flight authorisation service in Switzerland."
+            }
+        }
+    ],
     "steps": [
         {
             "name": "Inject flight via First-mover USS",
-            "uss_capabilities": [
-                {
-                    "capabilities": ["BasicStrategicConflictDetection"],
-                    "injection_target": {
-                        "uss_role": "First-Mover USS"
-                    },
-                    "generate_issue": {
-                        "test_code": "FirstMoverCapabilities",
-                        "relevant_requirements": [],
-                        "severity": "High",
-                        "subject": "",
-                        "summary": "Basic strategic conflict detection not supported",
-                        "details": "USSP indicated it does not support flight authorisation validation, so it cannot perform the First-Mover USS role to test basic strategic conflict detection required by the flight authorisation service in Switzerland."
-                    }
-                },
-                {
-                    "capabilities": ["BasicStrategicConflictDetection"],
-                    "injection_target": {
-                        "uss_role": "Second USS"
-                    },
-                    "generate_issue": {
-                        "test_code": "SecondUSSCapabilities",
-                        "relevant_requirements": [],
-                        "severity": "High",
-                        "subject": "",
-                        "summary": "Basic strategic conflict detection not supported",
-                        "details": "USSP indicated it does not support flight authorisation validation, so it cannot perform the Second USS role to test basic strategic conflict detection required by the flight authorisation service in Switzerland."
-                    }
-                }
-            ],
             "inject_flight": {
                 "reference_time": "2023-02-12T10:34:14.483425+00:00",
                 "test_injection": {

--- a/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-priority-1.json
+++ b/monitoring/uss_qualifier/scd/test_definitions/CHE/astm-strategic-coordination/nominal-planning-priority-1.json
@@ -1,22 +1,22 @@
 {
     "name": "Nominal Planning Test with Priority",
+    "uss_capabilities": [
+        {
+            "capabilities": ["FlightAuthorisationValidation"],
+            "injection_target": {
+                "uss_role": "First-Mover USS"
+            }
+        },
+        {
+            "capabilities": ["FlightAuthorisationValidation", "HighPriorityFlights"],
+            "injection_target": {
+                "uss_role": "Second USS"
+            }
+        }
+    ],
     "steps": [
         {
             "name": "Inject flight via First-mover USS",
-            "uss_capabilities": [
-                {
-                    "capabilities": ["FlightAuthorisationValidation"],
-                    "injection_target": {
-                        "uss_role": "First-Mover USS"
-                    }
-                },
-                {
-                    "capabilities": ["FlightAuthorisationValidation", "HighPriorityFlights"],
-                    "injection_target": {
-                        "uss_role": "Second USS"
-                    }
-                }
-            ],
             "inject_flight": {
                 "reference_time": "2023-02-12T10:34:14.483425+00:00",
                 "test_injection": {

--- a/monitoring/uss_qualifier/scd/test_definitions/CHE/u-space/flight-authorisation-validation-1.json
+++ b/monitoring/uss_qualifier/scd/test_definitions/CHE/u-space/flight-authorisation-validation-1.json
@@ -1,24 +1,24 @@
 {
     "name": "Flight Authorisation validation test",
+    "uss_capabilities": [
+        {
+            "capabilities": ["FlightAuthorisationValidation"],
+            "injection_target": {
+                "uss_role": "Submitting USS"
+            },
+            "generate_issue": {
+                "test_code": "Capabilities",
+                "relevant_requirements": [],
+                "severity": "High",
+                "subject": "",
+                "summary": "Flight authorisation validation not supported",
+                "details": "USSP indicated it does not support flight authorisation validation which is required to perform the flight authorisation U-space service in Switzerland."
+            }
+        }
+    ],
     "steps": [
         {
             "name": "Inject Fight Authorisation data",
-            "uss_capabilities": [
-                {
-                    "capabilities": ["FlightAuthorisationValidation"],
-                    "injection_target": {
-                        "uss_role": "Submitting USS"
-                    },
-                    "generate_issue": {
-                        "test_code": "Capabilities",
-                        "relevant_requirements": [],
-                        "severity": "High",
-                        "subject": "",
-                        "summary": "Flight authorisation validation not supported",
-                        "details": "USSP indicated it does not support flight authorisation validation which is required to perform the flight authorisation U-space service in Switzerland."
-                    }
-                }
-            ],
             "inject_flight": {
                 "reference_time": "2023-02-12T10:34:14.681217+00:00",
                 "name": "8vludg44",


### PR DESCRIPTION
Moved `uss_capabilities` out of test_steps, per the definition in https://github.com/interuss/dss/blob/master/monitoring/uss_qualifier/scd/data_interfaces.py#L89 

I found this issue while updating the simulator PR.