### PR TITLE
[deployment] Add the ability to specify a custom Prometheus image

### DIFF
--- a/build/deploy/metadata_base.libsonnet
+++ b/build/deploy/metadata_base.libsonnet
@@ -48,6 +48,7 @@
     },
   },
   prometheus: {
+    image: 'prom/prometheus:v2.35.0',
     expose_external: false,
     IP: '',  // This is the static external ip address for promethus ingress, leaving blank means your cloud provider will assign an ephemeral IP
     whitelist_ip_ranges: error 'must specify whitelisted CIDR IP Blocks, or empty list for fully public access',

--- a/build/deploy/prometheus.libsonnet
+++ b/build/deploy/prometheus.libsonnet
@@ -1,4 +1,4 @@
-local base = import 'base.libsonnet'; 
+local base = import 'base.libsonnet';
 local k8sEndpoints = import 'prometheus_configs/k8s-endpoints.libsonnet';
 local istioScrape = import 'prometheus_configs/istio.libsonnet';
 local crdbAggregation = import 'prometheus_configs/crdb-aggregation.libsonnet';
@@ -138,7 +138,7 @@ local PrometheusExternalService(metadata) = base.Service(metadata, 'prometheus-e
             containers: [
               {
                 name: 'prometheus',
-                image: 'prom/prometheus',
+                image: metadata.prometheus.image,
                 args: [
                   '--config.file=/etc/prometheus/prometheus.yml',
                   '--storage.tsdb.path=/data/prometheus/',


### PR DESCRIPTION
Setting a custom Prometheus image is useful for:

- Providing a drop-in modified image for exporting metrics, e.g. [Google Cloud Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-unmanaged).
- Setting a specific version to include bug fixes etc.

Additionally, the default Prometheus image was previously not pinned to a specific tag. This harms reproducibility, as the latest tag will be used at Pod startup. This PR addresses this by pinning the default image to the [latest version tag](https://hub.docker.com/r/prom/prometheus/tags) (`v2.35.0`). This improves reproducibility but does not completely guarantee it, as Docker Hub tags are mutable. Tagging to a digest would guarantee this, but this can be a topic for future discussion.