### PR TITLE
[uss_qualifier/rid]: Fix path and file name of report json in test executor

### DIFF
--- a/monitoring/uss_qualifier/rid/test_executor.py
+++ b/monitoring/uss_qualifier/rid/test_executor.py
@@ -63,6 +63,6 @@ def run_rid_tests(test_configuration: RIDQualifierTestConfiguration,
     display_data_evaluator.evaluate_system(
         injected_flights, observers, test_configuration.evaluation,
         report.findings)
-    with open('../report.json', 'w') as f:
+    with open('report_rid.json', 'w') as f:            
         json.dump(report, f)
     return report

--- a/monitoring/uss_qualifier/rid/test_executor.py
+++ b/monitoring/uss_qualifier/rid/test_executor.py
@@ -63,6 +63,6 @@ def run_rid_tests(test_configuration: RIDQualifierTestConfiguration,
     display_data_evaluator.evaluate_system(
         injected_flights, observers, test_configuration.evaluation,
         report.findings)
-    with open('report_rid.json', 'w') as f:            
+    with open('report_rid.json', 'w') as f:
         json.dump(report, f)
     return report


### PR DESCRIPTION
This PR fixes the output path of the report while running the `rid_qualifier` part of the toolset. 