### PR TITLE
[docs] Add link to SCD test coverage document

### DIFF
--- a/interfaces/automated-testing/scd/design/README.md
+++ b/interfaces/automated-testing/scd/design/README.md
@@ -21,3 +21,9 @@ categories:
 
 * [ASTM strategic coordination](astm-strategic-coordination)
 * [U-space](u-space)
+
+## Coverage
+
+The following references analyze the tests coverage of the uss_qualifier automated testing suite:
+
+* [U-space: UAS Flight Authorisation](https://docs.google.com/spreadsheets/d/1IJkNS21Ps-2411LGhXBqWF7inQnPVeEA23dWjXpCR-M/edit?usp=sharing)

--- a/interfaces/automated-testing/scd/design/astm-strategic-coordination/README.md
+++ b/interfaces/automated-testing/scd/design/astm-strategic-coordination/README.md
@@ -7,3 +7,4 @@ authorisations.
 ## Tests
 
 * [Nominal planning](nominal-planning/README.md)
+* [Nominal planning with different priorities](nominal-planning-priority/README.md)


### PR DESCRIPTION
This PR adds a reference to the tests coverage analysis document.

Please note that the objective is to use the following link as a stable reference for document published by FOCA:
https://github.com/interuss/dss/tree/master/interfaces/automated-testing/scd/design#coverage

@BenjaminPelletier, feel free to suggest another location for this reference.