### PR TITLE
[uss_qualifier] Generate stable pseudorandom simulated RID data

### DIFF
--- a/monitoring/uss_qualifier/resources/netrid/flight_data.py
+++ b/monitoring/uss_qualifier/resources/netrid/flight_data.py
@@ -29,6 +29,16 @@ class FlightDataJSONFileConfiguration(ImplicitDict):
 
 
 class AdjacentCircularFlightsSimulatorConfiguration(ImplicitDict):
+    reference_time: StringBasedDateTime = StringBasedDateTime("2022-01-01T00:00:00Z")
+    """The reference time relative to which flight data should be generated.
+    
+    The time should be irrelevant in real-world use as times are adjusted to be
+    relative to a time close to the time of test.
+    """
+
+    random_seed: Optional[int] = 12345
+    """Pseudorandom seed that should be used, or specify None to use default Random."""
+
     minx: float = 7.4735784530639648
     """Western edge of bounding box (degrees longitude)"""
 
@@ -49,6 +59,16 @@ class AdjacentCircularFlightsSimulatorConfiguration(ImplicitDict):
 
 
 class FlightDataKMLFileConfiguration(ImplicitDict):
+    reference_time: StringBasedDateTime = StringBasedDateTime("2022-01-01T00:00:00Z")
+    """The reference time relative to which flight data should be generated.
+    
+    The time should be irrelevant in real-world use as times are adjusted to be
+    relative to a time close to the time of test.
+    """
+
+    random_seed: Optional[int] = 12345
+    """Pseudorandom seed that should be used, or specify None to use default Random."""
+
     kml_path: str
     """Path to a local file containing a KML describing a FlightRecordCollection."""
 

--- a/monitoring/uss_qualifier/resources/netrid/flight_data_resources.py
+++ b/monitoring/uss_qualifier/resources/netrid/flight_data_resources.py
@@ -48,7 +48,9 @@ class FlightDataResource(Resource[FlightDataSpecification]):
             )
         elif specification.kml_file_source is not None:
             self.flight_collection = get_flight_records(
-                specification.kml_file_source.kml_path
+                specification.kml_file_source.kml_path,
+                specification.kml_file_source.reference_time.datetime,
+                specification.kml_file_source.random_seed,
             )
         else:
             raise ValueError(

--- a/monitoring/uss_qualifier/resources/netrid/simulation/operator_flight_details.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/operator_flight_details.py
@@ -9,15 +9,17 @@ from monitoring.monitorlib.rid_automated_testing.injection_api import OperatorLo
 class OperatorFlightDataGenerator:
     """A class to generate fake data detailing operator name, operation name and operator location, it can be customized for locales and locations"""
 
-    def __init__(self):
+    def __init__(self, random: random.Random):
         self.fake = Faker()
+        self.random = random
 
     def generate_serial_number(self):
-        return str(uuid.uuid4())
+        value = bytes(self.random.randint(0, 255) for _ in range(16))
+        return str(uuid.UUID(bytes=value, version=4))
 
     def generate_registration_number(self, prefix="CHE"):
         registration_number = prefix + "".join(
-            random.choices(string.ascii_lowercase + string.digits, k=13)
+            self.random.choices(string.ascii_lowercase + string.digits, k=13)
         )
         return registration_number
 
@@ -32,7 +34,7 @@ class OperatorFlightDataGenerator:
             "News recording, live event",
             "Crop spraying / Agricultural Inspection",
         ]
-        return random.choice(operation_description)
+        return self.random.choice(operation_description)
 
     def generate_operator_location(self, centroid):
         operator_location = OperatorLocation(lat=centroid.y, lng=centroid.x)
@@ -40,7 +42,7 @@ class OperatorFlightDataGenerator:
 
     def generate_operator_id(self, prefix="OP-"):
         operator_id = prefix + "".join(
-            random.choices(string.ascii_lowercase + string.digits, k=8)
+            self.random.choices(string.ascii_lowercase + string.digits, k=8)
         )
         return operator_id
 

--- a/monitoring/uss_qualifier/test_data/che/netrid/circular_flights.json
+++ b/monitoring/uss_qualifier/test_data/che/netrid/circular_flights.json
@@ -1,10 +1,10 @@
 {
   "flights": [
     {
-      "reference_time": "2022-10-17T02:07:29.683276+00:00",
+      "reference_time": "2022-01-01T00:00:00.000000Z",
       "states": [
         {
-          "timestamp": "2022-10-17T02:07:30.683276+00:00",
+          "timestamp": "2022-01-01T00:00:01.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9754225199202,
@@ -25,7 +25,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:31.683276+00:00",
+          "timestamp": "2022-01-01T00:00:02.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97537839156561,
@@ -46,7 +46,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:32.683276+00:00",
+          "timestamp": "2022-01-01T00:00:03.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97533460388938,
@@ -67,7 +67,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:33.683276+00:00",
+          "timestamp": "2022-01-01T00:00:04.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97529157858963,
@@ -88,7 +88,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:34.683276+00:00",
+          "timestamp": "2022-01-01T00:00:05.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97524973002137,
@@ -109,7 +109,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:35.683276+00:00",
+          "timestamp": "2022-01-01T00:00:06.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975209461206134,
@@ -130,7 +130,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:36.683276+00:00",
+          "timestamp": "2022-01-01T00:00:07.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97517115995081,
@@ -151,7 +151,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:37.683276+00:00",
+          "timestamp": "2022-01-01T00:00:08.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97513519511295,
@@ -172,7 +172,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:38.683276+00:00",
+          "timestamp": "2022-01-01T00:00:09.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97510191304869,
@@ -193,7 +193,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:39.683276+00:00",
+          "timestamp": "2022-01-01T00:00:10.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9750716342773,
@@ -214,7 +214,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:40.683276+00:00",
+          "timestamp": "2022-01-01T00:00:11.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97504465039461,
@@ -235,7 +235,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:41.683276+00:00",
+          "timestamp": "2022-01-01T00:00:12.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97502122126502,
@@ -256,7 +256,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:42.683276+00:00",
+          "timestamp": "2022-01-01T00:00:13.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97500157251901,
@@ -277,7 +277,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:43.683276+00:00",
+          "timestamp": "2022-01-01T00:00:14.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974985893380456,
@@ -298,7 +298,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:44.683276+00:00",
+          "timestamp": "2022-01-01T00:00:15.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974974334844354,
@@ -319,7 +319,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:45.683276+00:00",
+          "timestamp": "2022-01-01T00:00:16.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97496700822293,
@@ -340,7 +340,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:46.683276+00:00",
+          "timestamp": "2022-01-01T00:00:17.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97496398407367,
@@ -361,7 +361,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:47.683276+00:00",
+          "timestamp": "2022-01-01T00:00:18.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97496529151983,
@@ -382,7 +382,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:48.683276+00:00",
+          "timestamp": "2022-01-01T00:00:19.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974970917970175,
@@ -403,7 +403,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:49.683276+00:00",
+          "timestamp": "2022-01-01T00:00:20.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97498080924005,
@@ -424,7 +424,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:50.683276+00:00",
+          "timestamp": "2022-01-01T00:00:21.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97499487007325,
@@ -445,7 +445,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:51.683276+00:00",
+          "timestamp": "2022-01-01T00:00:22.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97501296505933,
@@ -466,7 +466,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:52.683276+00:00",
+          "timestamp": "2022-01-01T00:00:23.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9750349199375,
@@ -487,7 +487,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:53.683276+00:00",
+          "timestamp": "2022-01-01T00:00:24.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975060523274735,
@@ -508,7 +508,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:54.683276+00:00",
+          "timestamp": "2022-01-01T00:00:25.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975089528501826,
@@ -529,7 +529,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:55.683276+00:00",
+          "timestamp": "2022-01-01T00:00:26.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975121656287804,
@@ -550,7 +550,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:56.683276+00:00",
+          "timestamp": "2022-01-01T00:00:27.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9751565972298,
@@ -571,7 +571,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:57.683276+00:00",
+          "timestamp": "2022-01-01T00:00:28.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97519401483258,
@@ -592,7 +592,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:58.683276+00:00",
+          "timestamp": "2022-01-01T00:00:29.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975233548749024,
@@ -613,7 +613,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:59.683276+00:00",
+          "timestamp": "2022-01-01T00:00:30.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975274818250206,
@@ -636,22 +636,22 @@
       ],
       "flight_details": {
         "id": "0",
-        "serial_number": "1993ac68-20ae-4aac-98fc-e34a9233df0c",
-        "operation_description": "Solar Panel Inspection",
+        "serial_number": "d50598bc-638a-4f52-bf3f-dd85595fb52e",
+        "operation_description": "News recording, live event",
         "operator_location": {
           "lat": 46.97615311620088,
           "lng": 7.476099729537965
         },
-        "operator_id": "OP-ea5b60uk",
-        "registration_number": "CHEzqahfybqg0775"
+        "operator_id": "OP-vfhc4lqa",
+        "registration_number": "CHEsyoaxfukxdygn"
       },
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-10-17T02:07:29.683276+00:00",
+      "reference_time": "2022-01-01T00:00:00.000000Z",
       "states": [
         {
-          "timestamp": "2022-10-17T02:07:30.683276+00:00",
+          "timestamp": "2022-01-01T00:00:01.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97690122350781,
@@ -672,7 +672,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:31.683276+00:00",
+          "timestamp": "2022-01-01T00:00:02.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976857095163645,
@@ -693,7 +693,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:32.683276+00:00",
+          "timestamp": "2022-01-01T00:00:03.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97681330749575,
@@ -714,7 +714,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:33.683276+00:00",
+          "timestamp": "2022-01-01T00:00:04.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976770282202125,
@@ -735,7 +735,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:34.683276+00:00",
+          "timestamp": "2022-01-01T00:00:05.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97672843363776,
@@ -756,7 +756,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:35.683276+00:00",
+          "timestamp": "2022-01-01T00:00:06.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976688164824125,
@@ -777,7 +777,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:36.683276+00:00",
+          "timestamp": "2022-01-01T00:00:07.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9766498635681,
@@ -798,7 +798,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:37.683276+00:00",
+          "timestamp": "2022-01-01T00:00:08.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97661389872726,
@@ -819,7 +819,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:38.683276+00:00",
+          "timestamp": "2022-01-01T00:00:09.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97658061665774,
@@ -840,7 +840,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:39.683276+00:00",
+          "timestamp": "2022-01-01T00:00:10.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97655033787888,
@@ -861,7 +861,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:40.683276+00:00",
+          "timestamp": "2022-01-01T00:00:11.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97652335398656,
@@ -882,7 +882,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:41.683276+00:00",
+          "timestamp": "2022-01-01T00:00:12.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97649992484531,
@@ -903,7 +903,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:42.683276+00:00",
+          "timestamp": "2022-01-01T00:00:13.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976480276085674,
@@ -924,7 +924,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:43.683276+00:00",
+          "timestamp": "2022-01-01T00:00:14.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976464596931706,
@@ -945,7 +945,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:44.683276+00:00",
+          "timestamp": "2022-01-01T00:00:15.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97645303837853,
@@ -966,7 +966,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:45.683276+00:00",
+          "timestamp": "2022-01-01T00:00:16.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644571173855,
@@ -987,7 +987,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:46.683276+00:00",
+          "timestamp": "2022-01-01T00:00:17.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976442687569374,
@@ -1008,7 +1008,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:47.683276+00:00",
+          "timestamp": "2022-01-01T00:00:18.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644399499454,
@@ -1029,7 +1029,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:48.683276+00:00",
+          "timestamp": "2022-01-01T00:00:19.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644962142294,
@@ -1050,7 +1050,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:49.683276+00:00",
+          "timestamp": "2022-01-01T00:00:20.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97645951267017,
@@ -1071,7 +1071,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:50.683276+00:00",
+          "timestamp": "2022-01-01T00:00:21.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97647357348022,
@@ -1092,7 +1092,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:51.683276+00:00",
+          "timestamp": "2022-01-01T00:00:22.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97649166844289,
@@ -1113,7 +1113,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:52.683276+00:00",
+          "timestamp": "2022-01-01T00:00:23.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976513623297585,
@@ -1134,7 +1134,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:53.683276+00:00",
+          "timestamp": "2022-01-01T00:00:24.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97653922661156,
@@ -1155,7 +1155,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:54.683276+00:00",
+          "timestamp": "2022-01-01T00:00:25.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976568231815776,
@@ -1176,7 +1176,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:55.683276+00:00",
+          "timestamp": "2022-01-01T00:00:26.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976600359579514,
@@ -1197,7 +1197,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:56.683276+00:00",
+          "timestamp": "2022-01-01T00:00:27.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9766353005001,
@@ -1218,7 +1218,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:57.683276+00:00",
+          "timestamp": "2022-01-01T00:00:28.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97667271808253,
@@ -1239,7 +1239,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:58.683276+00:00",
+          "timestamp": "2022-01-01T00:00:29.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976712251979855,
@@ -1260,7 +1260,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:59.683276+00:00",
+          "timestamp": "2022-01-01T00:00:30.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976753521463344,
@@ -1283,22 +1283,22 @@
       ],
       "flight_details": {
         "id": "1",
-        "serial_number": "69a84e5d-0ed8-41fe-b645-8fb2d2abca51",
-        "operation_description": "Emergency services / rescue",
+        "serial_number": "a814763d-ff6e-4f83-9e42-15549a044c75",
+        "operation_description": "Delivery operation, see more details at https://deliveryops.com/operation",
         "operator_location": {
           "lat": 46.97615311620088,
           "lng": 7.476099729537965
         },
-        "operator_id": "OP-33fs89vw",
-        "registration_number": "CHEtuisg2t3rend6"
+        "operator_id": "OP-tflbzc97",
+        "registration_number": "CHE21ny1rcwlvp8h"
       },
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-10-17T02:07:29.683276+00:00",
+      "reference_time": "2022-01-01T00:00:00.000000Z",
       "states": [
         {
-          "timestamp": "2022-10-17T02:07:30.683276+00:00",
+          "timestamp": "2022-01-01T00:00:01.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97542251027387,
@@ -1319,7 +1319,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:31.683276+00:00",
+          "timestamp": "2022-01-01T00:00:02.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97537838193127,
@@ -1340,7 +1340,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:32.683276+00:00",
+          "timestamp": "2022-01-01T00:00:03.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975334594359815,
@@ -1361,7 +1361,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:33.683276+00:00",
+          "timestamp": "2022-01-01T00:00:04.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97529156925661,
@@ -1382,7 +1382,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:34.683276+00:00",
+          "timestamp": "2022-01-01T00:00:05.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97524972097478,
@@ -1403,7 +1403,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:35.683276+00:00",
+          "timestamp": "2022-01-01T00:00:06.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97520945253309,
@@ -1424,7 +1424,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:36.683276+00:00",
+          "timestamp": "2022-01-01T00:00:07.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975171151734834,
@@ -1445,7 +1445,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:37.683276+00:00",
+          "timestamp": "2022-01-01T00:00:08.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975135187433175,
@@ -1466,7 +1466,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:38.683276+00:00",
+          "timestamp": "2022-01-01T00:00:09.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97510190597907,
@@ -1487,7 +1487,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:39.683276+00:00",
+          "timestamp": "2022-01-01T00:00:10.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975071627885924,
@@ -1508,7 +1508,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:40.683276+00:00",
+          "timestamp": "2022-01-01T00:00:11.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975044644743015,
@@ -1529,7 +1529,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:41.683276+00:00",
+          "timestamp": "2022-01-01T00:00:12.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97502121640763,
@@ -1550,7 +1550,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:42.683276+00:00",
+          "timestamp": "2022-01-01T00:00:13.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97500156850261,
@@ -1571,7 +1571,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:43.683276+00:00",
+          "timestamp": "2022-01-01T00:00:14.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97498589024373,
@@ -1592,7 +1592,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:44.683276+00:00",
+          "timestamp": "2022-01-01T00:00:15.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974974332617506,
@@ -1613,7 +1613,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:45.683276+00:00",
+          "timestamp": "2022-01-01T00:00:16.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974967006927415,
@@ -1634,7 +1634,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:46.683276+00:00",
+          "timestamp": "2022-01-01T00:00:17.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97496398372193,
@@ -1655,7 +1655,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:47.683276+00:00",
+          "timestamp": "2022-01-01T00:00:18.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97496529211529,
@@ -1676,7 +1676,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:48.683276+00:00",
+          "timestamp": "2022-01-01T00:00:19.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97497091950708,
@@ -1697,7 +1697,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:49.683276+00:00",
+          "timestamp": "2022-01-01T00:00:20.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97498081170361,
@@ -1718,7 +1718,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:50.683276+00:00",
+          "timestamp": "2022-01-01T00:00:21.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974994873439734,
@@ -1739,7 +1739,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:51.683276+00:00",
+          "timestamp": "2022-01-01T00:00:22.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9750129692963,
@@ -1760,7 +1760,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:52.683276+00:00",
+          "timestamp": "2022-01-01T00:00:23.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975034925004174,
@@ -1781,7 +1781,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:53.683276+00:00",
+          "timestamp": "2022-01-01T00:00:24.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975060529122324,
@@ -1802,7 +1802,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:54.683276+00:00",
+          "timestamp": "2022-01-01T00:00:25.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975089535074005,
@@ -1823,7 +1823,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:55.683276+00:00",
+          "timestamp": "2022-01-01T00:00:26.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9751216635213,
@@ -1844,7 +1844,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:56.683276+00:00",
+          "timestamp": "2022-01-01T00:00:27.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97515660505494,
@@ -1865,7 +1865,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:57.683276+00:00",
+          "timestamp": "2022-01-01T00:00:28.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97519402317401,
@@ -1886,7 +1886,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:58.683276+00:00",
+          "timestamp": "2022-01-01T00:00:29.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97523355752641,
@@ -1907,7 +1907,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:59.683276+00:00",
+          "timestamp": "2022-01-01T00:00:30.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97527482737902,
@@ -1930,22 +1930,22 @@
       ],
       "flight_details": {
         "id": "2",
-        "serial_number": "9a3dbf8a-a995-4b2b-9eef-57c1efb75169",
-        "operation_description": "Emergency services / rescue",
+        "serial_number": "3d4c28fd-54ab-4668-9353-934c2e014b01",
+        "operation_description": "Crop spraying / Agricultural Inspection",
         "operator_location": {
           "lat": 46.97615311620088,
           "lng": 7.476099729537965
         },
-        "operator_id": "OP-yg4zn2vy",
-        "registration_number": "CHErym08rga36s5z"
+        "operator_id": "OP-5474j1c1",
+        "registration_number": "CHEqg7gnggu368sp"
       },
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-10-17T02:07:29.683276+00:00",
+      "reference_time": "2022-01-01T00:00:00.000000Z",
       "states": [
         {
-          "timestamp": "2022-10-17T02:07:30.683276+00:00",
+          "timestamp": "2022-01-01T00:00:01.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97690121386124,
@@ -1966,7 +1966,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:31.683276+00:00",
+          "timestamp": "2022-01-01T00:00:02.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976857085529076,
@@ -1987,7 +1987,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:32.683276+00:00",
+          "timestamp": "2022-01-01T00:00:03.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97681329796595,
@@ -2008,7 +2008,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:33.683276+00:00",
+          "timestamp": "2022-01-01T00:00:04.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976770272868876,
@@ -2029,7 +2029,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:34.683276+00:00",
+          "timestamp": "2022-01-01T00:00:05.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976728424590945,
@@ -2050,7 +2050,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:35.683276+00:00",
+          "timestamp": "2022-01-01T00:00:06.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97668815615087,
@@ -2071,7 +2071,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:36.683276+00:00",
+          "timestamp": "2022-01-01T00:00:07.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97664985535192,
@@ -2092,7 +2092,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:37.683276+00:00",
+          "timestamp": "2022-01-01T00:00:08.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97661389104729,
@@ -2113,7 +2113,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:38.683276+00:00",
+          "timestamp": "2022-01-01T00:00:09.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97658060958795,
@@ -2134,7 +2134,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:39.683276+00:00",
+          "timestamp": "2022-01-01T00:00:10.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97655033148734,
@@ -2155,7 +2155,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:40.683276+00:00",
+          "timestamp": "2022-01-01T00:00:11.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97652334833483,
@@ -2176,7 +2176,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:41.683276+00:00",
+          "timestamp": "2022-01-01T00:00:12.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9764999199878,
@@ -2197,7 +2197,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:42.683276+00:00",
+          "timestamp": "2022-01-01T00:00:13.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97648027206919,
@@ -2218,7 +2218,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:43.683276+00:00",
+          "timestamp": "2022-01-01T00:00:14.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9764645937949,
@@ -2239,7 +2239,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:44.683276+00:00",
+          "timestamp": "2022-01-01T00:00:15.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97645303615162,
@@ -2260,7 +2260,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:45.683276+00:00",
+          "timestamp": "2022-01-01T00:00:16.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644571044297,
@@ -2281,7 +2281,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:46.683276+00:00",
+          "timestamp": "2022-01-01T00:00:17.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976442687217634,
@@ -2302,7 +2302,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:47.683276+00:00",
+          "timestamp": "2022-01-01T00:00:18.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976443995589996,
@@ -2323,7 +2323,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:48.683276+00:00",
+          "timestamp": "2022-01-01T00:00:19.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976449622959876,
@@ -2344,7 +2344,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:49.683276+00:00",
+          "timestamp": "2022-01-01T00:00:20.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976459515133776,
@@ -2365,7 +2365,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:50.683276+00:00",
+          "timestamp": "2022-01-01T00:00:21.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97647357684678,
@@ -2386,7 +2386,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:51.683276+00:00",
+          "timestamp": "2022-01-01T00:00:22.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97649167267996,
@@ -2407,7 +2407,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:52.683276+00:00",
+          "timestamp": "2022-01-01T00:00:23.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976513628364394,
@@ -2428,7 +2428,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:53.683276+00:00",
+          "timestamp": "2022-01-01T00:00:24.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97653923245929,
@@ -2449,7 +2449,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:54.683276+00:00",
+          "timestamp": "2022-01-01T00:00:25.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97656823838812,
@@ -2470,7 +2470,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:55.683276+00:00",
+          "timestamp": "2022-01-01T00:00:26.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976600366813166,
@@ -2491,7 +2491,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:56.683276+00:00",
+          "timestamp": "2022-01-01T00:00:27.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97663530832542,
@@ -2512,7 +2512,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:57.683276+00:00",
+          "timestamp": "2022-01-01T00:00:28.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97667272642415,
@@ -2533,7 +2533,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:58.683276+00:00",
+          "timestamp": "2022-01-01T00:00:29.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976712260757445,
@@ -2554,7 +2554,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:59.683276+00:00",
+          "timestamp": "2022-01-01T00:00:30.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97675353059237,
@@ -2577,22 +2577,22 @@
       ],
       "flight_details": {
         "id": "3",
-        "serial_number": "2760693f-465c-4047-bfbd-150165b02383",
-        "operation_description": "Solar Panel Inspection",
+        "serial_number": "3d22eb63-6745-47a9-9540-1e85da16ba37",
+        "operation_description": "Wind farm survey",
         "operator_location": {
           "lat": 46.97615311620088,
           "lng": 7.476099729537965
         },
-        "operator_id": "OP-2oo99blv",
-        "registration_number": "CHEalihmnials65d"
+        "operator_id": "OP-f5wjpnlv",
+        "registration_number": "CHElrbqhea82cd55"
       },
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-10-17T02:07:29.683276+00:00",
+      "reference_time": "2022-01-01T00:00:00.000000Z",
       "states": [
         {
-          "timestamp": "2022-10-17T02:07:30.683276+00:00",
+          "timestamp": "2022-01-01T00:00:01.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97542250062755,
@@ -2613,7 +2613,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:31.683276+00:00",
+          "timestamp": "2022-01-01T00:00:02.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97537837229697,
@@ -2634,7 +2634,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:32.683276+00:00",
+          "timestamp": "2022-01-01T00:00:03.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97533458483033,
@@ -2655,7 +2655,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:33.683276+00:00",
+          "timestamp": "2022-01-01T00:00:04.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97529155992369,
@@ -2676,7 +2676,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:34.683276+00:00",
+          "timestamp": "2022-01-01T00:00:05.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97524971192833,
@@ -2697,7 +2697,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:35.683276+00:00",
+          "timestamp": "2022-01-01T00:00:06.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97520944386022,
@@ -2718,7 +2718,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:36.683276+00:00",
+          "timestamp": "2022-01-01T00:00:07.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975171143519084,
@@ -2739,7 +2739,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:37.683276+00:00",
+          "timestamp": "2022-01-01T00:00:08.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97513517975364,
@@ -2760,7 +2760,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:38.683276+00:00",
+          "timestamp": "2022-01-01T00:00:09.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975101898909735,
@@ -2781,7 +2781,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:39.683276+00:00",
+          "timestamp": "2022-01-01T00:00:10.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97507162149484,
@@ -2802,7 +2802,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:40.683276+00:00",
+          "timestamp": "2022-01-01T00:00:11.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97504463909175,
@@ -2823,7 +2823,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:41.683276+00:00",
+          "timestamp": "2022-01-01T00:00:12.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97502121155059,
@@ -2844,7 +2844,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:42.683276+00:00",
+          "timestamp": "2022-01-01T00:00:13.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975001564486575,
@@ -2865,7 +2865,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:43.683276+00:00",
+          "timestamp": "2022-01-01T00:00:14.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97498588710737,
@@ -2886,7 +2886,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:44.683276+00:00",
+          "timestamp": "2022-01-01T00:00:15.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974974330391035,
@@ -2907,7 +2907,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:45.683276+00:00",
+          "timestamp": "2022-01-01T00:00:16.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974967005632266,
@@ -2928,7 +2928,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:46.683276+00:00",
+          "timestamp": "2022-01-01T00:00:17.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974963983370586,
@@ -2949,7 +2949,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:47.683276+00:00",
+          "timestamp": "2022-01-01T00:00:18.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.974965292711126,
@@ -2970,7 +2970,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:48.683276+00:00",
+          "timestamp": "2022-01-01T00:00:19.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97497092104437,
@@ -2991,7 +2991,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:49.683276+00:00",
+          "timestamp": "2022-01-01T00:00:20.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97498081416754,
@@ -3012,7 +3012,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:50.683276+00:00",
+          "timestamp": "2022-01-01T00:00:21.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97499487680657,
@@ -3033,7 +3033,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:51.683276+00:00",
+          "timestamp": "2022-01-01T00:00:22.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97501297353365,
@@ -3054,7 +3054,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:52.683276+00:00",
+          "timestamp": "2022-01-01T00:00:23.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97503493007119,
@@ -3075,7 +3075,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:53.683276+00:00",
+          "timestamp": "2022-01-01T00:00:24.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975060534970225,
@@ -3096,7 +3096,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:54.683276+00:00",
+          "timestamp": "2022-01-01T00:00:25.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97508954164649,
@@ -3117,7 +3117,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:55.683276+00:00",
+          "timestamp": "2022-01-01T00:00:26.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975121670755044,
@@ -3138,7 +3138,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:56.683276+00:00",
+          "timestamp": "2022-01-01T00:00:27.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97515661288031,
@@ -3159,7 +3159,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:57.683276+00:00",
+          "timestamp": "2022-01-01T00:00:28.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97519403151563,
@@ -3180,7 +3180,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:58.683276+00:00",
+          "timestamp": "2022-01-01T00:00:29.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975233566303956,
@@ -3201,7 +3201,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:59.683276+00:00",
+          "timestamp": "2022-01-01T00:00:30.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.975274836507936,
@@ -3224,22 +3224,22 @@
       ],
       "flight_details": {
         "id": "4",
-        "serial_number": "44dfbcde-5c03-4bf8-aadc-3e5fc095dc24",
+        "serial_number": "fb5d8bb2-6a99-41c6-a69a-bc14d6615229",
         "operation_description": "Solar Panel Inspection",
         "operator_location": {
           "lat": 46.97615311620088,
           "lng": 7.476099729537965
         },
-        "operator_id": "OP-fgmd0o2w",
-        "registration_number": "CHEumvz67n6a9dmz"
+        "operator_id": "OP-3ipaes2m",
+        "registration_number": "CHElbdfhum9k4dst"
       },
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-10-17T02:07:29.683276+00:00",
+      "reference_time": "2022-01-01T00:00:00.000000Z",
       "states": [
         {
-          "timestamp": "2022-10-17T02:07:30.683276+00:00",
+          "timestamp": "2022-01-01T00:00:01.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97690120421468,
@@ -3260,7 +3260,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:31.683276+00:00",
+          "timestamp": "2022-01-01T00:00:02.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976857075894536,
@@ -3281,7 +3281,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:32.683276+00:00",
+          "timestamp": "2022-01-01T00:00:03.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976813288436226,
@@ -3302,7 +3302,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:33.683276+00:00",
+          "timestamp": "2022-01-01T00:00:04.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976770263535755,
@@ -3323,7 +3323,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:34.683276+00:00",
+          "timestamp": "2022-01-01T00:00:05.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97672841554428,
@@ -3344,7 +3344,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:35.683276+00:00",
+          "timestamp": "2022-01-01T00:00:06.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9766881474778,
@@ -3365,7 +3365,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:36.683276+00:00",
+          "timestamp": "2022-01-01T00:00:07.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97664984713598,
@@ -3386,7 +3386,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:37.683276+00:00",
+          "timestamp": "2022-01-01T00:00:08.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97661388336759,
@@ -3407,7 +3407,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:38.683276+00:00",
+          "timestamp": "2022-01-01T00:00:09.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976580602518446,
@@ -3428,7 +3428,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:39.683276+00:00",
+          "timestamp": "2022-01-01T00:00:10.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9765503250961,
@@ -3449,7 +3449,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:40.683276+00:00",
+          "timestamp": "2022-01-01T00:00:11.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976523342683436,
@@ -3470,7 +3470,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:41.683276+00:00",
+          "timestamp": "2022-01-01T00:00:12.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97649991513066,
@@ -3491,7 +3491,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:42.683276+00:00",
+          "timestamp": "2022-01-01T00:00:13.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97648026805306,
@@ -3512,7 +3512,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:43.683276+00:00",
+          "timestamp": "2022-01-01T00:00:14.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97646459065849,
@@ -3533,7 +3533,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:44.683276+00:00",
+          "timestamp": "2022-01-01T00:00:15.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97645303392511,
@@ -3554,7 +3554,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:45.683276+00:00",
+          "timestamp": "2022-01-01T00:00:16.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644570914782,
@@ -3575,7 +3575,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:46.683276+00:00",
+          "timestamp": "2022-01-01T00:00:17.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976442686866285,
@@ -3596,7 +3596,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:47.683276+00:00",
+          "timestamp": "2022-01-01T00:00:18.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976443996185864,
@@ -3617,7 +3617,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:48.683276+00:00",
+          "timestamp": "2022-01-01T00:00:19.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97644962449721,
@@ -3638,7 +3638,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:49.683276+00:00",
+          "timestamp": "2022-01-01T00:00:20.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97645951759776,
@@ -3659,7 +3659,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:50.683276+00:00",
+          "timestamp": "2022-01-01T00:00:21.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97647358021371,
@@ -3680,7 +3680,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:51.683276+00:00",
+          "timestamp": "2022-01-01T00:00:22.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97649167691741,
@@ -3701,7 +3701,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:52.683276+00:00",
+          "timestamp": "2022-01-01T00:00:23.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97651363343155,
@@ -3722,7 +3722,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:53.683276+00:00",
+          "timestamp": "2022-01-01T00:00:24.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.976539238307325,
@@ -3743,7 +3743,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:54.683276+00:00",
+          "timestamp": "2022-01-01T00:00:25.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97656824496077,
@@ -3764,7 +3764,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:55.683276+00:00",
+          "timestamp": "2022-01-01T00:00:26.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.9766003740471,
@@ -3785,7 +3785,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:56.683276+00:00",
+          "timestamp": "2022-01-01T00:00:27.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97663531615098,
@@ -3806,7 +3806,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:57.683276+00:00",
+          "timestamp": "2022-01-01T00:00:28.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97667273476598,
@@ -3827,7 +3827,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:58.683276+00:00",
+          "timestamp": "2022-01-01T00:00:29.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97671226953519,
@@ -3848,7 +3848,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:59.683276+00:00",
+          "timestamp": "2022-01-01T00:00:30.000000Z",
           "operational_status": "Airborne",
           "position": {
             "lat": 46.97675353972152,
@@ -3871,14 +3871,14 @@
       ],
       "flight_details": {
         "id": "5",
-        "serial_number": "5ed8b35f-ed0b-4790-8ab3-7511785f386d",
-        "operation_description": "Wind farm survey",
+        "serial_number": "d1074da6-53ea-44e1-8cbe-0ec6b508a3f0",
+        "operation_description": "Crop spraying / Agricultural Inspection",
         "operator_location": {
           "lat": 46.97615311620088,
           "lng": 7.476099729537965
         },
-        "operator_id": "OP-v04wdhhz",
-        "registration_number": "CHE0tczi33qy0ks4"
+        "operator_id": "OP-bl2eucd8",
+        "registration_number": "CHEdg7lhdrchh0fv"
       },
       "aircraft_type": "Helicopter"
     }

--- a/monitoring/uss_qualifier/test_data/usa/netrid/dcdemo_flights.json
+++ b/monitoring/uss_qualifier/test_data/usa/netrid/dcdemo_flights.json
@@ -1,10 +1,10 @@
 {
   "flights": [
     {
-      "reference_time": "2022-10-17T02:07:29.970345",
+      "reference_time": "2022-01-01T00:00:00+00:00",
       "states": [
         {
-          "timestamp": "2022-10-17T02:07:30.970345",
+          "timestamp": "2022-01-01T00:00:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55587396855303,
@@ -21,7 +21,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:31.970345",
+          "timestamp": "2022-01-01T00:00:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55589007520672,
@@ -38,7 +38,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:32.970345",
+          "timestamp": "2022-01-01T00:00:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55590618186042,
@@ -55,7 +55,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:33.970345",
+          "timestamp": "2022-01-01T00:00:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55592352683881,
@@ -72,7 +72,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:34.970345",
+          "timestamp": "2022-01-01T00:00:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55594117369401,
@@ -89,7 +89,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:35.970345",
+          "timestamp": "2022-01-01T00:00:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55595882054921,
@@ -106,7 +106,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:36.970345",
+          "timestamp": "2022-01-01T00:00:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55597646740442,
@@ -123,7 +123,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:37.970345",
+          "timestamp": "2022-01-01T00:00:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55599411425962,
@@ -140,7 +140,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:38.970345",
+          "timestamp": "2022-01-01T00:00:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55601176111482,
@@ -157,7 +157,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:39.970345",
+          "timestamp": "2022-01-01T00:00:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55602940797002,
@@ -174,7 +174,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:40.970345",
+          "timestamp": "2022-01-01T00:00:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55604705482523,
@@ -191,7 +191,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:41.970345",
+          "timestamp": "2022-01-01T00:00:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55606470168043,
@@ -208,7 +208,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:42.970345",
+          "timestamp": "2022-01-01T00:00:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55608234853563,
@@ -225,7 +225,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:43.970345",
+          "timestamp": "2022-01-01T00:00:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55609999539084,
@@ -242,7 +242,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:44.970345",
+          "timestamp": "2022-01-01T00:00:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55611764224604,
@@ -259,7 +259,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:45.970345",
+          "timestamp": "2022-01-01T00:00:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55613528910123,
@@ -276,7 +276,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:46.970345",
+          "timestamp": "2022-01-01T00:00:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55615293595643,
@@ -293,7 +293,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:47.970345",
+          "timestamp": "2022-01-01T00:00:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55617058281165,
@@ -310,7 +310,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:48.970345",
+          "timestamp": "2022-01-01T00:00:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55618822966684,
@@ -327,7 +327,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:49.970345",
+          "timestamp": "2022-01-01T00:00:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55620587652204,
@@ -344,7 +344,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:50.970345",
+          "timestamp": "2022-01-01T00:00:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55622352337726,
@@ -361,7 +361,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:51.970345",
+          "timestamp": "2022-01-01T00:00:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55624117023245,
@@ -378,7 +378,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:52.970345",
+          "timestamp": "2022-01-01T00:00:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55625881708765,
@@ -395,7 +395,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:53.970345",
+          "timestamp": "2022-01-01T00:00:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55627646394288,
@@ -412,7 +412,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:54.970345",
+          "timestamp": "2022-01-01T00:00:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55629411079806,
@@ -429,7 +429,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:55.970345",
+          "timestamp": "2022-01-01T00:00:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55631175765326,
@@ -446,7 +446,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:56.970345",
+          "timestamp": "2022-01-01T00:00:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55632940450846,
@@ -463,7 +463,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:57.970345",
+          "timestamp": "2022-01-01T00:00:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55634705136367,
@@ -480,7 +480,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:58.970345",
+          "timestamp": "2022-01-01T00:00:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55636469821887,
@@ -497,7 +497,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:59.970345",
+          "timestamp": "2022-01-01T00:00:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55638234507407,
@@ -514,7 +514,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:00.970345",
+          "timestamp": "2022-01-01T00:00:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55639999192928,
@@ -531,7 +531,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:01.970345",
+          "timestamp": "2022-01-01T00:00:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55642026768449,
@@ -548,7 +548,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:02.970345",
+          "timestamp": "2022-01-01T00:00:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55644295026563,
@@ -565,7 +565,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:03.970345",
+          "timestamp": "2022-01-01T00:00:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55646563284678,
@@ -582,7 +582,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:04.970345",
+          "timestamp": "2022-01-01T00:00:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55648831542793,
@@ -599,7 +599,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:05.970345",
+          "timestamp": "2022-01-01T00:00:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55651131696129,
@@ -616,7 +616,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:06.970345",
+          "timestamp": "2022-01-01T00:00:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55653446130167,
@@ -633,7 +633,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:07.970345",
+          "timestamp": "2022-01-01T00:00:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55655760564203,
@@ -650,7 +650,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:08.970345",
+          "timestamp": "2022-01-01T00:00:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55658074997348,
@@ -667,7 +667,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:09.970345",
+          "timestamp": "2022-01-01T00:00:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55660389430066,
@@ -684,7 +684,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:10.970345",
+          "timestamp": "2022-01-01T00:00:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55662703862784,
@@ -701,7 +701,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:11.970345",
+          "timestamp": "2022-01-01T00:00:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55665018295501,
@@ -718,7 +718,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:12.970345",
+          "timestamp": "2022-01-01T00:00:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55667332727569,
@@ -735,7 +735,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:13.970345",
+          "timestamp": "2022-01-01T00:00:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55669647159566,
@@ -752,7 +752,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:14.970345",
+          "timestamp": "2022-01-01T00:00:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5567196159146,
@@ -769,7 +769,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:15.970345",
+          "timestamp": "2022-01-01T00:00:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55674276023298,
@@ -786,7 +786,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:16.970345",
+          "timestamp": "2022-01-01T00:00:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55676590455134,
@@ -803,7 +803,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:17.970345",
+          "timestamp": "2022-01-01T00:00:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55678904886972,
@@ -820,7 +820,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:18.970345",
+          "timestamp": "2022-01-01T00:00:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5568121931881,
@@ -837,7 +837,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:19.970345",
+          "timestamp": "2022-01-01T00:00:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55683533750651,
@@ -854,7 +854,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:20.970345",
+          "timestamp": "2022-01-01T00:00:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55685848182495,
@@ -871,7 +871,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:21.970345",
+          "timestamp": "2022-01-01T00:00:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55688162614337,
@@ -888,7 +888,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:22.970345",
+          "timestamp": "2022-01-01T00:00:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55690453863392,
@@ -905,7 +905,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:23.970345",
+          "timestamp": "2022-01-01T00:00:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55692698017576,
@@ -922,7 +922,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:24.970345",
+          "timestamp": "2022-01-01T00:00:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55694942171759,
@@ -939,7 +939,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:25.970345",
+          "timestamp": "2022-01-01T00:00:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55697151348825,
@@ -956,7 +956,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:26.970345",
+          "timestamp": "2022-01-01T00:00:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55699219870603,
@@ -973,7 +973,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:27.970345",
+          "timestamp": "2022-01-01T00:00:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55701288392379,
@@ -990,7 +990,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:28.970345",
+          "timestamp": "2022-01-01T00:00:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55703356914155,
@@ -1007,7 +1007,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:29.970345",
+          "timestamp": "2022-01-01T00:01:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55704842741144,
@@ -1024,7 +1024,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:30.970345",
+          "timestamp": "2022-01-01T00:01:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5570614546619,
@@ -1041,7 +1041,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:31.970345",
+          "timestamp": "2022-01-01T00:01:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55707448191238,
@@ -1058,7 +1058,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:32.970345",
+          "timestamp": "2022-01-01T00:01:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55708663122641,
@@ -1075,7 +1075,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:33.970345",
+          "timestamp": "2022-01-01T00:01:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55709876400941,
@@ -1092,7 +1092,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:34.970345",
+          "timestamp": "2022-01-01T00:01:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55711089679241,
@@ -1109,7 +1109,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:35.970345",
+          "timestamp": "2022-01-01T00:01:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55712302957541,
@@ -1126,7 +1126,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:36.970345",
+          "timestamp": "2022-01-01T00:01:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55713444620947,
@@ -1143,7 +1143,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:37.970345",
+          "timestamp": "2022-01-01T00:01:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571451406536,
@@ -1160,7 +1160,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:38.970345",
+          "timestamp": "2022-01-01T00:01:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55715583509773,
@@ -1177,7 +1177,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:39.970345",
+          "timestamp": "2022-01-01T00:01:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55716652954052,
@@ -1194,7 +1194,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:40.970345",
+          "timestamp": "2022-01-01T00:01:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55717722394104,
@@ -1211,7 +1211,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:41.970345",
+          "timestamp": "2022-01-01T00:01:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55718791834155,
@@ -1228,7 +1228,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:42.970345",
+          "timestamp": "2022-01-01T00:01:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55719861274208,
@@ -1245,7 +1245,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:43.970345",
+          "timestamp": "2022-01-01T00:01:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55720667254693,
@@ -1262,7 +1262,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:44.970345",
+          "timestamp": "2022-01-01T00:01:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721267014918,
@@ -1279,7 +1279,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:45.970345",
+          "timestamp": "2022-01-01T00:01:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721866775144,
@@ -1296,7 +1296,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:46.970345",
+          "timestamp": "2022-01-01T00:01:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55722644606435,
@@ -1313,7 +1313,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:47.970345",
+          "timestamp": "2022-01-01T00:01:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55723692058861,
@@ -1330,7 +1330,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:48.970345",
+          "timestamp": "2022-01-01T00:01:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55724739511287,
@@ -1347,7 +1347,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:49.970345",
+          "timestamp": "2022-01-01T00:01:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55725777560312,
@@ -1364,7 +1364,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:50.970345",
+          "timestamp": "2022-01-01T00:01:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55726368763663,
@@ -1381,7 +1381,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:51.970345",
+          "timestamp": "2022-01-01T00:01:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55726959967014,
@@ -1398,7 +1398,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:52.970345",
+          "timestamp": "2022-01-01T00:01:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55727551170365,
@@ -1415,7 +1415,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:53.970345",
+          "timestamp": "2022-01-01T00:01:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55728142386525,
@@ -1432,7 +1432,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:54.970345",
+          "timestamp": "2022-01-01T00:01:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55728733604583,
@@ -1449,7 +1449,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:55.970345",
+          "timestamp": "2022-01-01T00:01:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55729324822643,
@@ -1466,7 +1466,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:56.970345",
+          "timestamp": "2022-01-01T00:01:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55729917266355,
@@ -1483,7 +1483,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:57.970345",
+          "timestamp": "2022-01-01T00:01:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55730510187047,
@@ -1500,7 +1500,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:58.970345",
+          "timestamp": "2022-01-01T00:01:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55731103107739,
@@ -1517,7 +1517,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:59.970345",
+          "timestamp": "2022-01-01T00:01:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55731697592192,
@@ -1534,7 +1534,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:00.970345",
+          "timestamp": "2022-01-01T00:01:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55732293376266,
@@ -1551,7 +1551,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:01.970345",
+          "timestamp": "2022-01-01T00:01:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573288916034,
@@ -1568,7 +1568,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:02.970345",
+          "timestamp": "2022-01-01T00:01:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733272841044,
@@ -1585,7 +1585,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:03.970345",
+          "timestamp": "2022-01-01T00:01:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733314313133,
@@ -1602,7 +1602,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:04.970345",
+          "timestamp": "2022-01-01T00:01:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733355785225,
@@ -1619,7 +1619,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:05.970345",
+          "timestamp": "2022-01-01T00:01:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733397945143,
@@ -1636,7 +1636,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:06.970345",
+          "timestamp": "2022-01-01T00:01:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733441518713,
@@ -1653,7 +1653,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:07.970345",
+          "timestamp": "2022-01-01T00:01:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733485134226,
@@ -1670,7 +1670,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:08.970345",
+          "timestamp": "2022-01-01T00:01:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733529972726,
@@ -1687,7 +1687,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:09.970345",
+          "timestamp": "2022-01-01T00:01:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733574811227,
@@ -1704,7 +1704,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:10.970345",
+          "timestamp": "2022-01-01T00:01:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733619649727,
@@ -1721,7 +1721,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:11.970345",
+          "timestamp": "2022-01-01T00:01:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733664920518,
@@ -1738,7 +1738,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:12.970345",
+          "timestamp": "2022-01-01T00:01:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733711862165,
@@ -1755,7 +1755,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:13.970345",
+          "timestamp": "2022-01-01T00:01:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733758803811,
@@ -1772,7 +1772,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:14.970345",
+          "timestamp": "2022-01-01T00:01:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733805745456,
@@ -1789,7 +1789,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:15.970345",
+          "timestamp": "2022-01-01T00:01:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733857636298,
@@ -1806,7 +1806,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:16.970345",
+          "timestamp": "2022-01-01T00:01:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733917734221,
@@ -1823,7 +1823,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:17.970345",
+          "timestamp": "2022-01-01T00:01:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733977832145,
@@ -1840,7 +1840,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:18.970345",
+          "timestamp": "2022-01-01T00:01:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573403793007,
@@ -1857,7 +1857,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:19.970345",
+          "timestamp": "2022-01-01T00:01:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734087410968,
@@ -1874,7 +1874,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:20.970345",
+          "timestamp": "2022-01-01T00:01:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734127111565,
@@ -1891,7 +1891,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:21.970345",
+          "timestamp": "2022-01-01T00:01:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734166812161,
@@ -1908,7 +1908,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:22.970345",
+          "timestamp": "2022-01-01T00:01:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573420993486,
@@ -1925,7 +1925,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:23.970345",
+          "timestamp": "2022-01-01T00:01:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734283198043,
@@ -1942,7 +1942,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:24.970345",
+          "timestamp": "2022-01-01T00:01:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734356378817,
@@ -1959,7 +1959,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:25.970345",
+          "timestamp": "2022-01-01T00:01:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734445067306,
@@ -1976,7 +1976,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:26.970345",
+          "timestamp": "2022-01-01T00:01:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734534755024,
@@ -1993,7 +1993,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:27.970345",
+          "timestamp": "2022-01-01T00:01:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734636030613,
@@ -2010,7 +2010,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:28.970345",
+          "timestamp": "2022-01-01T00:01:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573473908841,
@@ -2027,7 +2027,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:29.970345",
+          "timestamp": "2022-01-01T00:02:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734850333353,
@@ -2044,7 +2044,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:30.970345",
+          "timestamp": "2022-01-01T00:02:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734964476966,
@@ -2061,7 +2061,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:31.970345",
+          "timestamp": "2022-01-01T00:02:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55735081014656,
@@ -2078,7 +2078,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:32.970345",
+          "timestamp": "2022-01-01T00:02:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55735198139314,
@@ -2095,7 +2095,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:33.970345",
+          "timestamp": "2022-01-01T00:02:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55735327226601,
@@ -2112,7 +2112,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:34.970345",
+          "timestamp": "2022-01-01T00:02:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573545631389,
@@ -2129,7 +2129,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:35.970345",
+          "timestamp": "2022-01-01T00:02:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.557343954846,
@@ -2146,7 +2146,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:36.970345",
+          "timestamp": "2022-01-01T00:02:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55732943766462,
@@ -2163,7 +2163,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:37.970345",
+          "timestamp": "2022-01-01T00:02:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55731408486936,
@@ -2180,7 +2180,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:38.970345",
+          "timestamp": "2022-01-01T00:02:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55729968823441,
@@ -2197,7 +2197,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:39.970345",
+          "timestamp": "2022-01-01T00:02:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55728313009878,
@@ -2214,7 +2214,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:40.970345",
+          "timestamp": "2022-01-01T00:02:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55727517344461,
@@ -2231,7 +2231,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:41.970345",
+          "timestamp": "2022-01-01T00:02:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55727695104936,
@@ -2248,7 +2248,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:42.970345",
+          "timestamp": "2022-01-01T00:02:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55726265435754,
@@ -2265,7 +2265,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:43.970345",
+          "timestamp": "2022-01-01T00:02:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55724467575784,
@@ -2282,7 +2282,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:44.970345",
+          "timestamp": "2022-01-01T00:02:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721118858361,
@@ -2299,7 +2299,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:45.970345",
+          "timestamp": "2022-01-01T00:02:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721316383084,
@@ -2316,7 +2316,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:46.970345",
+          "timestamp": "2022-01-01T00:02:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721523471551,
@@ -2333,7 +2333,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:47.970345",
+          "timestamp": "2022-01-01T00:02:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721726121051,
@@ -2350,7 +2350,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:48.970345",
+          "timestamp": "2022-01-01T00:02:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721920016256,
@@ -2367,7 +2367,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:49.970345",
+          "timestamp": "2022-01-01T00:02:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55722563788848,
@@ -2384,7 +2384,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:50.970345",
+          "timestamp": "2022-01-01T00:02:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55725070062638,
@@ -2401,7 +2401,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:51.970345",
+          "timestamp": "2022-01-01T00:02:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55727118193124,
@@ -2418,7 +2418,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:52.970345",
+          "timestamp": "2022-01-01T00:02:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55730968274429,
@@ -2435,7 +2435,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:53.970345",
+          "timestamp": "2022-01-01T00:02:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573389012726,
@@ -2452,7 +2452,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:54.970345",
+          "timestamp": "2022-01-01T00:02:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55736887353636,
@@ -2469,7 +2469,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:55.970345",
+          "timestamp": "2022-01-01T00:02:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55739882853904,
@@ -2486,7 +2486,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:56.970345",
+          "timestamp": "2022-01-01T00:02:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55742296332538,
@@ -2503,7 +2503,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:57.970345",
+          "timestamp": "2022-01-01T00:02:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55746489902124,
@@ -2520,7 +2520,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:58.970345",
+          "timestamp": "2022-01-01T00:02:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55750395416608,
@@ -2537,7 +2537,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:59.970345",
+          "timestamp": "2022-01-01T00:02:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55753429158254,
@@ -2554,7 +2554,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:00.970345",
+          "timestamp": "2022-01-01T00:02:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55757325101276,
@@ -2571,7 +2571,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:01.970345",
+          "timestamp": "2022-01-01T00:02:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5576108687793,
@@ -2588,7 +2588,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:02.970345",
+          "timestamp": "2022-01-01T00:02:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5576318894644,
@@ -2605,7 +2605,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:03.970345",
+          "timestamp": "2022-01-01T00:02:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55764685004341,
@@ -2622,7 +2622,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:04.970345",
+          "timestamp": "2022-01-01T00:02:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55768577408388,
@@ -2639,7 +2639,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:05.970345",
+          "timestamp": "2022-01-01T00:02:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55772043283407,
@@ -2656,7 +2656,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:06.970345",
+          "timestamp": "2022-01-01T00:02:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55776043608212,
@@ -2673,7 +2673,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:07.970345",
+          "timestamp": "2022-01-01T00:02:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55779870272295,
@@ -2690,7 +2690,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:08.970345",
+          "timestamp": "2022-01-01T00:02:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55784343294158,
@@ -2707,7 +2707,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:09.970345",
+          "timestamp": "2022-01-01T00:02:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55789464396001,
@@ -2724,7 +2724,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:10.970345",
+          "timestamp": "2022-01-01T00:02:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55795157697321,
@@ -2741,7 +2741,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:11.970345",
+          "timestamp": "2022-01-01T00:02:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55798554733651,
@@ -2758,7 +2758,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:12.970345",
+          "timestamp": "2022-01-01T00:02:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55805216287122,
@@ -2775,7 +2775,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:13.970345",
+          "timestamp": "2022-01-01T00:02:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55811089893879,
@@ -2792,7 +2792,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:14.970345",
+          "timestamp": "2022-01-01T00:02:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55817150411879,
@@ -2809,7 +2809,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:15.970345",
+          "timestamp": "2022-01-01T00:02:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.558240539984,
@@ -2826,7 +2826,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:16.970345",
+          "timestamp": "2022-01-01T00:02:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55831398817026,
@@ -2843,7 +2843,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:17.970345",
+          "timestamp": "2022-01-01T00:02:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55838742357162,
@@ -2860,7 +2860,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:18.970345",
+          "timestamp": "2022-01-01T00:02:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55846761644754,
@@ -2877,7 +2877,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:19.970345",
+          "timestamp": "2022-01-01T00:02:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55854208512984,
@@ -2894,7 +2894,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:20.970345",
+          "timestamp": "2022-01-01T00:02:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55862710641618,
@@ -2911,7 +2911,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:21.970345",
+          "timestamp": "2022-01-01T00:02:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5586872996325,
@@ -2928,7 +2928,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:22.970345",
+          "timestamp": "2022-01-01T00:02:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5587808259695,
@@ -2945,7 +2945,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:23.970345",
+          "timestamp": "2022-01-01T00:02:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5588508146302,
@@ -2962,7 +2962,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:24.970345",
+          "timestamp": "2022-01-01T00:02:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5589343324195,
@@ -2979,7 +2979,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:25.970345",
+          "timestamp": "2022-01-01T00:02:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5590017581236,
@@ -2996,7 +2996,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:26.970345",
+          "timestamp": "2022-01-01T00:02:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55907414434347,
@@ -3013,7 +3013,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:27.970345",
+          "timestamp": "2022-01-01T00:02:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55915440065786,
@@ -3030,7 +3030,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:28.970345",
+          "timestamp": "2022-01-01T00:02:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55922732769312,
@@ -3047,7 +3047,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:29.970345",
+          "timestamp": "2022-01-01T00:03:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55930063226994,
@@ -3064,7 +3064,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:30.970345",
+          "timestamp": "2022-01-01T00:03:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.559373959728,
@@ -3081,7 +3081,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:31.970345",
+          "timestamp": "2022-01-01T00:03:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55946566708946,
@@ -3098,7 +3098,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:32.970345",
+          "timestamp": "2022-01-01T00:03:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5595493326404,
@@ -3115,7 +3115,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:33.970345",
+          "timestamp": "2022-01-01T00:03:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55963047018922,
@@ -3132,7 +3132,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:34.970345",
+          "timestamp": "2022-01-01T00:03:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55970754824102,
@@ -3149,7 +3149,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:35.970345",
+          "timestamp": "2022-01-01T00:03:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55977275501277,
@@ -3166,7 +3166,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:36.970345",
+          "timestamp": "2022-01-01T00:03:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55983361495983,
@@ -3183,7 +3183,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:37.970345",
+          "timestamp": "2022-01-01T00:03:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55988773040072,
@@ -3200,7 +3200,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:38.970345",
+          "timestamp": "2022-01-01T00:03:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55992736101369,
@@ -3217,7 +3217,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:39.970345",
+          "timestamp": "2022-01-01T00:03:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55997476478788,
@@ -3234,7 +3234,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:40.970345",
+          "timestamp": "2022-01-01T00:03:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56001607449427,
@@ -3251,7 +3251,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:41.970345",
+          "timestamp": "2022-01-01T00:03:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56004110927793,
@@ -3268,7 +3268,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:42.970345",
+          "timestamp": "2022-01-01T00:03:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56004387014573,
@@ -3285,7 +3285,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:43.970345",
+          "timestamp": "2022-01-01T00:03:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56006090382282,
@@ -3302,7 +3302,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:44.970345",
+          "timestamp": "2022-01-01T00:03:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5600819674061,
@@ -3319,7 +3319,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:45.970345",
+          "timestamp": "2022-01-01T00:03:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56010443781491,
@@ -3336,7 +3336,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:46.970345",
+          "timestamp": "2022-01-01T00:03:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56010821598646,
@@ -3353,7 +3353,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:47.970345",
+          "timestamp": "2022-01-01T00:03:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56015565670769,
@@ -3370,7 +3370,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:48.970345",
+          "timestamp": "2022-01-01T00:03:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56019834690878,
@@ -3387,7 +3387,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:49.970345",
+          "timestamp": "2022-01-01T00:03:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56025438766261,
@@ -3404,7 +3404,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:50.970345",
+          "timestamp": "2022-01-01T00:03:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56032126072544,
@@ -3421,7 +3421,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:51.970345",
+          "timestamp": "2022-01-01T00:03:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56040418870582,
@@ -3438,7 +3438,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:52.970345",
+          "timestamp": "2022-01-01T00:03:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56049412623985,
@@ -3455,7 +3455,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:53.970345",
+          "timestamp": "2022-01-01T00:03:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56058898017126,
@@ -3472,7 +3472,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:54.970345",
+          "timestamp": "2022-01-01T00:03:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56068587093156,
@@ -3489,7 +3489,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:55.970345",
+          "timestamp": "2022-01-01T00:03:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56078829968811,
@@ -3506,7 +3506,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:56.970345",
+          "timestamp": "2022-01-01T00:03:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56089244777561,
@@ -3523,7 +3523,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:57.970345",
+          "timestamp": "2022-01-01T00:03:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56099659587368,
@@ -3540,7 +3540,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:58.970345",
+          "timestamp": "2022-01-01T00:03:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56110074271807,
@@ -3557,7 +3557,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:59.970345",
+          "timestamp": "2022-01-01T00:03:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5612037165951,
@@ -3574,7 +3574,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:00.970345",
+          "timestamp": "2022-01-01T00:03:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56130160776804,
@@ -3591,7 +3591,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:01.970345",
+          "timestamp": "2022-01-01T00:03:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56139507858816,
@@ -3608,7 +3608,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:02.970345",
+          "timestamp": "2022-01-01T00:03:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56146761317322,
@@ -3625,7 +3625,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:03.970345",
+          "timestamp": "2022-01-01T00:03:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56153576951313,
@@ -3642,7 +3642,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:04.970345",
+          "timestamp": "2022-01-01T00:03:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5615907616452,
@@ -3659,7 +3659,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:05.970345",
+          "timestamp": "2022-01-01T00:03:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56162866580672,
@@ -3676,7 +3676,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:06.970345",
+          "timestamp": "2022-01-01T00:03:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56165794080306,
@@ -3693,7 +3693,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:07.970345",
+          "timestamp": "2022-01-01T00:03:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56166608928166,
@@ -3710,7 +3710,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:08.970345",
+          "timestamp": "2022-01-01T00:03:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56166321517145,
@@ -3727,7 +3727,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:09.970345",
+          "timestamp": "2022-01-01T00:03:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56166057971004,
@@ -3744,7 +3744,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:10.970345",
+          "timestamp": "2022-01-01T00:03:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56162357584547,
@@ -3761,7 +3761,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:11.970345",
+          "timestamp": "2022-01-01T00:03:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56157982336579,
@@ -3778,7 +3778,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:12.970345",
+          "timestamp": "2022-01-01T00:03:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56152753254581,
@@ -3795,7 +3795,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:13.970345",
+          "timestamp": "2022-01-01T00:03:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56146760565841,
@@ -3812,7 +3812,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:14.970345",
+          "timestamp": "2022-01-01T00:03:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5614162046886,
@@ -3829,7 +3829,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:15.970345",
+          "timestamp": "2022-01-01T00:03:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56134266423726,
@@ -3846,7 +3846,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:16.970345",
+          "timestamp": "2022-01-01T00:03:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5612862683198,
@@ -3863,7 +3863,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:17.970345",
+          "timestamp": "2022-01-01T00:03:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56120325364735,
@@ -3880,7 +3880,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:18.970345",
+          "timestamp": "2022-01-01T00:03:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56112023375648,
@@ -3897,7 +3897,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:19.970345",
+          "timestamp": "2022-01-01T00:03:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56103721337054,
@@ -3914,7 +3914,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:20.970345",
+          "timestamp": "2022-01-01T00:03:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56094719819912,
@@ -3931,7 +3931,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:21.970345",
+          "timestamp": "2022-01-01T00:03:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5608648620154,
@@ -3948,7 +3948,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:22.970345",
+          "timestamp": "2022-01-01T00:03:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56076877026625,
@@ -3965,7 +3965,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:23.970345",
+          "timestamp": "2022-01-01T00:03:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56067346175698,
@@ -3982,7 +3982,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:24.970345",
+          "timestamp": "2022-01-01T00:03:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56057502063146,
@@ -3999,7 +3999,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:25.970345",
+          "timestamp": "2022-01-01T00:03:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56047992560615,
@@ -4016,7 +4016,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:26.970345",
+          "timestamp": "2022-01-01T00:03:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56038053304883,
@@ -4033,7 +4033,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:27.970345",
+          "timestamp": "2022-01-01T00:03:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56030303785046,
@@ -4050,7 +4050,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:28.970345",
+          "timestamp": "2022-01-01T00:03:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56020826002636,
@@ -4067,7 +4067,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:29.970345",
+          "timestamp": "2022-01-01T00:04:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56012451383904,
@@ -4084,7 +4084,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:30.970345",
+          "timestamp": "2022-01-01T00:04:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56005797705193,
@@ -4101,7 +4101,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:31.970345",
+          "timestamp": "2022-01-01T00:04:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55998433175812,
@@ -4118,7 +4118,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:32.970345",
+          "timestamp": "2022-01-01T00:04:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55991775547116,
@@ -4135,7 +4135,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:33.970345",
+          "timestamp": "2022-01-01T00:04:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5598543095213,
@@ -4152,7 +4152,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:34.970345",
+          "timestamp": "2022-01-01T00:04:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5598249666531,
@@ -4169,7 +4169,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:35.970345",
+          "timestamp": "2022-01-01T00:04:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55979446220445,
@@ -4186,7 +4186,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:36.970345",
+          "timestamp": "2022-01-01T00:04:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55976686832963,
@@ -4203,7 +4203,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:37.970345",
+          "timestamp": "2022-01-01T00:04:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55975182736663,
@@ -4220,7 +4220,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:38.970345",
+          "timestamp": "2022-01-01T00:04:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55974391856105,
@@ -4237,7 +4237,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:39.970345",
+          "timestamp": "2022-01-01T00:04:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55974209622167,
@@ -4254,7 +4254,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:40.970345",
+          "timestamp": "2022-01-01T00:04:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55973882161435,
@@ -4271,7 +4271,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:41.970345",
+          "timestamp": "2022-01-01T00:04:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55974601728134,
@@ -4288,7 +4288,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:42.970345",
+          "timestamp": "2022-01-01T00:04:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55975021104906,
@@ -4305,7 +4305,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:43.970345",
+          "timestamp": "2022-01-01T00:04:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55974747185472,
@@ -4322,7 +4322,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:44.970345",
+          "timestamp": "2022-01-01T00:04:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55978289946131,
@@ -4339,7 +4339,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:45.970345",
+          "timestamp": "2022-01-01T00:04:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55981955219242,
@@ -4356,7 +4356,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:46.970345",
+          "timestamp": "2022-01-01T00:04:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5598542229314,
@@ -4373,7 +4373,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:47.970345",
+          "timestamp": "2022-01-01T00:04:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55989638450897,
@@ -4390,7 +4390,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:48.970345",
+          "timestamp": "2022-01-01T00:04:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55993426886542,
@@ -4407,7 +4407,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:49.970345",
+          "timestamp": "2022-01-01T00:04:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55999501716528,
@@ -4424,7 +4424,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:50.970345",
+          "timestamp": "2022-01-01T00:04:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56005598381806,
@@ -4441,7 +4441,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:51.970345",
+          "timestamp": "2022-01-01T00:04:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56012305333188,
@@ -4458,7 +4458,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:52.970345",
+          "timestamp": "2022-01-01T00:04:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56018961532554,
@@ -4475,7 +4475,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:53.970345",
+          "timestamp": "2022-01-01T00:04:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56027135174062,
@@ -4492,7 +4492,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:54.970345",
+          "timestamp": "2022-01-01T00:04:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5603389755723,
@@ -4509,7 +4509,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:55.970345",
+          "timestamp": "2022-01-01T00:04:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56041361967469,
@@ -4526,7 +4526,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:56.970345",
+          "timestamp": "2022-01-01T00:04:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56046719809441,
@@ -4543,7 +4543,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:57.970345",
+          "timestamp": "2022-01-01T00:04:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5605379168105,
@@ -4560,7 +4560,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:58.970345",
+          "timestamp": "2022-01-01T00:04:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56059723311317,
@@ -4577,7 +4577,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:59.970345",
+          "timestamp": "2022-01-01T00:04:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56065563022518,
@@ -4594,7 +4594,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:00.970345",
+          "timestamp": "2022-01-01T00:04:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56071574542776,
@@ -4611,7 +4611,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:01.970345",
+          "timestamp": "2022-01-01T00:04:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56073718987862,
@@ -4628,7 +4628,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:02.970345",
+          "timestamp": "2022-01-01T00:04:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56075837429901,
@@ -4645,7 +4645,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:03.970345",
+          "timestamp": "2022-01-01T00:04:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56076498921237,
@@ -4662,7 +4662,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:04.970345",
+          "timestamp": "2022-01-01T00:04:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56076111129099,
@@ -4679,7 +4679,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:05.970345",
+          "timestamp": "2022-01-01T00:04:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56075705697396,
@@ -4696,7 +4696,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:06.970345",
+          "timestamp": "2022-01-01T00:04:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56073903856318,
@@ -4713,7 +4713,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:07.970345",
+          "timestamp": "2022-01-01T00:04:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56069843481238,
@@ -4730,7 +4730,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:08.970345",
+          "timestamp": "2022-01-01T00:04:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5606759456639,
@@ -4747,7 +4747,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:09.970345",
+          "timestamp": "2022-01-01T00:04:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56064784460078,
@@ -4764,7 +4764,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:10.970345",
+          "timestamp": "2022-01-01T00:04:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56058760206267,
@@ -4781,7 +4781,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:11.970345",
+          "timestamp": "2022-01-01T00:04:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56053946174792,
@@ -4798,7 +4798,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:12.970345",
+          "timestamp": "2022-01-01T00:04:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56049114746669,
@@ -4815,7 +4815,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:13.970345",
+          "timestamp": "2022-01-01T00:04:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56044970732688,
@@ -4832,7 +4832,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:14.970345",
+          "timestamp": "2022-01-01T00:04:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.560368149753,
@@ -4849,7 +4849,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:15.970345",
+          "timestamp": "2022-01-01T00:04:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5602934603551,
@@ -4866,7 +4866,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:16.970345",
+          "timestamp": "2022-01-01T00:04:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56025269302518,
@@ -4883,7 +4883,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:17.970345",
+          "timestamp": "2022-01-01T00:04:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56017214019548,
@@ -4900,7 +4900,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:18.970345",
+          "timestamp": "2022-01-01T00:04:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5601022541763,
@@ -4917,7 +4917,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:19.970345",
+          "timestamp": "2022-01-01T00:04:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.56002409654442,
@@ -4934,7 +4934,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:20.970345",
+          "timestamp": "2022-01-01T00:04:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55994349348352,
@@ -4951,7 +4951,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:21.970345",
+          "timestamp": "2022-01-01T00:04:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55985498721256,
@@ -4968,7 +4968,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:22.970345",
+          "timestamp": "2022-01-01T00:04:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5597706170816,
@@ -4985,7 +4985,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:23.970345",
+          "timestamp": "2022-01-01T00:04:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55973340371712,
@@ -5002,7 +5002,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:24.970345",
+          "timestamp": "2022-01-01T00:04:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55963701888334,
@@ -5019,7 +5019,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:25.970345",
+          "timestamp": "2022-01-01T00:04:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5595439071141,
@@ -5036,7 +5036,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:26.970345",
+          "timestamp": "2022-01-01T00:04:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55944886430812,
@@ -5053,7 +5053,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:27.970345",
+          "timestamp": "2022-01-01T00:04:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55935452961204,
@@ -5070,7 +5070,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:28.970345",
+          "timestamp": "2022-01-01T00:04:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55925856632139,
@@ -5087,7 +5087,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:29.970345",
+          "timestamp": "2022-01-01T00:05:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55916867655685,
@@ -5104,7 +5104,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:30.970345",
+          "timestamp": "2022-01-01T00:05:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55908997174686,
@@ -5121,7 +5121,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:31.970345",
+          "timestamp": "2022-01-01T00:05:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55900229256031,
@@ -5138,7 +5138,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:32.970345",
+          "timestamp": "2022-01-01T00:05:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55891591009342,
@@ -5155,7 +5155,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:33.970345",
+          "timestamp": "2022-01-01T00:05:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55883127892191,
@@ -5172,7 +5172,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:34.970345",
+          "timestamp": "2022-01-01T00:05:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55873647510788,
@@ -5189,7 +5189,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:35.970345",
+          "timestamp": "2022-01-01T00:05:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.558644117806,
@@ -5206,7 +5206,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:36.970345",
+          "timestamp": "2022-01-01T00:05:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55855485884916,
@@ -5223,7 +5223,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:37.970345",
+          "timestamp": "2022-01-01T00:05:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5584808186344,
@@ -5240,7 +5240,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:38.970345",
+          "timestamp": "2022-01-01T00:05:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55839653458438,
@@ -5257,7 +5257,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:39.970345",
+          "timestamp": "2022-01-01T00:05:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55830664148189,
@@ -5274,7 +5274,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:40.970345",
+          "timestamp": "2022-01-01T00:05:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55821802522372,
@@ -5291,7 +5291,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:41.970345",
+          "timestamp": "2022-01-01T00:05:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5581330908226,
@@ -5308,7 +5308,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:42.970345",
+          "timestamp": "2022-01-01T00:05:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55803394711585,
@@ -5325,7 +5325,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:43.970345",
+          "timestamp": "2022-01-01T00:05:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55792979794114,
@@ -5342,7 +5342,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:44.970345",
+          "timestamp": "2022-01-01T00:05:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5578627252237,
@@ -5359,7 +5359,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:45.970345",
+          "timestamp": "2022-01-01T00:05:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55776700834028,
@@ -5376,7 +5376,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:46.970345",
+          "timestamp": "2022-01-01T00:05:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55768450192467,
@@ -5393,7 +5393,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:47.970345",
+          "timestamp": "2022-01-01T00:05:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55759665140987,
@@ -5410,7 +5410,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:48.970345",
+          "timestamp": "2022-01-01T00:05:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55750678209853,
@@ -5427,7 +5427,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:49.970345",
+          "timestamp": "2022-01-01T00:05:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55745503600211,
@@ -5444,7 +5444,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:50.970345",
+          "timestamp": "2022-01-01T00:05:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55741432069249,
@@ -5461,7 +5461,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:51.970345",
+          "timestamp": "2022-01-01T00:05:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55736659487134,
@@ -5478,7 +5478,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:52.970345",
+          "timestamp": "2022-01-01T00:05:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734576789125,
@@ -5495,7 +5495,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:53.970345",
+          "timestamp": "2022-01-01T00:05:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734257461468,
@@ -5512,7 +5512,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:54.970345",
+          "timestamp": "2022-01-01T00:05:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55735796293274,
@@ -5529,7 +5529,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:55.970345",
+          "timestamp": "2022-01-01T00:05:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55735649406601,
@@ -5546,7 +5546,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:56.970345",
+          "timestamp": "2022-01-01T00:05:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55735480309689,
@@ -5563,7 +5563,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:57.970345",
+          "timestamp": "2022-01-01T00:05:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55736051184904,
@@ -5580,7 +5580,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:58.970345",
+          "timestamp": "2022-01-01T00:05:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55738008999626,
@@ -5597,7 +5597,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:59.970345",
+          "timestamp": "2022-01-01T00:05:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55741725876157,
@@ -5614,7 +5614,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:00.970345",
+          "timestamp": "2022-01-01T00:05:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55746932812458,
@@ -5631,7 +5631,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:01.970345",
+          "timestamp": "2022-01-01T00:05:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55754718543506,
@@ -5648,7 +5648,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:02.970345",
+          "timestamp": "2022-01-01T00:05:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55761554554955,
@@ -5665,7 +5665,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:03.970345",
+          "timestamp": "2022-01-01T00:05:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5576877607415,
@@ -5682,7 +5682,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:04.970345",
+          "timestamp": "2022-01-01T00:05:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55778039822601,
@@ -5699,7 +5699,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:05.970345",
+          "timestamp": "2022-01-01T00:05:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55786055284712,
@@ -5716,7 +5716,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:06.970345",
+          "timestamp": "2022-01-01T00:05:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55796228748251,
@@ -5733,7 +5733,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:07.970345",
+          "timestamp": "2022-01-01T00:05:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55806551935714,
@@ -5750,7 +5750,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:08.970345",
+          "timestamp": "2022-01-01T00:05:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55816966772933,
@@ -5767,7 +5767,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:09.970345",
+          "timestamp": "2022-01-01T00:05:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55826319918164,
@@ -5784,7 +5784,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:10.970345",
+          "timestamp": "2022-01-01T00:05:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5583635066124,
@@ -5801,7 +5801,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:11.970345",
+          "timestamp": "2022-01-01T00:05:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55846102484777,
@@ -5818,7 +5818,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:12.970345",
+          "timestamp": "2022-01-01T00:05:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55856205500913,
@@ -5835,7 +5835,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:13.970345",
+          "timestamp": "2022-01-01T00:05:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55865994336506,
@@ -5852,7 +5852,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:14.970345",
+          "timestamp": "2022-01-01T00:05:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55875061951728,
@@ -5869,7 +5869,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:15.970345",
+          "timestamp": "2022-01-01T00:05:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55884012333146,
@@ -5886,7 +5886,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:16.970345",
+          "timestamp": "2022-01-01T00:05:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55889325519334,
@@ -5903,7 +5903,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:17.970345",
+          "timestamp": "2022-01-01T00:05:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55895805969759,
@@ -5920,7 +5920,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:18.970345",
+          "timestamp": "2022-01-01T00:05:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55902372521548,
@@ -5937,7 +5937,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:19.970345",
+          "timestamp": "2022-01-01T00:05:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5590752021792,
@@ -5954,7 +5954,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:20.970345",
+          "timestamp": "2022-01-01T00:05:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55910874853282,
@@ -5971,7 +5971,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:21.970345",
+          "timestamp": "2022-01-01T00:05:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55914529855345,
@@ -5988,7 +5988,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:22.970345",
+          "timestamp": "2022-01-01T00:05:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55916760993885,
@@ -6005,7 +6005,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:23.970345",
+          "timestamp": "2022-01-01T00:05:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55919476952135,
@@ -6022,7 +6022,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:24.970345",
+          "timestamp": "2022-01-01T00:05:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55922879774671,
@@ -6039,7 +6039,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:25.970345",
+          "timestamp": "2022-01-01T00:05:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55924177537496,
@@ -6056,7 +6056,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:26.970345",
+          "timestamp": "2022-01-01T00:05:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55924427353797,
@@ -6073,7 +6073,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:27.970345",
+          "timestamp": "2022-01-01T00:05:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5592459775485,
@@ -6090,7 +6090,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:28.970345",
+          "timestamp": "2022-01-01T00:05:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5592479894165,
@@ -6107,7 +6107,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:29.970345",
+          "timestamp": "2022-01-01T00:06:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55924938184411,
@@ -6124,7 +6124,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:30.970345",
+          "timestamp": "2022-01-01T00:06:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55925138065807,
@@ -6141,7 +6141,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:31.970345",
+          "timestamp": "2022-01-01T00:06:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55924424906752,
@@ -6158,7 +6158,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:32.970345",
+          "timestamp": "2022-01-01T00:06:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55922297192531,
@@ -6176,7 +6176,7 @@
         }
       ],
       "flight_details": {
-        "id": "b1f6a451-c44a-4347-8d5a-29857f7e8c13",
+        "id": "d50598bc-638a-4f52-bf3f-dd85595fb52e",
         "serial_number": "EXMPLx31bclx2guk",
         "operation_description": "Traffic Monitoring",
         "operator_location": {
@@ -6189,10 +6189,10 @@
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-10-17T02:07:30.126105",
+      "reference_time": "2022-01-01T00:00:00+00:00",
       "states": [
         {
-          "timestamp": "2022-10-17T02:07:31.126105",
+          "timestamp": "2022-01-01T00:00:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55581936582074,
@@ -6209,7 +6209,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:32.126105",
+          "timestamp": "2022-01-01T00:00:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55581669380187,
@@ -6226,7 +6226,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:33.126105",
+          "timestamp": "2022-01-01T00:00:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55581402178302,
@@ -6243,7 +6243,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:34.126105",
+          "timestamp": "2022-01-01T00:00:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55581134976417,
@@ -6260,7 +6260,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:35.126105",
+          "timestamp": "2022-01-01T00:00:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55580867774532,
@@ -6277,7 +6277,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:36.126105",
+          "timestamp": "2022-01-01T00:00:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55580600572645,
@@ -6294,7 +6294,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:37.126105",
+          "timestamp": "2022-01-01T00:00:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5558033337076,
@@ -6311,7 +6311,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:38.126105",
+          "timestamp": "2022-01-01T00:00:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55580071234004,
@@ -6328,7 +6328,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:39.126105",
+          "timestamp": "2022-01-01T00:00:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55580022829996,
@@ -6345,7 +6345,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:40.126105",
+          "timestamp": "2022-01-01T00:00:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55579974425989,
@@ -6362,7 +6362,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:41.126105",
+          "timestamp": "2022-01-01T00:00:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5557992602198,
@@ -6379,7 +6379,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:42.126105",
+          "timestamp": "2022-01-01T00:00:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5557987616816,
@@ -6396,7 +6396,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:43.126105",
+          "timestamp": "2022-01-01T00:00:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5557982627114,
@@ -6413,7 +6413,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:44.126105",
+          "timestamp": "2022-01-01T00:00:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55579776374123,
@@ -6430,7 +6430,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:45.126105",
+          "timestamp": "2022-01-01T00:00:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55579737157251,
@@ -6447,7 +6447,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:46.126105",
+          "timestamp": "2022-01-01T00:00:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55579698800017,
@@ -6464,7 +6464,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:47.126105",
+          "timestamp": "2022-01-01T00:00:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55580288469913,
@@ -6481,7 +6481,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:48.126105",
+          "timestamp": "2022-01-01T00:00:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55581533637773,
@@ -6498,7 +6498,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:49.126105",
+          "timestamp": "2022-01-01T00:00:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55582778805633,
@@ -6515,7 +6515,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:50.126105",
+          "timestamp": "2022-01-01T00:00:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55584021735116,
@@ -6532,7 +6532,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:51.126105",
+          "timestamp": "2022-01-01T00:00:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55585264062606,
@@ -6549,7 +6549,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:52.126105",
+          "timestamp": "2022-01-01T00:00:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5558660533437,
@@ -6566,7 +6566,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:53.126105",
+          "timestamp": "2022-01-01T00:00:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5558899065479,
@@ -6583,7 +6583,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:54.126105",
+          "timestamp": "2022-01-01T00:00:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5559137597521,
@@ -6600,7 +6600,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:55.126105",
+          "timestamp": "2022-01-01T00:00:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55593838038952,
@@ -6617,7 +6617,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:56.126105",
+          "timestamp": "2022-01-01T00:00:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55596306210226,
@@ -6634,7 +6634,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:57.126105",
+          "timestamp": "2022-01-01T00:00:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.555987743815,
@@ -6651,7 +6651,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:58.126105",
+          "timestamp": "2022-01-01T00:00:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55601290445293,
@@ -6668,7 +6668,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:59.126105",
+          "timestamp": "2022-01-01T00:00:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55603870088487,
@@ -6685,7 +6685,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:00.126105",
+          "timestamp": "2022-01-01T00:00:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55606449731681,
@@ -6702,7 +6702,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:01.126105",
+          "timestamp": "2022-01-01T00:00:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55609029341424,
@@ -6719,7 +6719,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:02.126105",
+          "timestamp": "2022-01-01T00:00:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.556116089399,
@@ -6736,7 +6736,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:03.126105",
+          "timestamp": "2022-01-01T00:00:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55614203636298,
@@ -6753,7 +6753,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:04.126105",
+          "timestamp": "2022-01-01T00:00:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55617008949211,
@@ -6770,7 +6770,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:05.126105",
+          "timestamp": "2022-01-01T00:00:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55619814262126,
@@ -6787,7 +6787,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:06.126105",
+          "timestamp": "2022-01-01T00:00:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55622671364368,
@@ -6804,7 +6804,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:07.126105",
+          "timestamp": "2022-01-01T00:00:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55625564403229,
@@ -6821,7 +6821,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:08.126105",
+          "timestamp": "2022-01-01T00:00:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55628441849824,
@@ -6838,7 +6838,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:09.126105",
+          "timestamp": "2022-01-01T00:00:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55631247057372,
@@ -6855,7 +6855,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:10.126105",
+          "timestamp": "2022-01-01T00:00:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55634052264918,
@@ -6872,7 +6872,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:11.126105",
+          "timestamp": "2022-01-01T00:00:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55636919085526,
@@ -6889,7 +6889,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:12.126105",
+          "timestamp": "2022-01-01T00:00:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55639812124602,
@@ -6906,7 +6906,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:13.126105",
+          "timestamp": "2022-01-01T00:00:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55642705163677,
@@ -6923,7 +6923,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:14.126105",
+          "timestamp": "2022-01-01T00:00:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.556455982029,
@@ -6940,7 +6940,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:15.126105",
+          "timestamp": "2022-01-01T00:00:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55648491243754,
@@ -6957,7 +6957,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:16.126105",
+          "timestamp": "2022-01-01T00:00:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55651384284609,
@@ -6974,7 +6974,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:17.126105",
+          "timestamp": "2022-01-01T00:00:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55653879700775,
@@ -6991,7 +6991,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:18.126105",
+          "timestamp": "2022-01-01T00:00:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55656183845352,
@@ -7008,7 +7008,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:19.126105",
+          "timestamp": "2022-01-01T00:00:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5565848798993,
@@ -7025,7 +7025,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:20.126105",
+          "timestamp": "2022-01-01T00:00:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55660601846391,
@@ -7042,7 +7042,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:21.126105",
+          "timestamp": "2022-01-01T00:00:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55662626141427,
@@ -7059,7 +7059,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:22.126105",
+          "timestamp": "2022-01-01T00:00:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55664648945434,
@@ -7076,7 +7076,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:23.126105",
+          "timestamp": "2022-01-01T00:00:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5566666244675,
@@ -7093,7 +7093,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:24.126105",
+          "timestamp": "2022-01-01T00:00:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55668675948067,
@@ -7110,7 +7110,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:25.126105",
+          "timestamp": "2022-01-01T00:00:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55670235357846,
@@ -7127,7 +7127,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:26.126105",
+          "timestamp": "2022-01-01T00:00:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55671485352369,
@@ -7144,7 +7144,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:27.126105",
+          "timestamp": "2022-01-01T00:00:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55672735346891,
@@ -7161,7 +7161,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:28.126105",
+          "timestamp": "2022-01-01T00:00:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55674394264378,
@@ -7178,7 +7178,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:29.126105",
+          "timestamp": "2022-01-01T00:00:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55676093843442,
@@ -7195,7 +7195,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:30.126105",
+          "timestamp": "2022-01-01T00:01:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55677793422507,
@@ -7212,7 +7212,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:31.126105",
+          "timestamp": "2022-01-01T00:01:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55677899240854,
@@ -7229,7 +7229,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:32.126105",
+          "timestamp": "2022-01-01T00:01:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55677843893281,
@@ -7246,7 +7246,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:33.126105",
+          "timestamp": "2022-01-01T00:01:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55677788545708,
@@ -7263,7 +7263,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:34.126105",
+          "timestamp": "2022-01-01T00:01:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55677733230891,
@@ -7280,7 +7280,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:35.126105",
+          "timestamp": "2022-01-01T00:01:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55677677920691,
@@ -7297,7 +7297,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:36.126105",
+          "timestamp": "2022-01-01T00:01:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5567762261049,
@@ -7314,7 +7314,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:37.126105",
+          "timestamp": "2022-01-01T00:01:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55677569702459,
@@ -7331,7 +7331,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:38.126105",
+          "timestamp": "2022-01-01T00:01:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5567751723022,
@@ -7348,7 +7348,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:39.126105",
+          "timestamp": "2022-01-01T00:01:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55676924941076,
@@ -7365,7 +7365,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:40.126105",
+          "timestamp": "2022-01-01T00:01:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55675596261567,
@@ -7382,7 +7382,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:41.126105",
+          "timestamp": "2022-01-01T00:01:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55674267582056,
@@ -7399,7 +7399,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:42.126105",
+          "timestamp": "2022-01-01T00:01:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55673511432451,
@@ -7416,7 +7416,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:43.126105",
+          "timestamp": "2022-01-01T00:01:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55673004521164,
@@ -7433,7 +7433,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:44.126105",
+          "timestamp": "2022-01-01T00:01:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55672497609876,
@@ -7450,7 +7450,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:45.126105",
+          "timestamp": "2022-01-01T00:01:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55671967762596,
@@ -7467,7 +7467,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:46.126105",
+          "timestamp": "2022-01-01T00:01:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55670635595425,
@@ -7484,7 +7484,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:47.126105",
+          "timestamp": "2022-01-01T00:01:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55669303428253,
@@ -7501,7 +7501,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:48.126105",
+          "timestamp": "2022-01-01T00:01:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55668082200667,
@@ -7518,7 +7518,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:49.126105",
+          "timestamp": "2022-01-01T00:01:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55667123716661,
@@ -7535,7 +7535,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:50.126105",
+          "timestamp": "2022-01-01T00:01:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55666165232655,
@@ -7552,7 +7552,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:51.126105",
+          "timestamp": "2022-01-01T00:01:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55665206748648,
@@ -7569,7 +7569,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:52.126105",
+          "timestamp": "2022-01-01T00:01:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55664660030925,
@@ -7586,7 +7586,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:53.126105",
+          "timestamp": "2022-01-01T00:01:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55664612593971,
@@ -7603,7 +7603,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:54.126105",
+          "timestamp": "2022-01-01T00:01:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55664565157018,
@@ -7620,7 +7620,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:55.126105",
+          "timestamp": "2022-01-01T00:01:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5566426152008,
@@ -7637,7 +7637,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:56.126105",
+          "timestamp": "2022-01-01T00:01:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55663630287302,
@@ -7654,7 +7654,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:57.126105",
+          "timestamp": "2022-01-01T00:01:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55662999054523,
@@ -7671,7 +7671,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:58.126105",
+          "timestamp": "2022-01-01T00:01:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55662563165315,
@@ -7688,7 +7688,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:59.126105",
+          "timestamp": "2022-01-01T00:01:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55662518059793,
@@ -7705,7 +7705,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:00.126105",
+          "timestamp": "2022-01-01T00:01:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5566247295427,
@@ -7722,7 +7722,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:01.126105",
+          "timestamp": "2022-01-01T00:01:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55662880793699,
@@ -7739,7 +7739,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:02.126105",
+          "timestamp": "2022-01-01T00:01:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55663328800304,
@@ -7756,7 +7756,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:03.126105",
+          "timestamp": "2022-01-01T00:01:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55663776806905,
@@ -7773,7 +7773,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:04.126105",
+          "timestamp": "2022-01-01T00:01:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55664459107314,
@@ -7790,7 +7790,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:05.126105",
+          "timestamp": "2022-01-01T00:01:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55665747176377,
@@ -7807,7 +7807,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:06.126105",
+          "timestamp": "2022-01-01T00:01:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5566703524544,
@@ -7824,7 +7824,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:07.126105",
+          "timestamp": "2022-01-01T00:01:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55667926926866,
@@ -7841,7 +7841,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:08.126105",
+          "timestamp": "2022-01-01T00:01:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55668561430355,
@@ -7858,7 +7858,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:09.126105",
+          "timestamp": "2022-01-01T00:01:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55669376248713,
@@ -7875,7 +7875,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:10.126105",
+          "timestamp": "2022-01-01T00:01:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55671384410076,
@@ -7892,7 +7892,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:11.126105",
+          "timestamp": "2022-01-01T00:01:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55673392571438,
@@ -7909,7 +7909,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:12.126105",
+          "timestamp": "2022-01-01T00:01:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55675207105895,
@@ -7926,7 +7926,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:13.126105",
+          "timestamp": "2022-01-01T00:01:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55676899175566,
@@ -7943,7 +7943,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:14.126105",
+          "timestamp": "2022-01-01T00:01:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55678591245236,
@@ -7960,7 +7960,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:15.126105",
+          "timestamp": "2022-01-01T00:01:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55680773889718,
@@ -7977,7 +7977,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:16.126105",
+          "timestamp": "2022-01-01T00:01:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55683235314352,
@@ -7994,7 +7994,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:17.126105",
+          "timestamp": "2022-01-01T00:01:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55685696738985,
@@ -8011,7 +8011,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:18.126105",
+          "timestamp": "2022-01-01T00:01:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55688220830228,
@@ -8028,7 +8028,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:19.126105",
+          "timestamp": "2022-01-01T00:01:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5569102346377,
@@ -8045,7 +8045,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:20.126105",
+          "timestamp": "2022-01-01T00:01:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55693826097311,
@@ -8062,7 +8062,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:21.126105",
+          "timestamp": "2022-01-01T00:01:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55696536418056,
@@ -8079,7 +8079,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:22.126105",
+          "timestamp": "2022-01-01T00:01:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55699213687274,
@@ -8096,7 +8096,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:23.126105",
+          "timestamp": "2022-01-01T00:01:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55701890956492,
@@ -8113,7 +8113,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:24.126105",
+          "timestamp": "2022-01-01T00:01:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55704685893409,
@@ -8130,7 +8130,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:25.126105",
+          "timestamp": "2022-01-01T00:01:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55707578929164,
@@ -8147,7 +8147,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:26.126105",
+          "timestamp": "2022-01-01T00:01:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55710457543387,
@@ -8164,7 +8164,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:27.126105",
+          "timestamp": "2022-01-01T00:01:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571326082402,
@@ -8181,7 +8181,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:28.126105",
+          "timestamp": "2022-01-01T00:01:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55716064104654,
@@ -8198,7 +8198,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:29.126105",
+          "timestamp": "2022-01-01T00:01:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55718931333095,
@@ -8215,7 +8215,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:30.126105",
+          "timestamp": "2022-01-01T00:02:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721804147369,
@@ -8232,7 +8232,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:31.126105",
+          "timestamp": "2022-01-01T00:02:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55724658272409,
@@ -8249,7 +8249,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:32.126105",
+          "timestamp": "2022-01-01T00:02:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55727512397449,
@@ -8266,7 +8266,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:33.126105",
+          "timestamp": "2022-01-01T00:02:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573036652249,
@@ -8283,7 +8283,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:34.126105",
+          "timestamp": "2022-01-01T00:02:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733205295975,
@@ -8300,7 +8300,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:35.126105",
+          "timestamp": "2022-01-01T00:02:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55736042095515,
@@ -8317,7 +8317,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:36.126105",
+          "timestamp": "2022-01-01T00:02:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55738878895053,
@@ -8334,7 +8334,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:37.126105",
+          "timestamp": "2022-01-01T00:02:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5574176216974,
@@ -8351,7 +8351,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:38.126105",
+          "timestamp": "2022-01-01T00:02:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55744619634365,
@@ -8368,7 +8368,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:39.126105",
+          "timestamp": "2022-01-01T00:02:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55747455704899,
@@ -8385,7 +8385,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:40.126105",
+          "timestamp": "2022-01-01T00:02:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55750291775432,
@@ -8402,7 +8402,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:41.126105",
+          "timestamp": "2022-01-01T00:02:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55753121437769,
@@ -8419,7 +8419,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:42.126105",
+          "timestamp": "2022-01-01T00:02:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55755945658069,
@@ -8436,7 +8436,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:43.126105",
+          "timestamp": "2022-01-01T00:02:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55758769878372,
@@ -8453,7 +8453,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:44.126105",
+          "timestamp": "2022-01-01T00:02:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55761594098671,
@@ -8470,7 +8470,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:45.126105",
+          "timestamp": "2022-01-01T00:02:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55764418318972,
@@ -8487,7 +8487,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:46.126105",
+          "timestamp": "2022-01-01T00:02:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55767242539272,
@@ -8504,7 +8504,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:47.126105",
+          "timestamp": "2022-01-01T00:02:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55769844703822,
@@ -8521,7 +8521,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:48.126105",
+          "timestamp": "2022-01-01T00:02:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55772436118676,
@@ -8538,7 +8538,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:49.126105",
+          "timestamp": "2022-01-01T00:02:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55775027785039,
@@ -8555,7 +8555,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:50.126105",
+          "timestamp": "2022-01-01T00:02:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55777620278593,
@@ -8572,7 +8572,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:51.126105",
+          "timestamp": "2022-01-01T00:02:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55780212772149,
@@ -8589,7 +8589,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:52.126105",
+          "timestamp": "2022-01-01T00:02:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55782669798748,
@@ -8606,7 +8606,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:53.126105",
+          "timestamp": "2022-01-01T00:02:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55784995929935,
@@ -8623,7 +8623,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:54.126105",
+          "timestamp": "2022-01-01T00:02:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55787322061123,
@@ -8640,7 +8640,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:55.126105",
+          "timestamp": "2022-01-01T00:02:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55789690408619,
@@ -8657,7 +8657,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:56.126105",
+          "timestamp": "2022-01-01T00:02:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55792107832002,
@@ -8674,7 +8674,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:57.126105",
+          "timestamp": "2022-01-01T00:02:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5579448791531,
@@ -8691,7 +8691,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:58.126105",
+          "timestamp": "2022-01-01T00:02:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55796764372427,
@@ -8708,7 +8708,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:59.126105",
+          "timestamp": "2022-01-01T00:02:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55799040829542,
@@ -8725,7 +8725,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:00.126105",
+          "timestamp": "2022-01-01T00:02:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55801317286658,
@@ -8742,7 +8742,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:01.126105",
+          "timestamp": "2022-01-01T00:02:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55803420141689,
@@ -8759,7 +8759,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:02.126105",
+          "timestamp": "2022-01-01T00:02:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5580519262727,
@@ -8776,7 +8776,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:03.126105",
+          "timestamp": "2022-01-01T00:02:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5580696511285,
@@ -8793,7 +8793,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:04.126105",
+          "timestamp": "2022-01-01T00:02:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55808613642122,
@@ -8810,7 +8810,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:05.126105",
+          "timestamp": "2022-01-01T00:02:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5580995662095,
@@ -8827,7 +8827,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:06.126105",
+          "timestamp": "2022-01-01T00:02:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55811299599779,
@@ -8844,7 +8844,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:07.126105",
+          "timestamp": "2022-01-01T00:02:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55811920681198,
@@ -8861,7 +8861,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:08.126105",
+          "timestamp": "2022-01-01T00:02:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5581198497026,
@@ -8878,7 +8878,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:09.126105",
+          "timestamp": "2022-01-01T00:02:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55812049259325,
@@ -8895,7 +8895,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:10.126105",
+          "timestamp": "2022-01-01T00:02:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5581121084415,
@@ -8912,7 +8912,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:11.126105",
+          "timestamp": "2022-01-01T00:02:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55809634582762,
@@ -8929,7 +8929,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:12.126105",
+          "timestamp": "2022-01-01T00:02:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55808428952315,
@@ -8946,7 +8946,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:13.126105",
+          "timestamp": "2022-01-01T00:02:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55807782122811,
@@ -8963,7 +8963,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:14.126105",
+          "timestamp": "2022-01-01T00:02:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55807135293308,
@@ -8980,7 +8980,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:15.126105",
+          "timestamp": "2022-01-01T00:02:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55805921422868,
@@ -8997,7 +8997,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:16.126105",
+          "timestamp": "2022-01-01T00:02:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55804662150776,
@@ -9014,7 +9014,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:17.126105",
+          "timestamp": "2022-01-01T00:02:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55803402987226,
@@ -9031,7 +9031,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:18.126105",
+          "timestamp": "2022-01-01T00:02:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55802144144666,
@@ -9048,7 +9048,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:19.126105",
+          "timestamp": "2022-01-01T00:02:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55800885302101,
@@ -9065,7 +9065,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:20.126105",
+          "timestamp": "2022-01-01T00:02:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55799631805053,
@@ -9082,7 +9082,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:21.126105",
+          "timestamp": "2022-01-01T00:02:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5579838220839,
@@ -9099,7 +9099,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:22.126105",
+          "timestamp": "2022-01-01T00:02:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55797132611727,
@@ -9116,7 +9116,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:23.126105",
+          "timestamp": "2022-01-01T00:02:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55795179633374,
@@ -9133,7 +9133,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:24.126105",
+          "timestamp": "2022-01-01T00:02:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55793149862994,
@@ -9150,7 +9150,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:25.126105",
+          "timestamp": "2022-01-01T00:02:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55791240499192,
@@ -9167,7 +9167,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:26.126105",
+          "timestamp": "2022-01-01T00:02:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55789536651432,
@@ -9184,7 +9184,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:27.126105",
+          "timestamp": "2022-01-01T00:02:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55787832803672,
@@ -9201,7 +9201,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:28.126105",
+          "timestamp": "2022-01-01T00:02:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.557858960293,
@@ -9218,7 +9218,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:29.126105",
+          "timestamp": "2022-01-01T00:02:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55783584490165,
@@ -9235,7 +9235,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:30.126105",
+          "timestamp": "2022-01-01T00:03:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55781272951029,
@@ -9252,7 +9252,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:31.126105",
+          "timestamp": "2022-01-01T00:03:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5577873454409,
@@ -9269,7 +9269,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:32.126105",
+          "timestamp": "2022-01-01T00:03:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55775841505631,
@@ -9286,7 +9286,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:33.126105",
+          "timestamp": "2022-01-01T00:03:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55772948467174,
@@ -9303,7 +9303,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:34.126105",
+          "timestamp": "2022-01-01T00:03:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55770055428717,
@@ -9320,7 +9320,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:35.126105",
+          "timestamp": "2022-01-01T00:03:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5576721565341,
@@ -9337,7 +9337,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:36.126105",
+          "timestamp": "2022-01-01T00:03:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55764392203402,
@@ -9354,7 +9354,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:37.126105",
+          "timestamp": "2022-01-01T00:03:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55761568753394,
@@ -9371,7 +9371,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:38.126105",
+          "timestamp": "2022-01-01T00:03:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55758745303388,
@@ -9388,7 +9388,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:39.126105",
+          "timestamp": "2022-01-01T00:03:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55755921853378,
@@ -9405,7 +9405,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:40.126105",
+          "timestamp": "2022-01-01T00:03:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55753113353965,
@@ -9422,7 +9422,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:41.126105",
+          "timestamp": "2022-01-01T00:03:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55750367733948,
@@ -9439,7 +9439,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:42.126105",
+          "timestamp": "2022-01-01T00:03:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55747622113931,
@@ -9456,7 +9456,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:43.126105",
+          "timestamp": "2022-01-01T00:03:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55744876493915,
@@ -9473,7 +9473,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:44.126105",
+          "timestamp": "2022-01-01T00:03:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55742074766027,
@@ -9490,7 +9490,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:45.126105",
+          "timestamp": "2022-01-01T00:03:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55739181748525,
@@ -9507,7 +9507,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:46.126105",
+          "timestamp": "2022-01-01T00:03:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55736288731022,
@@ -9524,7 +9524,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:47.126105",
+          "timestamp": "2022-01-01T00:03:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733516944828,
@@ -9541,7 +9541,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:48.126105",
+          "timestamp": "2022-01-01T00:03:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55730922661581,
@@ -9558,7 +9558,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:49.126105",
+          "timestamp": "2022-01-01T00:03:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55728235955023,
@@ -9575,7 +9575,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:50.126105",
+          "timestamp": "2022-01-01T00:03:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55725549248464,
@@ -9592,7 +9592,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:51.126105",
+          "timestamp": "2022-01-01T00:03:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55722862541906,
@@ -9609,7 +9609,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:52.126105",
+          "timestamp": "2022-01-01T00:03:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55720128155548,
@@ -9626,7 +9626,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:53.126105",
+          "timestamp": "2022-01-01T00:03:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55717381880625,
@@ -9643,7 +9643,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:54.126105",
+          "timestamp": "2022-01-01T00:03:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55714636402251,
@@ -9660,7 +9660,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:55.126105",
+          "timestamp": "2022-01-01T00:03:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55711891017162,
@@ -9677,7 +9677,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:56.126105",
+          "timestamp": "2022-01-01T00:03:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55709145632073,
@@ -9694,7 +9694,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:57.126105",
+          "timestamp": "2022-01-01T00:03:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55706413493878,
@@ -9711,7 +9711,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:58.126105",
+          "timestamp": "2022-01-01T00:03:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5570382371643,
@@ -9728,7 +9728,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:59.126105",
+          "timestamp": "2022-01-01T00:03:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55701233938983,
@@ -9745,7 +9745,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:00.126105",
+          "timestamp": "2022-01-01T00:03:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55698684646495,
@@ -9762,7 +9762,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:01.126105",
+          "timestamp": "2022-01-01T00:03:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55696200701288,
@@ -9779,7 +9779,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:02.126105",
+          "timestamp": "2022-01-01T00:03:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55693716756083,
@@ -9796,7 +9796,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:03.126105",
+          "timestamp": "2022-01-01T00:03:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55691232810877,
@@ -9813,7 +9813,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:04.126105",
+          "timestamp": "2022-01-01T00:03:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55688888584206,
@@ -9830,7 +9830,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:05.126105",
+          "timestamp": "2022-01-01T00:03:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55686567658265,
@@ -9847,7 +9847,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:06.126105",
+          "timestamp": "2022-01-01T00:03:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55684246732324,
@@ -9864,7 +9864,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:07.126105",
+          "timestamp": "2022-01-01T00:03:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55681702721182,
@@ -9881,7 +9881,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:08.126105",
+          "timestamp": "2022-01-01T00:03:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55679112843298,
@@ -9898,7 +9898,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:09.126105",
+          "timestamp": "2022-01-01T00:03:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55676502863138,
@@ -9915,7 +9915,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:10.126105",
+          "timestamp": "2022-01-01T00:03:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5567375992865,
@@ -9932,7 +9932,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:11.126105",
+          "timestamp": "2022-01-01T00:03:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55671016994162,
@@ -9949,7 +9949,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:12.126105",
+          "timestamp": "2022-01-01T00:03:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55668274059676,
@@ -9966,7 +9966,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:13.126105",
+          "timestamp": "2022-01-01T00:03:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55665515947948,
@@ -9983,7 +9983,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:14.126105",
+          "timestamp": "2022-01-01T00:03:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55662714231644,
@@ -10000,7 +10000,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:15.126105",
+          "timestamp": "2022-01-01T00:03:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5565991251534,
@@ -10017,7 +10017,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:16.126105",
+          "timestamp": "2022-01-01T00:03:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55657086131966,
@@ -10034,7 +10034,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:17.126105",
+          "timestamp": "2022-01-01T00:03:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55654249423065,
@@ -10051,7 +10051,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:18.126105",
+          "timestamp": "2022-01-01T00:03:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55651412714165,
@@ -10068,7 +10068,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:19.126105",
+          "timestamp": "2022-01-01T00:03:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55648576009102,
@@ -10085,7 +10085,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:20.126105",
+          "timestamp": "2022-01-01T00:03:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55645739306246,
@@ -10102,7 +10102,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:21.126105",
+          "timestamp": "2022-01-01T00:03:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55642902603388,
@@ -10119,7 +10119,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:22.126105",
+          "timestamp": "2022-01-01T00:03:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55640034080112,
@@ -10136,7 +10136,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:23.126105",
+          "timestamp": "2022-01-01T00:03:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55637141039261,
@@ -10153,7 +10153,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:24.126105",
+          "timestamp": "2022-01-01T00:03:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5563424799841,
@@ -10170,7 +10170,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:25.126105",
+          "timestamp": "2022-01-01T00:03:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55631354958096,
@@ -10187,7 +10187,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:26.126105",
+          "timestamp": "2022-01-01T00:03:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55628461918198,
@@ -10204,7 +10204,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:27.126105",
+          "timestamp": "2022-01-01T00:03:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.556255688783,
@@ -10221,7 +10221,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:28.126105",
+          "timestamp": "2022-01-01T00:03:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55622706691558,
@@ -10238,7 +10238,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:29.126105",
+          "timestamp": "2022-01-01T00:03:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55619868715925,
@@ -10255,7 +10255,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:30.126105",
+          "timestamp": "2022-01-01T00:04:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55617030740292,
@@ -10272,7 +10272,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:31.126105",
+          "timestamp": "2022-01-01T00:04:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55614238940736,
@@ -10289,7 +10289,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:32.126105",
+          "timestamp": "2022-01-01T00:04:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5561149370515,
@@ -10306,7 +10306,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:33.126105",
+          "timestamp": "2022-01-01T00:04:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5560878417587,
@@ -10323,7 +10323,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:34.126105",
+          "timestamp": "2022-01-01T00:04:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55606098167155,
@@ -10340,7 +10340,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:35.126105",
+          "timestamp": "2022-01-01T00:04:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55603412158442,
@@ -10357,7 +10357,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:36.126105",
+          "timestamp": "2022-01-01T00:04:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55600974296725,
@@ -10374,7 +10374,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:37.126105",
+          "timestamp": "2022-01-01T00:04:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55598943993078,
@@ -10391,7 +10391,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:38.126105",
+          "timestamp": "2022-01-01T00:04:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55596913689432,
@@ -10408,7 +10408,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:39.126105",
+          "timestamp": "2022-01-01T00:04:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55595267310675,
@@ -10425,7 +10425,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:40.126105",
+          "timestamp": "2022-01-01T00:04:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55593691541159,
@@ -10442,7 +10442,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:41.126105",
+          "timestamp": "2022-01-01T00:04:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55592115771644,
@@ -10459,7 +10459,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:42.126105",
+          "timestamp": "2022-01-01T00:04:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55590540002129,
@@ -10476,7 +10476,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:43.126105",
+          "timestamp": "2022-01-01T00:04:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.555891362286,
@@ -10493,7 +10493,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:44.126105",
+          "timestamp": "2022-01-01T00:04:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.555878826468,
@@ -10510,7 +10510,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:45.126105",
+          "timestamp": "2022-01-01T00:04:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55586629065002,
@@ -10527,7 +10527,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:46.126105",
+          "timestamp": "2022-01-01T00:04:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55585886486463,
@@ -10544,7 +10544,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:47.126105",
+          "timestamp": "2022-01-01T00:04:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55585232131345,
@@ -10561,7 +10561,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:48.126105",
+          "timestamp": "2022-01-01T00:04:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55584837814446,
@@ -10578,7 +10578,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:49.126105",
+          "timestamp": "2022-01-01T00:04:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55584884848844,
@@ -10595,7 +10595,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:50.126105",
+          "timestamp": "2022-01-01T00:04:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55584931883241,
@@ -10612,7 +10612,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:51.126105",
+          "timestamp": "2022-01-01T00:04:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55584978922903,
@@ -10629,7 +10629,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:52.126105",
+          "timestamp": "2022-01-01T00:04:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55585025972492,
@@ -10646,7 +10646,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:53.126105",
+          "timestamp": "2022-01-01T00:04:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55585078002834,
@@ -10663,7 +10663,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:54.126105",
+          "timestamp": "2022-01-01T00:04:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55585134433407,
@@ -10680,7 +10680,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:55.126105",
+          "timestamp": "2022-01-01T00:04:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55585190863981,
@@ -10697,7 +10697,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:56.126105",
+          "timestamp": "2022-01-01T00:04:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55585689212916,
@@ -10714,7 +10714,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:57.126105",
+          "timestamp": "2022-01-01T00:04:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5558663793219,
@@ -10731,7 +10731,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:58.126105",
+          "timestamp": "2022-01-01T00:04:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55587586651463,
@@ -10748,7 +10748,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:59.126105",
+          "timestamp": "2022-01-01T00:04:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55588535370737,
@@ -10765,7 +10765,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:00.126105",
+          "timestamp": "2022-01-01T00:04:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5558934894742,
@@ -10782,7 +10782,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:01.126105",
+          "timestamp": "2022-01-01T00:04:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55590089095256,
@@ -10799,7 +10799,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:02.126105",
+          "timestamp": "2022-01-01T00:04:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55590910288103,
@@ -10816,7 +10816,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:03.126105",
+          "timestamp": "2022-01-01T00:04:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55592231132788,
@@ -10833,7 +10833,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:04.126105",
+          "timestamp": "2022-01-01T00:04:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5559355197747,
@@ -10850,7 +10850,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:05.126105",
+          "timestamp": "2022-01-01T00:04:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55594872822154,
@@ -10867,7 +10867,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:06.126105",
+          "timestamp": "2022-01-01T00:04:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55596193700777,
@@ -10884,7 +10884,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:07.126105",
+          "timestamp": "2022-01-01T00:04:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55597515278664,
@@ -10901,7 +10901,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:08.126105",
+          "timestamp": "2022-01-01T00:04:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55598836856551,
@@ -10918,7 +10918,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:09.126105",
+          "timestamp": "2022-01-01T00:04:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55600158434439,
@@ -10935,7 +10935,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:10.126105",
+          "timestamp": "2022-01-01T00:04:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55601480012326,
@@ -10952,7 +10952,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:11.126105",
+          "timestamp": "2022-01-01T00:04:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55603209229668,
@@ -10969,7 +10969,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:12.126105",
+          "timestamp": "2022-01-01T00:04:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55604961401991,
@@ -10986,7 +10986,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:13.126105",
+          "timestamp": "2022-01-01T00:04:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55606713574315,
@@ -11003,7 +11003,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:14.126105",
+          "timestamp": "2022-01-01T00:04:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55608083408714,
@@ -11020,7 +11020,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:15.126105",
+          "timestamp": "2022-01-01T00:04:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55609405201518,
@@ -11037,7 +11037,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:16.126105",
+          "timestamp": "2022-01-01T00:04:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55610878253846,
@@ -11054,7 +11054,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:17.126105",
+          "timestamp": "2022-01-01T00:04:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55613195532908,
@@ -11071,7 +11071,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:18.126105",
+          "timestamp": "2022-01-01T00:04:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5561551281197,
@@ -11088,7 +11088,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:19.126105",
+          "timestamp": "2022-01-01T00:04:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55617804359491,
@@ -11105,7 +11105,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:20.126105",
+          "timestamp": "2022-01-01T00:04:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55619858748703,
@@ -11122,7 +11122,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:21.126105",
+          "timestamp": "2022-01-01T00:04:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55621913137914,
@@ -11139,7 +11139,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:22.126105",
+          "timestamp": "2022-01-01T00:04:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55623967471134,
@@ -11156,7 +11156,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:23.126105",
+          "timestamp": "2022-01-01T00:04:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55626021748765,
@@ -11173,7 +11173,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:24.126105",
+          "timestamp": "2022-01-01T00:04:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55628076026396,
@@ -11190,7 +11190,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:25.126105",
+          "timestamp": "2022-01-01T00:04:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55630612016907,
@@ -11207,7 +11207,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:26.126105",
+          "timestamp": "2022-01-01T00:04:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55633198629413,
@@ -11224,7 +11224,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:27.126105",
+          "timestamp": "2022-01-01T00:04:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5563578524192,
@@ -11241,7 +11241,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:28.126105",
+          "timestamp": "2022-01-01T00:04:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55638371854425,
@@ -11258,7 +11258,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:29.126105",
+          "timestamp": "2022-01-01T00:04:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55640958851379,
@@ -11275,7 +11275,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:30.126105",
+          "timestamp": "2022-01-01T00:05:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55643545932992,
@@ -11292,7 +11292,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:31.126105",
+          "timestamp": "2022-01-01T00:05:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55646154434221,
@@ -11309,7 +11309,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:32.126105",
+          "timestamp": "2022-01-01T00:05:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55648960121329,
@@ -11326,7 +11326,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:33.126105",
+          "timestamp": "2022-01-01T00:05:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55651765808435,
@@ -11343,7 +11343,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:34.126105",
+          "timestamp": "2022-01-01T00:05:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5565462387991,
@@ -11360,7 +11360,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:35.126105",
+          "timestamp": "2022-01-01T00:05:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55657516920775,
@@ -11377,7 +11377,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:36.126105",
+          "timestamp": "2022-01-01T00:05:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5566040996164,
@@ -11394,7 +11394,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:37.126105",
+          "timestamp": "2022-01-01T00:05:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55663302998735,
@@ -11411,7 +11411,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:38.126105",
+          "timestamp": "2022-01-01T00:05:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55666196033135,
@@ -11428,7 +11428,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:39.126105",
+          "timestamp": "2022-01-01T00:05:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55669089067536,
@@ -11445,7 +11445,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:40.126105",
+          "timestamp": "2022-01-01T00:05:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55671982101936,
@@ -11462,7 +11462,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:41.126105",
+          "timestamp": "2022-01-01T00:05:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55674875139904,
@@ -11479,7 +11479,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:42.126105",
+          "timestamp": "2022-01-01T00:05:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55677768178028,
@@ -11496,7 +11496,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:43.126105",
+          "timestamp": "2022-01-01T00:05:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55680630437752,
@@ -11513,7 +11513,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:44.126105",
+          "timestamp": "2022-01-01T00:05:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55683466711733,
@@ -11530,7 +11530,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:45.126105",
+          "timestamp": "2022-01-01T00:05:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55686302985714,
@@ -11547,7 +11547,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:46.126105",
+          "timestamp": "2022-01-01T00:05:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55689017624371,
@@ -11564,7 +11564,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:47.126105",
+          "timestamp": "2022-01-01T00:05:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55691597307035,
@@ -11581,7 +11581,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:48.126105",
+          "timestamp": "2022-01-01T00:05:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.556941769897,
@@ -11598,7 +11598,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:49.126105",
+          "timestamp": "2022-01-01T00:05:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55696621272774,
@@ -11615,7 +11615,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:50.126105",
+          "timestamp": "2022-01-01T00:05:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55699029910869,
@@ -11632,7 +11632,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:51.126105",
+          "timestamp": "2022-01-01T00:05:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55701553338696,
@@ -11649,7 +11649,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:52.126105",
+          "timestamp": "2022-01-01T00:05:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55704146617437,
@@ -11666,7 +11666,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:53.126105",
+          "timestamp": "2022-01-01T00:05:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55706739896176,
@@ -11683,7 +11683,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:54.126105",
+          "timestamp": "2022-01-01T00:05:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55708522616581,
@@ -11700,7 +11700,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:55.126105",
+          "timestamp": "2022-01-01T00:05:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55710239553494,
@@ -11717,7 +11717,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:56.126105",
+          "timestamp": "2022-01-01T00:05:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55711956490407,
@@ -11734,7 +11734,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:57.126105",
+          "timestamp": "2022-01-01T00:05:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571396404282,
@@ -11751,7 +11751,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:58.126105",
+          "timestamp": "2022-01-01T00:05:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55715996306648,
@@ -11768,7 +11768,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:59.126105",
+          "timestamp": "2022-01-01T00:05:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55717729927376,
@@ -11785,7 +11785,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:00.126105",
+          "timestamp": "2022-01-01T00:05:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55718964782649,
@@ -11802,7 +11802,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:01.126105",
+          "timestamp": "2022-01-01T00:05:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55720199637923,
@@ -11819,7 +11819,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:02.126105",
+          "timestamp": "2022-01-01T00:05:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55720930499152,
@@ -11836,7 +11836,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:03.126105",
+          "timestamp": "2022-01-01T00:05:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721426036745,
@@ -11853,7 +11853,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:04.126105",
+          "timestamp": "2022-01-01T00:05:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721921574337,
@@ -11870,7 +11870,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:05.126105",
+          "timestamp": "2022-01-01T00:05:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55722085095074,
@@ -11887,7 +11887,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:06.126105",
+          "timestamp": "2022-01-01T00:05:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55722018814062,
@@ -11904,7 +11904,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:07.126105",
+          "timestamp": "2022-01-01T00:05:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721952533051,
@@ -11921,7 +11921,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:08.126105",
+          "timestamp": "2022-01-01T00:05:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721197209455,
@@ -11938,7 +11938,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:09.126105",
+          "timestamp": "2022-01-01T00:05:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55719876697506,
@@ -11955,7 +11955,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:10.126105",
+          "timestamp": "2022-01-01T00:05:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55718556185559,
@@ -11972,7 +11972,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:11.126105",
+          "timestamp": "2022-01-01T00:05:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55717225546587,
@@ -11989,7 +11989,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:12.126105",
+          "timestamp": "2022-01-01T00:05:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55715892544264,
@@ -12006,7 +12006,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:13.126105",
+          "timestamp": "2022-01-01T00:05:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55714493250676,
@@ -12023,7 +12023,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:14.126105",
+          "timestamp": "2022-01-01T00:05:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55712435935912,
@@ -12040,7 +12040,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:15.126105",
+          "timestamp": "2022-01-01T00:05:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571037862115,
@@ -12057,7 +12057,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:16.126105",
+          "timestamp": "2022-01-01T00:05:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55708474607125,
@@ -12074,7 +12074,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:17.126105",
+          "timestamp": "2022-01-01T00:05:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55706717945559,
@@ -12091,7 +12091,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:18.126105",
+          "timestamp": "2022-01-01T00:05:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55704961283992,
@@ -12108,7 +12108,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:19.126105",
+          "timestamp": "2022-01-01T00:05:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55703204826152,
@@ -12125,7 +12125,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:20.126105",
+          "timestamp": "2022-01-01T00:05:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55701448601081,
@@ -12142,7 +12142,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:21.126105",
+          "timestamp": "2022-01-01T00:05:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55699692376011,
@@ -12159,7 +12159,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:22.126105",
+          "timestamp": "2022-01-01T00:05:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55697722512262,
@@ -12176,7 +12176,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:23.126105",
+          "timestamp": "2022-01-01T00:05:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55695458322029,
@@ -12193,7 +12193,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:24.126105",
+          "timestamp": "2022-01-01T00:05:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55693194131797,
@@ -12210,7 +12210,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:25.126105",
+          "timestamp": "2022-01-01T00:05:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55690929941564,
@@ -12227,7 +12227,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:26.126105",
+          "timestamp": "2022-01-01T00:05:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55688770552952,
@@ -12244,7 +12244,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:27.126105",
+          "timestamp": "2022-01-01T00:05:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55686712850816,
@@ -12261,7 +12261,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:28.126105",
+          "timestamp": "2022-01-01T00:05:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5568464931583,
@@ -12278,7 +12278,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:29.126105",
+          "timestamp": "2022-01-01T00:05:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55682584131587,
@@ -12295,7 +12295,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:30.126105",
+          "timestamp": "2022-01-01T00:06:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55680518947342,
@@ -12312,7 +12312,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:31.126105",
+          "timestamp": "2022-01-01T00:06:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55678323687098,
@@ -12330,7 +12330,7 @@
         }
       ],
       "flight_details": {
-        "id": "10ffadac-b9a8-42ef-99b4-e6f9b8f33562",
+        "id": "d50598bc-638a-4f52-bf3f-dd85595fb52e",
         "serial_number": "EXMPLjNb2D9Eya9Q",
         "operation_description": "Tight S's",
         "operator_location": {
@@ -12343,10 +12343,10 @@
       "aircraft_type": "Helicopter"
     },
     {
-      "reference_time": "2022-10-17T02:07:30.251627",
+      "reference_time": "2022-01-01T00:00:00+00:00",
       "states": [
         {
-          "timestamp": "2022-10-17T02:07:31.251627",
+          "timestamp": "2022-01-01T00:00:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55585370976215,
@@ -12363,7 +12363,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:32.251627",
+          "timestamp": "2022-01-01T00:00:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55586759636044,
@@ -12380,7 +12380,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:33.251627",
+          "timestamp": "2022-01-01T00:00:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55588148295875,
@@ -12397,7 +12397,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:34.251627",
+          "timestamp": "2022-01-01T00:00:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55589536955705,
@@ -12414,7 +12414,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:35.251627",
+          "timestamp": "2022-01-01T00:00:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55590925615536,
@@ -12431,7 +12431,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:36.251627",
+          "timestamp": "2022-01-01T00:00:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55592314275367,
@@ -12448,7 +12448,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:37.251627",
+          "timestamp": "2022-01-01T00:00:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55593702935197,
@@ -12465,7 +12465,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:38.251627",
+          "timestamp": "2022-01-01T00:00:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55595091595028,
@@ -12482,7 +12482,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:39.251627",
+          "timestamp": "2022-01-01T00:00:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55596480254857,
@@ -12499,7 +12499,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:40.251627",
+          "timestamp": "2022-01-01T00:00:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55597868914688,
@@ -12516,7 +12516,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:41.251627",
+          "timestamp": "2022-01-01T00:00:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5559925757452,
@@ -12533,7 +12533,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:42.251627",
+          "timestamp": "2022-01-01T00:00:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55600646234349,
@@ -12550,7 +12550,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:43.251627",
+          "timestamp": "2022-01-01T00:00:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5560203489418,
@@ -12567,7 +12567,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:44.251627",
+          "timestamp": "2022-01-01T00:00:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5560342355401,
@@ -12584,7 +12584,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:45.251627",
+          "timestamp": "2022-01-01T00:00:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5560481221384,
@@ -12601,7 +12601,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:46.251627",
+          "timestamp": "2022-01-01T00:00:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55606200873672,
@@ -12618,7 +12618,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:47.251627",
+          "timestamp": "2022-01-01T00:00:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55607589533501,
@@ -12635,7 +12635,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:48.251627",
+          "timestamp": "2022-01-01T00:00:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55608978193332,
@@ -12652,7 +12652,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:49.251627",
+          "timestamp": "2022-01-01T00:00:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55610366853162,
@@ -12669,7 +12669,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:50.251627",
+          "timestamp": "2022-01-01T00:00:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55611755512993,
@@ -12686,7 +12686,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:51.251627",
+          "timestamp": "2022-01-01T00:00:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55613144172824,
@@ -12703,7 +12703,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:52.251627",
+          "timestamp": "2022-01-01T00:00:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55614532832655,
@@ -12720,7 +12720,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:53.251627",
+          "timestamp": "2022-01-01T00:00:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55615921492485,
@@ -12737,7 +12737,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:54.251627",
+          "timestamp": "2022-01-01T00:00:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55617310152314,
@@ -12754,7 +12754,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:55.251627",
+          "timestamp": "2022-01-01T00:00:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55618698812145,
@@ -12771,7 +12771,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:56.251627",
+          "timestamp": "2022-01-01T00:00:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55620087471978,
@@ -12788,7 +12788,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:57.251627",
+          "timestamp": "2022-01-01T00:00:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55621476131806,
@@ -12805,7 +12805,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:58.251627",
+          "timestamp": "2022-01-01T00:00:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55622864791637,
@@ -12822,7 +12822,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:07:59.251627",
+          "timestamp": "2022-01-01T00:00:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55624253451467,
@@ -12839,7 +12839,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:00.251627",
+          "timestamp": "2022-01-01T00:00:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55625642111298,
@@ -12856,7 +12856,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:01.251627",
+          "timestamp": "2022-01-01T00:00:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55627008777437,
@@ -12873,7 +12873,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:02.251627",
+          "timestamp": "2022-01-01T00:00:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55628369535076,
@@ -12890,7 +12890,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:03.251627",
+          "timestamp": "2022-01-01T00:00:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55629730292715,
@@ -12907,7 +12907,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:04.251627",
+          "timestamp": "2022-01-01T00:00:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55631091050354,
@@ -12924,7 +12924,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:05.251627",
+          "timestamp": "2022-01-01T00:00:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55632451807995,
@@ -12941,7 +12941,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:06.251627",
+          "timestamp": "2022-01-01T00:00:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55633812565634,
@@ -12958,7 +12958,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:07.251627",
+          "timestamp": "2022-01-01T00:00:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55635167509824,
@@ -12975,7 +12975,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:08.251627",
+          "timestamp": "2022-01-01T00:00:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5563651348335,
@@ -12992,7 +12992,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:09.251627",
+          "timestamp": "2022-01-01T00:00:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55637859456874,
@@ -13009,7 +13009,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:10.251627",
+          "timestamp": "2022-01-01T00:00:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55639205430398,
@@ -13026,7 +13026,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:11.251627",
+          "timestamp": "2022-01-01T00:00:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55640551403923,
@@ -13043,7 +13043,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:12.251627",
+          "timestamp": "2022-01-01T00:00:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55641897356604,
@@ -13060,7 +13060,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:13.251627",
+          "timestamp": "2022-01-01T00:00:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55643243239017,
@@ -13077,7 +13077,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:14.251627",
+          "timestamp": "2022-01-01T00:00:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55644589121428,
@@ -13094,7 +13094,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:15.251627",
+          "timestamp": "2022-01-01T00:00:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5564593500384,
@@ -13111,7 +13111,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:16.251627",
+          "timestamp": "2022-01-01T00:00:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55647280886252,
@@ -13128,7 +13128,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:17.251627",
+          "timestamp": "2022-01-01T00:00:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55648626826533,
@@ -13145,7 +13145,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:18.251627",
+          "timestamp": "2022-01-01T00:00:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55649973701982,
@@ -13162,7 +13162,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:19.251627",
+          "timestamp": "2022-01-01T00:00:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5565132057743,
@@ -13179,7 +13179,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:20.251627",
+          "timestamp": "2022-01-01T00:00:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55652667452877,
@@ -13196,7 +13196,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:21.251627",
+          "timestamp": "2022-01-01T00:00:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55654014328324,
@@ -13213,7 +13213,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:22.251627",
+          "timestamp": "2022-01-01T00:00:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55655361203772,
@@ -13230,7 +13230,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:23.251627",
+          "timestamp": "2022-01-01T00:00:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55656744845481,
@@ -13247,7 +13247,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:24.251627",
+          "timestamp": "2022-01-01T00:00:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55658133496311,
@@ -13264,7 +13264,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:25.251627",
+          "timestamp": "2022-01-01T00:00:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55659482215987,
@@ -13281,7 +13281,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:26.251627",
+          "timestamp": "2022-01-01T00:00:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55660757874293,
@@ -13298,7 +13298,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:27.251627",
+          "timestamp": "2022-01-01T00:00:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55662033532597,
@@ -13315,7 +13315,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:28.251627",
+          "timestamp": "2022-01-01T00:00:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55663309190902,
@@ -13332,7 +13332,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:29.251627",
+          "timestamp": "2022-01-01T00:00:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55664584849208,
@@ -13349,7 +13349,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:30.251627",
+          "timestamp": "2022-01-01T00:01:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55665860507514,
@@ -13366,7 +13366,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:31.251627",
+          "timestamp": "2022-01-01T00:01:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55667136165819,
@@ -13383,7 +13383,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:32.251627",
+          "timestamp": "2022-01-01T00:01:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55668411824124,
@@ -13400,7 +13400,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:33.251627",
+          "timestamp": "2022-01-01T00:01:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55669687482428,
@@ -13417,7 +13417,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:34.251627",
+          "timestamp": "2022-01-01T00:01:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55670963140734,
@@ -13434,7 +13434,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:35.251627",
+          "timestamp": "2022-01-01T00:01:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5567220151049,
@@ -13451,7 +13451,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:36.251627",
+          "timestamp": "2022-01-01T00:01:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55673430406176,
@@ -13468,7 +13468,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:37.251627",
+          "timestamp": "2022-01-01T00:01:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55674659301864,
@@ -13485,7 +13485,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:38.251627",
+          "timestamp": "2022-01-01T00:01:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55675888197553,
@@ -13502,7 +13502,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:39.251627",
+          "timestamp": "2022-01-01T00:01:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55677117093241,
@@ -13519,7 +13519,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:40.251627",
+          "timestamp": "2022-01-01T00:01:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5567834802343,
@@ -13536,7 +13536,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:41.251627",
+          "timestamp": "2022-01-01T00:01:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55679585668304,
@@ -13553,7 +13553,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:42.251627",
+          "timestamp": "2022-01-01T00:01:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55680823313179,
@@ -13570,7 +13570,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:43.251627",
+          "timestamp": "2022-01-01T00:01:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55682060958053,
@@ -13587,7 +13587,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:44.251627",
+          "timestamp": "2022-01-01T00:01:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55683298602926,
@@ -13604,7 +13604,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:45.251627",
+          "timestamp": "2022-01-01T00:01:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.556845362478,
@@ -13621,7 +13621,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:46.251627",
+          "timestamp": "2022-01-01T00:01:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55685773994225,
@@ -13638,7 +13638,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:47.251627",
+          "timestamp": "2022-01-01T00:01:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5568701179878,
@@ -13655,7 +13655,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:48.251627",
+          "timestamp": "2022-01-01T00:01:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55688249603334,
@@ -13672,7 +13672,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:49.251627",
+          "timestamp": "2022-01-01T00:01:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55689487407889,
@@ -13689,7 +13689,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:50.251627",
+          "timestamp": "2022-01-01T00:01:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55690725212445,
@@ -13706,7 +13706,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:51.251627",
+          "timestamp": "2022-01-01T00:01:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55691957453533,
@@ -13723,7 +13723,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:52.251627",
+          "timestamp": "2022-01-01T00:01:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55693059483325,
@@ -13740,7 +13740,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:53.251627",
+          "timestamp": "2022-01-01T00:01:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55694161513117,
@@ -13757,7 +13757,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:54.251627",
+          "timestamp": "2022-01-01T00:01:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55695263542907,
@@ -13774,7 +13774,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:55.251627",
+          "timestamp": "2022-01-01T00:01:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55696365572699,
@@ -13791,7 +13791,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:56.251627",
+          "timestamp": "2022-01-01T00:01:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5569746760249,
@@ -13808,7 +13808,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:57.251627",
+          "timestamp": "2022-01-01T00:01:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55698569632281,
@@ -13825,7 +13825,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:58.251627",
+          "timestamp": "2022-01-01T00:01:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55699782384448,
@@ -13842,7 +13842,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:08:59.251627",
+          "timestamp": "2022-01-01T00:01:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55701025106353,
@@ -13859,7 +13859,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:00.251627",
+          "timestamp": "2022-01-01T00:01:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55702267828259,
@@ -13876,7 +13876,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:01.251627",
+          "timestamp": "2022-01-01T00:01:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55703510550164,
@@ -13893,7 +13893,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:02.251627",
+          "timestamp": "2022-01-01T00:01:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5570475327207,
@@ -13910,7 +13910,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:03.251627",
+          "timestamp": "2022-01-01T00:01:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55705949791648,
@@ -13927,7 +13927,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:04.251627",
+          "timestamp": "2022-01-01T00:01:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55706925011457,
@@ -13944,7 +13944,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:05.251627",
+          "timestamp": "2022-01-01T00:01:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55707900231266,
@@ -13961,7 +13961,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:06.251627",
+          "timestamp": "2022-01-01T00:01:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55708875451074,
@@ -13978,7 +13978,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:07.251627",
+          "timestamp": "2022-01-01T00:01:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55709850657776,
@@ -13995,7 +13995,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:08.251627",
+          "timestamp": "2022-01-01T00:01:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55710825856784,
@@ -14012,7 +14012,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:09.251627",
+          "timestamp": "2022-01-01T00:01:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55711801055793,
@@ -14029,7 +14029,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:10.251627",
+          "timestamp": "2022-01-01T00:01:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.557127762548,
@@ -14046,7 +14046,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:11.251627",
+          "timestamp": "2022-01-01T00:01:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571375145381,
@@ -14063,7 +14063,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:12.251627",
+          "timestamp": "2022-01-01T00:01:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55714726652818,
@@ -14080,7 +14080,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:13.251627",
+          "timestamp": "2022-01-01T00:01:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55715701851827,
@@ -14097,7 +14097,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:14.251627",
+          "timestamp": "2022-01-01T00:01:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571667705119,
@@ -14114,7 +14114,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:15.251627",
+          "timestamp": "2022-01-01T00:01:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571765225085,
@@ -14131,7 +14131,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:16.251627",
+          "timestamp": "2022-01-01T00:01:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571862745051,
@@ -14148,7 +14148,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:17.251627",
+          "timestamp": "2022-01-01T00:01:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55719602650169,
@@ -14165,7 +14165,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:18.251627",
+          "timestamp": "2022-01-01T00:01:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55720577849829,
@@ -14182,7 +14182,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:19.251627",
+          "timestamp": "2022-01-01T00:01:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721517108445,
@@ -14199,7 +14199,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:20.251627",
+          "timestamp": "2022-01-01T00:01:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55722339031324,
@@ -14216,7 +14216,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:21.251627",
+          "timestamp": "2022-01-01T00:01:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55723160954203,
@@ -14233,7 +14233,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:22.251627",
+          "timestamp": "2022-01-01T00:01:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55723982877083,
@@ -14250,7 +14250,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:23.251627",
+          "timestamp": "2022-01-01T00:01:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55724804799962,
@@ -14267,7 +14267,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:24.251627",
+          "timestamp": "2022-01-01T00:01:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55725626722841,
@@ -14284,7 +14284,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:25.251627",
+          "timestamp": "2022-01-01T00:01:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5572644864572,
@@ -14301,7 +14301,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:26.251627",
+          "timestamp": "2022-01-01T00:01:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55727406654408,
@@ -14318,7 +14318,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:27.251627",
+          "timestamp": "2022-01-01T00:01:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55728368570651,
@@ -14335,7 +14335,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:28.251627",
+          "timestamp": "2022-01-01T00:01:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55729330486895,
@@ -14352,7 +14352,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:29.251627",
+          "timestamp": "2022-01-01T00:01:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55730292403138,
@@ -14369,7 +14369,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:30.251627",
+          "timestamp": "2022-01-01T00:02:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55731254319382,
@@ -14386,7 +14386,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:31.251627",
+          "timestamp": "2022-01-01T00:02:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55732110763225,
@@ -14403,7 +14403,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:32.251627",
+          "timestamp": "2022-01-01T00:02:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55732916321422,
@@ -14420,7 +14420,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:33.251627",
+          "timestamp": "2022-01-01T00:02:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573372187962,
@@ -14437,7 +14437,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:34.251627",
+          "timestamp": "2022-01-01T00:02:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55734527437819,
@@ -14454,7 +14454,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:35.251627",
+          "timestamp": "2022-01-01T00:02:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55735332996016,
@@ -14471,7 +14471,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:36.251627",
+          "timestamp": "2022-01-01T00:02:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55736138554215,
@@ -14488,7 +14488,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:37.251627",
+          "timestamp": "2022-01-01T00:02:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55736853189086,
@@ -14505,7 +14505,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:38.251627",
+          "timestamp": "2022-01-01T00:02:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573744131437,
@@ -14522,7 +14522,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:39.251627",
+          "timestamp": "2022-01-01T00:02:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55738029439655,
@@ -14539,7 +14539,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:40.251627",
+          "timestamp": "2022-01-01T00:02:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573861756494,
@@ -14556,7 +14556,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:41.251627",
+          "timestamp": "2022-01-01T00:02:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55739205690226,
@@ -14573,7 +14573,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:42.251627",
+          "timestamp": "2022-01-01T00:02:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573979381551,
@@ -14590,7 +14590,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:43.251627",
+          "timestamp": "2022-01-01T00:02:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55740680767242,
@@ -14607,7 +14607,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:44.251627",
+          "timestamp": "2022-01-01T00:02:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55741641040069,
@@ -14624,7 +14624,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:45.251627",
+          "timestamp": "2022-01-01T00:02:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55742601312895,
@@ -14641,7 +14641,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:46.251627",
+          "timestamp": "2022-01-01T00:02:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55743561585722,
@@ -14658,7 +14658,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:47.251627",
+          "timestamp": "2022-01-01T00:02:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55744521858547,
@@ -14675,7 +14675,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:48.251627",
+          "timestamp": "2022-01-01T00:02:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55745482135515,
@@ -14692,7 +14692,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:49.251627",
+          "timestamp": "2022-01-01T00:02:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55746442416367,
@@ -14709,7 +14709,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:50.251627",
+          "timestamp": "2022-01-01T00:02:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5574740269722,
@@ -14726,7 +14726,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:51.251627",
+          "timestamp": "2022-01-01T00:02:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5574836297807,
@@ -14743,7 +14743,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:52.251627",
+          "timestamp": "2022-01-01T00:02:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55749323258924,
@@ -14760,7 +14760,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:53.251627",
+          "timestamp": "2022-01-01T00:02:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55750247775727,
@@ -14777,7 +14777,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:54.251627",
+          "timestamp": "2022-01-01T00:02:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55751053566024,
@@ -14794,7 +14794,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:55.251627",
+          "timestamp": "2022-01-01T00:02:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55751859356323,
@@ -14811,7 +14811,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:56.251627",
+          "timestamp": "2022-01-01T00:02:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55752665146619,
@@ -14828,7 +14828,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:57.251627",
+          "timestamp": "2022-01-01T00:02:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55753470936915,
@@ -14845,7 +14845,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:58.251627",
+          "timestamp": "2022-01-01T00:02:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55754276727212,
@@ -14862,7 +14862,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:09:59.251627",
+          "timestamp": "2022-01-01T00:02:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5575508251751,
@@ -14879,7 +14879,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:00.251627",
+          "timestamp": "2022-01-01T00:02:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55755823991903,
@@ -14896,7 +14896,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:01.251627",
+          "timestamp": "2022-01-01T00:02:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55756564840684,
@@ -14913,7 +14913,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:02.251627",
+          "timestamp": "2022-01-01T00:02:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55757305689464,
@@ -14930,7 +14930,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:03.251627",
+          "timestamp": "2022-01-01T00:02:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55758046538244,
@@ -14947,7 +14947,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:04.251627",
+          "timestamp": "2022-01-01T00:02:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55758894224792,
@@ -14964,7 +14964,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:05.251627",
+          "timestamp": "2022-01-01T00:02:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55759854559508,
@@ -14981,7 +14981,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:06.251627",
+          "timestamp": "2022-01-01T00:02:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55760814894226,
@@ -14998,7 +14998,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:07.251627",
+          "timestamp": "2022-01-01T00:02:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55761775228943,
@@ -15015,7 +15015,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:08.251627",
+          "timestamp": "2022-01-01T00:02:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5576273556366,
@@ -15032,7 +15032,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:09.251627",
+          "timestamp": "2022-01-01T00:02:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55763723923343,
@@ -15049,7 +15049,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:10.251627",
+          "timestamp": "2022-01-01T00:02:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55764817699519,
@@ -15066,7 +15066,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:11.251627",
+          "timestamp": "2022-01-01T00:02:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55765911475696,
@@ -15083,7 +15083,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:12.251627",
+          "timestamp": "2022-01-01T00:02:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55767005251873,
@@ -15100,7 +15100,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:13.251627",
+          "timestamp": "2022-01-01T00:02:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5576809902805,
@@ -15117,7 +15117,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:14.251627",
+          "timestamp": "2022-01-01T00:02:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55769192804227,
@@ -15134,7 +15134,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:15.251627",
+          "timestamp": "2022-01-01T00:02:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5577028637592,
@@ -15151,7 +15151,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:16.251627",
+          "timestamp": "2022-01-01T00:02:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55771280059341,
@@ -15168,7 +15168,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:17.251627",
+          "timestamp": "2022-01-01T00:02:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55772273742761,
@@ -15185,7 +15185,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:18.251627",
+          "timestamp": "2022-01-01T00:02:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55773267426181,
@@ -15202,7 +15202,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:19.251627",
+          "timestamp": "2022-01-01T00:02:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55774261109602,
@@ -15219,7 +15219,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:20.251627",
+          "timestamp": "2022-01-01T00:02:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55775254793022,
@@ -15236,7 +15236,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:21.251627",
+          "timestamp": "2022-01-01T00:02:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55776247256551,
@@ -15253,7 +15253,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:22.251627",
+          "timestamp": "2022-01-01T00:02:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.557772959937,
@@ -15270,7 +15270,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:23.251627",
+          "timestamp": "2022-01-01T00:02:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55778344730844,
@@ -15287,7 +15287,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:24.251627",
+          "timestamp": "2022-01-01T00:02:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5577939346799,
@@ -15304,7 +15304,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:25.251627",
+          "timestamp": "2022-01-01T00:02:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55780442205136,
@@ -15321,7 +15321,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:26.251627",
+          "timestamp": "2022-01-01T00:02:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55781631091229,
@@ -15338,7 +15338,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:27.251627",
+          "timestamp": "2022-01-01T00:02:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55782885408514,
@@ -15355,7 +15355,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:28.251627",
+          "timestamp": "2022-01-01T00:02:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.557841397258,
@@ -15372,7 +15372,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:29.251627",
+          "timestamp": "2022-01-01T00:02:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55785394043087,
@@ -15389,7 +15389,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:30.251627",
+          "timestamp": "2022-01-01T00:03:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55786648360372,
@@ -15406,7 +15406,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:31.251627",
+          "timestamp": "2022-01-01T00:03:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5578784395447,
@@ -15423,7 +15423,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:32.251627",
+          "timestamp": "2022-01-01T00:03:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55788988059413,
@@ -15440,7 +15440,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:33.251627",
+          "timestamp": "2022-01-01T00:03:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55790132164356,
@@ -15457,7 +15457,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:34.251627",
+          "timestamp": "2022-01-01T00:03:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55791276269298,
@@ -15474,7 +15474,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:35.251627",
+          "timestamp": "2022-01-01T00:03:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55792420374242,
@@ -15491,7 +15491,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:36.251627",
+          "timestamp": "2022-01-01T00:03:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55793405510464,
@@ -15508,7 +15508,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:37.251627",
+          "timestamp": "2022-01-01T00:03:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5579441610487,
@@ -15525,7 +15525,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:38.251627",
+          "timestamp": "2022-01-01T00:03:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55795426699277,
@@ -15542,7 +15542,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:39.251627",
+          "timestamp": "2022-01-01T00:03:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55796437293682,
@@ -15559,7 +15559,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:40.251627",
+          "timestamp": "2022-01-01T00:03:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55797447888088,
@@ -15576,7 +15576,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:41.251627",
+          "timestamp": "2022-01-01T00:03:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55798606471234,
@@ -15593,7 +15593,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:42.251627",
+          "timestamp": "2022-01-01T00:03:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55799862609582,
@@ -15610,7 +15610,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:43.251627",
+          "timestamp": "2022-01-01T00:03:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55801118747931,
@@ -15627,7 +15627,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:44.251627",
+          "timestamp": "2022-01-01T00:03:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5580237488628,
@@ -15644,7 +15644,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:45.251627",
+          "timestamp": "2022-01-01T00:03:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55803314438698,
@@ -15661,7 +15661,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:46.251627",
+          "timestamp": "2022-01-01T00:03:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55804121455448,
@@ -15678,7 +15678,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:47.251627",
+          "timestamp": "2022-01-01T00:03:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55804928472197,
@@ -15695,7 +15695,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:48.251627",
+          "timestamp": "2022-01-01T00:03:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55805735488948,
@@ -15712,7 +15712,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:49.251627",
+          "timestamp": "2022-01-01T00:03:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55806136605631,
@@ -15729,7 +15729,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:50.251627",
+          "timestamp": "2022-01-01T00:03:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55806094075717,
@@ -15746,7 +15746,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:51.251627",
+          "timestamp": "2022-01-01T00:03:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55806051545804,
@@ -15763,7 +15763,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:52.251627",
+          "timestamp": "2022-01-01T00:03:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55806009015892,
@@ -15780,7 +15780,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:53.251627",
+          "timestamp": "2022-01-01T00:03:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55805231232922,
@@ -15797,7 +15797,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:54.251627",
+          "timestamp": "2022-01-01T00:03:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55804294317193,
@@ -15814,7 +15814,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:55.251627",
+          "timestamp": "2022-01-01T00:03:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55803357401462,
@@ -15831,7 +15831,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:56.251627",
+          "timestamp": "2022-01-01T00:03:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55802420485732,
@@ -15848,7 +15848,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:57.251627",
+          "timestamp": "2022-01-01T00:03:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55801014098884,
@@ -15865,7 +15865,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:58.251627",
+          "timestamp": "2022-01-01T00:03:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55799525134512,
@@ -15882,7 +15882,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:10:59.251627",
+          "timestamp": "2022-01-01T00:03:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5579803617014,
@@ -15899,7 +15899,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:00.251627",
+          "timestamp": "2022-01-01T00:03:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55796609174739,
@@ -15916,7 +15916,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:01.251627",
+          "timestamp": "2022-01-01T00:03:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55795316456107,
@@ -15933,7 +15933,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:02.251627",
+          "timestamp": "2022-01-01T00:03:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55794023737474,
@@ -15950,7 +15950,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:03.251627",
+          "timestamp": "2022-01-01T00:03:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5579273101884,
@@ -15967,7 +15967,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:04.251627",
+          "timestamp": "2022-01-01T00:03:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55791387790126,
@@ -15984,7 +15984,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:05.251627",
+          "timestamp": "2022-01-01T00:03:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55789571436937,
@@ -16001,7 +16001,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:06.251627",
+          "timestamp": "2022-01-01T00:03:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55787755083747,
@@ -16018,7 +16018,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:07.251627",
+          "timestamp": "2022-01-01T00:03:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5578595055629,
@@ -16035,7 +16035,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:08.251627",
+          "timestamp": "2022-01-01T00:03:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55784183190652,
@@ -16052,7 +16052,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:09.251627",
+          "timestamp": "2022-01-01T00:03:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55782415825014,
@@ -16069,7 +16069,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:10.251627",
+          "timestamp": "2022-01-01T00:03:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55780648459375,
@@ -16086,7 +16086,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:11.251627",
+          "timestamp": "2022-01-01T00:03:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5577884986982,
@@ -16103,7 +16103,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:12.251627",
+          "timestamp": "2022-01-01T00:03:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55776839341311,
@@ -16120,7 +16120,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:13.251627",
+          "timestamp": "2022-01-01T00:03:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55774828812801,
@@ -16137,7 +16137,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:14.251627",
+          "timestamp": "2022-01-01T00:03:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55772818284291,
@@ -16154,7 +16154,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:15.251627",
+          "timestamp": "2022-01-01T00:03:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55770701640472,
@@ -16171,7 +16171,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:16.251627",
+          "timestamp": "2022-01-01T00:03:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55768502552793,
@@ -16188,7 +16188,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:17.251627",
+          "timestamp": "2022-01-01T00:03:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55766303465113,
@@ -16205,7 +16205,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:18.251627",
+          "timestamp": "2022-01-01T00:03:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55764176978441,
@@ -16222,7 +16222,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:19.251627",
+          "timestamp": "2022-01-01T00:03:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55762145757117,
@@ -16239,7 +16239,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:20.251627",
+          "timestamp": "2022-01-01T00:03:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55760114535789,
@@ -16256,7 +16256,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:21.251627",
+          "timestamp": "2022-01-01T00:03:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55758083314464,
@@ -16273,7 +16273,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:22.251627",
+          "timestamp": "2022-01-01T00:03:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55755979013539,
@@ -16290,7 +16290,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:23.251627",
+          "timestamp": "2022-01-01T00:03:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55753850131799,
@@ -16307,7 +16307,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:24.251627",
+          "timestamp": "2022-01-01T00:03:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5575172125006,
@@ -16324,7 +16324,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:25.251627",
+          "timestamp": "2022-01-01T00:03:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55749592368319,
@@ -16341,7 +16341,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:26.251627",
+          "timestamp": "2022-01-01T00:03:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5574733121204,
@@ -16358,7 +16358,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:27.251627",
+          "timestamp": "2022-01-01T00:03:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55745028351616,
@@ -16375,7 +16375,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:28.251627",
+          "timestamp": "2022-01-01T00:03:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55742725491194,
@@ -16392,7 +16392,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:29.251627",
+          "timestamp": "2022-01-01T00:03:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5574042263076,
@@ -16409,7 +16409,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:30.251627",
+          "timestamp": "2022-01-01T00:04:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55738142914292,
@@ -16426,7 +16426,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:31.251627",
+          "timestamp": "2022-01-01T00:04:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55735863197825,
@@ -16443,7 +16443,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:32.251627",
+          "timestamp": "2022-01-01T00:04:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55733583481359,
@@ -16460,7 +16460,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:33.251627",
+          "timestamp": "2022-01-01T00:04:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55731362373082,
@@ -16477,7 +16477,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:34.251627",
+          "timestamp": "2022-01-01T00:04:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55729330781057,
@@ -16494,7 +16494,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:35.251627",
+          "timestamp": "2022-01-01T00:04:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55727299189031,
@@ -16511,7 +16511,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:36.251627",
+          "timestamp": "2022-01-01T00:04:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55725267597008,
@@ -16528,7 +16528,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:37.251627",
+          "timestamp": "2022-01-01T00:04:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55723573512256,
@@ -16545,7 +16545,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:38.251627",
+          "timestamp": "2022-01-01T00:04:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55721942772152,
@@ -16562,7 +16562,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:39.251627",
+          "timestamp": "2022-01-01T00:04:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55720098524692,
@@ -16579,7 +16579,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:40.251627",
+          "timestamp": "2022-01-01T00:04:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571810040379,
@@ -16596,7 +16596,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:41.251627",
+          "timestamp": "2022-01-01T00:04:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55716102282888,
@@ -16613,7 +16613,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:42.251627",
+          "timestamp": "2022-01-01T00:04:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55714104161986,
@@ -16630,7 +16630,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:43.251627",
+          "timestamp": "2022-01-01T00:04:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55712189306911,
@@ -16647,7 +16647,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:44.251627",
+          "timestamp": "2022-01-01T00:04:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571051676227,
@@ -16664,7 +16664,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:45.251627",
+          "timestamp": "2022-01-01T00:04:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55708844217625,
@@ -16681,7 +16681,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:46.251627",
+          "timestamp": "2022-01-01T00:04:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5570721646154,
@@ -16698,7 +16698,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:47.251627",
+          "timestamp": "2022-01-01T00:04:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5570611214741,
@@ -16715,7 +16715,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:48.251627",
+          "timestamp": "2022-01-01T00:04:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55705007833281,
@@ -16732,7 +16732,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:49.251627",
+          "timestamp": "2022-01-01T00:04:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55703903519151,
@@ -16749,7 +16749,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:50.251627",
+          "timestamp": "2022-01-01T00:04:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55702518546406,
@@ -16766,7 +16766,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:51.251627",
+          "timestamp": "2022-01-01T00:04:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55701012929165,
@@ -16783,7 +16783,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:52.251627",
+          "timestamp": "2022-01-01T00:04:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55699507311927,
@@ -16800,7 +16800,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:53.251627",
+          "timestamp": "2022-01-01T00:04:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55698085525333,
@@ -16817,7 +16817,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:54.251627",
+          "timestamp": "2022-01-01T00:04:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55696919710047,
@@ -16834,7 +16834,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:55.251627",
+          "timestamp": "2022-01-01T00:04:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5569575389476,
@@ -16851,7 +16851,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:56.251627",
+          "timestamp": "2022-01-01T00:04:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55694652392228,
@@ -16868,7 +16868,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:57.251627",
+          "timestamp": "2022-01-01T00:04:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55693968172389,
@@ -16885,7 +16885,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:58.251627",
+          "timestamp": "2022-01-01T00:04:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55693283952552,
@@ -16902,7 +16902,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:11:59.251627",
+          "timestamp": "2022-01-01T00:04:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55692818273324,
@@ -16919,7 +16919,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:00.251627",
+          "timestamp": "2022-01-01T00:04:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55692756542201,
@@ -16936,7 +16936,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:01.251627",
+          "timestamp": "2022-01-01T00:04:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5569269481108,
@@ -16953,7 +16953,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:02.251627",
+          "timestamp": "2022-01-01T00:04:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55693110930888,
@@ -16970,7 +16970,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:03.251627",
+          "timestamp": "2022-01-01T00:04:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55693720206138,
@@ -16987,7 +16987,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:04.251627",
+          "timestamp": "2022-01-01T00:04:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55694403828696,
@@ -17004,7 +17004,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:05.251627",
+          "timestamp": "2022-01-01T00:04:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55695609332486,
@@ -17021,7 +17021,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:06.251627",
+          "timestamp": "2022-01-01T00:04:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55696814836274,
@@ -17038,7 +17038,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:07.251627",
+          "timestamp": "2022-01-01T00:04:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55697787153183,
@@ -17055,7 +17055,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:08.251627",
+          "timestamp": "2022-01-01T00:04:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55698429499498,
@@ -17072,7 +17072,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:09.251627",
+          "timestamp": "2022-01-01T00:04:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55699071845812,
@@ -17089,7 +17089,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:10.251627",
+          "timestamp": "2022-01-01T00:04:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55700716941114,
@@ -17106,7 +17106,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:11.251627",
+          "timestamp": "2022-01-01T00:04:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55702484027337,
@@ -17123,7 +17123,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:12.251627",
+          "timestamp": "2022-01-01T00:04:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55704217383149,
@@ -17140,7 +17140,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:13.251627",
+          "timestamp": "2022-01-01T00:04:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55705534995435,
@@ -17157,7 +17157,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:14.251627",
+          "timestamp": "2022-01-01T00:04:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55706852607723,
@@ -17174,7 +17174,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:15.251627",
+          "timestamp": "2022-01-01T00:04:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55708815000298,
@@ -17191,7 +17191,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:16.251627",
+          "timestamp": "2022-01-01T00:04:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5571133247862,
@@ -17208,7 +17208,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:17.251627",
+          "timestamp": "2022-01-01T00:04:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55713849956942,
@@ -17225,7 +17225,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:18.251627",
+          "timestamp": "2022-01-01T00:04:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55715688770893,
@@ -17242,7 +17242,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:19.251627",
+          "timestamp": "2022-01-01T00:04:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55717463691987,
@@ -17259,7 +17259,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:20.251627",
+          "timestamp": "2022-01-01T00:04:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55719719553741,
@@ -17276,7 +17276,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:21.251627",
+          "timestamp": "2022-01-01T00:04:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55722195178427,
@@ -17293,7 +17293,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:22.251627",
+          "timestamp": "2022-01-01T00:04:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55724870669509,
@@ -17310,7 +17310,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:23.251627",
+          "timestamp": "2022-01-01T00:04:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5572754616059,
@@ -17327,7 +17327,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:24.251627",
+          "timestamp": "2022-01-01T00:04:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55730221651672,
@@ -17344,7 +17344,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:25.251627",
+          "timestamp": "2022-01-01T00:04:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55732897142754,
@@ -17361,7 +17361,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:26.251627",
+          "timestamp": "2022-01-01T00:04:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55735342924525,
@@ -17378,7 +17378,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:27.251627",
+          "timestamp": "2022-01-01T00:04:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55737412740216,
@@ -17395,7 +17395,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:28.251627",
+          "timestamp": "2022-01-01T00:04:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55739482555906,
@@ -17412,7 +17412,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:29.251627",
+          "timestamp": "2022-01-01T00:04:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55741885182817,
@@ -17429,7 +17429,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:30.251627",
+          "timestamp": "2022-01-01T00:05:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55744412610463,
@@ -17446,7 +17446,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:31.251627",
+          "timestamp": "2022-01-01T00:05:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55747317854242,
@@ -17463,7 +17463,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:32.251627",
+          "timestamp": "2022-01-01T00:05:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55750258682059,
@@ -17480,7 +17480,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:33.251627",
+          "timestamp": "2022-01-01T00:05:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55752433887606,
@@ -17497,7 +17497,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:34.251627",
+          "timestamp": "2022-01-01T00:05:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55754609093154,
@@ -17514,7 +17514,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:35.251627",
+          "timestamp": "2022-01-01T00:05:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55755724348279,
@@ -17531,7 +17531,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:36.251627",
+          "timestamp": "2022-01-01T00:05:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55756568663625,
@@ -17548,7 +17548,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:37.251627",
+          "timestamp": "2022-01-01T00:05:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55756581532887,
@@ -17565,7 +17565,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:38.251627",
+          "timestamp": "2022-01-01T00:05:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55756488561777,
@@ -17582,7 +17582,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:39.251627",
+          "timestamp": "2022-01-01T00:05:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55756403051068,
@@ -17599,7 +17599,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:40.251627",
+          "timestamp": "2022-01-01T00:05:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55756320007985,
@@ -17616,7 +17616,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:41.251627",
+          "timestamp": "2022-01-01T00:05:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55756237090618,
@@ -17633,7 +17633,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:42.251627",
+          "timestamp": "2022-01-01T00:05:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55756152250684,
@@ -17650,7 +17650,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:43.251627",
+          "timestamp": "2022-01-01T00:05:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55754006111431,
@@ -17667,7 +17667,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:44.251627",
+          "timestamp": "2022-01-01T00:05:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5575105630646,
@@ -17684,7 +17684,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:45.251627",
+          "timestamp": "2022-01-01T00:05:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55748106424252,
@@ -17701,7 +17701,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:46.251627",
+          "timestamp": "2022-01-01T00:05:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55745066119741,
@@ -17718,7 +17718,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:47.251627",
+          "timestamp": "2022-01-01T00:05:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.557416814776,
@@ -17735,7 +17735,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:48.251627",
+          "timestamp": "2022-01-01T00:05:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55738290406012,
@@ -17752,7 +17752,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:49.251627",
+          "timestamp": "2022-01-01T00:05:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5573473693699,
@@ -17769,7 +17769,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:50.251627",
+          "timestamp": "2022-01-01T00:05:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55730882074478,
@@ -17786,7 +17786,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:51.251627",
+          "timestamp": "2022-01-01T00:05:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55726762302835,
@@ -17803,7 +17803,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:52.251627",
+          "timestamp": "2022-01-01T00:05:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55722642531191,
@@ -17820,7 +17820,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:53.251627",
+          "timestamp": "2022-01-01T00:05:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55718475047982,
@@ -17837,7 +17837,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:54.251627",
+          "timestamp": "2022-01-01T00:05:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55714264282489,
@@ -17854,7 +17854,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:55.251627",
+          "timestamp": "2022-01-01T00:05:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55710244653919,
@@ -17871,7 +17871,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:56.251627",
+          "timestamp": "2022-01-01T00:05:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5570638311811,
@@ -17888,7 +17888,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:57.251627",
+          "timestamp": "2022-01-01T00:05:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55702632044628,
@@ -17905,7 +17905,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:58.251627",
+          "timestamp": "2022-01-01T00:05:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55698894537808,
@@ -17922,7 +17922,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:12:59.251627",
+          "timestamp": "2022-01-01T00:05:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5569495714798,
@@ -17939,7 +17939,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:00.251627",
+          "timestamp": "2022-01-01T00:05:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55690653109045,
@@ -17956,7 +17956,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:01.251627",
+          "timestamp": "2022-01-01T00:05:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55686349070109,
@@ -17973,7 +17973,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:02.251627",
+          "timestamp": "2022-01-01T00:05:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5568241447701,
@@ -17990,7 +17990,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:03.251627",
+          "timestamp": "2022-01-01T00:05:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55678546600573,
@@ -18007,7 +18007,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:04.251627",
+          "timestamp": "2022-01-01T00:05:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55675005032205,
@@ -18024,7 +18024,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:05.251627",
+          "timestamp": "2022-01-01T00:05:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55671319160516,
@@ -18041,7 +18041,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:06.251627",
+          "timestamp": "2022-01-01T00:05:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55666947627553,
@@ -18058,7 +18058,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:07.251627",
+          "timestamp": "2022-01-01T00:05:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55662587435522,
@@ -18075,7 +18075,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:08.251627",
+          "timestamp": "2022-01-01T00:05:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55658257798372,
@@ -18092,7 +18092,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:09.251627",
+          "timestamp": "2022-01-01T00:05:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55653843338003,
@@ -18109,7 +18109,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:10.251627",
+          "timestamp": "2022-01-01T00:05:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55649364910344,
@@ -18126,7 +18126,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:11.251627",
+          "timestamp": "2022-01-01T00:05:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55645210349662,
@@ -18143,7 +18143,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:12.251627",
+          "timestamp": "2022-01-01T00:05:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55641185418285,
@@ -18160,7 +18160,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:13.251627",
+          "timestamp": "2022-01-01T00:05:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5563716091875,
@@ -18177,7 +18177,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:14.251627",
+          "timestamp": "2022-01-01T00:05:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55633306332817,
@@ -18194,7 +18194,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:15.251627",
+          "timestamp": "2022-01-01T00:05:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55630052380911,
@@ -18211,7 +18211,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:16.251627",
+          "timestamp": "2022-01-01T00:05:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55628123853384,
@@ -18228,7 +18228,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:17.251627",
+          "timestamp": "2022-01-01T00:05:47+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55627025853234,
@@ -18245,7 +18245,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:18.251627",
+          "timestamp": "2022-01-01T00:05:48+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5562693602182,
@@ -18262,7 +18262,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:19.251627",
+          "timestamp": "2022-01-01T00:05:49+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55626130952353,
@@ -18279,7 +18279,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:20.251627",
+          "timestamp": "2022-01-01T00:05:50+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55625043351519,
@@ -18296,7 +18296,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:21.251627",
+          "timestamp": "2022-01-01T00:05:51+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55624950963757,
@@ -18313,7 +18313,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:22.251627",
+          "timestamp": "2022-01-01T00:05:52+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55625294850773,
@@ -18330,7 +18330,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:23.251627",
+          "timestamp": "2022-01-01T00:05:53+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55626412374563,
@@ -18347,7 +18347,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:24.251627",
+          "timestamp": "2022-01-01T00:05:54+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55627309987291,
@@ -18364,7 +18364,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:25.251627",
+          "timestamp": "2022-01-01T00:05:55+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55628215622167,
@@ -18381,7 +18381,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:26.251627",
+          "timestamp": "2022-01-01T00:05:56+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5562913276993,
@@ -18398,7 +18398,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:27.251627",
+          "timestamp": "2022-01-01T00:05:57+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55631127745534,
@@ -18415,7 +18415,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:28.251627",
+          "timestamp": "2022-01-01T00:05:58+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55634230618793,
@@ -18432,7 +18432,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:29.251627",
+          "timestamp": "2022-01-01T00:05:59+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55635641223911,
@@ -18449,7 +18449,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:30.251627",
+          "timestamp": "2022-01-01T00:06:00+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55637989460318,
@@ -18466,7 +18466,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:31.251627",
+          "timestamp": "2022-01-01T00:06:01+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55641317716007,
@@ -18483,7 +18483,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:32.251627",
+          "timestamp": "2022-01-01T00:06:02+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55644449649304,
@@ -18500,7 +18500,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:33.251627",
+          "timestamp": "2022-01-01T00:06:03+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55647563338026,
@@ -18517,7 +18517,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:34.251627",
+          "timestamp": "2022-01-01T00:06:04+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55650861461203,
@@ -18534,7 +18534,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:35.251627",
+          "timestamp": "2022-01-01T00:06:05+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55654690665982,
@@ -18551,7 +18551,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:36.251627",
+          "timestamp": "2022-01-01T00:06:06+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5565877738728,
@@ -18568,7 +18568,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:37.251627",
+          "timestamp": "2022-01-01T00:06:07+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55663464825643,
@@ -18585,7 +18585,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:38.251627",
+          "timestamp": "2022-01-01T00:06:08+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55667514359311,
@@ -18602,7 +18602,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:39.251627",
+          "timestamp": "2022-01-01T00:06:09+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55672158714357,
@@ -18619,7 +18619,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:40.251627",
+          "timestamp": "2022-01-01T00:06:10+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5567558233412,
@@ -18636,7 +18636,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:41.251627",
+          "timestamp": "2022-01-01T00:06:11+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55678583213903,
@@ -18653,7 +18653,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:42.251627",
+          "timestamp": "2022-01-01T00:06:12+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55681845661996,
@@ -18670,7 +18670,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:43.251627",
+          "timestamp": "2022-01-01T00:06:13+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55685412308863,
@@ -18687,7 +18687,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:44.251627",
+          "timestamp": "2022-01-01T00:06:14+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55686723666122,
@@ -18704,7 +18704,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:45.251627",
+          "timestamp": "2022-01-01T00:06:15+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55685663620643,
@@ -18721,7 +18721,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:46.251627",
+          "timestamp": "2022-01-01T00:06:16+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5568214975683,
@@ -18738,7 +18738,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:47.251627",
+          "timestamp": "2022-01-01T00:06:17+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55677431539078,
@@ -18755,7 +18755,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:48.251627",
+          "timestamp": "2022-01-01T00:06:18+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55672346244411,
@@ -18772,7 +18772,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:49.251627",
+          "timestamp": "2022-01-01T00:06:19+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55667162063853,
@@ -18789,7 +18789,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:50.251627",
+          "timestamp": "2022-01-01T00:06:20+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55663798203346,
@@ -18806,7 +18806,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:51.251627",
+          "timestamp": "2022-01-01T00:06:21+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55658980558893,
@@ -18823,7 +18823,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:52.251627",
+          "timestamp": "2022-01-01T00:06:22+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55653287579727,
@@ -18840,7 +18840,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:53.251627",
+          "timestamp": "2022-01-01T00:06:23+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55648260986996,
@@ -18857,7 +18857,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:54.251627",
+          "timestamp": "2022-01-01T00:06:24+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55642197729561,
@@ -18874,7 +18874,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:55.251627",
+          "timestamp": "2022-01-01T00:06:25+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55636134132494,
@@ -18891,7 +18891,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:56.251627",
+          "timestamp": "2022-01-01T00:06:26+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55629883211247,
@@ -18908,7 +18908,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:57.251627",
+          "timestamp": "2022-01-01T00:06:27+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55623429165654,
@@ -18925,7 +18925,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:58.251627",
+          "timestamp": "2022-01-01T00:06:28+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55617020585322,
@@ -18942,7 +18942,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:13:59.251627",
+          "timestamp": "2022-01-01T00:06:29+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55610465824212,
@@ -18959,7 +18959,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:00.251627",
+          "timestamp": "2022-01-01T00:06:30+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55603934212782,
@@ -18976,7 +18976,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:01.251627",
+          "timestamp": "2022-01-01T00:06:31+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55597512329695,
@@ -18993,7 +18993,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:02.251627",
+          "timestamp": "2022-01-01T00:06:32+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5559131300106,
@@ -19010,7 +19010,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:03.251627",
+          "timestamp": "2022-01-01T00:06:33+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5558491590448,
@@ -19027,7 +19027,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:04.251627",
+          "timestamp": "2022-01-01T00:06:34+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5557840065971,
@@ -19044,7 +19044,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:05.251627",
+          "timestamp": "2022-01-01T00:06:35+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55572033287609,
@@ -19061,7 +19061,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:06.251627",
+          "timestamp": "2022-01-01T00:06:36+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55565680611703,
@@ -19078,7 +19078,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:07.251627",
+          "timestamp": "2022-01-01T00:06:37+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55559145505325,
@@ -19095,7 +19095,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:08.251627",
+          "timestamp": "2022-01-01T00:06:38+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55552807626107,
@@ -19112,7 +19112,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:09.251627",
+          "timestamp": "2022-01-01T00:06:39+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55546232884824,
@@ -19129,7 +19129,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:10.251627",
+          "timestamp": "2022-01-01T00:06:40+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55539988688297,
@@ -19146,7 +19146,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:11.251627",
+          "timestamp": "2022-01-01T00:06:41+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55535599836026,
@@ -19163,7 +19163,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:12.251627",
+          "timestamp": "2022-01-01T00:06:42+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5553251513872,
@@ -19180,7 +19180,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:13.251627",
+          "timestamp": "2022-01-01T00:06:43+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5553106710854,
@@ -19197,7 +19197,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:14.251627",
+          "timestamp": "2022-01-01T00:06:44+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55530959852501,
@@ -19214,7 +19214,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:15.251627",
+          "timestamp": "2022-01-01T00:06:45+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.55530851369866,
@@ -19231,7 +19231,7 @@
           "vertical_speed": 0.0
         },
         {
-          "timestamp": "2022-10-17T02:14:16.251627",
+          "timestamp": "2022-01-01T00:06:46+00:00",
           "operational_status": "Airborne",
           "position": {
             "lng": -77.5553072718354,
@@ -19249,7 +19249,7 @@
         }
       ],
       "flight_details": {
-        "id": "975c4952-4535-45e9-af69-e457a9214277",
+        "id": "d50598bc-638a-4f52-bf3f-dd85595fb52e",
         "serial_number": "EXMPLS8YEC3L5dyn",
         "operation_description": "Zig zags to the south",
         "operator_location": {


### PR DESCRIPTION
Currently, whenever RID simulation is run (including when the entire suite of local tests is run), different file content is generated for the two simulation outputs (circular_flights.json and dcdemo_flights.json).  This PR introduces configurable stable/controlled pseudorandomness and stable reference times so that, by default, the same content will be simulated each time.  This means that the two simulation output files should not change when the simulation is run again.