### PR TITLE
[uss_qualifier] Rename TestTarget and simplify FlightPlanner

### DIFF
--- a/monitoring/monitorlib/clients/scd_automated_testing.py
+++ b/monitoring/monitorlib/clients/scd_automated_testing.py
@@ -34,7 +34,6 @@ def create_flight(
 ) -> Tuple[str, InjectFlightResponse, fetch.Query]:
     flight_id = str(uuid.uuid4())
     url = "{}/v1/flights/{}".format(uss_base_url, flight_id)
-    print("[SCD] PUT {}".format(url))
 
     initiated_at = datetime.utcnow()
     resp = utm_client.put(url, json=flight_request, scope=SCOPE_SCD_QUALIFIER_INJECT)
@@ -56,7 +55,6 @@ def delete_flight(
     utm_client: UTMClientSession, uss_base_url: str, flight_id: str
 ) -> Tuple[DeleteFlightResponse, fetch.Query]:
     url = "{}/v1/flights/{}".format(uss_base_url, flight_id)
-    print("[SCD] DELETE {}".format(url))
 
     initiated_at = datetime.utcnow()
     resp = utm_client.delete(url, scope=SCOPE_SCD_QUALIFIER_INJECT)
@@ -77,7 +75,6 @@ def get_capabilities(
     utm_client: UTMClientSession, uss_base_url: str
 ) -> Tuple[CapabilitiesResponse, fetch.Query]:
     url = "{}/v1/capabilities".format(uss_base_url)
-    print("[SCD] GET {}".format(url))
 
     initiated_at = datetime.utcnow()
     resp = utm_client.get(url, scope=SCOPE_SCD_QUALIFIER_INJECT)
@@ -98,7 +95,6 @@ def get_version(
     utm_client: UTMClientSession, uss_base_url: str
 ) -> Tuple[StatusResponse, fetch.Query]:
     url = "{}/v1/status".format(uss_base_url)
-    print("[SCD] GET {}".format(url))
 
     initiated_at = datetime.utcnow()
     resp = utm_client.get(url, scope=SCOPE_SCD_QUALIFIER_INJECT)

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_planners.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_planners.py
@@ -4,9 +4,9 @@ from implicitdict import ImplicitDict
 
 from monitoring.uss_qualifier.resources.resource import Resource
 from monitoring.uss_qualifier.resources.communications import AuthAdapterResource
-from monitoring.uss_qualifier.resources.flight_planning.target import (
+from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
     FlightPlannerConfiguration,
-    TestTarget,
+    FlightPlanner,
 )
 
 
@@ -15,7 +15,7 @@ class FlightPlannersSpecification(ImplicitDict):
 
 
 class FlightPlannersResource(Resource[FlightPlannersSpecification]):
-    flight_planners: List[TestTarget]
+    flight_planners: List[FlightPlanner]
 
     def __init__(
         self,
@@ -23,7 +23,8 @@ class FlightPlannersResource(Resource[FlightPlannersSpecification]):
         auth_adapter: AuthAdapterResource,
     ):
         self.flight_planners = [
-            TestTarget(p, auth_adapter.adapter) for p in specification.flight_planners
+            FlightPlanner(p, auth_adapter.adapter)
+            for p in specification.flight_planners
         ]
 
     def make_subset(self, select_indices: Iterable[int]) -> "FlightPlannersResource":

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
@@ -10,7 +10,9 @@ from monitoring.uss_qualifier.resources.flight_planning import (
     FlightIntentsResource,
     FlightPlannersResource,
 )
-from monitoring.uss_qualifier.resources.flight_planning.target import TestTarget
+from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
+    FlightPlanner,
+)
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
     clear_area,
@@ -24,8 +26,8 @@ from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
 class NominalPlanning(TestScenario):
     first_flight: InjectFlightRequest
     conflicting_flight: InjectFlightRequest
-    uss1: TestTarget
-    uss2: TestTarget
+    uss1: FlightPlanner
+    uss2: FlightPlanner
     dss: DSSInstance
 
     def __init__(
@@ -146,17 +148,5 @@ class NominalPlanning(TestScenario):
 
     def cleanup(self):
         self.begin_cleanup()
-
-        flights = {
-            uss: list(uss.created_flight_ids.values()) for uss in (self.uss2, self.uss1)
-        }
-        flights = cleanup_flights(self, flights)
-
-        for uss in (self.uss2, self.uss1):
-            names_to_remove = [
-                k for k, v in uss.created_flight_ids if v in flights[uss]
-            ]
-            for name in names_to_remove:
-                del uss.created_flight_ids[name]
-
+        cleanup_flights(self, (self.uss2, self.uss1))
         self.end_cleanup()

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
@@ -87,6 +87,26 @@ In this step, the second USS executes a user intent to plan a priority flight th
 
 All flight intent data provided is correct and valid and free of conflict in space and time, therefore it should have been planned by the USS.  If the USS indicates a conflict, this check will fail since the intersecting flight is lower priority.  If the USS indicates that the flight was rejected, this check will fail.  If the USS indicates that the injection attempt failed, this check will fail.
 
+### Validate flight creation test step
+
+TODO: uss_qualifier should verify that the flight actually planned is not too different from the flight request
+
+### Validate flight sharing test step
+
+This step verifies that the created flight is shared properly per ASTM F3548-21 by querying the DSS for flights in the area of the flight intent, and then retrieving the details from the USS if the operational intent reference is found.
+
+#### DSS response check
+
+If the DSS does not respond properly to the query that should yield the planned flight, this check will fail.
+
+#### Operational intent shared correctly check
+
+If a reference to the operational intent for the flight is not found in the DSS or the details cannot be retrieved from the USS, this check will fail and one of the requirements **ASTM F3548-21::USS0005** or **ASTM F3548-21::USS0105** were not met.
+
+#### Correct operational intent details check
+
+If the operational intent details reported by the USS do not match the user's flight intent, this check will fail.
+
 ## Activate priority flight test case
 
 In this step, the second USS successfully executes a user intent to activate the priority flight.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.py
@@ -8,7 +8,9 @@ from monitoring.uss_qualifier.resources.flight_planning import (
     FlightIntentsResource,
     FlightPlannersResource,
 )
-from monitoring.uss_qualifier.resources.flight_planning.target import TestTarget
+from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
+    FlightPlanner,
+)
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
     clear_area,
@@ -22,8 +24,8 @@ from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
 class NominalPlanningPriority(TestScenario):
     first_flight: InjectFlightRequest
     priority_flight: InjectFlightRequest
-    uss1: TestTarget
-    uss2: TestTarget
+    uss1: FlightPlanner
+    uss2: FlightPlanner
     dss: DSSInstance
 
     def __init__(
@@ -145,17 +147,5 @@ class NominalPlanningPriority(TestScenario):
 
     def cleanup(self):
         self.begin_cleanup()
-
-        flights = {
-            uss: list(uss.created_flight_ids.values()) for uss in (self.uss2, self.uss1)
-        }
-        flights = cleanup_flights(self, flights)
-
-        for uss in (self.uss2, self.uss1):
-            names_to_remove = [
-                k for k, v in uss.created_flight_ids if v in flights[uss]
-            ]
-            for name in names_to_remove:
-                del uss.created_flight_ids[name]
-
+        cleanup_flights(self, (self.uss2, self.uss1))
         self.end_cleanup()

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -64,6 +64,7 @@ def clear_area(
                 return False
 
     scenario.end_test_step()
+    return True
 
 
 OneOrMoreFlightPlanners = Union[FlightPlanner, List[FlightPlanner]]
@@ -220,12 +221,14 @@ def inject_successful_flight_intent(
     scenario.begin_test_step(test_step)
     resp, query, flight_id = flight_planner.request_flight(flight_intent)
     scenario.record_query(query)
-    with scenario.check("Successful planning", [scenario.uss1.participant_id]) as check:
+    with scenario.check(
+        "Successful planning", [flight_planner.participant_id]
+    ) as check:
         if resp.result == InjectFlightResult.ConflictWithFlight:
             check.record_failed(
                 summary="Conflict-free flight not created due to conflict",
                 severity=Severity.High,
-                details=f'{scenario.uss1.participant_id} indicated ConflictWithFlight: "{resp.notes}"',
+                details=f'{flight_planner.participant_id} indicated ConflictWithFlight: "{resp.notes}"',
                 query_timestamps=[query.request.timestamp],
             )
             return None
@@ -233,7 +236,7 @@ def inject_successful_flight_intent(
             check.record_failed(
                 summary="Valid flight rejected",
                 severity=Severity.High,
-                details=f'{scenario.uss1.participant_id} indicated Rejected: "{resp.notes}"',
+                details=f'{flight_planner.participant_id} indicated Rejected: "{resp.notes}"',
                 query_timestamps=[query.request.timestamp],
             )
             return None
@@ -241,7 +244,7 @@ def inject_successful_flight_intent(
             check.record_failed(
                 summary="Failed to create flight",
                 severity=Severity.High,
-                details=f'{scenario.uss1.participant_id} Failed to process the user flight intent: "{resp.notes}"',
+                details=f'{flight_planner.participant_id} Failed to process the user flight intent: "{resp.notes}"',
                 query_timestamps=[query.request.timestamp],
             )
             return None

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -1,6 +1,6 @@
 import traceback
 from datetime import datetime
-from typing import List, Dict, Union, Optional, Tuple
+from typing import List, Dict, Union, Optional, Tuple, Iterable
 
 from monitoring.monitorlib.clients.scd_automated_testing import QueryError
 from monitoring.monitorlib.scd import bounding_vol4
@@ -12,7 +12,9 @@ from monitoring.monitorlib.scd_automated_testing.scd_injection_api import (
     DeleteFlightResult,
 )
 from monitoring.uss_qualifier.common_data_definitions import Severity
-from monitoring.uss_qualifier.resources.flight_planning.target import TestTarget
+from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
+    FlightPlanner,
+)
 from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
 from monitoring.uss_qualifier.scenarios.astm.utm.evaluation import (
     validate_op_intent_details,
@@ -23,7 +25,7 @@ def clear_area(
     scenario: TestScenarioType,
     test_step: str,
     flight_intents: List[InjectFlightRequest],
-    flight_planners: List[TestTarget],
+    flight_planners: List[FlightPlanner],
 ) -> bool:
     """Perform a test step to clear the area that will be used in the scenario.
 
@@ -64,7 +66,7 @@ def clear_area(
     scenario.end_test_step()
 
 
-OneOrMoreTestTargets = Union[TestTarget, List[TestTarget]]
+OneOrMoreFlightPlanners = Union[FlightPlanner, List[FlightPlanner]]
 OneOrMoreCapabilities = Union[Capability, List[Capability]]
 
 
@@ -72,10 +74,10 @@ def check_capabilities(
     scenario: TestScenarioType,
     test_step: str,
     required_capabilities: Optional[
-        List[Tuple[OneOrMoreTestTargets, OneOrMoreCapabilities]]
+        List[Tuple[OneOrMoreFlightPlanners, OneOrMoreCapabilities]]
     ] = None,
     prerequisite_capabilities: Optional[
-        List[Tuple[OneOrMoreTestTargets, OneOrMoreCapabilities]]
+        List[Tuple[OneOrMoreFlightPlanners, OneOrMoreCapabilities]]
     ] = None,
 ) -> bool:
     """Perform a check that flight planners support certain capabilities.
@@ -106,7 +108,7 @@ def check_capabilities(
         prerequisite_capabilities = []
 
     # Collect all the flight planners that need to be queried
-    all_flight_planners: List[TestTarget] = []
+    all_flight_planners: List[FlightPlanner] = []
     for flight_planner_list in [p for p, _ in required_capabilities] + [
         p for p, _ in prerequisite_capabilities
     ]:
@@ -117,8 +119,10 @@ def check_capabilities(
                 all_flight_planners.append(flight_planner)
 
     # Query all the flight planners and collect key results
-    flight_planner_capabilities: List[Tuple[TestTarget, List[Capability]]] = []
-    flight_planner_capability_query_timestamps: List[Tuple[TestTarget, datetime]] = []
+    flight_planner_capabilities: List[Tuple[FlightPlanner, List[Capability]]] = []
+    flight_planner_capability_query_timestamps: List[
+        Tuple[FlightPlanner, datetime]
+    ] = []
     for flight_planner in all_flight_planners:
         check = scenario.check("Valid responses", [flight_planner.participant_id])
         try:
@@ -201,7 +205,7 @@ def check_capabilities(
 def inject_successful_flight_intent(
     scenario: TestScenarioType,
     test_step: str,
-    flight_planner: TestTarget,
+    flight_planner: FlightPlanner,
     flight_intent: InjectFlightRequest,
 ) -> Optional[InjectFlightResponse]:
     """Inject a flight intent that should result in success.
@@ -328,21 +332,18 @@ def validate_shared_operational_intent(
 
 
 def cleanup_flights(
-    self: TestScenarioType, flights: Dict[TestTarget, List[str]]
-) -> Dict[TestTarget, List[str]]:
+    self: TestScenarioType, flight_planners: Iterable[FlightPlanner]
+) -> None:
     """Remove flights during a cleanup test step.
 
     This function assumes:
     * `scenario` is currently cleaning up (cleanup has started)
     * "Successful flight deletion" check declared for cleanup phase in `scenario`'s documentation
-
-    Returns:
-      False if the scenario should stop, True otherwise.
     """
-    removed_flights: Dict[TestTarget, List[str]] = {}
-    for flight_planner, flight_ids in flights.items():
+    for flight_planner in flight_planners:
         removed = []
-        for flight_id in flight_ids:
+        to_remove = flight_planner.created_flight_ids.copy()
+        for flight_id in to_remove:
             resp, query = flight_planner.cleanup_flight(flight_id)
             self.record_query(query)
             with self.check(
@@ -356,5 +357,3 @@ def cleanup_flights(
                         severity=Severity.Medium,
                         query_timestamps=[query.request.timestamp],
                     )
-        removed_flights[flight_planner] = removed
-    return removed_flights

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
@@ -56,7 +56,7 @@ Each of the attempted flight intents contains invalid flight authorisation data.
 
 Although the flight authorisation data is invalid, it is properly formatted and should allow the USSP to process it and reject the flight rather than causing a failure.  If the USS indicates that the injection attempt failed, this check will fail.
 
-## Plan valid flights test case
+## Plan valid flight test case
 
 ### Inject valid flight intent test step
 
@@ -65,6 +65,26 @@ uss_qualifier indicates to the flight planner a user intent to create a valid fl
 #### Successful planning check
 
 All flight intent data provided is correct and valid and free of conflict in space and time, therefore it should have been planned by the USS.  If the USSP indicates a conflict, this check will fail.  If the USSP indicates that the flight was rejected, this check will fail.  If the USSP indicates that the injection attempt failed, this check will fail.
+
+### Validate flight creation test step
+
+TODO: uss_qualifier should verify that the flight actually planned is not too different from the flight request
+
+### Validate flight sharing test step
+
+This step verifies that the created flight is shared properly per ASTM F3548-21 by querying the DSS for flights in the area of the flight intent, and then retrieving the details from the USS if the operational intent reference is found.
+
+#### DSS response check
+
+If the DSS does not respond properly to the query that should yield the planned flight, this check will fail.
+
+#### Operational intent shared correctly check
+
+If a reference to the operational intent for the flight is not found in the DSS or the details cannot be retrieved from the USS, this check will fail and one of the requirements **ASTM F3548-21::USS0005** or **ASTM F3548-21::USS0105** were not met.
+
+#### Correct operational intent details check
+
+If the operational intent details reported by the USS do not match the user's flight intent, this check will fail.
 
 ## Cleanup
 

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
@@ -103,7 +103,7 @@ class Validation(TestScenario):
         return True
 
     def _attempt_invalid_flights(self) -> bool:
-        self.begin_test_step("Inject invalid flight intent")
+        self.begin_test_step("Inject invalid flight intents")
 
         for flight_intent in self.flight_intents[0:-1]:
             resp, query, flight_id = self.ussp.request_flight(flight_intent)
@@ -130,7 +130,7 @@ class Validation(TestScenario):
                         query_timestamps=[query.request.timestamp],
                     )
 
-            self.end_test_step()  # Inject flight intent
+            self.end_test_step()  # Inject flight intents
 
         return True
 

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
@@ -11,7 +11,9 @@ from monitoring.uss_qualifier.resources.flight_planning import (
     FlightIntentsResource,
     FlightPlannersResource,
 )
-from monitoring.uss_qualifier.resources.flight_planning.target import TestTarget
+from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
+    FlightPlanner,
+)
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
     clear_area,
@@ -23,7 +25,7 @@ from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
 
 class Validation(TestScenario):
     flight_intents: List[InjectFlightRequest]
-    ussp: TestTarget
+    ussp: FlightPlanner
 
     def __init__(
         self,
@@ -143,14 +145,5 @@ class Validation(TestScenario):
 
     def cleanup(self):
         self.begin_cleanup()
-
-        flights = {self.ussp: list(self.ussp.created_flight_ids.values())}
-        flights = cleanup_flights(self, flights)
-
-        names_to_remove = [
-            k for k, v in self.ussp.created_flight_ids if v in flights[self.ussp]
-        ]
-        for name in names_to_remove:
-            del self.ussp.created_flight_ids[name]
-
+        cleanup_flights(self, [self.ussp])
         self.end_cleanup()


### PR DESCRIPTION
This PR does a little bit of cleanup on SCD by renaming the tool used to tell USSPs to attempt to plan flights from `TestTarget` to `FlightPlanner`.  It also removes unneeded names for flights (flight IDs are sufficient) which simplifies a number of places somewhat.

Additionally, a critical missing `return True` is added to `test_steps.py::clear_area` -- without this return, a major portion of flight planning tests were being skipped as the attempt to clear the area appeared to have indicated that the test should not continue.  Fixing this revealed incorrect/missing documentation in the priority planning and U-space validation scenarios, as well as some shared logic, which is corrected in this PR.