### PR TITLE
[uss_qualifier/geo-awareness] Improve /check response in geo-awareness API

### DIFF
--- a/interfaces/automated-testing/geo-awareness/geo-awareness.yaml
+++ b/interfaces/automated-testing/geo-awareness/geo-awareness.yaml
@@ -212,8 +212,6 @@ components:
           format: date-time
         ed269:
           $ref: '#/components/schemas/ED269Filters'
-        flightPlanningEffect:
-          $ref: '#/components/schemas/FlightPlanningEffectFilter'
 
     ED269Filters:
       description: >-
@@ -231,31 +229,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Restriction'
-
-    FlightPlanningEffectFilter:
-      description: >-
-        Filter criteria for the selection of Geozones according to how the Geozones would affect the outcome of an attempt to plan a flight.
-      type: object
-      required:
-        - ruleSetName
-        - outcome
-      properties:
-        ruleSetName:
-          type: string
-          description: >-
-            Region-specific name of the set of operating rules under which an attempted flight would be planned.
-          example: Recreational
-        outcome:
-          type: string
-          description: >-
-            Only select Geozones which, if an attempt were made to plan a flight that intersected those Geozones under the operating rules specified by `ruleSetName`, would cause this outcome for the flight planning attempt.
-            
-            * Failure: The USSP would not allow the flight to be created/planned.
-            
-            * Advisory: The USSP would provide the operator with an advisory along with the planned flight if no other factor would cause the flight planning attempt to fail.
-          enum:
-          - Failure
-          - Advisory
 
     GeozonesCheckReply:
       type: object

--- a/interfaces/automated-testing/geo-awareness/geo-awareness.yaml
+++ b/interfaces/automated-testing/geo-awareness/geo-awareness.yaml
@@ -286,6 +286,7 @@ components:
           - Present
           - Absent
           - UnsupportedFilter
+          - Error
         message:
           type: string
           description: >-

--- a/interfaces/automated-testing/geo-awareness/geo-awareness.yaml
+++ b/interfaces/automated-testing/geo-awareness/geo-awareness.yaml
@@ -212,6 +212,8 @@ components:
           format: date-time
         ed269:
           $ref: '#/components/schemas/ED269Filters'
+        flightPlanningEffect:
+          $ref: '#/components/schemas/FlightPlanningEffectFilter'
 
     ED269Filters:
       description: >-
@@ -230,6 +232,31 @@ components:
           items:
             $ref: '#/components/schemas/Restriction'
 
+    FlightPlanningEffectFilter:
+      description: >-
+        Filter criteria for the selection of Geozones according to how the Geozones would affect the outcome of an attempt to plan a flight.
+      type: object
+      required:
+        - ruleSetName
+        - outcome
+      properties:
+        ruleSetName:
+          type: string
+          description: >-
+            Region-specific name of the set of operating rules under which an attempted flight would be planned.
+          example: Recreational
+        outcome:
+          type: string
+          description: >-
+            Only select Geozones which, if an attempt were made to plan a flight that intersected those Geozones under the operating rules specified by `ruleSetName`, would cause this outcome for the flight planning attempt.
+            
+            * Failure: The USSP would not allow the flight to be created/planned.
+            
+            * Advisory: The USSP would provide the operator with an advisory along with the planned flight if no other factor would cause the flight planning attempt to fail.
+          enum:
+          - Failure
+          - Advisory
+
     GeozonesCheckReply:
       type: object
       properties:
@@ -238,10 +265,33 @@ components:
             Responses to each of the `checks` in the request.  The number of entries in this array should match the number of entries in the `checks` field of the request.
           type: array
           items:
-            type: boolean
-            description: >-
-              True if and only if one or more applicable Geozones were selected according to the selection criteria of the corresponding check.
+            $ref: '#/components/schemas/GeozonesCheckResult'
           default: []
+
+    GeozonesCheckResult:
+      type: object
+      required:
+      - geozone
+      properties:
+        geozone:
+          type: string
+          description: >-
+            Indication of whether one or more applicable Geozones were selected according to the selection criteria of the corresponding check.
+            
+            * Present: One or more applicable Geozones were selected.
+            * Absent: No applicable Geozones were selected.
+            * UnsupportedFilter: Applicable Geozones could not be selected because one or more filter criteria are not supported by the USSP.  If this value is specified, `message` must be populated.
+            * Error: An error or condition not enumerated above occurred.  If this value is specified, `message` must be populated.
+          enum:
+          - Present
+          - Absent
+          - UnsupportedFilter
+        message:
+          type: string
+          description: >-
+            A human-readable description of why the non-standard `geozone` value was reported.  Should only be populated when appropriate according to the value of the `geozone` field.
+          example: >-
+            U-space flight authorisations are not blocked by the USSP according to geo-awareness data (GM1 Article 10 (7)).
 
 paths:
   /status:


### PR DESCRIPTION
This PR also improves on the GeozonesCheckResult (previously a simple boolean) by adding `UnsupportedFilter` and `Error` cases as well so that a USSP could return more granular and structured results rather than resorting to returning a 400 for the entire call.

Note: this PR previously made an additional change which is now *not* part of the PR.  That change was:

> This PR adds a filter to the geo-awareness automated testing API necessary to test geo-awareness capabilities in Australia where certain flight planning outcomes are expected on the basis of geo-awareness data.