### PR TITLE
[deployment] Add the ability to specify custom Prometheus command-line arguments and scrape/evaluation intervals

### DIFF
--- a/build/deploy/metadata_base.libsonnet
+++ b/build/deploy/metadata_base.libsonnet
@@ -54,6 +54,9 @@
     whitelist_ip_ranges: error 'must specify whitelisted CIDR IP Blocks, or empty list for fully public access',
     retention: '15d',
     storage_size: '100Gi',
+    scrape_interval: '5s',
+    evaluation_interval: '5s',
     custom_rules: [],  // An array of Prometheus recording rules, each of which is an object with "record" and "expr" properties.
+    custom_args: [], // An array of strings to pass as commandline arguments to Prometheus.
   },
 }

--- a/build/deploy/prometheus.libsonnet
+++ b/build/deploy/prometheus.libsonnet
@@ -6,8 +6,8 @@ local crdbAggregation = import 'prometheus_configs/crdb-aggregation.libsonnet';
 
 local PrometheusConfig(metadata) = {
   global: {
-    scrape_interval: '5s',
-    evaluation_interval: '5s',
+    scrape_interval: metadata.prometheus.scrape_interval,
+    evaluation_interval: metadata.prometheus.evaluation_interval,
     // label for federated Prometheus.
     external_labels:{
       k8s_cluster: metadata.clusterName,
@@ -154,7 +154,7 @@ local PrometheusExternalService(metadata) = base.Service(metadata, 'prometheus-e
                   '--storage.tsdb.retention.time=' + metadata.prometheus.retention,
                   // following thanos recommendation
                   '--storage.tsdb.max-block-duration=2h',
-                ],
+                ] + metadata.prometheus.custom_args,
                 ports: [
                   {
                     containerPort: 9090,


### PR DESCRIPTION
The default scrape/evaluation intervals may result in more samples being recorded than desired. Command-line arguments can also be used to manipulate the volume of metrics down to a desirable size.

Here, we expose these parameters to the "metadata" object to allow consumers to safely specify these values (the alternative is the consumer extending the base config using Jsonnet's object orientation, however this is brittle in the presence of changes to the underlying object structure).