### PR TITLE
[docs] Add InterUSS logo to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # USS to USS Communication and Synchronization [![Build Status](https://dev.azure.com/astm/dss/_apis/build/status/interuss.dss?branchName=master)](https://dev.azure.com/astm/dss/_build/latest?definitionId=2&branchName=master) [![GoDoc](https://godoc.org/github.com/interuss/dss?status.svg)](https://godoc.org/github.com/interuss/dss)
 
+<img src="assets/color_logo_transparent.png" width="200">
+
 This repository contains the implementation of the Discovery and Synchronization Service (DSS) and a monitoring
 framework to test UAS Service Suppliers (USS). See the [InterUSS website](https://interuss.org) for background information.
 


### PR DESCRIPTION
This PR more clearly displays the InterUSS Platform logo on the main page of the DSS repo