### PR TITLE
[deployment] Update removed v1beta1 resource types to v1.

### DIFF
--- a/build/deploy/base.libsonnet
+++ b/build/deploy/base.libsonnet
@@ -8,13 +8,13 @@ local util = import 'util.libsonnet';
       name: name,
       namespace: metadata.namespace,
       clusterName: metadata.clusterName,
-      labels: { 
+      labels: {
         name: std.join('-', std.split(name, ':')),
       },
     },
   },
 
-  _RoleRelated(kind, metadata, name): $._Object('rbac.authorization.k8s.io/v1beta1', kind, metadata, name) {
+  _RoleRelated(kind, metadata, name): $._Object('rbac.authorization.k8s.io/v1', kind, metadata, name) {
     local rr = self,
     app:: "",
     metadata+: {
@@ -38,7 +38,7 @@ local util = import 'util.libsonnet';
     metadata+: {
       namespace: null,
     },
-  }, 
+  },
 
   Role(metadata, name): $._RoleRelated('Role', metadata, name) {
 
@@ -76,7 +76,7 @@ local util = import 'util.libsonnet';
 
   },
 
-  Ingress(metadata, name): $._Object('networking.k8s.io/v1beta1', 'Ingress', metadata, name) {
+  Ingress(metadata, name): $._Object('networking.k8s.io/v1', 'Ingress', metadata, name) {
 
   },
 

--- a/build/deploy/http-gateway.libsonnet
+++ b/build/deploy/http-gateway.libsonnet
@@ -8,9 +8,13 @@ local ingress(metadata) = base.Ingress(metadata, 'https-ingress') {
     },
   },
   spec: {
-    backend: {
-      serviceName: 'http-gateway',
-      servicePort: metadata.gateway.port,
+    defaultBackend: {
+      service: {
+        name: 'http-gateway',
+        port: {
+          number: metadata.gateway.port,
+        }
+      }
     },
   },
 };


### PR DESCRIPTION
With Kubernetes v1.22, some (deprecated) `v1beta1` resources we relied on were removed entirely, with the expectation to upgrade to `v1`. These were:

- [`Ingress`, with some minor changes to the config structure.](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)
- [`RBAC` resources, with no changes other than the version bump.](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122)
