### PR TITLE
[uss_qualifier] Implement resources, move RID injection targets to resources

### DIFF
--- a/monitoring/uss_qualifier/README.md
+++ b/monitoring/uss_qualifier/README.md
@@ -60,12 +60,4 @@ Note: We are currently in the process of migrating the technical implementation 
     * This means that a complete test configuration can't be tracked in the InterUSS repository because it wouldn't make sense to list, e.g., Display Provider observation endpoint URLs in the SUSI qual-partners environment.
     * Partial test configurations, including RID telemetry to inject, operational intents to inject, etc, can be tracked in the InterUSS repository, but they could not be used without specifying the missing resources describing systems under test.
 
-### Test resources
-
-1. A particular type of test resource must have a globally unique name.
-    * Example: `netrid.service_providers`, which would provide access to the RID injection API for each ASTM NetRID Service Provider under test.
-    * Example: `netrid.flight_data.nominal_flights`, which would provide flight data for nominal flights which could be injected into Service Providers under test.
-2. Every type of test resource must define a "resource specification", which is a serializable data type that fully defines how to create an instance of that resource type.
-3. Only one instance of a particular resource type may be specified in a single test configuration.
-    * The specification of a resource type in a test configuration is accomplished by providing an instance of the resource type's resource specification.
-4. Every type of test resource must define how to create an instance of the test resource from an instance of the resource specification.
+### [Test resources](resources/README.md)

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -35,12 +35,10 @@ def parseArgs() -> argparse.Namespace:
 def uss_test_executor(
     config, auth_spec, rid_flight_records=None, scd_test_definitions_path=None
 ) -> Dict[str, Dict[str, reports.Report]]:
+    resources = config.resources.create_resources()
+
     test_executor = {"rid": {}, "scd": {}}
     if "rid" in config:
-        print(
-            f"[RID] Configuration provided with {len(config.rid.injection_targets)} injection targets."
-        )
-        rid_test_executor.validate_configuration(config.rid)
         if not rid_flight_records:
             rid_flight_records = rid_test_executor.load_rid_test_definitions(
                 config.locale
@@ -48,6 +46,7 @@ def uss_test_executor(
         test_executor["rid"].update(
             {
                 "report": rid_test_executor.run_rid_tests(
+                    resources=resources,
                     test_configuration=config.rid,
                     auth_spec=auth_spec,
                     flight_records=rid_flight_records,

--- a/monitoring/uss_qualifier/resources/README.md
+++ b/monitoring/uss_qualifier/resources/README.md
@@ -1,0 +1,32 @@
+## Overview
+
+In order to execute a test scenario, it is normally necessary to provide configuration-specific resources that the scenario depends on.  This could include, for example:
+
+* The set of NetRID Service Providers under test in a particular environment
+* Flight data to be injected into the NetRID service providers, reflective of the jurisdiction in which the test is being conducted
+* Performance evaluation criteria defining what additional latency or other factors may be introduced by the test apparatus
+
+These things are provided to the test scenarios as resources via a named dependency injection framework described below.
+
+## Resource types
+
+A resource provider to a test scenario is an instance of a particular kind of resource.  This kind of resource is the "resource type", and resource types are implemented as subclasses of [the abstract `Resource` class](resource.py).  Therefore, a resource available to a test scenario will always be an instance of a subclass of `Resource`.
+
+### Creating a new resource type
+
+A new resource type is simply a Python subclass of [the abstract `Resource` class](resource.py).  It should be placed in the appropriate sub-module of the [`resources` module](.).  A requirement for any resource type is that the resource type must be constructable from 1) a specification for the resource and 2) any required dependencies (which must also be resources).
+
+## Using resources in a test scenario
+
+A test scenario requiring a resource should declare a named dependency on a resource of a particular type.  For example, the ASTM NetRID Nominal Behavior test scenario may declare that it has a `service_providers` dependency which must be satisfied with a `netrid.NetRIDServiceProviders` resource type.  The test scenario's configuration must specify the resource from the global resource pool (by specifying the globally-unique ID of the resource) that should be used to satisfy the test scenario's `service_providers` dependency.
+
+## Declaring resources
+
+Resources for a given test configuration are all declared in a single global resource collection, and then the resources generated from that collection are placed in a single global resource pool.  A resource from that pool may be referenced using its globally-unique (within the test configuration) identifier.  To declare a resource, a [`ResourceDeclaration`](resource.py) must be added to the test configuration's [`ResourceCollection`](resource.py).
+
+
+2. A particular instance of test resource must have a globally unique name.
+    * Example: `netrid.service_providers`, which would provide access to the RID injection API for each ASTM NetRID Service Provider under test.
+    * Example: `netrid.flight_data.nominal_flights`, which would provide flight data for nominal flights which could be injected into Service Providers under test.
+3. Every type of test resource must define a "resource specification", which is a serializable data type that fully defines how to create an instance of that resource type.
+4. Every type of test resource must define how to create an instance of the test resource from an instance of the resource specification.

--- a/monitoring/uss_qualifier/resources/__init__.py
+++ b/monitoring/uss_qualifier/resources/__init__.py
@@ -1,0 +1,1 @@
+from .resource import Resource, ResourceCollection

--- a/monitoring/uss_qualifier/resources/communications/__init__.py
+++ b/monitoring/uss_qualifier/resources/communications/__init__.py
@@ -1,0 +1,1 @@
+from .auth_adapter import AuthAdapter

--- a/monitoring/uss_qualifier/resources/communications/auth_adapter.py
+++ b/monitoring/uss_qualifier/resources/communications/auth_adapter.py
@@ -1,0 +1,43 @@
+import os
+from typing import Optional
+
+from implicitdict import ImplicitDict
+
+from monitoring.monitorlib.auth import make_auth_adapter
+from monitoring.monitorlib import infrastructure
+from monitoring.uss_qualifier.resources import Resource
+
+
+class AuthAdapterSpecification(ImplicitDict):
+    """Specification for an AuthAdapter resource.
+
+    Exactly one of the fields defined must be populated.
+    """
+
+    auth_spec: Optional[str]
+    """Literal representation of auth spec.  WARNING: Specifying this directly may cause sensitive information to be included in reports and unprotected configuration files."""
+
+    environment_variable_containing_auth_spec: Optional[str]
+    """Name of environment variable containing the auth spec.  This is the preferred method of providing the auth spec."""
+
+
+class AuthAdapter(Resource[AuthAdapterSpecification]):
+    adapter: infrastructure.AuthAdapter
+
+    def __init__(self, specification: AuthAdapterSpecification):
+        if specification.environment_variable_containing_auth_spec:
+            if (
+                specification.environment_variable_containing_auth_spec
+                not in os.environ
+            ):
+                raise ValueError(
+                    "Environment variable {} could not be found".format(
+                        specification.environment_variable_containing_auth_spec
+                    )
+                )
+            spec = os.environ[specification.environment_variable_containing_auth_spec]
+        elif specification.auth_spec:
+            spec = specification.auth_spec
+        else:
+            raise ValueError("No auth spec was declared")
+        self.adapter = make_auth_adapter(spec)

--- a/monitoring/uss_qualifier/resources/netrid/__init__.py
+++ b/monitoring/uss_qualifier/resources/netrid/__init__.py
@@ -1,0 +1,1 @@
+from .service_providers import NetRIDServiceProviders

--- a/monitoring/uss_qualifier/resources/netrid/service_providers.py
+++ b/monitoring/uss_qualifier/resources/netrid/service_providers.py
@@ -1,1 +1,98 @@
-# TODO: Migrate uss_qualifier/rid/utils.py::{InjectionTargetConfiguration,RIDQualifierTestConfiguration.injection_targets}, uss_qualifier/rid/aircraft_state_replayer.py::TestHarness here
+import datetime
+from typing import List
+from urllib.parse import urlparse
+
+from implicitdict import ImplicitDict
+
+from monitoring.monitorlib import fetch, infrastructure
+from monitoring.monitorlib.rid_automated_testing.injection_api import (
+    TestFlight,
+    CreateTestParameters,
+    SCOPE_RID_QUALIFIER_INJECT,
+    ChangeTestResponse,
+)
+from monitoring.uss_qualifier.resources import Resource
+from monitoring.uss_qualifier.resources.communications import AuthAdapter
+
+
+class ServiceProviderConfiguration(ImplicitDict):
+    name: str
+    """Name of the NetRID Service Provider into which test data can be injected"""
+
+    injection_base_url: str
+    """Base URL for the Service Provider's implementation of the interfaces/automated-testing/rid/injection.yaml API"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(**kwargs)
+        try:
+            urlparse(self.injection_base_url)
+        except ValueError:
+            raise ValueError(
+                "ServiceProviderConfiguration.injection_base_url must be a URL"
+            )
+
+
+class NetRIDServiceProvidersSpecification(ImplicitDict):
+    service_providers: List[ServiceProviderConfiguration]
+
+
+class NetRIDServiceProvider(object):
+    name: str
+    client: infrastructure.UTMClientSession
+
+    def __init__(
+        self, name: str, base_url: str, auth_adapter: infrastructure.AuthAdapter
+    ):
+        self.name = name
+        self._base_url = base_url
+        self.client = infrastructure.UTMClientSession(base_url, auth_adapter)
+
+    @property
+    def config(self) -> ServiceProviderConfiguration:
+        return ServiceProviderConfiguration(
+            name=self.name, injection_base_url=self._base_url
+        )
+
+    def submit_test(
+        self, payload: CreateTestParameters, test_id: str, setup
+    ) -> List[TestFlight]:
+        # Note: this method imported from uss_qualifier/rid/aircraft_state_replayer.py::TestHarness
+        # TODO: clean up according to new architecture and encapsulation models
+
+        injection_path = "/tests/{}".format(test_id)
+
+        initiated_at = datetime.datetime.utcnow()
+        response = self.client.put(
+            url=injection_path, json=payload, scope=SCOPE_RID_QUALIFIER_INJECT
+        )
+        setup.injections.append(fetch.describe_query(response, initiated_at))
+
+        if response.status_code == 200:
+            changed_test: ChangeTestResponse = ImplicitDict.parse(
+                response.json(), ChangeTestResponse
+            )
+            print("New test with ID %s created" % test_id)
+            return changed_test.injected_flights
+        else:
+            raise RuntimeError(
+                "Error {} submitting test ID {} to {}: {}".format(
+                    response.status_code,
+                    test_id,
+                    self._base_url,
+                    response.content.decode("utf-8"),
+                )
+            )
+
+
+class NetRIDServiceProviders(Resource[NetRIDServiceProvidersSpecification]):
+    service_providers: List[NetRIDServiceProvider]
+
+    def __init__(
+        self,
+        specification: NetRIDServiceProvidersSpecification,
+        auth_adapter: AuthAdapter,
+    ):
+        self.service_providers = [
+            NetRIDServiceProvider(s.name, s.injection_base_url, auth_adapter.adapter)
+            for s in specification.service_providers
+        ]

--- a/monitoring/uss_qualifier/resources/resource.py
+++ b/monitoring/uss_qualifier/resources/resource.py
@@ -1,0 +1,119 @@
+from abc import ABC, abstractmethod
+import inspect
+from typing import Dict, Generic, Type, TypeVar
+
+from implicitdict import ImplicitDict
+
+from monitoring.uss_qualifier import resources as resources_module
+
+
+SpecificationType = TypeVar("SpecificationType", bound=ImplicitDict)
+
+
+class Resource(ABC, Generic[SpecificationType]):
+    @abstractmethod
+    def __init__(self, specification: SpecificationType, **dependencies):
+        """Create an instance of the resource.
+
+        Concrete subclasses of Resource must implement their constructor according to this specification.
+
+        :param specification: A serializable (subclass of implicitdict.ImplicitDict) specification for how to create the resource.
+        :param dependencies: If this resource depends on any other resources, each of the other dependencies should be declared as an additional typed parameter to the constructor.  Each parameter type should be a class that is a subclass of Resource.
+        """
+        raise NotImplementedError(
+            "A concrete resource type must implement __init__ method"
+        )
+
+
+def _resource_type_from_string(type_name: str) -> Type:
+    resource_type = resources_module
+    for component in type_name.split("."):
+        if not hasattr(resource_type, component):
+            raise ValueError(
+                "Could not find {} defined in {} while trying to create resource type {}".format(
+                    component, resource_type.__name__, type_name
+                )
+            )
+        resource_type = getattr(resource_type, component)
+    if not issubclass(resource_type, Resource):
+        raise NotImplementedError(
+            "Resource type {} is not a subclass of the Resource base class".format(
+                resource_type
+            )
+        )
+    return resource_type
+
+
+class ResourceDeclaration(ImplicitDict):
+    resource_type: str
+    """Type of resource, expressed as a Python class name qualified relative to this `resources` module"""
+
+    dependencies: Dict[str, str] = {}
+    """Mapping of dependency parameter (additional argument to concrete resource constructor) to `name` of resource to use"""
+
+    specification: dict = {}
+    """Specification of resource; format is the SpecificationType that corresponds to the Resource `type`"""
+
+    def make_resource(self, resource_pool: Dict[str, Resource]) -> Resource:
+        resource_type = _resource_type_from_string(self.resource_type)
+
+        constructor_signature = inspect.signature(resource_type.__init__)
+        specification_type = None
+        constructor_args = {}
+        for arg_name, arg in constructor_signature.parameters.items():
+            if arg_name == "self":
+                continue
+            if arg_name == "specification":
+                specification_type = arg.annotation
+                continue
+            if arg_name not in self.dependencies:
+                raise ValueError(
+                    'Resource declaration for {} is missing a source for dependency "{}"'.format(
+                        self.resource_type, arg
+                    )
+                )
+            if self.dependencies[arg_name] not in resource_pool:
+                raise ValueError(
+                    'Resource "{}" was not found in the resource pool when trying to create resource "{}" ({})'.format(
+                        self.dependencies[arg], self.name, self.type
+                    )
+                )
+            constructor_args[arg_name] = resource_pool[self.dependencies[arg_name]]
+        if specification_type is not None:
+            constructor_args["specification"] = ImplicitDict.parse(
+                self.specification, specification_type
+            )
+
+        return resource_type(**constructor_args)
+
+
+class ResourceCollection(ImplicitDict):
+    resource_declarations: Dict[str, ResourceDeclaration]
+    """Mapping of globally (within resource collection) unique name identifying a resource to the declaration of that resource"""
+
+    def create_resources(self) -> Dict[str, Resource]:
+        resource_pool: Dict[str, Resource] = {}
+
+        resources_created = 1
+        while resources_created > 0:
+            resources_created = 0
+            for name, declaration in self.resource_declarations.items():
+                if name in resource_pool:
+                    continue
+                unmet_dependencies = sum(
+                    1 if d in resource_pool else 0 for d in declaration.dependencies
+                )
+                if unmet_dependencies == 0:
+                    resource_pool[name] = declaration.make_resource(resource_pool)
+
+        if len(resource_pool) != len(self.resource_declarations):
+            uncreated_resources = [
+                r for r in self.resource_declarations if r not in resource_pool
+            ]
+            raise ValueError(
+                "Could not create resources: {} (do you have circular dependencies?)".format(
+                    ", ".join(uncreated_resources)
+                )
+            )
+
+        return resource_pool

--- a/monitoring/uss_qualifier/rid/utils.py
+++ b/monitoring/uss_qualifier/rid/utils.py
@@ -5,15 +5,10 @@ from datetime import datetime
 from monitoring.monitorlib.rid_common import RIDVersion
 from monitoring.monitorlib.rid_automated_testing import injection_api
 from monitoring.monitorlib.rid import RIDAircraftState, RIDFlightDetails
+from monitoring.uss_qualifier.resources.netrid.service_providers import (
+    ServiceProviderConfiguration,
+)
 from implicitdict import ImplicitDict, StringBasedTimeDelta
-
-
-# TODO: This class is used in both RID and SCD; it should therefore be moved to a shared tools file rather than an RID utils file
-class InjectionTargetConfiguration(ImplicitDict):
-    """This object defines the data required for a uss"""
-
-    name: str
-    injection_base_url: str
 
 
 class ObserverConfiguration(ImplicitDict):
@@ -36,9 +31,6 @@ class EvaluationConfiguration(ImplicitDict):
 
 
 class RIDQualifierTestConfiguration(ImplicitDict):
-    injection_targets: List[InjectionTargetConfiguration]
-    """Set of Service Providers into which data should be injected"""
-
     observers: List[ObserverConfiguration]
     """Set of Display Providers through with the system should be observed"""
 
@@ -93,5 +85,5 @@ class FullFlightRecord(ImplicitDict):
 
 
 class InjectedFlight(ImplicitDict):
-    uss: InjectionTargetConfiguration
+    uss: ServiceProviderConfiguration
     flight: injection_api.TestFlight

--- a/monitoring/uss_qualifier/run_locally_rid.sh
+++ b/monitoring/uss_qualifier/run_locally_rid.sh
@@ -24,18 +24,37 @@ monitoring/build.sh || exit 1
 CONFIG_LOCATION="monitoring/uss_qualifier/config_run_locally_rid.json"
 CONFIG='--config config_run_locally_rid.json'
 
-AUTH='--auth DummyOAuth(http://host.docker.internal:8085/token,uss_qualifier)'
+AUTH_SPEC='DummyOAuth(http://host.docker.internal:8085/token,uss_qualifier)'
+AUTH_FLAG="--auth ${AUTH_SPEC}"
 
 echo '{
     "locale": "CHE",
+    "resources": {
+      "resource_declarations": {
+        "utm_auth": {
+          "resource_type": "communications.AuthAdapter",
+          "specification": {
+            "environment_variable_containing_auth_spec": "AUTH_SPEC"
+          }
+        },
+        "netrid_service_providers": {
+          "resource_type": "netrid.NetRIDServiceProviders",
+          "dependencies": {
+            "auth_adapter": "utm_auth"
+          },
+          "specification": {
+            "service_providers": [
+              {
+                "name": "uss1",
+                "injection_base_url": "http://host.docker.internal:8071/ridsp/injection"
+              }
+            ]
+          }
+        }
+      }
+    },
     "rid": {
       "rid_version": "F3411-19",
-      "injection_targets": [
-        {
-          "name": "uss1",
-          "injection_base_url": "http://host.docker.internal:8071/ridsp/injection"
-        }
-      ],
       "observers": [
         {
           "name": "uss2",
@@ -45,7 +64,7 @@ echo '{
     }
 }' > ${CONFIG_LOCATION}
 
-QUALIFIER_OPTIONS="$AUTH $CONFIG"
+QUALIFIER_OPTIONS="$AUTH_FLAG $CONFIG"
 
 REPORT_FILE="$(pwd)/monitoring/uss_qualifier/report_rid.json"
 # Report file must already exist to share correctly with the Docker container
@@ -62,6 +81,7 @@ docker run ${docker_args} --name uss_qualifier \
   --rm \
   -e QUALIFIER_OPTIONS="${QUALIFIER_OPTIONS}" \
   -e PYTHONBUFFERED=1 \
+  -e AUTH_SPEC=${AUTH_SPEC} \
   -v "${REPORT_FILE}:/app/monitoring/uss_qualifier/report_rid.json" \
   -v "$(pwd):/app" \
   -w /app/monitoring/uss_qualifier \

--- a/monitoring/uss_qualifier/run_locally_scd.sh
+++ b/monitoring/uss_qualifier/run_locally_scd.sh
@@ -27,6 +27,10 @@ AUTH='--auth DummyOAuth(http://host.docker.internal:8085/token,uss_qualifier)'
 
 echo '{
     "locale": "CHE",
+    "resources": {
+          "resource_declarations": {
+          }
+    },
     "scd": {
         "injection_targets": [
             {

--- a/monitoring/uss_qualifier/scd/configuration.py
+++ b/monitoring/uss_qualifier/scd/configuration.py
@@ -1,7 +1,13 @@
 from typing import List, Optional
 
 from implicitdict import ImplicitDict
-from monitoring.uss_qualifier.rid.utils import InjectionTargetConfiguration
+
+
+class InjectionTargetConfiguration(ImplicitDict):
+    """This object defines the data required for a uss"""
+
+    name: str
+    injection_base_url: str
 
 
 class SCDQualifierTestConfiguration(ImplicitDict):

--- a/monitoring/uss_qualifier/scd/data_interfaces.py
+++ b/monitoring/uss_qualifier/scd/data_interfaces.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-from enum import Enum
 from typing import Optional, List, Dict
 from monitoring.monitorlib.locality import Locality
 from implicitdict import (

--- a/monitoring/uss_qualifier/scd/executor/executor.py
+++ b/monitoring/uss_qualifier/scd/executor/executor.py
@@ -7,8 +7,10 @@ from typing import Dict, List
 
 from monitoring.monitorlib.locality import Locality
 from implicitdict import ImplicitDict
-from monitoring.uss_qualifier.rid.utils import InjectionTargetConfiguration
-from monitoring.uss_qualifier.scd.configuration import SCDQualifierTestConfiguration
+from monitoring.uss_qualifier.scd.configuration import (
+    SCDQualifierTestConfiguration,
+    InjectionTargetConfiguration,
+)
 from monitoring.uss_qualifier.scd.data_interfaces import (
     AutomatedTest,
     TestStep,

--- a/monitoring/uss_qualifier/scd/executor/target.py
+++ b/monitoring/uss_qualifier/scd/executor/target.py
@@ -14,7 +14,7 @@ from monitoring.monitorlib.scd_automated_testing.scd_injection_api import (
     InjectFlightResponse,
     DeleteFlightResponse,
 )
-from monitoring.uss_qualifier.rid.utils import InjectionTargetConfiguration
+from monitoring.uss_qualifier.scd.configuration import InjectionTargetConfiguration
 from monitoring.uss_qualifier.scd.data_interfaces import FlightInjectionAttempt
 
 

--- a/monitoring/uss_qualifier/scd/executor/test_executor.py
+++ b/monitoring/uss_qualifier/scd/executor/test_executor.py
@@ -2,7 +2,7 @@ from monitoring.monitorlib.scd_automated_testing.scd_injection_api import (
     InjectFlightRequest,
     InjectFlightResult,
 )
-from monitoring.uss_qualifier.rid.utils import InjectionTargetConfiguration
+from monitoring.uss_qualifier.scd.configuration import InjectionTargetConfiguration
 from monitoring.uss_qualifier.scd.data_interfaces import (
     AutomatedTest,
     TestStep,

--- a/monitoring/uss_qualifier/utils.py
+++ b/monitoring/uss_qualifier/utils.py
@@ -2,6 +2,8 @@ from typing import Optional
 from urllib.parse import urlparse
 
 from implicitdict import ImplicitDict
+
+from monitoring.uss_qualifier.resources import ResourceCollection
 from monitoring.uss_qualifier.rid.utils import RIDQualifierTestConfiguration
 from monitoring.uss_qualifier.scd.configuration import SCDQualifierTestConfiguration
 
@@ -18,6 +20,9 @@ class USSQualifierTestConfiguration(ImplicitDict):
 
     scd: Optional[SCDQualifierTestConfiguration]
     """Test configuration for SCD"""
+
+    resources: Optional[ResourceCollection]
+    """Declarations for resources used by the test suite"""
 
 
 def is_url(url_string):


### PR DESCRIPTION
This PR establishes an implementation framework for test resources (along with documentation in uss_qualifier/resources/README.md) and moves RID's "injection targets" from the "RID configuration" into this resources framework.  Future PRs will move all or nearly all of the RID configuration data structure into resource specifications in a similar way.