### PR TITLE
[deployment] Add publishNotReadyAddresses to replace tolerate-unready-endpoints

### DIFF
--- a/build/deploy/cockroachdb-auxiliary.libsonnet
+++ b/build/deploy/cockroachdb-auxiliary.libsonnet
@@ -46,6 +46,7 @@ local cockroachLB(metadata, name, ip) = base.Service(metadata, name) {
           selector: {
             'statefulset.kubernetes.io/pod-name': 'cockroachdb-' + i,
           },
+          publishNotReadyAddresses: true,
         },
       }
       for i in std.range(0, std.length(metadata.cockroach.nodeIPs) - 1)


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/63741: the annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints` has been replaced by the Service spec argument `publishNotReadyAddresses`.  This PR adds the new spec argument.  This is important because CRDB nodes must be able to communicate before they are ready in order to become ready.