### PR TITLE
[cockroachdb][certs] explicitly set default namespace in apply-certs.sh

### DIFF
--- a/build/apply-certs.sh
+++ b/build/apply-certs.sh
@@ -34,14 +34,14 @@ UPLOAD_CA_KEY=true
 # Delete previous secrets in case they have changed.
 kubectl create namespace "$NAMESPACE"  --context "$CONTEXT" || true
 
-kubectl delete secret cockroachdb.client.root --context "$CONTEXT" || true
+kubectl delete secret cockroachdb.client.root --namespace default --context "$CONTEXT" || true
 kubectl delete secret cockroachdb.client.root --namespace "$NAMESPACE"  --context "$CONTEXT" || true
 kubectl delete secret cockroachdb.node --namespace "$NAMESPACE"  --context "$CONTEXT" || true
 kubectl delete secret cockroachdb.ca.crt --namespace "$NAMESPACE"  --context "$CONTEXT" || true
 kubectl delete secret cockroachdb.ca.key --namespace "$NAMESPACE"  --context "$CONTEXT" || true
 kubectl delete secret dss.public.certs --namespace "$NAMESPACE"  --context "$CONTEXT" || true
 
-kubectl create secret generic cockroachdb.client.root --from-file "$CLIENTS_CERTS_DIR"  --context "$CONTEXT"
+kubectl create secret generic cockroachdb.client.root --namespace default --from-file "$CLIENTS_CERTS_DIR"  --context "$CONTEXT"
 if [[ $NAMESPACE != "default" ]]; then
   kubectl create secret generic cockroachdb.client.root --namespace "$NAMESPACE" --from-file "$CLIENTS_CERTS_DIR"  --context "$CONTEXT"
 fi


### PR DESCRIPTION
I guess the intention is that the default namespace should also contain the `cockroach.client.root` secret? If the namespace is not explicitly defined the secret will end up in whatever the user is currently using as current context namespace.