### PR TITLE
[tanka][ingress] optional ingress

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -309,10 +309,6 @@ a PR to that effect would be greatly appreciated.
         volumes. You can check your cluster's possible values with
         `kubectl get storageclass`.
 
-    1.  `VAR_INGRESS_NAME`: If using Google Kubernetes Engine, set this to the
-        the name of the gateway static IP address created above (e.g.,
-        `CLUSTER_NAME-gateway`).
-
     1.  `VAR_DOCKER_IMAGE_NAME`: Full name of the docker image built in the
         section above.  `build.sh` prints this name as the last thing it does
         when run with `DOCKER_URL` set.  It should look something like
@@ -324,6 +320,14 @@ a PR to that effect would be greatly appreciated.
 
     1.  `VAR_APP_HOSTNAME`: Fully-qualified domain name of your HTTPS Gateway
         ingress endpoint.  For example, `dss.example.com`.
+
+    1.  `VAR_INGRESS`: Optional Ingress configuration. For some Kubernetes
+        instances, a generic Ingress can be created as well. Values can
+        be: `none`, `gke`
+
+    1.  `VAR_GKE_IP_NAME`: If using Google Kubernetes Engine, set this to the
+        the name of the gateway static IP address created above (e.g.,
+        `CLUSTER_NAME-gateway`).
 
     1.  `VAR_PUBLIC_KEY_PEM_PATH`: If providing a .pem file directly as the
         public key to validate incoming access tokens, specify the name of this

--- a/build/deploy/examples/minimum/main.jsonnet
+++ b/build/deploy/examples/minimum/main.jsonnet
@@ -19,9 +19,13 @@ local metadata = metadataBase {
     storageClass: 'VAR_CRDB_STORAGE_CLASS',
   },
   gateway+: {
-    ipName: 'VAR_INGRESS_NAME',
     image: 'VAR_DOCKER_IMAGE_NAME',
     hostname: 'VAR_APP_HOSTNAME',
+    ingress: 'none', // <-- This string value is VAR_INGRESS
+    // uncomment if ingress == 'gke'
+    // gkeIngress: {
+    //  ipName: 'VAR_GKE_IP_NAME',
+    // },
     traceRequests: true,
   },
   backend+: {

--- a/build/deploy/metadata_base.libsonnet
+++ b/build/deploy/metadata_base.libsonnet
@@ -25,10 +25,13 @@
   },
   gateway: {
     port: 8080,
-    ipName: error 'must supply ip name',
     image: error 'must specify image',
     prof_http_name: '',
     hostname: error 'must specify hostname',
+    ingress: 'none',
+    gkeIngress: {
+      ipName: error 'must supply ip name',
+    },
     traceRequests: false,
   },
   backend: {


### PR DESCRIPTION
The idea is to have one generic ingress configuration per cloud/k8s distribution to get started. The configuration is done with one variable that would take values in `gke`, `azure`, `aws` or `none` to select the target cloud. For each cloud, there would be one object with custom variables:

```
gkeIngress: {
  ipName: 'VAR_GKE_IP_NAME',
},
azureIngress: {
  ...
}
awsIngress: {
  ...
}
```