### PR TITLE
[uss_qualifier] Remove left-over record_failed key `name`

### DIFF
--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
@@ -210,7 +210,6 @@ class NominalBehavior(TestScenario):
                     )
                 )
                 check.record_failed(
-                    name="Successful test deletion",
                     summary="Error while trying to delete test flight",
                     severity=Severity.High,
                     details=f"While trying to delete a test flight from {sp.participant_id}, encountered error:\n{stacktrace}",


### PR DESCRIPTION
This PR removes a left-over `name` argument in a `record_failed` call.