### PR TITLE
[deployment_manager] Add CRDB cluster info via port-forwarded cluster API

### DIFF
--- a/monitoring/deployment_manager/actions/dss/v1/common.py
+++ b/monitoring/deployment_manager/actions/dss/v1/common.py
@@ -1,0 +1,13 @@
+import functools
+
+from monitoring.deployment_manager.infrastructure import Context
+
+
+def requires_v1_dss(func):
+    """Make sure v1 DSS is well-specified"""
+    @functools.wraps(func)
+    def wrapper_v1_dss_required(context: Context, *args, **kwargs):
+        if 'dss' not in context.spec:
+            raise ValueError('DSS system is not defined in deployment configuration')
+        return func(context, *args, **kwargs)
+    return wrapper_v1_dss_required

--- a/monitoring/deployment_manager/actions/dss/v1/crdb.py
+++ b/monitoring/deployment_manager/actions/dss/v1/crdb.py
@@ -1,15 +1,20 @@
 import base64
+import os
 
 from kubernetes.client import V1Secret
+import pem
+import yaml
 
+from monitoring.deployment_manager.deploylib.crdb_cluster_api import ClusterAPI
+from monitoring.deployment_manager.deploylib.port_forwarding import get_requests_session_for_pod
 from monitoring.deployment_manager.infrastructure import deployment_action, Context
+from monitoring.deployment_manager.actions.dss.v1.common import requires_v1_dss
 
 import cryptography.exceptions
 import cryptography.hazmat.backends
 import cryptography.hazmat.primitives.hashes
 import cryptography.hazmat.primitives.serialization
 import cryptography.x509
-import pem
 
 
 def _public_key_bytes(public_key) -> bytes:
@@ -19,9 +24,9 @@ def _public_key_bytes(public_key) -> bytes:
 
 
 @deployment_action('dss/info/print_ca_public_certs')
+@requires_v1_dss
 def print_ca_public_certs(context: Context):
-    if 'dss' not in context.spec:
-        raise ValueError('DSS system is not defined in deployment configuration')
+    """Print the accepted CA certificates accepted by the cluster."""
     backend = cryptography.hazmat.backends.default_backend()
 
     # Read the list of accepted CA certificates
@@ -45,3 +50,32 @@ def print_ca_public_certs(context: Context):
         context.log.warn('This DSS instance\'s public key does not appear in any of the listed certificates')
     else:
         context.log.msg('This DSS instance\'s public key matches the {} certificate{} in those above'.format(', '.join(match_words[m] for m in matches), 's' if len(matches) > 1 else ''))
+
+
+@deployment_action('dss/crdb/status')
+@requires_v1_dss
+def crdb_status(context: Context):
+    """Retrieve and print information about the CockroachDB cluster.
+
+    The following environment variables must be set to describe a CRDB user with
+    admin priviledges: CRDB_WEBVIEWER_USERNAME,  CRDB_WEBVIEWER_PASSWORD
+    """
+    username = os.environ.get('CRDB_WEBVIEWER_USERNAME', None)
+    password = os.environ.get('CRDB_WEBVIEWER_PASSWORD', None)
+    if username is None or password is None:
+        raise ValueError('Environment variables CRDB_WEBVIEWER_USERNAME and CRDB_WEBVIEWER_PASSWORD must be set; see usage help')
+    pod_name = 'cockroachdb-0'
+    pod_session, host_port = get_requests_session_for_pod(pod_name, context.spec.dss.v1.namespace, 8080, context.clients.core)
+    cluster = ClusterAPI(pod_session, base_url='https://{}/api/v2'.format(host_port), username=username, password=password)
+    up = cluster.is_up()
+    ready = cluster.is_ready()
+    source = '{} ({}, {})'.format(pod_name, 'up' if up else 'DOWN', 'ready' if ready else 'NOT READY')
+    if up and ready:
+        nodes = cluster.get_nodes()
+        summary = dict()
+        for n in nodes:
+            k, v = n.summarize()
+            summary[k] = v
+        context.log.msg('{} reports:\n'.format(source) + yaml.dump(summary))
+    else:
+        context.log.msg('{} not ready to query nodes'.format(source))

--- a/monitoring/deployment_manager/deploylib/comparisons.py
+++ b/monitoring/deployment_manager/deploylib/comparisons.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Dict, List, Optional, Type
 
-from kubernetes.client import V1ObjectMeta, V1Deployment, V1Ingress, V1Namespace, V1Service
+from kubernetes.client import V1ObjectMeta, V1Deployment, V1Ingress, V1Namespace, V1Service, V1Secret
 
 
 _special_comparisons: Dict[Type, Callable[[Any, Any], bool]] = {}
@@ -29,6 +29,10 @@ def specs_are_the_same(obj1: Any, obj2: Any, field_paths: Optional[List[str]]=No
             return special_are_the_same(obj1, obj2)
         elif hasattr(obj1, 'attribute_map'):
             return specs_are_the_same(obj1, obj2, list(getattr(obj1, 'attribute_map').keys))
+        elif isinstance(obj1, dict) and isinstance(obj2, dict):
+            return all(obj2[k] == v for k, v in obj1.items()) and all(obj1[k] == v for k, v in obj2.items())
+        elif isinstance(obj1, list) and isinstance(obj2, list):
+            return all(v1 == v2 for v1, v2 in zip(obj1, obj2))
         else:
             return obj1 == obj2
 
@@ -89,3 +93,8 @@ def _v1service_are_the_same(svc1: V1Service, svc2: V1Service) -> bool:
 @_special_comparison(V1Ingress)
 def _v1ingress_are_the_same(ingress1: V1Ingress, ingress2: V1Ingress) -> bool:
     return specs_are_the_same(ingress1, ingress2, ['metadata', 'spec'])
+
+
+@_special_comparison(V1Secret)
+def _v1secret_are_the_same(secret1: V1Secret, secret2: V1Secret) -> bool:
+    return specs_are_the_same(secret1, secret2, ['metadata', 'data'])

--- a/monitoring/deployment_manager/deploylib/crdb_cluster_api.py
+++ b/monitoring/deployment_manager/deploylib/crdb_cluster_api.py
@@ -1,0 +1,115 @@
+import math
+import requests
+from typing import Dict, List, Optional, Tuple
+
+import arrow
+
+from monitoring.monitorlib.typing import ImplicitDict
+
+
+class Address(ImplicitDict):
+    network_field: str
+    address_field: str
+
+
+class ServerVersion(ImplicitDict):
+    major_val: int
+    minor_val: int
+    patch: int
+    internal: int
+
+
+class Locality(ImplicitDict):
+    tiers: List[dict]
+
+
+class Node(ImplicitDict):
+    node_id: int
+    address: Address
+    locality: Locality
+    ServerVersion: ServerVersion
+    build_tag: str
+    started_at: int
+    cluster_name: str
+    sql_address: Address
+    metrics: dict
+    total_system_memory: int
+    num_cpus: int
+    updated_at: int
+    liveness_status: int
+
+    def summarize(self) -> Tuple[str, Dict[str, str]]:
+        key = 'Node {} ({})'.format(self.node_id, self.address.address_field)
+        t0 = arrow.get(math.floor(self.started_at / 1e9))
+        values = {
+            'locality': ' '.join('{}:{}'.format(t['key'], t['value']) for t in self.locality.tiers),
+            'status': 'Running {} since {}, liveness {}'.format(self.build_tag, t0.to('local').isoformat(),self.liveness_status)
+        }
+        return key, values
+
+
+class ClusterAPI(object):
+    """Wrapper for retrieving CockroachDB cluster information.
+
+    API: https://www.cockroachlabs.com/docs/api/cluster/v2
+    """
+    def __init__(self, session: requests.Session, base_url: str='https://localhost:8080/api/v2', username: Optional[str]=None, password: Optional[str]=None):
+        self._session = session
+        self._base_url = base_url
+        self._username = username
+        self._password = password
+        self._session_auth = None
+
+    def __del__(self):
+        self.log_out()
+
+    def is_ready(self) -> bool:
+        resp = self._session.get('{}/health/?ready=true'.format(self._base_url))
+        if resp.status_code == 200:
+            return True
+        elif resp.status_code == 500:
+            return False
+        else:
+            raise ValueError('Call to {} returned unexpected status code {}: {}'.format(resp.url, resp.status_code, resp.content.decode('utf-8')))
+
+    def is_up(self) -> bool:
+        resp = self._session.get('{}/health/'.format(self._base_url))
+        if resp.status_code == 200:
+            return True
+        elif resp.status_code == 500:
+            return False
+        else:
+            raise ValueError('Call to {} returned unexpected status code {}: {}'.format(resp.url, resp.status_code, resp.content.decode('utf-8')))
+
+    def log_in(self) -> str:
+        if self._username is None:
+            raise ValueError('Cannot log in to CockroachDB cluster at {} when username is not specified'.format(self._base_url))
+        if self._password is None:
+            raise ValueError('Cannot log in to CockroachDB cluster at {} when password is not specified'.format(self._base_url))
+        resp = self._session.post('{}/login/'.format(self._base_url), data={'username': self._username, 'password': self._password})
+        resp.raise_for_status()
+        session = resp.json().get('session', None)
+        if session is None:
+            raise ValueError('Invalid CockroachDB cluster response: `session` not specified: {}'.format(resp.content.decode('utf-8')))
+        self._session_auth = session
+        return session
+
+    def _get_headers(self) -> Dict[str, str]:
+        if self._session_auth is None:
+            self.log_in()
+        return {'X-Cockroach-API-Session': self._session_auth}
+
+    def log_out(self) -> None:
+        if self._session_auth is None:
+            return
+        resp = self._session.post('{}/logout/'.format(self._base_url), headers=self._get_headers())
+        resp.raise_for_status()
+        self._session_auth = None
+
+    def get_nodes(self) -> List[Node]:
+        resp = self._session.get('{}/nodes/'.format(self._base_url), headers=self._get_headers())
+        resp.raise_for_status()
+        nodes = resp.json().get('nodes', None)
+        if nodes is None:
+            raise ValueError('Invalid CockroachDB cluster response: `nodes` not specified: {}'.format(resp.content.decode('utf-8')))
+        return [ImplicitDict.parse(n, Node) for n in nodes]

--- a/monitoring/deployment_manager/deploylib/crdb_sql.py
+++ b/monitoring/deployment_manager/deploylib/crdb_sql.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass
+import datetime
+import hashlib
+import random
+from typing import List, Tuple
+
+from kubernetes import client as k8s
+import kubernetes.stream
+
+
+@dataclass
+class User(object):
+    username: str
+    options: List[str]
+    member_of: List[str]
+
+
+def execute_sql(client: k8s.CoreV1Api, namespace: str, sql_commands: List[str]) -> str:
+    """Execute the specfied sql_commands directly on a CRDB node.
+
+    :param client: Kubernetes core client which can access the CRDB node
+    :param namespace: Namespace in which an accessible CRDB node is located
+    :param sql_commands: SQL commands to be executed (no semicolons)
+    :return: stdout of console from executing `cockroach sql`
+    """
+    exec_command = ['./cockroach', 'sql', '--certs-dir=cockroach-certs/']
+    exec_command += ['--execute=' + cmd for cmd in sql_commands]
+    resp = kubernetes.stream.stream(client.connect_get_namespaced_pod_exec,
+                  'cockroachdb-0',
+                  namespace,
+                  command=exec_command,
+                  stderr=True, stdin=False,
+                  stdout=True, tty=False)
+    if 'Failed running' in resp:
+        raise ValueError('SQL error: ' + resp)
+    return resp
+
+
+def list_users(client: k8s.CoreV1Api, namespace: str) -> List[User]:
+    lines = execute_sql(client, namespace, ['SHOW USERS']).split('\n')
+    lines = [line for line in lines[1:] if line]
+    users = []
+    for line in lines:
+        username, options_text, member_of_text = [col.strip() for col in line.split('\t')]
+        options = [opt.strip() for opt in options_text.split(',')]
+        member_of = [group.strip() for group in member_of_text[1:-1].split(',')]
+        users.append(User(username=username, options=options, member_of=member_of))
+    return users
+
+
+def get_monitoring_user(client: k8s.CoreV1Api, namespace: str, cluster_name: str) -> Tuple[str, str]:
+    """Get the username and password for a CRDB user intended for monitoring.
+
+    Whenever this routine is called, it sets the validity of the user to 1-2
+    days beyond the current time.  To continue to use the user after that time,
+    this routine must be called again.
+
+    :param client: Kubernetes core client which can access the CRDB node
+    :param namespace: Namespace in which an accessible CRDB node is located
+    :param cluster_name: Name of Kubernetes cluster in which this user will be operating
+    :return:
+        * Username
+        * Password
+    """
+    # Create username according to cluster_name
+    prefix = 'monitoring_user_'
+    suffix = hashlib.md5(cluster_name.encode('utf-8')).hexdigest()[-8:]
+    username = prefix + suffix
+
+    # Create a new password
+    r = random.Random()
+    password = ''.join(random.choice('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-=_+[]\\{}|;:",./<>?') for _ in range(32))
+
+    # Compute validity
+    valid_until = (datetime.datetime.utcnow() + datetime.timedelta(days=2)).isoformat()
+    execute_sql(
+        client, namespace,
+        ['CREATE USER IF NOT EXISTS {}'.format(username),
+         'GRANT admin TO {}'.format(username),
+         'ALTER USER {} WITH LOGIN PASSWORD \'{}\' VALID UNTIL \'{}\''.format(username, password, valid_until)])
+
+    return username, password

--- a/monitoring/deployment_manager/deploylib/port_forwarding.py
+++ b/monitoring/deployment_manager/deploylib/port_forwarding.py
@@ -1,0 +1,145 @@
+from http.client import HTTPConnection
+from urllib3 import PoolManager, HTTPConnectionPool, HTTPSConnectionPool
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+import urllib3.connection
+from typing import Tuple
+
+from kubernetes.client import CoreV1Api
+import kubernetes.stream
+import requests
+from requests.adapters import HTTPAdapter
+
+
+def _get_session_for_socket(sock, host: str, port: int) -> requests.Session:
+    sock.setblocking(True)
+    s = requests.Session()
+    s.verify = False
+    http_adapter = SocketHTTPAdapter(sock, host, port)
+    s.mount('http://', http_adapter)
+    s.mount('https://', http_adapter)
+    return s
+
+
+def get_requests_session_for_pod(pod_name: str, namespace: str, port: int, client: CoreV1Api) -> Tuple[requests.Session, str]:
+    """Make a Session to connect to the specified port on the named pod.
+
+    Retrieves a requests Session that will send http(s) queries to the specified
+    port on the specified pod.  Only requests sent to the returned host:port
+    combination will be sent to the pod; other requests will result in errors.
+
+    :param pod_name: Name of Kubernetes pod to connect to
+    :param namespace: Kubernetes namespace in which the pod is located
+    :param port: Pod's port to connect to
+    :param client: Kubernetes client that can access the Kubernetes cluster
+    :return:
+        * requests.Session that will can be used to make HTTP(S) requests
+        * host:port combination to which requests should be addressed
+    """
+    pf = kubernetes.stream.portforward(
+        client.connect_get_namespaced_pod_portforward,
+        pod_name, namespace, ports=str(port),
+    )
+    host = '{}.pod.{}'.format(pod_name, namespace)
+    return _get_session_for_socket(pf.socket(port), host, port), '{}:{}'.format(host, port)
+
+
+# ==== Custom requests handlers to inject/use an explicitly-provided socket ====
+
+
+class SocketHTTPAdapter(HTTPAdapter):
+    def __init__(self, sock, host: str, port: int, *args, **kwargs):
+        self._socket = sock
+        self._host = host
+        self._port = port
+        super(SocketHTTPAdapter, self).__init__(*args, **kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=requests.adapters.DEFAULT_POOLBLOCK, **pool_kwargs):
+        """Overrides method in base class"""
+        self.poolmanager = SocketPoolManager(self._socket, self._host, self._port, num_pools=connections, maxsize=maxsize)
+
+
+class SocketPoolManager(PoolManager):
+    def __init__(self, sock, host: str, port: int, *args, **kwargs):
+        self._socket = sock
+        self._host = host
+        self._port = port
+        super(SocketPoolManager, self).__init__(*args, **kwargs)
+
+    def _new_pool(self, scheme, host, port, request_context=None):
+        """Overrides method in base class"""
+        # return super(SocketPoolManager, self)._new_pool(scheme, host, port, request_context)
+        if host == self._host and port == self._port:
+            if scheme == 'http':
+                return SocketHTTPConnectionPool(self._socket, host, port, **self.connection_pool_kw)
+            elif scheme == 'https':
+                return SocketHTTPSConnectionPool(self._socket, host, port, **self.connection_pool_kw)
+        raise ValueError('{}:{} is not supported by SocketPoolManager intended for {}:{}'.format(host, port, self._host, self._port))
+
+
+class SocketHTTPConnectionPool(HTTPConnectionPool):
+    def __init__(self, sock, *args, **kwargs):
+        self._socket = sock
+        super(SocketHTTPConnectionPool, self).__init__(*args, **kwargs)
+
+    def _new_conn(self):
+        """Overrides method in base class"""
+        self.num_connections += 1
+        return SocketHTTPConnection(
+            self._socket,
+            host=self.host,
+            port=self.port,
+            timeout=self.timeout.connect_timeout,
+            **self.conn_kw
+        )
+
+
+class SocketHTTPConnection(HTTPConnection):
+    def __init__(self, sock, *args, **kwargs):
+        self._socket = sock
+        super(SocketHTTPConnection, self).__init__(*args, **kwargs)
+
+    def connect(self):
+        """Overrides method in base class"""
+        self.sock = self._socket
+        if self._tunnel_host:
+            self._tunnel()
+
+
+class SocketHTTPSConnectionPool(HTTPSConnectionPool):
+    def __init__(self, sock, *args, **kwargs):
+        self._socket = sock
+        kwargs['assert_hostname'] = False
+        super(SocketHTTPSConnectionPool, self).__init__(*args, **kwargs)
+
+    def _new_conn(self):
+        """Overrides method in base class"""
+        self.num_connections += 1
+
+        actual_host = self.host
+        actual_port = self.port
+        if self.proxy is not None:
+            actual_host = self.proxy.host
+            actual_port = self.proxy.port
+
+        conn = SocketHTTPSConnection(
+            self._socket,
+            host=actual_host,
+            port=actual_port,
+            timeout=self.timeout.connect_timeout,
+            cert_file=self.cert_file,
+            key_file=self.key_file,
+            **self.conn_kw
+        )
+
+        return self._prepare_conn(conn)
+
+
+class SocketHTTPSConnection(urllib3.connection.HTTPSConnection):
+    def __init__(self, sock, *args, **kwargs):
+        self._socket = sock
+        super(SocketHTTPSConnection, self).__init__(*args, **kwargs)
+
+    def _new_conn(self):
+        """Overrides method in base class"""
+        return self._socket

--- a/monitoring/deployment_manager/deploylib/secrets.py
+++ b/monitoring/deployment_manager/deploylib/secrets.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from kubernetes.client import CoreV1Api, V1Secret, V1Namespace
+from structlog import BoundLogger
+
+from monitoring.deployment_manager.deploylib import common_k8s
+
+
+def get(client: CoreV1Api, log: BoundLogger, namespace: V1Namespace, name: str) -> Optional[V1Secret]:
+    return common_k8s.get_resource(
+        lambda: client.list_namespaced_secret(namespace=namespace.metadata.name),
+        log, 'secret', name)
+
+
+def upsert(client: CoreV1Api, log: BoundLogger, namespace: V1Namespace, secret: V1Secret) -> V1Secret:
+    existing_secret = get(client, log, namespace, secret.metadata.name)
+    return common_k8s.upsert_resource(
+        existing_secret, secret, log, 'secret',
+        lambda: client.create_namespaced_secret(
+            body=secret, namespace=namespace.metadata.name),
+        lambda: client.patch_namespaced_secret(
+            existing_secret.metadata.name, namespace.metadata.name, secret))

--- a/monitoring/deployment_manager/deployment_manager.py
+++ b/monitoring/deployment_manager/deployment_manager.py
@@ -46,11 +46,19 @@ def main() -> int:
     # Parse deployment spec
     with open(args.deployment_spec, 'r') as f:
         spec = ImplicitDict.parse(json.load(f), DeploymentSpec)
+    original_spec = json.dumps(spec)
     context = make_context(spec)
 
     # Execute action
     context.log.msg('Executing action', action=args.action, spec_file=args.deployment_spec)
     action_method(context)
+
+    # Check if the deployment spec was updated
+    new_spec = json.dumps(context.spec)
+    if new_spec != original_spec:
+        context.log.msg('Deployment spec updated; writing changes to {}'.format(args.deployment_spec))
+        with open(args.deployment_spec, 'w') as f:
+            json.dump(context.spec, f, indent=2)
 
     return os.EX_OK
 

--- a/monitoring/deployment_manager/requirements.txt
+++ b/monitoring/deployment_manager/requirements.txt
@@ -1,3 +1,4 @@
 kubernetes==23.3.0
 pem==21.2.0
+pyopenssl==22.0.0
 structlog==21.5.0


### PR DESCRIPTION
This PR demonstrates interactions with a CockroachDB node's [cluster API](https://www.cockroachlabs.com/docs/api/cluster/v2) using a standard `requests.Session` via an underlying socket supplied by the `kubernetes` package that forwards to a port on the CockroachDB node's pod.

To use the action introduced in this PR:
1. Have a [standard DSS deployment](https://github.com/interuss/dss/tree/master/build) (deployed via Tanka using Kubernetes)
2. Create a `sites` folder within monitoring/deployment_manager
3. Add a deployment description in that `sites` folder pointing to the live DSS deployment; something like:

```json
{
  "cluster": {
    "name": "gke_your-cloud-project_your-region_your-cluster-name"
  },
  "dss": {
    "v1": {
      "namespace": "default"
    }
  }
}
```

4. You may need to have that context already selected with `kubectl` (this shouldn't be necessary, but seems like it may need to be under certain conditions)
5. After [preparing your development system](https://github.com/interuss/dss/tree/master/monitoring/deployment_manager#prerequisites), run the action: `python3 deployment_manager.py dss/crdb/status sites/your-deployment-definition.json` from the deployment_manager folder
6. Another useful action may be `python3 deployment_manager.py dss/crdb/print_monitoring_user sites/your-deployment-definition.json`.