### PR TITLE
[geo-awareness] Adapt CHE dataset to comply with ED269

### DIFF
--- a/interfaces/automated-testing/geo-awareness/design/CHE/geo-awareness-che-1.json
+++ b/interfaces/automated-testing/geo-awareness/design/CHE/geo-awareness-che-1.json
@@ -1,5 +1,5 @@
 {
-  "title": "UASZoneTestData 2022-06-13",
+  "title": "UASZoneTestData 2022-10-16",
   "description": "Sample data for Automated Testing development",
   "features": [
     {
@@ -8,12 +8,10 @@
       "name": "Sample protected area active during evening",
       "type": "COMMON",
       "restriction": "PROHIBITED",
-      "restrictionConditions": "",
-      "region": "",
-      "reason": ["OTHER"],
+      "reason": [
+        "OTHER"
+      ],
       "otherReasonInfo": "Concert Area",
-      "regulationExemption": "",
-      "uSpaceClass": "",
       "message": "Concert area - prohibited flights during active times",
       "applicability": [
         {
@@ -22,7 +20,10 @@
           "permanent": "NO",
           "schedule": [
             {
-              "day": ["SAT", "SUN"],
+              "day": [
+                "SAT",
+                "SUN"
+              ],
               "startTime": "17:00:00.00Z",
               "endTime": "23:59:59.00Z"
             }
@@ -32,13 +33,9 @@
       "zoneAuthority": [
         {
           "name": "Local Canton",
-          "service": "",
-          "email": "",
           "contactName": "Commune de Montreux",
           "siteURL": "https://www.montreux.ch/accueil",
-          "phone": "",
-          "purpose": "",
-          "intervalBefore": ""
+          "purpose": "AUTHORIZATION"
         }
       ],
       "geometry": [
@@ -46,11 +43,14 @@
           "uomDimensions": "M",
           "lowerLimit": 0,
           "lowerVerticalReference": "AGL",
-          "upperLimit": 6259.45,
+          "upperLimit": 6259,
           "upperVerticalReference": "AMSL",
           "horizontalProjection": {
             "type": "Circle",
-            "center": [6.913146, 46.430758],
+            "center": [
+              6.913146,
+              46.430758
+            ],
             "radius": 3000
           }
         }
@@ -62,31 +62,23 @@
       "name": "Flugplatz Reichenbach",
       "type": "COMMON",
       "restriction": "PROHIBITED",
-      "restrictionConditions": "",
-      "region": "",
-      "reason": ["AIR_TRAFFIC"],
-      "otherReasonInfo": "",
-      "regulationExemption": "",
-      "uSpaceClass": "",
+      "reason": [
+        "AIR_TRAFFIC"
+      ],
       "message": "Flugplatz Reichenbach Drone Access Restrictions",
       "applicability": [
         {
           "startDateTime": "2022-06-15T09:00:00.00Z",
           "endDateTime": "2023-06-15T09:00:00.00Z",
-          "permanent": "YES",
-          "schedule": []
+          "permanent": "YES"
         }
       ],
       "zoneAuthority": [
         {
           "name": "Flugplatz Reichenbach",
-          "service": "",
-          "email": "",
           "contactName": "Flugplatzleitung",
           "siteURL": "https://www.flugplatz-reichenbach.ch/",
-          "phone": "079 642 17 61",
-          "purpose": "",
-          "intervalBefore": ""
+          "phone": "079 642 17 61"
         }
       ],
       "geometry": [
@@ -98,7 +90,10 @@
           "upperVerticalReference": "AGL",
           "horizontalProjection": {
             "type": "Circle",
-            "center": [7.67807, 46.612893],
+            "center": [
+              7.67807,
+              46.612893
+            ],
             "radius": 1000
           }
         },
@@ -110,7 +105,10 @@
           "upperVerticalReference": "AGL",
           "horizontalProjection": {
             "type": "Circle",
-            "center": [7.67807, 46.612893],
+            "center": [
+              7.67807,
+              46.612893
+            ],
             "radius": 2500
           }
         },
@@ -122,7 +120,10 @@
           "upperVerticalReference": "AGL",
           "horizontalProjection": {
             "type": "Circle",
-            "center": [7.67807, 46.612893],
+            "center": [
+              7.67807,
+              46.612893
+            ],
             "radius": 3500
           }
         }
@@ -134,12 +135,11 @@
       "name": "Lausanne Airport",
       "type": "COMMON",
       "restriction": "PROHIBITED",
-      "restrictionConditions": "",
-      "region": "",
-      "reason": ["AIR_TRAFFIC", "OTHER"],
+      "reason": [
+        "AIR_TRAFFIC",
+        "OTHER"
+      ],
       "otherReasonInfo": "Lausanne Airport Operational Restrictions",
-      "regulationExemption": "",
-      "uSpaceClass": "",
       "message": "Drone operations must only fly below the maximum allowed ceiling near active airports",
       "applicability": [
         {
@@ -149,13 +149,7 @@
       "zoneAuthority": [
         {
           "name": "Lausanne Airport",
-          "service": "",
-          "email": "",
-          "contactName": "",
-          "siteURL": "http://www.lausanne-airport.ch/",
-          "phone": "",
-          "purpose": "",
-          "intervalBefore": ""
+          "siteURL": "http://www.lausanne-airport.ch/"
         }
       ],
       "geometry": [
@@ -169,11 +163,26 @@
             "type": "Polygon",
             "coordinates": [
               [
-                [6.609821, 46.532886],
-                [6.624755, 46.532886],
-                [6.624755, 46.558624],
-                [6.609821, 46.558624],
-                [6.609821, 46.532886]
+                [
+                  6.609821,
+                  46.532886
+                ],
+                [
+                  6.624755,
+                  46.532886
+                ],
+                [
+                  6.624755,
+                  46.558624
+                ],
+                [
+                  6.609821,
+                  46.558624
+                ],
+                [
+                  6.609821,
+                  46.532886
+                ]
               ]
             ]
           }
@@ -188,11 +197,26 @@
             "type": "Polygon",
             "coordinates": [
               [
-                [6.596603, 46.531941],
-                [6.596603, 46.531941],
-                [6.637458, 46.55945],
-                [6.596603, 46.55945],
-                [6.596603, 46.531941]
+                [
+                  6.596603,
+                  46.531941
+                ],
+                [
+                  6.596603,
+                  46.531941
+                ],
+                [
+                  6.637458,
+                  46.55945
+                ],
+                [
+                  6.596603,
+                  46.55945
+                ],
+                [
+                  6.596603,
+                  46.531941
+                ]
               ]
             ]
           }
@@ -207,11 +231,26 @@
             "type": "Polygon",
             "coordinates": [
               [
-                [6.585617, 46.526036],
-                [6.585617, 46.526036],
-                [6.649818, 46.565233],
-                [6.585617, 46.565233],
-                [6.585617, 46.526036]
+                [
+                  6.585617,
+                  46.526036
+                ],
+                [
+                  6.585617,
+                  46.526036
+                ],
+                [
+                  6.649818,
+                  46.565233
+                ],
+                [
+                  6.585617,
+                  46.565233
+                ],
+                [
+                  6.585617,
+                  46.526036
+                ]
               ]
             ]
           }
@@ -224,12 +263,10 @@
       "name": "Lake Geneva Wildlife Preserve",
       "type": "COMMON",
       "restriction": "REQ_AUTHORISATION",
-      "restrictionConditions": "",
-      "region": "",
-      "reason": ["NATURE"],
+      "reason": [
+        "NATURE"
+      ],
       "otherReasonInfo": "Lake Geneva Wildlife Preserve",
-      "regulationExemption": "",
-      "uSpaceClass": "",
       "message": "Drone operations must only be permitted inside the Lake Geneva Wild Preserve with prior authorisation",
       "applicability": [
         {
@@ -239,13 +276,7 @@
       "zoneAuthority": [
         {
           "name": "Lake Geneva Wildlife Preserve",
-          "service": "",
-          "email": "",
-          "contactName": "",
-          "siteURL": "https://www.nationalpark.ch/en/",
-          "phone": "",
-          "purpose": "",
-          "intervalBefore": ""
+          "siteURL": "https://www.nationalpark.ch/en/"
         }
       ],
       "geometry": [
@@ -259,13 +290,34 @@
             "type": "Polygon",
             "coordinates": [
               [
-                [6.852035, 46.453943],
-                [6.806716, 46.3917],
-                [6.827659, 46.383649],
-                [6.893234, 46.393239],
-                [6.932373, 46.403302],
-                [6.920871, 46.42993],
-                [6.852035, 46.453943]
+                [
+                  6.852035,
+                  46.453943
+                ],
+                [
+                  6.806716,
+                  46.3917
+                ],
+                [
+                  6.827659,
+                  46.383649
+                ],
+                [
+                  6.893234,
+                  46.393239
+                ],
+                [
+                  6.932373,
+                  46.403302
+                ],
+                [
+                  6.920871,
+                  46.42993
+                ],
+                [
+                  6.852035,
+                  46.453943
+                ]
               ]
             ]
           }
@@ -278,11 +330,9 @@
       "name": "Gantrisch Nature Park",
       "type": "COMMON",
       "restriction": "NO_RESTRICTION",
-      "restrictionConditions": "",
-      "region": "",
-      "reason": ["NATURE"],
-      "otherReasonInfo": "",
-      "regulationExemption": "",
+      "reason": [
+        "NATURE"
+      ],
       "uSpaceClass": "OPEN",
       "message": "Drone operations inside Gantrisch Nature Park should minimise disturbance to wildlife",
       "applicability": [
@@ -293,13 +343,7 @@
       "zoneAuthority": [
         {
           "name": "Gantrisch Nature Park",
-          "service": "",
-          "email": "",
-          "contactName": "",
-          "siteURL": "https://www.nationalpark.ch/en/",
-          "phone": "",
-          "purpose": "",
-          "intervalBefore": ""
+          "siteURL": "https://www.nationalpark.ch/en/"
         }
       ],
       "geometry": [
@@ -313,31 +357,49 @@
             "type": "Polygon",
             "coordinates": [
               [
-                [7.315521, 46.818857],
-                [7.282562, 46.703143],
-                [7.506408, 46.717268],
-                [7.516021, 46.797239],
-                [7.404785, 46.844225],
-                [7.315521, 46.818857]
+                [
+                  7.315521,
+                  46.818857
+                ],
+                [
+                  7.282562,
+                  46.703143
+                ],
+                [
+                  7.506408,
+                  46.717268
+                ],
+                [
+                  7.516021,
+                  46.797239
+                ],
+                [
+                  7.404785,
+                  46.844225
+                ],
+                [
+                  7.315521,
+                  46.818857
+                ]
               ]
             ]
           }
         }
       ]
     },
-
     {
       "identifier": "Gantrisch Nature Park",
       "country": "CHE",
       "name": "Gantrisch Nature Park",
       "type": "COMMON",
       "restriction": "REQ_AUTHORISATION",
-      "restrictionConditions": "",
-      "region": "",
-      "reason": ["NATURE"],
-      "otherReasonInfo": "",
-      "regulationExemption": "",
-      "uSpaceClass": ["SPECIFIC", "CERTIFIED"],
+      "reason": [
+        "NATURE"
+      ],
+      "uSpaceClass": [
+        "SPECIFIC",
+        "CERTIFIED"
+      ],
       "message": "Drone operations inside Gantrisch Nature Park can only be permitted in VLOS unless prior authorisation is granted",
       "applicability": [
         {
@@ -347,13 +409,7 @@
       "zoneAuthority": [
         {
           "name": "Gantrisch Nature Park",
-          "service": "",
-          "email": "",
-          "contactName": "",
-          "siteURL": "https://www.nationalpark.ch/en/",
-          "phone": "",
-          "purpose": "",
-          "intervalBefore": ""
+          "siteURL": "https://www.nationalpark.ch/en/"
         }
       ],
       "geometry": [
@@ -367,12 +423,30 @@
             "type": "Polygon",
             "coordinates": [
               [
-                [7.315521, 46.818857],
-                [7.282562, 46.703143],
-                [7.506408, 46.717268],
-                [7.516021, 46.797239],
-                [7.404785, 46.844225],
-                [7.315521, 46.818857]
+                [
+                  7.315521,
+                  46.818857
+                ],
+                [
+                  7.282562,
+                  46.703143
+                ],
+                [
+                  7.506408,
+                  46.717268
+                ],
+                [
+                  7.516021,
+                  46.797239
+                ],
+                [
+                  7.404785,
+                  46.844225
+                ],
+                [
+                  7.315521,
+                  46.818857
+                ]
               ]
             ]
           }


### PR DESCRIPTION
While working on the mock_uss implementation of the geo-awareness service, some inaccuracies in the `interfaces/automated-testing/geo-awareness/design/CHE/geo-awareness-che-1.json` dataset appeared. This PR addresses them by removing empty fields and fix end of line markers to match the repository practice.

Note: Configure the diff to `Hide whitespace` to see the changes of interest. 
![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)