### PR TITLE
[uss_qualifier] Add passed_checks

### DIFF
--- a/monitoring/uss_qualifier/action_generators/flight_planning/planner_combinations.py
+++ b/monitoring/uss_qualifier/action_generators/flight_planning/planner_combinations.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 from implicitdict import ImplicitDict
 
 from monitoring.monitorlib.inspection import fullname
-from monitoring.uss_qualifier.reports import TestSuiteActionReport
+from monitoring.uss_qualifier.reports.report import TestSuiteActionReport
 from monitoring.uss_qualifier.resources.definitions import ResourceID
 from monitoring.uss_qualifier.resources.flight_planning import FlightPlannersResource
 from monitoring.uss_qualifier.resources.resource import ResourceType

--- a/monitoring/uss_qualifier/action_generators/repeat.py
+++ b/monitoring/uss_qualifier/action_generators/repeat.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
 from implicitdict import ImplicitDict
-from monitoring.uss_qualifier.reports import TestSuiteActionReport
+from monitoring.uss_qualifier.reports.report import TestSuiteActionReport
 from monitoring.uss_qualifier.resources.definitions import ResourceID
 from monitoring.uss_qualifier.resources.resource import ResourceType
 

--- a/monitoring/uss_qualifier/reports/__init__.py
+++ b/monitoring/uss_qualifier/reports/__init__.py
@@ -1,9 +1,0 @@
-from .report import (
-    TestScenarioReport,
-    TestCaseReport,
-    TestStepReport,
-    FailedCheck,
-    ErrorReport,
-    TestSuiteReport,
-    TestSuiteActionReport,
-)

--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -8,6 +8,12 @@ from monitoring.monitorlib import fetch, inspection
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.configurations.configuration import TestConfiguration
 
+ParticipantID = str
+"""String that refers to a participant being qualified by uss_qualifier"""
+
+
+RequirementID = str
+
 
 class FailedCheck(ImplicitDict):
     name: str
@@ -25,20 +31,31 @@ class FailedCheck(ImplicitDict):
     details: str
     """Human-readable description of the issue"""
 
-    relevant_requirements: List[str]
-    """Requirements that this issue relates to"""
+    requirements: List[RequirementID]
+    """Requirements that are not met due to this failed check"""
 
     severity: Severity
     """How severe the issue is"""
 
-    relevant_participants: List[str]
-    """Participant IDs of actors or organizations to which this failure may be relevant"""
+    participants: List[ParticipantID]
+    """Participants that may not meet the relevant requirements due to this failed check"""
 
     query_report_timestamps: Optional[List[str]]
     """List of the `report` timestamp field for queries relevant to this failed check"""
 
     additional_data: Optional[dict]
     """Additional data, structured according to the checks' needs, that may be relevant for understanding this failed check"""
+
+
+class PassedCheck(ImplicitDict):
+    name: str
+    """Name of the check that passed"""
+
+    requirements: List[RequirementID]
+    """Requirements that would not have been met if this check had failed"""
+
+    participants: List[ParticipantID]
+    """Participants that may not have met the relevant requirements if this check had failed"""
 
 
 class TestStepReport(ImplicitDict):
@@ -56,6 +73,9 @@ class TestStepReport(ImplicitDict):
 
     failed_checks: List[FailedCheck]
     """The checks which failed in this test step"""
+
+    passed_checks: List[PassedCheck]
+    """The checks which successfully passed in this test step"""
 
     end_time: Optional[StringBasedDateTime]
     """Time at which the test step completed or encountered an error"""

--- a/monitoring/uss_qualifier/scenarios/documentation/__init__.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/__init__.py
@@ -8,7 +8,7 @@ import marko.element
 import marko.inline
 
 from monitoring.monitorlib.inspection import fullname
-
+from monitoring.uss_qualifier.reports.report import RequirementID
 
 RESOURCES_HEADING = "resources"
 CLEANUP_HEADING = "cleanup"
@@ -21,7 +21,7 @@ TEST_CHECK_SUFFIX = " check"
 class TestCheckDocumentation(ImplicitDict):
     name: str
     url: Optional[str] = None
-    applicable_requirements: List[str]
+    applicable_requirements: List[RequirementID]
 
 
 class TestStepDocumentation(ImplicitDict):

--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -11,20 +11,23 @@ from implicitdict import StringBasedDateTime
 from monitoring.monitorlib import fetch, inspection
 from monitoring.uss_qualifier import scenarios as scenarios_module
 from monitoring.uss_qualifier.common_data_definitions import Severity
-from monitoring.uss_qualifier.reports import (
+from monitoring.uss_qualifier.reports.report import (
     TestScenarioReport,
     TestCaseReport,
     TestStepReport,
     FailedCheck,
     ErrorReport,
+    Note,
+    ParticipantID,
+    PassedCheck,
 )
-from monitoring.uss_qualifier.reports.report import Note
 from monitoring.uss_qualifier.scenarios.definitions import TestScenarioDeclaration
 from monitoring.uss_qualifier.scenarios.documentation import (
     TestScenarioDocumentation,
     TestCaseDocumentation,
     TestStepDocumentation,
     parse_documentation,
+    TestCheckDocumentation,
 )
 from monitoring.uss_qualifier.resources.definitions import ResourceTypeName, ResourceID
 
@@ -38,6 +41,88 @@ class ScenarioPhase(str, Enum):
     ReadyForCleanup = "ReadyForCleanup"
     CleaningUp = "CleaningUp"
     Complete = "Complete"
+
+
+class PendingCheck(object):
+    _documentation: TestCheckDocumentation
+    _step_report: TestStepReport
+    _on_failed_check: Optional[Callable[[FailedCheck], None]]
+    _participants: List[ParticipantID]
+    _outcome_recorded: bool = False
+
+    def __init__(
+        self,
+        documentation: TestCheckDocumentation,
+        participants: List[ParticipantID],
+        step_report: TestStepReport,
+        on_failed_check: Optional[Callable[[FailedCheck], None]],
+    ):
+        self._documentation = documentation
+        self._participants = participants
+        self._step_report = step_report
+        self._on_failed_check = on_failed_check
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if not self._outcome_recorded:
+            self.record_passed()
+
+    def record_failed(
+        self,
+        summary: str,
+        severity: Severity,
+        details: str = "",
+        participants: Optional[List[ParticipantID]] = None,
+        query_timestamps: Optional[List[datetime]] = None,
+        additional_data: Optional[dict] = None,
+        requirements: Optional[List[str]] = None,
+    ) -> None:
+        self._outcome_recorded = True
+        if participants is None:
+            participants = self._participants
+        if requirements is None:
+            requirements = self._documentation.applicable_requirements
+
+        kwargs = {
+            "name": self._documentation.name,
+            "documentation_url": self._documentation.url,
+            "timestamp": StringBasedDateTime(datetime.utcnow()),
+            "summary": summary,
+            "details": details,
+            "requirements": requirements,
+            "severity": severity,
+            "participants": participants,
+        }
+        if additional_data is not None:
+            kwargs["additional_data"] = additional_data
+        if query_timestamps is not None:
+            kwargs["query_report_timestamps"] = [
+                StringBasedDateTime(t) for t in query_timestamps
+            ]
+        failed_check = FailedCheck(**kwargs)
+        self._step_report.failed_checks.append(failed_check)
+        if self._on_failed_check is not None:
+            self._on_failed_check(failed_check)
+
+    def record_passed(
+        self,
+        participants: Optional[List[ParticipantID]] = None,
+        requirements: Optional[List[str]] = None,
+    ) -> None:
+        self._outcome_recorded = True
+        if participants is None:
+            participants = self._participants
+        if requirements is None:
+            requirements = self._documentation.applicable_requirements
+
+        passed_check = PassedCheck(
+            name=self._documentation.name,
+            participants=participants,
+            requirements=requirements,
+        )
+        self._step_report.passed_checks.append(passed_check)
 
 
 class TestScenario(ABC):
@@ -186,6 +271,7 @@ class TestScenario(ABC):
             documentation_url=self._current_step.url,
             start_time=StringBasedDateTime(datetime.utcnow()),
             failed_checks=[],
+            passed_checks=[],
         )
         self._case_report.steps.append(self._step_report)
         self._phase = ScenarioPhase.RunningTestStep
@@ -199,45 +285,32 @@ class TestScenario(ABC):
             f"Queried {query.request['method']} {query.request['url']} -> {query.response.status_code}"
         )
 
-    def record_failed_check(
-        self,
-        name: str,
-        summary: str,
-        severity: Severity,
-        relevant_participants: List[str],
-        details: str = "",
-        query_timestamps: Optional[List[datetime]] = None,
-        additional_data: Optional[dict] = None,
-    ) -> None:
+    def _get_check(self, name: str) -> TestCheckDocumentation:
+        available_checks = {c.name: c for c in self._current_step.checks}
+        if name not in available_checks:
+            check_list = ", ".join(available_checks)
+            raise RuntimeError(
+                f'Test scenario `{self.me()}` was instructed to record outcome for check "{name}" during test step "{self._current_step.name}" during test case "{self._current_case.name}", but that check is not declared in documentation; declared checks are: {check_list}'
+            )
+        return available_checks[name]
+
+    def check(
+        self, name: str, participants: Optional[List[ParticipantID]] = None
+    ) -> PendingCheck:
         self._expect_phase({ScenarioPhase.RunningTestStep, ScenarioPhase.CleaningUp})
         available_checks = {c.name: c for c in self._current_step.checks}
         if name not in available_checks:
             check_list = ", ".join(available_checks)
             raise RuntimeError(
-                f'Test scenario `{self.me()}` was instructed to record_failed_check "{name}" during test step "{self._current_step.name}" during test case "{self._current_case.name}", but that check is not declared in documentation; declared checks are: {check_list}'
+                f'Test scenario `{self.me()}` was instructed to prepare to record outcome for check "{name}" during test step "{self._current_step.name}" during test case "{self._current_case.name}", but that check is not declared in documentation; declared checks are: {check_list}'
             )
-        check = available_checks[name]
-
-        kwargs = {
-            "name": check.name,
-            "documentation_url": check.url,
-            "timestamp": StringBasedDateTime(datetime.utcnow()),
-            "summary": summary,
-            "details": details,
-            "relevant_requirements": check.applicable_requirements,
-            "severity": severity,
-            "relevant_participants": relevant_participants,
-        }
-        if additional_data is not None:
-            kwargs["additional_data"] = additional_data
-        if query_timestamps is not None:
-            kwargs["query_report_timestamps"] = [
-                StringBasedDateTime(t) for t in query_timestamps
-            ]
-        failed_check = FailedCheck(**kwargs)
-        self._step_report.failed_checks.append(failed_check)
-        if self.on_failed_check is not None:
-            self.on_failed_check(failed_check)
+        check_documentation = available_checks[name]
+        return PendingCheck(
+            documentation=check_documentation,
+            participants=[] if participants is None else participants,
+            step_report=self._step_report,
+            on_failed_check=self.on_failed_check,
+        )
 
     def end_test_step(self) -> None:
         self._expect_phase(ScenarioPhase.RunningTestStep)
@@ -281,6 +354,7 @@ class TestScenario(ABC):
             documentation_url=self._current_step.url,
             start_time=StringBasedDateTime(datetime.utcnow()),
             failed_checks=[],
+            passed_checks=[],
         )
         self._scenario_report.cleanup = self._step_report
         self._phase = ScenarioPhase.CleaningUp


### PR DESCRIPTION
The primary purpose of uss_qualifier is to determine which requirements participants do and do not meet.  We capture failed checks, but prior to this PR, we did not capture successful checks.  Originally, the assumption was that completion of a test with an absence of failed checks implied success in all the checks.  This is not a good assumption, however, when some checks are conditionally not performed.

This PR addresses this issue by also logging passed checks in addition to failed checks.  Instead of calling `TestScenario`'s `record_failed_check` method directly, a `PendingCheck` object can be obtained by calling `TestScenario`'s new `check` method.  That `PendingCheck` can then `record_passed` or `record_failed`, or it can be entered (`with scenario.check(...) as check:`) which will automatically record a passed check if a failed check is not recorded.  All invocations of `record_failed_check` are therefore updated to the new approach.

Also, some dependencies were untangled which lead to report objects being referenced in `uss_qualifier.reports.report` rather than just `uss_qualifier.reports`.