### PR TITLE
[uss_qualifier/rid] Move RID observers and evaluation configuration to resources

### DIFF
--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -48,7 +48,6 @@ def uss_test_executor(
                 "report": rid_test_executor.run_rid_tests(
                     resources=resources,
                     test_configuration=config.rid,
-                    auth_spec=auth_spec,
                     flight_records=rid_flight_records,
                 )
             }

--- a/monitoring/uss_qualifier/resources/netrid/__init__.py
+++ b/monitoring/uss_qualifier/resources/netrid/__init__.py
@@ -1,1 +1,2 @@
 from .service_providers import NetRIDServiceProviders
+from .observers import NetRIDObserversResource

--- a/monitoring/uss_qualifier/resources/netrid/__init__.py
+++ b/monitoring/uss_qualifier/resources/netrid/__init__.py
@@ -1,2 +1,3 @@
 from .service_providers import NetRIDServiceProviders
 from .observers import NetRIDObserversResource
+from .evaluation import EvaluationConfigurationResource

--- a/monitoring/uss_qualifier/resources/netrid/evaluation.py
+++ b/monitoring/uss_qualifier/resources/netrid/evaluation.py
@@ -1,1 +1,24 @@
-# TODO: Migrate uss_qualifier/rid/utils.py::EvaluationConfiguration, uss_qualifier/rid/display_data_evaluator.py::RIDSystemObserver here
+from implicitdict import ImplicitDict, StringBasedTimeDelta
+
+from monitoring.uss_qualifier.resources import Resource
+
+
+class EvaluationConfiguration(ImplicitDict):
+    min_polling_interval: StringBasedTimeDelta = StringBasedTimeDelta("5s")
+    """Do not repeat system observations with intervals smaller than this."""
+
+    max_propagation_latency: StringBasedTimeDelta = StringBasedTimeDelta("10s")
+    """Allow up to this much time for data to propagate through the system."""
+
+    min_query_diagonal: float = 100
+    """Do not make queries with diagonals smaller than this many meters."""
+
+    repeat_query_rect_period: int = 3
+    """If set to a value above zero, reuse the most recent query rectangle/view every this many queries."""
+
+
+class EvaluationConfigurationResource(Resource[EvaluationConfiguration]):
+    configuration: EvaluationConfiguration
+
+    def __init__(self, specification: EvaluationConfiguration):
+        self.configuration = specification

--- a/monitoring/uss_qualifier/resources/netrid/observers.py
+++ b/monitoring/uss_qualifier/resources/netrid/observers.py
@@ -1,1 +1,88 @@
-# TODO: Migrate uss_qualifier/rid/utils.py::{ObserverConfiguration,RIDQualifierTestConfiguration.observers}, uss_qualifier/rid/display_data_evaluator.py::RIDSystemObserver here
+import datetime
+from typing import List, Optional, Tuple
+
+import s2sphere
+from implicitdict import ImplicitDict
+
+from monitoring.monitorlib import fetch, infrastructure
+from monitoring.monitorlib.infrastructure import UTMClientSession
+from monitoring.monitorlib.rid_common import RIDVersion
+from monitoring.monitorlib.rid_automated_testing import observation_api
+from monitoring.uss_qualifier.resources import Resource
+from monitoring.uss_qualifier.resources.communications import AuthAdapter
+
+
+class RIDSystemObserver(object):
+    def __init__(
+        self, name: str, base_url: str, auth_adapter: infrastructure.AuthAdapter
+    ):
+        self.session = UTMClientSession(base_url, auth_adapter)
+        self.name = name
+
+        # TODO: Change observation API to use an InterUSS scope rather than re-using an ASTM scope
+        self.rid_version = RIDVersion.f3411_19
+
+    def observe_system(
+        self, rect: s2sphere.LatLngRect
+    ) -> Tuple[Optional[observation_api.GetDisplayDataResponse], fetch.Query]:
+        initiated_at = datetime.datetime.utcnow()
+        resp = self.session.get(
+            "/display_data?view={},{},{},{}".format(
+                rect.lo().lat().degrees,
+                rect.lo().lng().degrees,
+                rect.hi().lat().degrees,
+                rect.hi().lng().degrees,
+            ),
+            scope=self.rid_version.read_scope,
+        )
+        try:
+            result = (
+                ImplicitDict.parse(resp.json(), observation_api.GetDisplayDataResponse)
+                if resp.status_code == 200
+                else None
+            )
+        except ValueError as e:
+            print("Error parsing observation response: {}".format(e))
+            result = None
+        return (result, fetch.describe_query(resp, initiated_at))
+
+    def observe_flight_details(
+        self, flight_id: str
+    ) -> Tuple[Optional[observation_api.GetDetailsResponse], fetch.Query]:
+        initiated_at = datetime.datetime.utcnow()
+        resp = self.session.get("/display_data/{}".format(flight_id))
+        try:
+            result = (
+                ImplicitDict.parse(resp.json(), observation_api.GetDetailsResponse)
+                if resp.status_code == 200
+                else None
+            )
+        except ValueError:
+            result = None
+        return (result, fetch.describe_query(resp, initiated_at))
+
+
+class ObserverConfiguration(ImplicitDict):
+    name: str
+    """Name of the NetRID Service Provider into which test data can be injected"""
+
+    observation_base_url: str
+    """Base URL for the observer's implementation of the interfaces/automated-testing/rid/observation.yaml API"""
+
+
+class NetRIDObserversSpecification(ImplicitDict):
+    observers: List[ObserverConfiguration]
+
+
+class NetRIDObserversResource(Resource[NetRIDObserversSpecification]):
+    observers: List[RIDSystemObserver]
+
+    def __init__(
+        self,
+        specification: NetRIDObserversSpecification,
+        auth_adapter: AuthAdapter,
+    ):
+        self.observers = [
+            RIDSystemObserver(o.name, o.observation_base_url, auth_adapter.adapter)
+            for o in specification.observers
+        ]

--- a/monitoring/uss_qualifier/rid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/rid/display_data_evaluator.py
@@ -9,11 +9,9 @@ import s2sphere
 from monitoring.monitorlib import fetch, geo
 from monitoring.monitorlib.rid_common import RIDVersion
 from monitoring.uss_qualifier.rid.reports import Findings
+from monitoring.uss_qualifier.resources.netrid.evaluation import EvaluationConfiguration
 from monitoring.uss_qualifier.resources.netrid.observers import RIDSystemObserver
-from monitoring.uss_qualifier.rid.utils import (
-    EvaluationConfiguration,
-    InjectedFlight,
-)
+from monitoring.uss_qualifier.rid.utils import InjectedFlight
 from monitoring.monitorlib.rid_automated_testing import observation_api
 
 

--- a/monitoring/uss_qualifier/rid/display_data_evaluator.py
+++ b/monitoring/uss_qualifier/rid/display_data_evaluator.py
@@ -1,67 +1,20 @@
 import datetime
 import json
 import time
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import arrow
 import s2sphere
 
 from monitoring.monitorlib import fetch, geo
-from monitoring.monitorlib.infrastructure import UTMClientSession
 from monitoring.monitorlib.rid_common import RIDVersion
-from implicitdict import ImplicitDict
 from monitoring.uss_qualifier.rid.reports import Findings
+from monitoring.uss_qualifier.resources.netrid.observers import RIDSystemObserver
 from monitoring.uss_qualifier.rid.utils import (
     EvaluationConfiguration,
     InjectedFlight,
 )
 from monitoring.monitorlib.rid_automated_testing import observation_api
-
-
-class RIDSystemObserver(object):
-    def __init__(self, name: str, session: UTMClientSession, rid_version: RIDVersion):
-        self.session = session
-        self.name = name
-        self.rid_version = rid_version
-
-    def observe_system(
-        self, rect: s2sphere.LatLngRect
-    ) -> Tuple[Optional[observation_api.GetDisplayDataResponse], fetch.Query]:
-        initiated_at = datetime.datetime.utcnow()
-        resp = self.session.get(
-            "/display_data?view={},{},{},{}".format(
-                rect.lo().lat().degrees,
-                rect.lo().lng().degrees,
-                rect.hi().lat().degrees,
-                rect.hi().lng().degrees,
-            ),
-            scope=self.rid_version.read_scope,
-        )
-        try:
-            result = (
-                ImplicitDict.parse(resp.json(), observation_api.GetDisplayDataResponse)
-                if resp.status_code == 200
-                else None
-            )
-        except ValueError as e:
-            print("Error parsing observation response: {}".format(e))
-            result = None
-        return (result, fetch.describe_query(resp, initiated_at))
-
-    def observe_flight_details(
-        self, flight_id: str
-    ) -> Tuple[Optional[observation_api.GetDetailsResponse], fetch.Query]:
-        initiated_at = datetime.datetime.utcnow()
-        resp = self.session.get("/display_data/{}".format(flight_id))
-        try:
-            result = (
-                ImplicitDict.parse(resp.json(), observation_api.GetDetailsResponse)
-                if resp.status_code == 200
-                else None
-            )
-        except ValueError:
-            result = None
-        return (result, fetch.describe_query(resp, initiated_at))
 
 
 class RIDObservationEvaluator(object):

--- a/monitoring/uss_qualifier/rid/test_executor.py
+++ b/monitoring/uss_qualifier/rid/test_executor.py
@@ -7,7 +7,10 @@ from typing import List
 from monitoring.monitorlib.auth import make_auth_adapter
 from monitoring.monitorlib.infrastructure import UTMClientSession
 from monitoring.uss_qualifier.resources import ResourceCollection
-from monitoring.uss_qualifier.resources.netrid import NetRIDServiceProviders
+from monitoring.uss_qualifier.resources.netrid import (
+    NetRIDServiceProviders,
+    NetRIDObserversResource,
+)
 from monitoring.uss_qualifier.rid import (
     display_data_evaluator,
     reports,
@@ -68,16 +71,8 @@ def run_rid_tests(
             injected_flights.append(InjectedFlight(uss=target.config, flight=flight))
 
     # Create observers
-    observers: List[display_data_evaluator.RIDSystemObserver] = []
-    for observer_config in test_configuration.observers:
-        observer = display_data_evaluator.RIDSystemObserver(
-            observer_config.name,
-            UTMClientSession(
-                observer_config.observation_base_url, make_auth_adapter(auth_spec)
-            ),
-            test_configuration.rid_version,
-        )
-        observers.append(observer)
+    # TODO: Replace magic string 'netrid_observers' with dependency explicitly declared by the test scenario/case/step
+    observers: NetRIDObserversResource = resources["netrid_observers"]
 
     # Evaluate observed RID system states
     evaluator = display_data_evaluator.RIDObservationEvaluator(
@@ -86,7 +81,7 @@ def run_rid_tests(
         test_configuration.evaluation,
         test_configuration.rid_version,
     )
-    evaluator.evaluate_system(observers)
+    evaluator.evaluate_system(observers.observers)
     with open("report_rid.json", "w") as f:
         json.dump(report, f)
     return report

--- a/monitoring/uss_qualifier/rid/test_executor.py
+++ b/monitoring/uss_qualifier/rid/test_executor.py
@@ -51,7 +51,6 @@ def load_rid_test_definitions(locale: str):
 def run_rid_tests(
     resources: ResourceCollection,
     test_configuration: RIDQualifierTestConfiguration,
-    auth_spec: str,
     flight_records: List[FullFlightRecord],
 ) -> reports.Report:
     my_test_builder = TestBuilder(
@@ -78,7 +77,8 @@ def run_rid_tests(
     evaluator = display_data_evaluator.RIDObservationEvaluator(
         report.findings,
         injected_flights,
-        test_configuration.evaluation,
+        # TODO: Replace magic string 'netrid_observation_evaluation_configuration' with dependency explicitly declared by the test scenario/case/step
+        resources["netrid_observation_evaluation_configuration"].configuration,
         test_configuration.rid_version,
     )
     evaluator.evaluate_system(observers.observers)

--- a/monitoring/uss_qualifier/rid/utils.py
+++ b/monitoring/uss_qualifier/rid/utils.py
@@ -11,26 +11,9 @@ from monitoring.uss_qualifier.resources.netrid.service_providers import (
 from implicitdict import ImplicitDict, StringBasedTimeDelta
 
 
-class EvaluationConfiguration(ImplicitDict):
-    min_polling_interval: StringBasedTimeDelta = StringBasedTimeDelta("5s")
-    """Do not repeat system observations with intervals smaller than this."""
-
-    max_propagation_latency: StringBasedTimeDelta = StringBasedTimeDelta("10s")
-    """Allow up to this much time for data to propagate through the system."""
-
-    min_query_diagonal: float = 100
-    """Do not make queries with diagonals smaller than this many meters."""
-
-    repeat_query_rect_period: int = 3
-    """If set to a value above zero, reuse the most recent query rectangle/view every this many queries."""
-
-
 class RIDQualifierTestConfiguration(ImplicitDict):
     flight_start_delay: StringBasedTimeDelta = StringBasedTimeDelta("15s")
     """Amount of time between starting the test and commencement of flights"""
-
-    evaluation: EvaluationConfiguration = EvaluationConfiguration()
-    """Settings to control behavior when evaluating observed system data"""
 
     rid_version: RIDVersion
     """Version of remote ID API/standard to use"""

--- a/monitoring/uss_qualifier/rid/utils.py
+++ b/monitoring/uss_qualifier/rid/utils.py
@@ -11,11 +11,6 @@ from monitoring.uss_qualifier.resources.netrid.service_providers import (
 from implicitdict import ImplicitDict, StringBasedTimeDelta
 
 
-class ObserverConfiguration(ImplicitDict):
-    name: str
-    observation_base_url: str
-
-
 class EvaluationConfiguration(ImplicitDict):
     min_polling_interval: StringBasedTimeDelta = StringBasedTimeDelta("5s")
     """Do not repeat system observations with intervals smaller than this."""
@@ -31,9 +26,6 @@ class EvaluationConfiguration(ImplicitDict):
 
 
 class RIDQualifierTestConfiguration(ImplicitDict):
-    observers: List[ObserverConfiguration]
-    """Set of Display Providers through with the system should be observed"""
-
     flight_start_delay: StringBasedTimeDelta = StringBasedTimeDelta("15s")
     """Amount of time between starting the test and commencement of flights"""
 

--- a/monitoring/uss_qualifier/run_locally_rid.sh
+++ b/monitoring/uss_qualifier/run_locally_rid.sh
@@ -50,17 +50,25 @@ echo '{
               }
             ]
           }
+        },
+        "netrid_observers": {
+          "resource_type": "netrid.NetRIDObserversResource",
+          "dependencies": {
+            "auth_adapter": "utm_auth"
+          },
+          "specification": {
+            "observers": [
+              {
+                "name": "uss2",
+                "observation_base_url": "http://host.docker.internal:8073/riddp/observation"
+              }
+            ]
+          }
         }
       }
     },
     "rid": {
-      "rid_version": "F3411-19",
-      "observers": [
-        {
-          "name": "uss2",
-          "observation_base_url": "http://host.docker.internal:8073/riddp/observation"
-        }
-      ]
+      "rid_version": "F3411-19"
     }
 }' > ${CONFIG_LOCATION}
 

--- a/monitoring/uss_qualifier/run_locally_rid.sh
+++ b/monitoring/uss_qualifier/run_locally_rid.sh
@@ -64,6 +64,10 @@ echo '{
               }
             ]
           }
+        },
+        "netrid_observation_evaluation_configuration": {
+          "resource_type": "netrid.EvaluationConfigurationResource",
+          "specification": {}
         }
       }
     },


### PR DESCRIPTION
This PR follows #825 by moving RID observers and observation evaluation configuration into resource objects as well.