### PR TITLE
[uss_qualifier] Add optional cleanup phase to TestScenario

### DIFF
--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -121,6 +121,9 @@ class TestScenarioReport(ImplicitDict):
     cases: List[TestCaseReport]
     """Reports for each of the test cases in this test scenario"""
 
+    cleanup: Optional[TestStepReport]
+    """If this test scenario performed cleanup, this report captures the relevant information."""
+
     execution_error: Optional[ErrorReport]
     """If there was an error while executing this test scenario, this field describes the error"""
 

--- a/monitoring/uss_qualifier/resources/netrid/service_providers.py
+++ b/monitoring/uss_qualifier/resources/netrid/service_providers.py
@@ -57,6 +57,15 @@ class NetRIDServiceProvider(object):
         )
         return fetch.describe_query(response, initiated_at)
 
+    def delete_test(self, test_id: str) -> fetch.Query:
+        deletion_path = "/tests/{}".format(test_id)
+
+        initiated_at = datetime.datetime.utcnow()
+        response = self.client.delete(
+            url=deletion_path, scope=SCOPE_RID_QUALIFIER_INJECT
+        )
+        return fetch.describe_query(response, initiated_at)
+
 
 class NetRIDServiceProviders(Resource[NetRIDServiceProvidersSpecification]):
     service_providers: List[NetRIDServiceProvider]

--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -59,3 +59,12 @@ Each test case in the documentation must document at least one test step (otherw
 Each check a test step performs that may result in a finding/issue must be documented via a subsection of the parent test step, named with a " check" suffix (example: `#### Successful injection check`).
 
 A check should document the requirement(s) violated if the check fails.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**ASTM F3411-19::NET0420**`).
+
+### Cleanup phase
+
+If a test scenario wants to perform a cleanup procedure follow any non-error termination of the rest of the scenario, it must:
+
+1) Override the `cleanup()` method on the base `TestScenario` class
+2) Include a main section in the documentation named "Cleanup" that is documented like a test step (including, e.g., test checks when appropriate).
+
+The `cleanup()` method may not be overridden unless the cleanup phase is documented for that test scenario.  If the cleanup phase is documented for the test scenario, the `cleanup()` method must be overridden.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/injection.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/injection.py
@@ -7,5 +7,6 @@ from monitoring.monitorlib.rid_automated_testing.injection_api import TestFlight
 
 class InjectedFlight(ImplicitDict):
     uss_participant_id: str
+    test_id: str
     flight: TestFlight
     query_timestamp: datetime

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
@@ -66,3 +66,11 @@ The timestamps of the injected telemetry usually start in the future.  If a flig
 #### Area too large check
 
 **ASTM F3411-19::NET0430** and **ASTM F3411-22a::NET0430** require that a NetRID Display Provider reject a request for a very large view area with a diagonal greater than *NetMaxDisplayAreaDiagonal*.  If such a large view is requested and a 413 error code is not received, then this check will fail.
+
+## Cleanup
+
+The cleanup phase of this test scenario attempts to remove injected data from all SPs.
+
+### Successful test deletion check
+
+Per **[injection.yaml::DeleteTestSuccess](../../../../../interfaces/automated-testing/rid/injection.yaml)**, the deletion attempt of the previously-injected test should succeed for every NetRID Service Provider under test.

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
@@ -1,6 +1,9 @@
+import traceback
 import uuid
+from typing import List
 
 from implicitdict import ImplicitDict
+from requests.exceptions import RequestException
 
 from monitoring.monitorlib.rid_automated_testing.injection_api import (
     CreateTestParameters,
@@ -25,6 +28,8 @@ class NominalBehavior(TestScenario):
     _observers: NetRIDObserversResource
     _evaluation_configuration: EvaluationConfigurationResource
 
+    _injected_flights: List[InjectedFlight]
+
     def __init__(
         self,
         flights_data: FlightDataResource,
@@ -37,6 +42,7 @@ class NominalBehavior(TestScenario):
         self._service_providers = service_providers
         self._observers = observers
         self._evaluation_configuration = evaluation_configuration
+        self._injected_flights = []
 
     def run(self):
         self.begin_test_scenario()
@@ -53,10 +59,24 @@ class NominalBehavior(TestScenario):
                     len(service_providers), len(test_flights)
                 )
             )
-        injected_flights = []
         for i, target in enumerate(service_providers):
             p = CreateTestParameters(requested_flights=[test_flights[i]])
-            query = target.submit_test(p, test_id)
+            try:
+                query = target.submit_test(p, test_id)
+            except RequestException as e:
+                stacktrace = "".join(
+                    traceback.format_exception(
+                        etype=type(e), value=e, tb=e.__traceback__
+                    )
+                )
+                self.record_failed_check(
+                    name="Successful injection",
+                    summary="Error while trying to inject test flight",
+                    severity=Severity.Critical,
+                    relevant_participants=[target.participant_id],
+                    details=f"While trying to inject a test flight into {target.participant_id}, encountered error:\n{stacktrace}",
+                )
+                return
             self.record_query(query)
             try:
                 if query.status_code != 200:
@@ -72,17 +92,18 @@ class NominalBehavior(TestScenario):
             except ValueError as e:
                 self.record_failed_check(
                     name="Successful injection",
-                    summary="Error while trying to inject test flight",
+                    summary="Error injecting test flight",
                     severity=Severity.Critical,
                     relevant_participants=[target.participant_id],
-                    details=f"While trying to inject a test flight into {target.participant_id}, encountered status code {query.status_code}: {str(e)}",
+                    details=f"Attempting to inject a test flight into {target.participant_id}, encountered status code {query.status_code}: {str(e)}",
                 )
                 return
             # TODO: Validate injected flights, especially to make sure they contain the specified injection IDs
             for flight in injections:
-                injected_flights.append(
+                self._injected_flights.append(
                     InjectedFlight(
                         uss_participant_id=target.participant_id,
+                        test_id=test_id,
                         flight=flight,
                         query_timestamp=query.request.timestamp,
                     )
@@ -93,7 +114,7 @@ class NominalBehavior(TestScenario):
         self.begin_test_step("Polling")
         evaluator = display_data_evaluator.RIDObservationEvaluator(
             self,
-            injected_flights,
+            self._injected_flights,
             self._evaluation_configuration.configuration,
             # TODO: Replace hardcoded value
             RIDVersion.f3411_19,
@@ -103,3 +124,40 @@ class NominalBehavior(TestScenario):
 
         self.end_test_case()  # Nominal flight
         self.end_test_scenario()
+
+    def cleanup(self):
+        self.begin_cleanup()
+        while self._injected_flights:
+            injected_flight = self._injected_flights.pop()
+            matching_sps = [
+                sp
+                for sp in self._service_providers.service_providers
+                if sp.participant_id == injected_flight.uss_participant_id
+            ]
+            if len(matching_sps) != 1:
+                matching_ids = ", ".join(sp.participant_id for sp in matching_sps)
+                raise RuntimeError(
+                    f"Found {len(matching_sps)} service providers with participant ID {injected_flight.uss_participant_id} ({matching_ids}) when exactly 1 was expected"
+                )
+            sp = matching_sps[0]
+            try:
+                query = sp.delete_test(injected_flight.test_id)
+                self.record_query(query)
+                if query.status_code != 200:
+                    raise ValueError(
+                        f"Received status code {query.status_code} after attempting to delete test {injected_flight.test_id} from service provider {sp.participant_id}"
+                    )
+            except (RequestException, ValueError) as e:
+                stacktrace = "".join(
+                    traceback.format_exception(
+                        etype=type(e), value=e, tb=e.__traceback__
+                    )
+                )
+                self.record_failed_check(
+                    name="Successful test deletion",
+                    summary="Error while trying to delete test flight",
+                    severity=Severity.High,
+                    relevant_participants=[sp.participant_id],
+                    details=f"While trying to delete a test flight from {sp.participant_id}, encountered error:\n{stacktrace}",
+                )
+        self.end_cleanup()

--- a/monitoring/uss_qualifier/suites/suite.py
+++ b/monitoring/uss_qualifier/suites/suite.py
@@ -89,6 +89,8 @@ class TestSuiteAction(object):
         scenario.on_failed_check = _print_failed_check
         try:
             scenario.run()
+            scenario.go_to_cleanup()
+            scenario.cleanup()
         except KeyboardInterrupt:
             raise
         except Exception as e:


### PR DESCRIPTION
Many test scenarios will want to attempt to clean up resources, both at the end of successful execution and when there is an aborting failure earlier.  This PR formalizes that mechanism by adding an optional special test step to test scenarios.  The state machine logic was less than obvious in TestScenario, so this PR also adds explicit state machine states ("phases") to hopefully make expectations and behavior a lot more clear in TestScenario.

A cleanup phase is also added to the NetRID nominal behavior test where the injected tests are deleted.