### PR TITLE
[deployment] Add the ability to specify custom Prometheus recording rules

### DIFF
--- a/build/deploy/metadata_base.libsonnet
+++ b/build/deploy/metadata_base.libsonnet
@@ -54,5 +54,6 @@
     whitelist_ip_ranges: error 'must specify whitelisted CIDR IP Blocks, or empty list for fully public access',
     retention: '15d',
     storage_size: '100Gi',
+    custom_rules: [],  // An array of Prometheus recording rules, each of which is an object with "record" and "expr" properties.
   },
 }

--- a/build/deploy/prometheus.libsonnet
+++ b/build/deploy/prometheus.libsonnet
@@ -16,6 +16,7 @@ local PrometheusConfig(metadata) = {
   },
   rule_files: [
     'aggregation.rules.yml',
+    'custom.rules.yml',
   ],
   scrape_configs: k8sEndpoints.scrape_configs + istioScrape.scrape_configs,
 };
@@ -94,6 +95,14 @@ local PrometheusExternalService(metadata) = base.Service(metadata, 'prometheus-e
       data: {
         'prometheus.yml': std.manifestYamlDoc(PrometheusConfig(metadata)),
         'aggregation.rules.yml': std.manifestYamlDoc(crdbAggregation),
+        'custom.rules.yml': std.manifestYamlDoc({
+          groups: [
+            {
+              name: 'rules/custom.rules',
+              rules: metadata.prometheus.custom_rules
+            },
+          ],
+        }),
       },
     },
     statefulset: base.StatefulSet(metadata, 'prometheus') {


### PR DESCRIPTION
Prometheus [recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) provide a way to  create new time series which contain the results of a query. By providing the ability to add rules from within the Jsonnet config, consumers can easily create custom queries in PromQL, which can then be queried from other tools (e.g. Google Cloud Monitoring for alerting on these queries crossing thresholds).