### PR TITLE
[uss_qualifier/rid] Use injected flights from test response rather than from request

### DIFF
--- a/monitoring/uss_qualifier/rid/aircraft_state_replayer.py
+++ b/monitoring/uss_qualifier/rid/aircraft_state_replayer.py
@@ -131,7 +131,9 @@ class TestHarness:
         setup.injections.append(fetch.describe_query(response, initiated_at))
 
         if response.status_code == 200:
-            changed_test: ChangeTestResponse = ImplicitDict.parse(response.json(), ChangeTestResponse)
+            changed_test: ChangeTestResponse = ImplicitDict.parse(
+                response.json(), ChangeTestResponse
+            )
             print("New test with ID %s created" % test_id)
             return changed_test.injected_flights
         else:

--- a/monitoring/uss_qualifier/rid/aircraft_state_replayer.py
+++ b/monitoring/uss_qualifier/rid/aircraft_state_replayer.py
@@ -12,6 +12,7 @@ from monitoring.monitorlib.rid_automated_testing.injection_api import (
     TestFlight,
     CreateTestParameters,
     SCOPE_RID_QUALIFIER_INJECT,
+    ChangeTestResponse,
 )
 from monitoring.monitorlib.typing import ImplicitDict
 import arrow
@@ -120,18 +121,19 @@ class TestHarness:
 
     def submit_test(
         self, payload: CreateTestParameters, test_id: str, setup: reports.Setup
-    ) -> None:
+    ) -> List[TestFlight]:
         injection_path = "/tests/{}".format(test_id)
 
         initiated_at = datetime.datetime.utcnow()
         response = self.uss_session.put(
             url=injection_path, json=payload, scope=SCOPE_RID_QUALIFIER_INJECT
         )
-        # TODO: Use response to specify flights as actually-injected rather than assuming no modifications
         setup.injections.append(fetch.describe_query(response, initiated_at))
 
         if response.status_code == 200:
+            changed_test: ChangeTestResponse = ImplicitDict.parse(response.json(), ChangeTestResponse)
             print("New test with ID %s created" % test_id)
+            return changed_test.injected_flights
         else:
             raise RuntimeError(
                 "Error {} submitting test ID {} to {}: {}".format(

--- a/monitoring/uss_qualifier/rid/test_executor.py
+++ b/monitoring/uss_qualifier/rid/test_executor.py
@@ -70,7 +70,9 @@ def run_rid_tests(
         uss_injection_harness = TestHarness(
             auth_spec=auth_spec, injection_base_url=target.injection_base_url
         )
-        injections = uss_injection_harness.submit_test(test_payloads[i], test_id, report.setup)
+        injections = uss_injection_harness.submit_test(
+            test_payloads[i], test_id, report.setup
+        )
         for flight in injections:
             injected_flights.append(InjectedFlight(uss=target, flight=flight))
 

--- a/monitoring/uss_qualifier/rid/test_executor.py
+++ b/monitoring/uss_qualifier/rid/test_executor.py
@@ -70,8 +70,8 @@ def run_rid_tests(
         uss_injection_harness = TestHarness(
             auth_spec=auth_spec, injection_base_url=target.injection_base_url
         )
-        uss_injection_harness.submit_test(test_payloads[i], test_id, report.setup)
-        for flight in test_payloads[i].requested_flights:
+        injections = uss_injection_harness.submit_test(test_payloads[i], test_id, report.setup)
+        for flight in injections:
             injected_flights.append(InjectedFlight(uss=target, flight=flight))
 
     # Create observers


### PR DESCRIPTION
Currently, the `rid` module of `uss_qualifier` discards the response from the test injection rather than using the flights (as injected) in the response.  This PR fixes that issue.