### PR TITLE
[mock_uss] Add RID misbehaviors to mock_uss

### DIFF
--- a/monitoring/mock_uss/postman_collection.json
+++ b/monitoring/mock_uss/postman_collection.json
@@ -19,8 +19,8 @@
 									"tests[\"Status code is 200\"] = responseCode.code === 200;",
 									"",
 									"var data = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"production_token\", data.access_token);",
-									"postman.setEnvironmentVariable(\"uss_id\", \"uss1\");",
+									"postman.setEnvironmentVariable(\"mock_ridsp_token\", data.access_token);",
+									"postman.setEnvironmentVariable(\"mock_ridsp_uss_id\", \"uss1\");",
 									"",
 									""
 								],
@@ -87,6 +87,166 @@
 					"response": []
 				},
 				{
+					"name": "Behavior",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:8071/ridsp/behavior",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8071",
+							"path": [
+								"ridsp",
+								"behavior"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Good behavior",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"switch_latitude_and_longitude_when_reporting\": false,\n    \"use_agl_instead_of_wgs84_for_altitude\": false,\n    \"use_feet_instead_of_meters_for_altitude\": false\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8071/ridsp/behavior",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8071",
+							"path": [
+								"ridsp",
+								"behavior"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Bad behavior",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"switch_latitude_and_longitude_when_reporting\": false,\n    \"use_agl_instead_of_wgs84_for_altitude\": true,\n    \"use_feet_instead_of_meters_for_altitude\": false\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8071/ridsp/behavior",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8071",
+							"path": [
+								"ridsp",
+								"behavior"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Create test in mock_ridsp",
 					"event": [
 						{
@@ -95,10 +255,10 @@
 								"exec": [
 									"const moment = require('moment');",
 									"pm.globals.set(\"t_1\", moment().add(5, 'seconds').toISOString());",
-									"pm.globals.set(\"t_2\", moment().add(1, 'minutes').toISOString());",
-									"pm.globals.set(\"t_3\", moment().add(2, 'minutes').toISOString());",
+									"pm.globals.set(\"t_2\", moment().add(15, 'seconds').toISOString());",
+									"pm.globals.set(\"t_3\", moment().add(1, 'minutes').toISOString());",
 									"pm.globals.set(\"t_4\", moment().add(2, 'minutes').toISOString());",
-									"pm.globals.set(\"t_5\", moment().add(2, 'minutes').toISOString());",
+									"pm.globals.set(\"t_5\", moment().add(3, 'minutes').toISOString());",
 									""
 								],
 								"type": "text/javascript"
@@ -111,7 +271,7 @@
 							"bearer": [
 								{
 									"key": "token",
-									"value": "{{production_token}}",
+									"value": "{{mock_ridsp_token}}",
 									"type": "string"
 								}
 							]
@@ -152,7 +312,7 @@
 							"bearer": [
 								{
 									"key": "token",
-									"value": "{{production_token}}",
+									"value": "{{mock_ridsp_token}}",
 									"type": "string"
 								}
 							]
@@ -160,7 +320,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:8071/mock/ridsp/v1/uss/flights?view=34.122,-118.453,34.125,-118.458&include_recent_positions=false",
+							"raw": "http://localhost:8071/mock/ridsp/v1/uss/flights?view=34.122,-118.453,34.125,-118.458&include_recent_positions=true",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -180,7 +340,7 @@
 								},
 								{
 									"key": "include_recent_positions",
-									"value": "false"
+									"value": "true"
 								}
 							]
 						}
@@ -195,7 +355,7 @@
 							"bearer": [
 								{
 									"key": "token",
-									"value": "{{production_token}}",
+									"value": "{{mock_ridsp_token}}",
 									"type": "string"
 								}
 							]
@@ -241,7 +401,7 @@
 							"bearer": [
 								{
 									"key": "token",
-									"value": "{{production_token}}",
+									"value": "{{mock_ridsp_token}}",
 									"type": "string"
 								}
 							]
@@ -686,8 +846,8 @@
 									"tests[\"Status code is 200\"] = responseCode.code === 200;",
 									"",
 									"var data = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"production_token\", data.access_token);",
-									"postman.setEnvironmentVariable(\"uss_id\", \"uss1\");",
+									"postman.setEnvironmentVariable(\"mock_riddp_token\", data.access_token);",
+									"postman.setEnvironmentVariable(\"mock_riddp_uss_id\", \"uss1\");",
 									"",
 									""
 								],
@@ -754,6 +914,166 @@
 					"response": []
 				},
 				{
+					"name": "Behavior",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:8073/riddp/behavior",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8073",
+							"path": [
+								"riddp",
+								"behavior"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Good behavior",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"always_omit_recent_paths\": false,\n    \"do_not_display_flights_from\": []\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8073/riddp/behavior",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8073",
+							"path": [
+								"riddp",
+								"behavior"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Bad behavior",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"tests[\"Status code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"always_omit_recent_paths\": false,\n    \"do_not_display_flights_from\": [\"uss1\"]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8073/riddp/behavior",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8073",
+							"path": [
+								"riddp",
+								"behavior"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Flights in mock_ridsp test area",
 					"request": {
 						"auth": {
@@ -761,7 +1081,7 @@
 							"bearer": [
 								{
 									"key": "token",
-									"value": "{{production_token}}",
+									"value": "{{mock_riddp_token}}",
 									"type": "string"
 								}
 							]
@@ -798,7 +1118,7 @@
 							"bearer": [
 								{
 									"key": "token",
-									"value": "{{production_token}}",
+									"value": "{{mock_riddp_token}}",
 									"type": "string"
 								}
 							]

--- a/monitoring/mock_uss/riddp/behavior.py
+++ b/monitoring/mock_uss/riddp/behavior.py
@@ -1,0 +1,11 @@
+from typing import List, Optional
+
+from monitoring.monitorlib.typing import ImplicitDict
+
+
+ServiceProviderID = str
+
+
+class DisplayProviderBehavior(ImplicitDict):
+  always_omit_recent_paths: Optional[bool] = False
+  do_not_display_flights_from: Optional[List[ServiceProviderID]] = []

--- a/monitoring/mock_uss/riddp/clustering.py
+++ b/monitoring/mock_uss/riddp/clustering.py
@@ -1,0 +1,64 @@
+import random
+from typing import List
+
+import s2sphere
+
+from monitoring.monitorlib import geo
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.monitorlib.rid_automated_testing import observation_api
+
+
+class Point(object):
+  x: float
+  y: float
+
+  def __init__(self, x: float, y: float):
+    self.x = x
+    self.y = y
+
+
+class Cluster(ImplicitDict):
+  x_min: float
+  x_max: float
+  y_min: float
+  y_max: float
+  points: List[Point]
+
+  def randomize(self):
+    u_min = min(p.x for p in self.points)
+    v_min = min(p.y for p in self.points)
+    u_max = max(p.x for p in self.points)
+    v_max = max(p.y for p in self.points)
+    return Cluster(
+      x_min=self.x_min + (u_min - self.x_min) * random.random(),
+      y_min=self.y_min + (v_min - self.y_min) * random.random(),
+      x_max=u_max + (self.x_max - u_max) * random.random(),
+      y_max=v_max + (self.y_max - v_max) * random.random(),
+      points=self.points)
+
+
+def make_clusters(flights: List[observation_api.Flight], view_min: s2sphere.LatLng, view_max: s2sphere.LatLng) -> List[observation_api.Cluster]:
+  if not flights:
+    return []
+
+  # Make the initial cluster
+  points: List[Point] = [
+    Point(*geo.flatten(view_min, s2sphere.LatLng.from_degrees(flight.most_recent_position.lat, flight.most_recent_position.lng)))
+    for flight in flights]
+  x_max, y_max = geo.flatten(view_min, view_max)
+  clusters: List[Cluster] = [Cluster(x_min=0, y_min=0, x_max=x_max, y_max=y_max, points=points)]
+
+  # TODO: subdivide cluster into many clusters
+
+  result: List[observation_api.Cluster] = []
+  for cluster in clusters:
+    cluster = cluster.randomize()  # TODO: Set random seed according to view extents so a static view will have static cluster subdivisions
+    p1 = geo.unflatten(view_min, (cluster.x_min, cluster.y_min))
+    p2 = geo.unflatten(view_min, (cluster.x_max, cluster.y_max))
+    result.append(observation_api.Cluster(
+      corners=[observation_api.Position(lat=p1.lat().degrees, lng=p1.lng().degrees), observation_api.Position(lat=p2.lat().degrees, lng=p2.lng().degrees)],
+      area_sqm=geo.area_of_latlngrect(s2sphere.LatLngRect(p1, p2)),
+      number_of_flights=len(cluster.points)
+    ))
+
+  return result

--- a/monitoring/mock_uss/riddp/database.py
+++ b/monitoring/mock_uss/riddp/database.py
@@ -1,6 +1,7 @@
 import json
 from typing import Dict
 
+from .behavior import DisplayProviderBehavior
 from monitoring.monitorlib.typing import ImplicitDict
 from monitoring.monitorlib.multiprocessing import SynchronizedValue
 
@@ -12,6 +13,7 @@ class FlightInfo(ImplicitDict):
 class Database(ImplicitDict):
   """Simple pseudo-database structure tracking the state of the mock system"""
   flights: Dict[str, FlightInfo] = {}
+  behavior: DisplayProviderBehavior = DisplayProviderBehavior()
 
 
 db = SynchronizedValue(

--- a/monitoring/mock_uss/riddp/routes.py
+++ b/monitoring/mock_uss/riddp/routes.py
@@ -7,3 +7,4 @@ def riddp_status():
 
 
 from . import routes_observation
+from . import routes_behavior

--- a/monitoring/mock_uss/riddp/routes_behavior.py
+++ b/monitoring/mock_uss/riddp/routes_behavior.py
@@ -1,0 +1,32 @@
+from typing import Tuple
+
+import flask
+
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.mock_uss import webapp
+from .behavior import DisplayProviderBehavior
+from .database import db
+
+
+@webapp.route('/riddp/behavior', methods=['PUT'])
+def set_dp_behavior() -> Tuple[str, int]:
+  """Set the behavior of the mock Display Provider."""
+  try:
+    json = flask.request.json
+    if json is None:
+      raise ValueError('Request did not contain a JSON payload')
+    dp_behavior = ImplicitDict.parse(json, DisplayProviderBehavior)
+  except ValueError as e:
+    msg = 'Change behavior for Display Provider unable to parse JSON: {}'.format(e)
+    return msg, 400
+
+  with db as tx:
+      tx.behavior = dp_behavior
+
+  return flask.jsonify(dp_behavior)
+
+
+@webapp.route('/riddp/behavior', methods=['GET'])
+def get_dp_behavior() -> Tuple[str, int]:
+    """Get the behavior of the mock Display Provider."""
+    return flask.jsonify(db.value.behavior)

--- a/monitoring/mock_uss/ridsp/behavior.py
+++ b/monitoring/mock_uss/ridsp/behavior.py
@@ -1,0 +1,53 @@
+from typing import Optional
+
+from monitoring.monitorlib.rid_automated_testing.injection_api import TestFlight
+from monitoring.monitorlib.rid import RIDFlight
+from monitoring.monitorlib.typing import ImplicitDict
+
+
+FEET_PER_METER = 1 / 0.3048
+
+
+class ServiceProviderBehavior(ImplicitDict):
+    switch_latitude_and_longitude_when_reporting: Optional[bool] = False
+    use_agl_instead_of_wgs84_for_altitude: Optional[bool] = False
+    use_feet_instead_of_meters_for_altitude: Optional[bool] = False
+
+
+def adjust_reported_flight(flight: TestFlight, reported_flight: RIDFlight, behavior: ServiceProviderBehavior) -> RIDFlight:
+    """Adjust how a flight is reported based on the SP behavior"""
+
+    adjusted = ImplicitDict.parse(reported_flight, RIDFlight)
+    if behavior.switch_latitude_and_longitude_when_reporting:
+        if adjusted.has_field_with_value('current_state'):
+            lng = adjusted.current_state.position.lat
+            adjusted.current_state.position.lat = adjusted.current_state.position.lng
+            adjusted.current_state.position.lng = lng
+        if adjusted.has_field_with_value('recent_positions'):
+            for p in adjusted.recent_positions:
+                lng = p.position.lat
+                p.position.lat = p.position.lng
+                p.position.lng = lng
+
+    if behavior.use_agl_instead_of_wgs84_for_altitude:
+        ground_altitude = min(t.position.alt for t in flight.telemetry)
+        if adjusted.has_field_with_value('current_state'):
+            if adjusted.current_state.has_field_with_value('height'):
+                adjusted.current_state.position.alt = adjusted.current_state.height.distance
+            else:
+                adjusted.current_state.position.alt -= ground_altitude
+
+        if adjusted.has_field_with_value('recent_positions'):
+            for p in adjusted.recent_positions:
+                p.position.alt -= ground_altitude
+
+    if behavior.use_feet_instead_of_meters_for_altitude:
+        if adjusted.has_field_with_value('current_state'):
+            adjusted.current_state.position.alt *= FEET_PER_METER
+            if adjusted.current_state.has_field_with_value('height'):
+                adjusted.current_state.height.distance *= FEET_PER_METER
+        if adjusted.has_field_with_value('recent_positions'):
+            for p in adjusted.recent_positions:
+                p.position.alt *= FEET_PER_METER
+
+    return adjusted

--- a/monitoring/mock_uss/ridsp/database.py
+++ b/monitoring/mock_uss/ridsp/database.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 from monitoring.monitorlib.multiprocessing import SynchronizedValue
 from monitoring.monitorlib.rid_automated_testing import injection_api
 from monitoring.monitorlib.typing import ImplicitDict
+from .behavior import ServiceProviderBehavior
 
 
 class TestRecord(ImplicitDict):
@@ -23,6 +24,7 @@ class TestRecord(ImplicitDict):
 class Database(ImplicitDict):
   """Simple pseudo-database structure tracking the state of the mock system"""
   tests: Dict[str, TestRecord] = {}
+  behavior: ServiceProviderBehavior = ServiceProviderBehavior()
 
 
 db = SynchronizedValue(

--- a/monitoring/mock_uss/ridsp/routes.py
+++ b/monitoring/mock_uss/ridsp/routes.py
@@ -8,3 +8,4 @@ def ridsp_status():
 
 from . import routes_ridsp
 from . import routes_injection
+from . import routes_behavior

--- a/monitoring/mock_uss/ridsp/routes_behavior.py
+++ b/monitoring/mock_uss/ridsp/routes_behavior.py
@@ -1,0 +1,32 @@
+from typing import Tuple
+
+import flask
+
+from monitoring.monitorlib.typing import ImplicitDict
+from monitoring.mock_uss import webapp
+from .behavior import ServiceProviderBehavior
+from .database import db
+
+
+@webapp.route('/ridsp/behavior', methods=['PUT'])
+def set_dp_behavior() -> Tuple[str, int]:
+    """Set the behavior of the mock Display Provider."""
+    try:
+        json = flask.request.json
+        if json is None:
+            raise ValueError('Request did not contain a JSON payload')
+        dp_behavior = ImplicitDict.parse(json, ServiceProviderBehavior)
+    except ValueError as e:
+        msg = 'Change behavior for Service Provider unable to parse JSON: {}'.format(e)
+        return msg, 400
+
+    with db as tx:
+        tx.behavior = dp_behavior
+
+    return flask.jsonify(dp_behavior)
+
+
+@webapp.route('/ridsp/behavior', methods=['GET'])
+def get_dp_behavior() -> Tuple[str, int]:
+    """Get the behavior of the mock Display Provider."""
+    return flask.jsonify(db.value.behavior)

--- a/monitoring/mock_uss/ridsp/routes_ridsp.py
+++ b/monitoring/mock_uss/ridsp/routes_ridsp.py
@@ -10,6 +10,7 @@ from monitoring.monitorlib.rid_automated_testing.injection_api import TestFlight
 from monitoring.monitorlib.typing import StringBasedDateTime
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.auth import requires_scope
+from . import behavior
 from .database import db
 
 
@@ -73,6 +74,7 @@ def flights():
     for flight in record.flights:
       reported_flight = _get_report(flight, now, view, include_recent_positions)
       if reported_flight is not None:
+        reported_flight = behavior.adjust_reported_flight(flight, reported_flight, tx.behavior)
         flights.append(reported_flight)
   return flask.jsonify(rid.GetFlightsResponse(timestamp=StringBasedDateTime(now), flights=flights)), 200
 

--- a/monitoring/monitorlib/fetch/rid.py
+++ b/monitoring/monitorlib/fetch/rid.py
@@ -42,12 +42,13 @@ class FetchedISAs(fetch.Query):
     return {isa.get('id', ''): rid.ISA(isa) for isa in isa_list}
 
   @property
-  def flight_urls(self) -> List[str]:
-    urls = set()
+  def flight_urls(self) -> Dict[str, str]:
+    """Returns map of flight URL to USS"""
+    urls = dict()
     for _, isa in self.isas.items():
       if isa.flights_url is not None:
-        urls.add(isa.flights_url)
-    return list(urls)
+        urls[isa.flights_url] = isa.owner
+    return urls
 
   def has_different_content_than(self, other):
     if not isinstance(other, FetchedISAs):

--- a/monitoring/monitorlib/typing.py
+++ b/monitoring/monitorlib/typing.py
@@ -165,6 +165,9 @@ class ImplicitDict(dict):
     else:
       super(ImplicitDict, self).__setattr__(key, value)
 
+  def has_field_with_value(self, field_name: str) -> bool:
+    return field_name in self and self[field_name] is not None
+
 
 def _parse_value(value, value_type: Type):
   generic_type = get_origin(value_type)

--- a/monitoring/uss_qualifier/README.md
+++ b/monitoring/uss_qualifier/README.md
@@ -8,4 +8,4 @@ service providers. It currently includes the following components:
 - [Remote ID](./rid/README.md): ASTM F3411-19 - Remote ID and Tracking
     - See [run_locally_rid.sh](run_locally_rid.sh)
 - [ASTM strategic coordination and UAS Flight Authorisation](./scd/README.md): ASTM WK63418 and U-Space Regulation
-    - See [run_locally_rid.sh](run_locally_scd.sh)
+    - See [run_locally_scd.sh](run_locally_scd.sh)

--- a/monitoring/uss_qualifier/README.md
+++ b/monitoring/uss_qualifier/README.md
@@ -6,4 +6,6 @@ The USS Qualifier automates testing standards compliance and interoperability of
 service providers. It currently includes the following components:
 
 - [Remote ID](./rid/README.md): ASTM F3411-19 - Remote ID and Tracking
+    - See [run_locally_rid.sh](run_locally_rid.sh)
 - [ASTM strategic coordination and UAS Flight Authorisation](./scd/README.md): ASTM WK63418 and U-Space Regulation
+    - See [run_locally_rid.sh](run_locally_scd.sh)


### PR DESCRIPTION
Currently, there are two forms of mock systems for testing the RID portion of uss_qualifier:
* mock_uss, which behaves similarly to a real USS including use of a DSS
* The uss_qualifier RID mock, which does not require a DSS

An important characteristic the RID portion of uss_qualifier currently lacks is the ability to determine which USS is likely the cause of an interoperability problem.  The reason that this is the case currently is that the RID portion of uss_qualifier relies solely on the injection and observation interfaces, and so only observes that an injected flight does not reach the observation interface -- it cannot determine whether the problem between the injection and observation was due to the Service Provider or the Display Provider.  If uss_qualifier first probed a Service Provider directly (acting as a Display Provider), it could determine whether the incorrect transmission of a particular injected flight to the observation interface was due to the Service Provider (in which case the problem would be observed when probing the Service Provider directly) or the Display Provider (in which case probing the Service Provider directly would yield no problems, but probing the observation interface would indicate a problem).

In order to add this feature to the RID portion of the uss_qualifier, the mock USS(s) must use the DSS.  Since the uss_qualifier RID mock does not use the DSS, we should remove that mock from the codebase as inferior to mock_uss.  The RID qualifier mock is slightly easier to use in that it does not require a DSS instance to run, but this is a negligible advantage when a local DSS instance can be deployed with a single command.  Meanwhile, maintaining two separate mock systems that accomplish the same goal requires a lot of development attention; it would be better to spend that attention refining and testing a single mock instead.

Before removing the uss_qualifier RID mock, we should transfer any capabilities it currently has but mock_uss does not currently have.  The main capability is misbehaviors: settings that can be changed to cause the mock to misbehave in various ways (which should be detected by automated tests).  This PR transfers that misbehavior capability, as well as some clustering code and a few other small things, to mock_uss.

Following this PR, I intend to remove the uss_qualifier RID mock in favor of mock_uss.