### PR TITLE
[uss_qualifier] Add strict scenario documentation

### DIFF
--- a/monitoring/monitorlib/inspection.py
+++ b/monitoring/monitorlib/inspection.py
@@ -31,6 +31,6 @@ def get_module_object_by_name(parent_module, object_name: str):
 
 def fullname(class_type: Type) -> str:
     module = class_type.__module__
-    if module == 'builtins':
+    if module == "builtins":
         return class_type.__qualname__  # avoid outputs like 'builtins.str'
-    return module + '.' + class_type.__qualname__
+    return module + "." + class_type.__qualname__

--- a/monitoring/monitorlib/inspection.py
+++ b/monitoring/monitorlib/inspection.py
@@ -27,3 +27,10 @@ def get_module_object_by_name(parent_module, object_name: str):
             )
         module_object = getattr(module_object, component)
     return module_object
+
+
+def fullname(class_type: Type) -> str:
+    module = class_type.__module__
+    if module == 'builtins':
+        return class_type.__qualname__  # avoid outputs like 'builtins.str'
+    return module + '.' + class_type.__qualname__

--- a/monitoring/uss_qualifier/Makefile
+++ b/monitoring/uss_qualifier/Makefile
@@ -1,6 +1,10 @@
 .PHONY: test
-test: lint
+test: validate_documentation lint
 	./scripts/test_docker_fully_mocked.sh
+
+.PHONY: validate_documentation
+validate_documentation:
+	./scripts/validate_test_definitions.sh
 
 .PHONY: lint
 lint:

--- a/monitoring/uss_qualifier/README.md
+++ b/monitoring/uss_qualifier/README.md
@@ -15,16 +15,7 @@ Note: We are currently in the process of migrating the technical implementation 
 2. A test suite is composed of a list of {test suite|test scenario}.
     * Each element on the list is executed sequentially.
 
-### Test scenarios
-
-1. A test scenario is a logical, self-contained scenario designed to test specific sets of functionality of the systems under test.
-    * The activities in a test scenario should read like a narrative of a simple play with a single plot.
-2. A test scenario is composed of a list of test cases.
-    * Each test case on the list is executed sequentially.
-3. Test scenarios will usually be enumerated/identified/created by mapping a list of requirements onto a set of test scenarios (e.g., [NetRID](https://docs.google.com/spreadsheets/d/1YByckmK6hfMrGec53CxRM2BPvcgm6HQNoFxOrOEfrUQ/edit#gid=0), [Flight Authorisation](https://docs.google.com/spreadsheets/d/1IJkNS21Ps-2411LGhXBqWF7inQnPVeEA23dWjXpCR-M/edit#gid=0), [ED-269](https://docs.google.com/spreadsheets/d/1NIlRHtWzBXOyJ58pYimhDQDqsEyToTQRu2ma3AYXWEU/edit))
-    * While unmapped requirements still exist: create new, simple test scenario that verifies a set of remaining unmapped requirements.
-4. Most test scenarios will require test resources (like NetRID telemetry to inject, NetRID service providers under test, etc) customized to the ecosystem in which the tests are being performed; see [Test definitions](#test-definitions) below
-    * A test scenario declares what kind of resource(s) it requires.
+### [Test scenarios](scenarios/README.md)
 
 ### Test cases
 
@@ -37,7 +28,7 @@ Note: We are currently in the process of migrating the technical implementation 
 
 ### Test steps
 
-1. A test step is a single low-level task that must be performed in order to accomplish its associated test case.
+1. A test step is a single task that must be performed in order to accomplish its associated test case.
    * Test steps are like scenes in the "play/act" of the test scenario/test case they are a part of.
 2. A given test step belongs to exactly one test case.
 3. A test step may have a list of checks associated with it.

--- a/monitoring/uss_qualifier/requirements.txt
+++ b/monitoring/uss_qualifier/requirements.txt
@@ -1,5 +1,5 @@
 pyproj==3.0.0
-arrow==1.1.0
 faker===8.1.0
 geojson===2.5.0
+marko==1.2.2
 -r ../monitorlib/requirements.txt

--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -1,0 +1,58 @@
+# Test scenarios
+
+## Definition
+
+A test scenario is a logical, self-contained scenario designed to test specific sets of functionality of the systems under test.  The activities in a test scenario should read like a narrative of a simple play with a single plot.
+
+## Structure
+
+A test scenario is separated into of a list of test cases.  Each test case on the list is executed sequentially.  A test case is like an act in a play.
+
+## Creation
+
+Test scenarios will usually be enumerated/identified/created by mapping a list of requirements onto a set of test scenarios (e.g., [NetRID](https://docs.google.com/spreadsheets/d/1YByckmK6hfMrGec53CxRM2BPvcgm6HQNoFxOrOEfrUQ/edit#gid=0), [Flight Authorisation](https://docs.google.com/spreadsheets/d/1IJkNS21Ps-2411LGhXBqWF7inQnPVeEA23dWjXpCR-M/edit#gid=0), [ED-269](https://docs.google.com/spreadsheets/d/1NIlRHtWzBXOyJ58pYimhDQDqsEyToTQRu2ma3AYXWEU/edit)).  To form a complete set of scenarios to cover a set of requirements, While unmapped requirements still exist: create new, simple test scenario that verifies a set of remaining unmapped requirements.
+
+## Resources
+
+Most test scenarios will require [test resources](../resources/README.md) (like NetRID telemetry to inject, NetRID service providers under test, etc) usually customized to the ecosystem in which the tests are being performed.  A test scenario declares what kind of resource(s) it requires, and a test suite identifies which available resources should be used to fulfill each test scenario's needs.
+
+## Documentation
+
+Traceability between requirements and test activities is of the utmost importance in automated testing.  As such, every test scenario must be documented, and that documentation must follow a precise format.  Conformance to this format is [checked by an automated test](../scripts/validate_test_definitions.sh) before changes to test scenarios or their documentation can be submitted to this repository.
+
+Documentation requirements include:
+
+### Documentation location
+
+The documentation must be located in a .md file with the same name as the Python file that defines the `TestScenario`.  For instance, if a `NominalBehavior` class inherited from `TestScenario` and was defined in nominal_behavior.py, then documentation for `NominalBehavior` would be expected in nominal_behavior.md located in the same folder as nominal_behavior.py.
+
+### Scenario name
+
+The first line of the documentation file must be a top-level section header with the name of the test scenario ending in " test scenario".  Example: `# ASTM NetRID nominal behavior test scenario`
+
+### Resources
+
+A main section in the documentation must be named "Resources" (example: `## Resources`).  This section must have a subsection for each resource required by the test scenario, and each of these sections must be named according to the parameter in the `TestScenario` subclass's constructor for that resource.  For example, if a test scenario were defined as:
+
+```python
+class NominalBehavior(TestScenario):
+    def __init__(self, flights_data: FlightDataResource,
+                 service_providers: NetRIDServiceProviders:
+        ...
+```
+
+...then the Resources section (`# Resources`) of the documentation would be expected to have two subsections: one for `flights_data` (`## flights_data`) and one for `service_providers` (`## service_providers`).  These sections should generally explain the purpose, use, expectations, and/or requirements for the resources.
+
+### Test cases
+
+A scenario must document at least one test case (otherwise the scenario is doing nothing).  Each test case must be documented via a main section in the documentation named with a " test case" suffix (example: `## Nominal flight test case`).
+
+### Test steps
+
+Each test case in the documentation must document at least one test step (otherwise nothing is happening in the test case).  Each test step must be documented via a subsection of the parent test case named with a " test step" suffix (example: `### Injection test step`).
+
+### Test checks
+
+Each check a test step performs that may result in a finding/issue must be documented via a subsection of the parent test step, named with a " check" suffix (example: `#### Successful injection check`).
+
+A check should document the requirement(s) violated if the check fails.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**ASTM F3411-19::NET0420`).

--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -10,7 +10,10 @@ A test scenario is separated into of a list of test cases.  Each test case on th
 
 ## Creation
 
-Test scenarios will usually be enumerated/identified/created by mapping a list of requirements onto a set of test scenarios (e.g., [NetRID](https://docs.google.com/spreadsheets/d/1YByckmK6hfMrGec53CxRM2BPvcgm6HQNoFxOrOEfrUQ/edit#gid=0), [Flight Authorisation](https://docs.google.com/spreadsheets/d/1IJkNS21Ps-2411LGhXBqWF7inQnPVeEA23dWjXpCR-M/edit#gid=0), [ED-269](https://docs.google.com/spreadsheets/d/1NIlRHtWzBXOyJ58pYimhDQDqsEyToTQRu2ma3AYXWEU/edit)).  To form a complete set of scenarios to cover a set of requirements, While unmapped requirements still exist: create new, simple test scenario that verifies a set of remaining unmapped requirements.
+Test scenarios will usually be enumerated/identified/created by mapping a list of requirements onto a set of test scenarios (e.g., [NetRID](https://docs.google.com/spreadsheets/d/1YByckmK6hfMrGec53CxRM2BPvcgm6HQNoFxOrOEfrUQ/edit#gid=0), [Flight Authorisation](https://docs.google.com/spreadsheets/d/1IJkNS21Ps-2411LGhXBqWF7inQnPVeEA23dWjXpCR-M/edit#gid=0), [ED-269](https://docs.google.com/spreadsheets/d/1NIlRHtWzBXOyJ58pYimhDQDqsEyToTQRu2ma3AYXWEU/edit)).  To form a complete set of scenarios to cover a set of requirements:
+
+    While unmapped requirements still exist:
+        Create new, simple test scenario that verifies a set of remaining unmapped requirements.
 
 ## Resources
 

--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -55,4 +55,4 @@ Each test case in the documentation must document at least one test step (otherw
 
 Each check a test step performs that may result in a finding/issue must be documented via a subsection of the parent test step, named with a " check" suffix (example: `#### Successful injection check`).
 
-A check should document the requirement(s) violated if the check fails.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**ASTM F3411-19::NET0420`).
+A check should document the requirement(s) violated if the check fails.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**ASTM F3411-19::NET0420**`).

--- a/monitoring/uss_qualifier/scenarios/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/__init__.py
@@ -1,1 +1,28 @@
-from .scenario import TestScenario
+import inspect
+from typing import Optional, Set
+
+from .scenario import TestScenario, TestScenarioType
+
+
+def find_test_scenarios(
+    module, already_checked: Optional[Set[str]] = None
+) -> Set[TestScenarioType]:
+    if already_checked is None:
+        already_checked = set()
+    already_checked.add(module.__name__)
+    test_scenarios = set()
+    for name, member in inspect.getmembers(module):
+        if (
+            inspect.ismodule(member)
+            and member.__name__ not in already_checked
+            and member.__name__.startswith("monitoring.uss_qualifier.scenarios")
+        ):
+            descendants = find_test_scenarios(member, already_checked)
+            for descendant in descendants:
+                if descendant not in test_scenarios:
+                    test_scenarios.add(descendant)
+        elif inspect.isclass(member) and member is not TestScenario:
+            if issubclass(member, TestScenario):
+                if member not in test_scenarios:
+                    test_scenarios.add(member)
+    return test_scenarios

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
@@ -1,0 +1,68 @@
+# ASTM NetRID nominal behavior test scenario
+
+## Overview
+
+In this scenario, a single nominal flight is injected into each NetRID Service Provider (SP) under test.  Each of the injected flights is expected to be visible to all the observers at appropriate times and for appropriate requests. 
+
+## Resources
+
+### flights_data
+
+A [`FlightDataResource`](../../../resources/netrid/flight_data.py) containing 1 nominal flight per SP under test.
+
+### service_providers
+
+A set of [`NetRIDServiceProviders`](../../../resources/netrid/service_providers.py) to be tested via the injection of RID flight data.  This scenario requires at least one SP under test.
+
+### observers
+
+A set of [`NetRIDObserversResource`](../../../resources/netrid/observers.py) to be tested via checking their observations of the NetRID system and comparing the observations against expectations.  An observer generally represents a "Display Application", in ASTM F3411 terminology.  This scenario requires at least one observer.
+
+### evaluation_configuration
+
+This [`EvaluationConfigurationResource`](../../../resources/netrid/observers.py) defines how to gauge success when observing the injected flights.
+
+## Nominal flight test case
+
+### Injection test step
+
+In this step, uss_qualifier injects a single nominal flight into each SP under test, usually with a start time in the future.  Each SP is expected to queue the provided telemetry and later simulate that telemetry coming from an aircraft at the designated timestamps.
+
+#### Successful injection check
+
+Per **[injection.yaml::UpsertTestSuccess](../../../../../interfaces/automated-testing/rid/injection.yaml)**, the injection attempt of the valid flight should succeed for every NetRID Service Provider under test.
+
+#### Valid flight check
+
+Per **[injection.yaml::UpsertTestResult](../../../../../interfaces/automated-testing/rid/injection.yaml)**, the NetRID Service Provider under test should only make valid modifications to the injected flights.  This includes:
+* A flight with the specified injection ID must be returned.
+
+### Polling test step
+
+In this step, all observers are periodically queried for the flights they observe.  Based on the known flights that were injected into the SPs in the previous step, these observations are checked against expected behavior/data.  Observation rectangles are chosen to encompass the known flights when possible.
+
+#### Successful observation check
+
+Per **[observation.yaml::ObservationSuccess](../../../../../interfaces/automated-testing/rid/observation.yaml)**, the call to each observer is expected to succeed since a valid view was provided by uss_qualifier.
+
+#### Duplicate flights check
+
+An assumption this test scenario currently makes is that the flight ID reported by the SP the flight was injected into is the same flight ID that each observer will report.  This is probably not a robust assumption and should be adjusted.
+
+This check will fail if an observation contains two flights with the same ID.
+
+#### Premature flight check
+
+The timestamps of the injected telemetry usually start in the future.  If a flight with injected telemetry only in the future is observed prior to the timestamp of the first telemetry point, this check will fail because the SP does not satisfy **[injection.yaml::ExpectedBehavior](../../../../../interfaces/automated-testing/rid/injection.yaml)**.
+
+#### Lingering flight check
+
+**ASTM F3411-19::NET0260** and **ASTM F3411-22a::NET0260** require a SP to provide flights up to *NetMaxNearRealTimeDataPeriod* in the past, but an SP should preserve privacy and ensure relevancy by not sharing flights that are further in the past than this window.
+
+#### Missing flight check
+
+**ASTM F3411-19::NET0610** and **ASTM F3411-22a::NET0610** require that SPs make all UAS operations discoverable over the duration of the flight plus *NetMaxNearRealTimeDataPeriod*, so each injected flight should be observable during this time.  If one of the flights is not observed during its appropriate time period, this check will fail.
+
+#### Area too large check
+
+**ASTM F3411-19::NET0430** and **ASTM F3411-22a::NET0430** require that a NetRID Display Provider reject a request for a very large view area with a diagonal greater than *NetMaxDisplayAreaDiagonal*.  If such a large view is requested and a 413 error code is not received, then this check will fail.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
@@ -30,6 +30,7 @@ class NominalBehavior(TestScenario):
         observers: NetRIDObserversResource,
         evaluation_configuration: EvaluationConfigurationResource,
     ):
+        super().__init__()
         self._flights_data = flights_data
         self._service_providers = service_providers
         self._observers = observers

--- a/monitoring/uss_qualifier/scenarios/documentation/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/__init__.py
@@ -1,0 +1,199 @@
+import inspect
+import os
+from typing import List, Optional, Type
+
+from implicitdict import ImplicitDict
+import marko
+import marko.element
+import marko.inline
+
+from monitoring.monitorlib.inspection import fullname
+
+
+RESOURCES_HEADING = "resources"
+TEST_SCENARIO_SUFFIX = " test scenario"
+TEST_CASE_SUFFIX = " test case"
+TEST_STEP_SUFFIX = " test step"
+TEST_CHECK_SUFFIX = " check"
+
+
+class TestCheckDocumentation(ImplicitDict):
+    name: str
+    applicable_requirements: List[str]
+
+
+class TestStepDocumentation(ImplicitDict):
+    name: str
+    checks: List[TestCheckDocumentation]
+
+
+class TestCaseDocumentation(ImplicitDict):
+    name: str
+    steps: List[TestStepDocumentation]
+
+
+class TestScenarioDocumentation(ImplicitDict):
+    name: str
+    resources: Optional[List[str]]
+    cases: List[TestCaseDocumentation]
+
+
+def _text_of(value) -> str:
+    if isinstance(value, str):
+        return value
+    elif isinstance(value, marko.block.BlockElement):
+        result = ""
+        for child in value.children:
+            result += _text_of(child)
+        return result
+    elif isinstance(value, marko.inline.InlineElement):
+        if isinstance(value.children, str):
+            return value.children
+        result = ""
+        for child in value.children:
+            result += _text_of(child)
+        return result
+    else:
+        raise NotImplementedError(
+            "Cannot yet extract raw text from {}".format(value.__class__.__name__)
+        )
+
+
+def _length_of_section(values, start_of_section: int) -> int:
+    level = values[start_of_section].level
+    c = start_of_section + 1
+    while c < len(values):
+        if isinstance(values[c], marko.block.Heading) and values[c].level == level:
+            break
+        c += 1
+    return c - start_of_section - 1
+
+
+def _parse_test_check(values) -> TestCheckDocumentation:
+    name = _text_of(values[0])[0 : -len(TEST_CHECK_SUFFIX)]
+
+    reqs: List[str] = []
+    c = 1
+    while c < len(values):
+        if isinstance(values[c], marko.block.Paragraph):
+            for child in values[c].children:
+                if isinstance(child, marko.inline.StrongEmphasis):
+                    reqs.append(_text_of(child))
+        c += 1
+
+    return TestCheckDocumentation(name=name, applicable_requirements=reqs)
+
+
+def _parse_test_step(values) -> TestStepDocumentation:
+    name = _text_of(values[0])[0 : -len(TEST_STEP_SUFFIX)]
+
+    checks: List[TestCheckDocumentation] = []
+    c = 1
+    while c < len(values):
+        if isinstance(values[c], marko.block.Heading) and _text_of(
+            values[c]
+        ).lower().endswith(TEST_CHECK_SUFFIX):
+            # Start of a test step section
+            dc = _length_of_section(values, c)
+            check = _parse_test_check(values[c : c + dc + 1])
+            checks.append(check)
+            c += dc
+        else:
+            c += 1
+
+    return TestStepDocumentation(name=name, checks=checks)
+
+
+def _parse_test_case(values) -> TestCaseDocumentation:
+    name = _text_of(values[0])[0 : -len(TEST_CASE_SUFFIX)]
+
+    steps: List[TestStepDocumentation] = []
+    c = 1
+    while c < len(values):
+        if isinstance(values[c], marko.block.Heading) and _text_of(
+            values[c]
+        ).lower().endswith(TEST_STEP_SUFFIX):
+            # Start of a test step section
+            dc = _length_of_section(values, c)
+            step = _parse_test_step(values[c : c + dc + 1])
+            steps.append(step)
+            c += dc
+        else:
+            c += 1
+
+    return TestCaseDocumentation(name=name, steps=steps)
+
+
+def _parse_resources(values) -> List[str]:
+    resource_level = values[0].level + 1
+    resources: List[str] = []
+    c = 1
+    while c < len(values):
+        if (
+            isinstance(values[c], marko.block.Heading)
+            and values[c].level == resource_level
+        ):
+            # This is a resource
+            resources.append(_text_of(values[c]))
+        c += 1
+    return resources
+
+
+def parse_documentation(scenario: Type) -> TestScenarioDocumentation:
+    # Load the .md file matching the Python file where this scenario type is defined
+    doc_filename = os.path.splitext(inspect.getfile(scenario))[0] + ".md"
+    if not os.path.exists(doc_filename):
+        raise ValueError(
+            "Test scenario `{}` does not have the required documentation file `{}`".format(
+                fullname(scenario), doc_filename
+            )
+        )
+    with open(doc_filename, "r") as f:
+        doc = marko.parse(f.read())
+
+    # Extract the scenario name from the first top-level header
+    if (
+        not isinstance(doc.children[0], marko.block.Heading)
+        or doc.children[0].level != 1
+        or not _text_of(doc.children[0]).lower().endswith(TEST_SCENARIO_SUFFIX)
+    ):
+        raise ValueError(
+            'The first line of {} must be a level-1 heading with the name of the scenario + "{}" (e.g., "# ASTM NetRID nominal behavior test scenario")'.format(
+                doc_filename, TEST_SCENARIO_SUFFIX
+            )
+        )
+    scenario_name = _text_of(doc.children[0])[0 : -len(TEST_SCENARIO_SUFFIX)]
+
+    # Step through the document to extract important structured components
+    test_cases: List[TestCaseDocumentation] = []
+    resources = None
+    c = 1
+    while c < len(doc.children):
+        if (
+            isinstance(doc.children[c], marko.block.Heading)
+            and _text_of(doc.children[c]).lower().strip() == RESOURCES_HEADING
+        ):
+            # Start of the Resources section
+            if resources is not None:
+                raise ValueError(
+                    'Only one major section may be titled "{}"'.format(
+                        RESOURCES_HEADING
+                    )
+                )
+            dc = _length_of_section(doc.children, c)
+            resources = _parse_resources(doc.children[c : c + dc + 1])
+            c += dc
+        if isinstance(doc.children[c], marko.block.Heading) and _text_of(
+            doc.children[c]
+        ).lower().endswith(TEST_CASE_SUFFIX):
+            # Start of a test case section
+            dc = _length_of_section(doc.children, c)
+            test_case = _parse_test_case(doc.children[c : c + dc + 1])
+            test_cases.append(test_case)
+            c += dc
+        else:
+            c += 1
+
+    return TestScenarioDocumentation(
+        name=scenario_name, cases=test_cases, resources=resources
+    )

--- a/monitoring/uss_qualifier/scenarios/documentation/validate_documentation.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/validate_documentation.py
@@ -1,0 +1,19 @@
+import inspect
+import os
+import sys
+from typing import Optional, Set, Type
+
+from monitoring.monitorlib import inspection
+from monitoring.uss_qualifier import scenarios
+from monitoring.uss_qualifier.scenarios.documentation import validation
+
+
+def main() -> int:
+    inspection.import_submodules(scenarios)
+    test_scenarios = scenarios.find_test_scenarios(scenarios)
+    validation.validate(list(test_scenarios))
+    return os.EX_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/monitoring/uss_qualifier/scenarios/documentation/validation.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/validation.py
@@ -1,0 +1,43 @@
+import inspect
+from typing import List
+
+from monitoring.monitorlib.inspection import fullname
+from monitoring.uss_qualifier.scenarios import documentation, TestScenarioType
+
+
+def validate(test_scenarios: List[TestScenarioType]):
+    for test_scenario in test_scenarios:
+        # Verify that documentation parses
+        docs = documentation.parse_documentation(test_scenario)
+
+        # Verify that all resources are documented
+        constructor_signature = inspect.signature(test_scenario.__init__)
+        args = []
+        for arg_name, arg in constructor_signature.parameters.items():
+            if arg_name == "self":
+                continue
+            if "resources" not in docs:
+                raise ValueError(
+                    f'Test scenario {fullname(test_scenario)} declares resources in its constructor, but there is no "{documentation.RESOURCES_HEADING}" section in its documentation'
+                )
+            if arg_name not in docs.resources:
+                raise ValueError(
+                    f"Test scenario {fullname(test_scenario)} declares resource {arg_name} ({fullname(arg.annotation)}), but this resource is not documented"
+                )
+            args.append(arg_name)
+        for documented_resource in docs.resources:
+            if documented_resource not in args:
+                raise ValueError(
+                    f"Documentation for test scenario {fullname(test_scenario)} specifies a resource named {documented_resource}, but this resource is not declared as a resource in the constructor"
+                )
+
+        # Verify minimal content
+        if not docs.cases:
+            raise ValueError(
+                f"Documentation for test scenario {fullname(test_scenario)} does not specify any test cases"
+            )
+        for test_case in docs.cases:
+            if not test_case.steps:
+                raise ValueError(
+                    f'Documentation for test case "{test_case.name}" in test scenario {fullname(test_scenario)} does not specify any test steps'
+                )

--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -1,26 +1,30 @@
 from abc import ABC, abstractmethod
 import inspect
-from typing import Dict, Type
+from typing import Dict, TypeVar
 
 from implicitdict import ImplicitDict
 
 from monitoring.monitorlib import inspection
 from monitoring.uss_qualifier import scenarios as scenarios_module
+from monitoring.uss_qualifier.scenarios.documentation import (
+    TestScenarioDocumentation,
+    parse_documentation,
+)
 from monitoring.uss_qualifier.resources import Resource
 
 
 class TestScenario(ABC):
-    @abstractmethod
-    def __init__(self, **dependencies):
-        """Create an instance of the test scenario.
+    """Instance of a test scenario, ready to run after construction.
 
-        Concrete subclasses of TestScenario must implement their constructor according to this specification.
+    Concrete subclasses of TestScenario must:
+      1) Implement a constructor that accepts only parameters with types that are subclasses of Resource
+      2) Call TestScenario.__init__ from the subclass's __init__
+    """
 
-        :param dependencies: If this scenario depends on any resources, each of these required resources should be declared as an additional typed parameter to the constructor.  Each parameter type should be a class that is a subclass of Resource.
-        """
-        raise NotImplementedError(
-            "A concrete test scenario type must implement __init__ method"
-        )
+    documentation: TestScenarioDocumentation
+
+    def __init__(self):
+        self.documentation = parse_documentation(self.__class__)
 
     @abstractmethod
     # TODO: have `run` interact with an encapsulated portion of a report, or return contributions to a report
@@ -28,6 +32,9 @@ class TestScenario(ABC):
         raise NotImplementedError(
             "A concrete test scenario must implement `run` method"
         )
+
+
+TestScenarioType = TypeVar("TestScenarioType", bound=TestScenario)
 
 
 class TestScenarioDeclaration(ImplicitDict):

--- a/monitoring/uss_qualifier/scripts/in_container/validate_test_definitions.sh
+++ b/monitoring/uss_qualifier/scripts/in_container/validate_test_definitions.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script is intended to be called from within a Docker container running
+# mock_uss via the interuss/monitoring image.  In that context, this script is
+# the entrypoint into the test definition validation tool.
+
+# Ensure uss_qualifier is the working directory
+OS=$(uname)
+if [[ $OS == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../.." || exit 1
+
+# Run validation
+python scenarios/documentation/validate_documentation.py

--- a/monitoring/uss_qualifier/scripts/validate_test_definitions.sh
+++ b/monitoring/uss_qualifier/scripts/validate_test_definitions.sh
@@ -16,7 +16,7 @@ cd "${BASEDIR}/../../.." || exit 1
 monitoring/build.sh || exit 1
 
 # shellcheck disable=SC2086
-docker run ${docker_args} --name test_definition_validator \
+docker run --name test_definition_validator \
   --rm \
   interuss/monitoring \
   uss_qualifier/scripts/in_container/validate_test_definitions.sh

--- a/monitoring/uss_qualifier/scripts/validate_test_definitions.sh
+++ b/monitoring/uss_qualifier/scripts/validate_test_definitions.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -o xtrace
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../../.." || exit 1
+
+monitoring/build.sh || exit 1
+
+# shellcheck disable=SC2086
+docker run ${docker_args} --name test_definition_validator \
+  --rm \
+  interuss/monitoring \
+  uss_qualifier/scripts/in_container/validate_test_definitions.sh


### PR DESCRIPTION
This PR adds documentation for the ASTM NetRID nominal behavior test scenario.  In addition, it adds programmatic documentation validation as a presubmit check to make sure all scenarios are fully documented, and it adds runtime availability of certain documentation information (especially requirements violated by failed test checks).  This is documented in uss_qualifier/scenarios/README.md.  Finally, this PR starts to transition TestScenario from a pure abstract class to more of a base class with some shared functionality (relating to reports) to be added in later PRs.