### PR TITLE
[uss_qualifier] Update documented requirements

### DIFF
--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -60,7 +60,7 @@ If the entire test step heading is enclosed in a link, the contents of that link
 
 Each check a test step performs that may result in a finding/issue must be documented via a subsection of the parent test step, named with a " check" suffix (example: `#### Successful injection check`).
 
-A check should document the requirement(s) violated if the check fails.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**astm.f3411.v19.NET0420**`).
+A check should document the requirement(s) violated if the check fails.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**astm.f3411.v19.NET0420**`).  The description of a check should generally explain why the relevant requirement would fail when that information is useful, but the requirement itself should generally not be re-iterated in this description.  If the check is self-evident from the requirement, the requirement can be noted without further explanation.
 
 ### Cleanup phase
 

--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -54,11 +54,13 @@ A scenario must document at least one test case (otherwise the scenario is doing
 
 Each test case in the documentation must document at least one test step (otherwise nothing is happening in the test case).  Each test step must be documented via a subsection of the parent test case named with a " test step" suffix (example: `### Injection test step`).
 
+If the entire test step heading is enclosed in a link, the contents of that linked file will be used to populate the test step (example: `### [Plan flight test step](plan_flight_step.md)`) and any content in this section will be ignored.  The linked file must follow the format requirements for a test step, starting with the first line being a top-level heading ending with " test step" (example: `# Plan flight test step`).
+
 ### Test checks
 
 Each check a test step performs that may result in a finding/issue must be documented via a subsection of the parent test step, named with a " check" suffix (example: `#### Successful injection check`).
 
-A check should document the requirement(s) violated if the check fails.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**ASTM F3411-19::NET0420**`).
+A check should document the requirement(s) violated if the check fails.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**astm.f3411.v19.NET0420**`).
 
 ### Cleanup phase
 

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
@@ -30,11 +30,11 @@ In this step, uss_qualifier injects a single nominal flight into each SP under t
 
 #### Successful injection check
 
-Per **[injection.yaml::UpsertTestSuccess](../../../../../interfaces/automated-testing/rid/injection.yaml)**, the injection attempt of the valid flight should succeed for every NetRID Service Provider under test.
+Per **interuss.automated_testing.rid.injection.UpsertTestSuccess**, the injection attempt of the valid flight should succeed for every NetRID Service Provider under test.
 
 #### Valid flight check
 
-Per **[injection.yaml::UpsertTestResult](../../../../../interfaces/automated-testing/rid/injection.yaml)**, the NetRID Service Provider under test should only make valid modifications to the injected flights.  This includes:
+Per **interuss.automated_testing.rid.injection.UpsertTestResult**, the NetRID Service Provider under test should only make valid modifications to the injected flights.  This includes:
 * A flight with the specified injection ID must be returned.
 
 ### Polling test step
@@ -43,29 +43,29 @@ In this step, all observers are periodically queried for the flights they observ
 
 #### Successful observation check
 
-Per **[observation.yaml::ObservationSuccess](../../../../../interfaces/automated-testing/rid/observation.yaml)**, the call to each observer is expected to succeed since a valid view was provided by uss_qualifier.
+Per **interuss.automated_testing.rid.observation.ObservationSuccess**, the call to each observer is expected to succeed since a valid view was provided by uss_qualifier.
 
 #### Duplicate flights check
 
-An assumption this test scenario currently makes is that the flight ID reported by the SP the flight was injected into is the same flight ID that each observer will report.  This is probably not a robust assumption and should be adjusted.
+An assumption (**interuss.automated_testing.rid.ObservationFlightID**) this test scenario currently makes is that the flight ID reported by the SP the flight was injected into is the same flight ID that each observer will report.  This is probably not a robust assumption and should be adjusted.
 
 This check will fail if an observation contains two flights with the same ID.
 
 #### Premature flight check
 
-The timestamps of the injected telemetry usually start in the future.  If a flight with injected telemetry only in the future is observed prior to the timestamp of the first telemetry point, this check will fail because the SP does not satisfy **[injection.yaml::ExpectedBehavior](../../../../../interfaces/automated-testing/rid/injection.yaml)**.
+The timestamps of the injected telemetry usually start in the future.  If a flight with injected telemetry only in the future is observed prior to the timestamp of the first telemetry point, this check will fail because the SP does not satisfy **interuss.automated_testing.rid.injection.ExpectedBehavior**.
 
 #### Lingering flight check
 
-**ASTM F3411-19::NET0260** and **ASTM F3411-22a::NET0260** require a SP to provide flights up to *NetMaxNearRealTimeDataPeriod* in the past, but an SP should preserve privacy and ensure relevancy by not sharing flights that are further in the past than this window.
+**astm.f3411.v19.NET0260** requires a SP to provide flights up to *NetMaxNearRealTimeDataPeriod* in the past, but an SP should preserve privacy and ensure relevancy by not sharing flights that are further in the past than this window.
 
 #### Missing flight check
 
-**ASTM F3411-19::NET0610** and **ASTM F3411-22a::NET0610** require that SPs make all UAS operations discoverable over the duration of the flight plus *NetMaxNearRealTimeDataPeriod*, so each injected flight should be observable during this time.  If one of the flights is not observed during its appropriate time period, this check will fail.
+**astm.f3411.v19.NET0610** require that SPs make all UAS operations discoverable over the duration of the flight plus *NetMaxNearRealTimeDataPeriod*, so each injected flight should be observable during this time.  If one of the flights is not observed during its appropriate time period, this check will fail.
 
 #### Area too large check
 
-**ASTM F3411-19::NET0430** and **ASTM F3411-22a::NET0430** require that a NetRID Display Provider reject a request for a very large view area with a diagonal greater than *NetMaxDisplayAreaDiagonal*.  If such a large view is requested and a 413 error code is not received, then this check will fail.
+**astm.f3411.v19.NET0430** require that a NetRID Display Provider reject a request for a very large view area with a diagonal greater than *NetMaxDisplayAreaDiagonal*.  If such a large view is requested and a 413 error code is not received, then this check will fail.
 
 ## Cleanup
 
@@ -73,4 +73,4 @@ The cleanup phase of this test scenario attempts to remove injected data from al
 
 ### Successful test deletion check
 
-Per **[injection.yaml::DeleteTestSuccess](../../../../../interfaces/automated-testing/rid/injection.yaml)**, the deletion attempt of the previously-injected test should succeed for every NetRID Service Provider under test.
+**interuss.automated_testing.rid.injection.DeleteTestSuccess**

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.md
@@ -49,33 +49,15 @@ If either USS does not respond appropriately or fails to clear the area of opera
 
 ## Plan first flight test case
 
-### Inject flight intent test step
+### [Inject flight intent test step](../../../flight_planning/inject_successful_flight_intent.md)
 
-uss_qualifier indicates to the first flight planner a user intent to create the first flight.
+The first flight intent should be successfully planned by the first flight planner.
 
-#### Successful planning check
-
-All flight intent data provided is correct and valid and free of conflict in space and time, therefore it should have been planned by the USS.  If the USS indicates a conflict, this check will fail.  If the USS indicates that the flight was rejected, this check will fail.  If the USS indicates that the injection attempt failed, this check will fail.
+### [Validate flight sharing test step](../validate_shared_operational_intent.md)
 
 ### Validate flight creation test step
 
 TODO: uss_qualifier should verify that the flight actually planned is not too different from the flight request
-
-### Validate flight sharing test step
-
-This step verifies that the created flight is shared properly per ASTM F3548-21 by querying the DSS for flights in the area of the flight intent, and then retrieving the details from the USS if the operational intent reference is found.
-
-#### DSS response check
-
-If the DSS does not respond properly to the query that should yield the planned flight, this check will fail.
-
-#### Operational intent shared correctly check
-
-If a reference to the operational intent for the flight is not found in the DSS or the details cannot be retrieved from the USS, this check will fail and one of the requirements **ASTM F3548-21::USS0005** or **ASTM F3548-21::USS0105** were not met.
-
-#### Correct operational intent details check
-
-If the operational intent details reported by the USS do not match the user's flight intent, this check will fail.
 
 ## Attempt second flight test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.md
@@ -37,7 +37,7 @@ If either USS does not respond appropriately to the endpoint queried to determin
 
 #### Support BasicStrategicConflictDetection check
 
-If either USS does not support BasicStrategicConflictDetection, then this check will fail.
+If either USS does not support BasicStrategicConflictDetection, then this check will fail per **astm.f3548.v21.GEN0310** as the USS does not support the InterUSS implementation of that requirement.
 
 ### Area clearing test step
 
@@ -45,7 +45,7 @@ Both USSs are requested to remove all flights from the area under test.
 
 #### Area cleared successfully check
 
-If either USS does not respond appropriately or fails to clear the area of operations, this check will fail.
+**interuss.automated_testing.flight_planning.ClearArea**
 
 ## Plan first flight test case
 
@@ -55,24 +55,20 @@ The first flight intent should be successfully planned by the first flight plann
 
 ### [Validate flight sharing test step](../validate_shared_operational_intent.md)
 
-### Validate flight creation test step
-
-TODO: uss_qualifier should verify that the flight actually planned is not too different from the flight request
-
 ## Attempt second flight test case
 
 ### Inject flight intent test step
 
 #### Incorrectly planned check
 
-The second flight intent conflicts with the first flight that was already planned.  If the USS successfully plans the flight, it means they failed to detect the conflict with the pre-existing flight, or else they modified the flight more than the user wanted.  Therefore, this check will fail if the second USS indicates success in creating the flight from the user flight intent.
+The second flight intent conflicts with the first flight that was already planned.  If the USS successfully plans the flight, it means they failed to detect the conflict with the pre-existing flight.  Therefore, this check will fail if the second USS indicates success in creating the flight from the user flight intent, per **astm.f3548.v21.SCD0035**.
 
 #### Failure check
 
-All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS to reject or accept the flight.  If the USS indicates that the injection attempt failed, this check will fail.
+All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS to reject or accept the flight.  If the USS indicates that the injection attempt failed, this check will fail per **interuss.automated_testing.flight_planning.ExpectedBehavior**.
 
 ## Cleanup
 
 ### Successful flight deletion check
 
-Per **[scd.yaml::DeleteFlightSuccess](../../../../../interfaces/automated-testing/scd/scd.yaml)**, the deletion attempt of the previously-created flight should succeed for every flight planner under test.
+**interuss.automated_testing.flight_planning.DeleteFlightSuccess**

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
@@ -111,10 +111,6 @@ class NominalPlanning(TestScenario):
             return False
         op_intent_id = resp.operational_intent_id
 
-        self.begin_test_step("Validate flight creation")
-        # TODO
-        self.end_test_step()  # Validate flight creation
-
         validate_shared_operational_intent(
             self, "Validate flight sharing", self.first_flight, op_intent_id
         )

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
@@ -13,12 +13,14 @@ from monitoring.uss_qualifier.resources.flight_planning import (
 from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
     FlightPlanner,
 )
+from monitoring.uss_qualifier.scenarios.astm.utm.test_steps import (
+    validate_shared_operational_intent,
+)
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
     clear_area,
     check_capabilities,
     inject_successful_flight_intent,
-    validate_shared_operational_intent,
     cleanup_flights,
 )
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
@@ -37,7 +37,7 @@ If either USS does not respond appropriately to the endpoint queried to determin
 
 #### Support BasicStrategicConflictDetection check
 
-This check will fail if the first flight planner does not support BasicStrategicConflictDetection.  If the second flight planner does not support HighPriorityFlights, this scenario will end normally at this point.
+This check will fail if the first flight planner does not support BasicStrategicConflictDetection per **astm.f3548.v21.GEN0310** as the USS does not support the InterUSS implementation of that requirement.  If the second flight planner does not support HighPriorityFlights, this scenario will end normally at this point.
 
 ### Area clearing test step
 
@@ -45,7 +45,7 @@ Both USSs are requested to remove all flights from the area under test.
 
 #### Area cleared successfully check
 
-If either USS does not respond appropriately or fails to clear the area of operations, this check will fail.
+**interuss.automated_testing.flight_planning.ClearArea**
 
 ## Plan first flight test case
 
@@ -54,10 +54,6 @@ If either USS does not respond appropriately or fails to clear the area of opera
 The first flight intent should be successfully planned by the first flight planner.
 
 ### [Validate flight sharing test step](../validate_shared_operational_intent.md)
-
-### Validate flight creation test step
-
-TODO: uss_qualifier should verify that the flight actually planned is not too different from the flight request
 
 ## Plan priority flight test case
 
@@ -68,10 +64,6 @@ In this step, the second USS executes a user intent to plan a priority flight th
 The first flight intent should be successfully planned by the first flight planner.
 
 ### [Validate flight sharing test step](../validate_shared_operational_intent.md)
-
-### Validate flight creation test step
-
-TODO: uss_qualifier should verify that the flight actually planned is not too different from the flight request
 
 ## Activate priority flight test case
 
@@ -85,8 +77,10 @@ In this step, the first USS fails to activate the flight it previously created.
 
 TODO: Complete this test case
 
+**astm.f3548.v21.SCD0015**
+
 ## Cleanup
 
 ### Successful flight deletion check
 
-Per **[scd.yaml::DeleteFlightSuccess](../../../../../interfaces/automated-testing/scd/scd.yaml)**, the deletion attempt of the previously-created flight should succeed for every flight planner under test.
+**interuss.automated_testing.flight_planning.DeleteFlightSuccess**

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
@@ -49,63 +49,29 @@ If either USS does not respond appropriately or fails to clear the area of opera
 
 ## Plan first flight test case
 
-### Inject flight intent test step
+### [Inject flight intent test step](../../../flight_planning/inject_successful_flight_intent.md)
 
-uss_qualifier indicates to the first flight planner a user intent to create the first flight.
+The first flight intent should be successfully planned by the first flight planner.
 
-#### Successful planning check
-
-All flight intent data provided is correct and valid and free of conflict in space and time, therefore it should have been planned by the USS.  If the USS indicates a conflict, this check will fail.  If the USS indicates that the flight was rejected, this check will fail.  If the USS indicates that the injection attempt failed, this check will fail.
+### [Validate flight sharing test step](../validate_shared_operational_intent.md)
 
 ### Validate flight creation test step
 
 TODO: uss_qualifier should verify that the flight actually planned is not too different from the flight request
-
-### Validate flight sharing test step
-
-This step verifies that the created flight is shared properly per ASTM F3548-21 by querying the DSS for flights in the area of the flight intent, and then retrieving the details from the USS if the operational intent reference is found.
-
-#### DSS response check
-
-If the DSS does not respond properly to the query that should yield the planned flight, this check will fail.
-
-#### Operational intent shared correctly check
-
-If a reference to the operational intent for the flight is not found in the DSS or the details cannot be retrieved from the USS, this check will fail and one of the requirements **ASTM F3548-21::USS0005** or **ASTM F3548-21::USS0105** were not met.
-
-#### Correct operational intent details check
-
-If the operational intent details reported by the USS do not match the user's flight intent, this check will fail.
 
 ## Plan priority flight test case
 
 In this step, the second USS executes a user intent to plan a priority flight that conflicts with the first flight.
 
-### Inject flight intent test step
+### [Inject flight intent test step](../../../flight_planning/inject_successful_flight_intent.md)
 
-#### Successful planning check
+The first flight intent should be successfully planned by the first flight planner.
 
-All flight intent data provided is correct and valid and free of conflict in space and time, therefore it should have been planned by the USS.  If the USS indicates a conflict, this check will fail since the intersecting flight is lower priority.  If the USS indicates that the flight was rejected, this check will fail.  If the USS indicates that the injection attempt failed, this check will fail.
+### [Validate flight sharing test step](../validate_shared_operational_intent.md)
 
 ### Validate flight creation test step
 
 TODO: uss_qualifier should verify that the flight actually planned is not too different from the flight request
-
-### Validate flight sharing test step
-
-This step verifies that the created flight is shared properly per ASTM F3548-21 by querying the DSS for flights in the area of the flight intent, and then retrieving the details from the USS if the operational intent reference is found.
-
-#### DSS response check
-
-If the DSS does not respond properly to the query that should yield the planned flight, this check will fail.
-
-#### Operational intent shared correctly check
-
-If a reference to the operational intent for the flight is not found in the DSS or the details cannot be retrieved from the USS, this check will fail and one of the requirements **ASTM F3548-21::USS0005** or **ASTM F3548-21::USS0105** were not met.
-
-#### Correct operational intent details check
-
-If the operational intent details reported by the USS do not match the user's flight intent, this check will fail.
 
 ## Activate priority flight test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.py
@@ -11,12 +11,14 @@ from monitoring.uss_qualifier.resources.flight_planning import (
 from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
     FlightPlanner,
 )
+from monitoring.uss_qualifier.scenarios.astm.utm.test_steps import (
+    validate_shared_operational_intent,
+)
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
     clear_area,
     check_capabilities,
     inject_successful_flight_intent,
-    validate_shared_operational_intent,
     cleanup_flights,
 )
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.py
@@ -115,10 +115,6 @@ class NominalPlanningPriority(TestScenario):
             return False
         op_intent_id = resp.operational_intent_id
 
-        self.begin_test_step("Validate flight creation")
-        # TODO
-        self.end_test_step()  # Validate flight creation
-
         validate_shared_operational_intent(
             self, "Validate flight sharing", self.first_flight, op_intent_id
         )
@@ -132,10 +128,6 @@ class NominalPlanningPriority(TestScenario):
         if resp is None:
             return False
         op_intent_id = resp.operational_intent_id
-
-        self.begin_test_step("Validate flight creation")
-        # TODO
-        self.end_test_step()  # Validate flight creation
 
         validate_shared_operational_intent(
             self, "Validate flight sharing", self.priority_flight, op_intent_id

--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -1,0 +1,88 @@
+from monitoring.monitorlib.scd import bounding_vol4
+from monitoring.monitorlib.scd_automated_testing.scd_injection_api import (
+    InjectFlightRequest,
+)
+from monitoring.uss_qualifier.common_data_definitions import Severity
+from monitoring.uss_qualifier.scenarios.astm.utm.evaluation import (
+    validate_op_intent_details,
+)
+from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
+
+
+def validate_shared_operational_intent(
+    scenario: TestScenarioType,
+    test_step: str,
+    flight_intent: InjectFlightRequest,
+    op_intent_id: str,
+) -> bool:
+    """Validate that operational intent information was correctly shared for a flight intent.
+
+    This function implements the test step described in
+    validate_shared_operational_intent.md.
+
+    Returns:
+      False if the scenario should stop, True otherwise.
+    """
+    scenario.begin_test_step(test_step)
+    extent = bounding_vol4(
+        flight_intent.operational_intent.volumes
+        + flight_intent.operational_intent.off_nominal_volumes
+    )
+    op_intent_refs, query = scenario.dss.find_op_intent(extent)
+    scenario.record_query(query)
+    with scenario.check("DSS response", [scenario.dss.participant_id]) as check:
+        if query.status_code != 200:
+            check.record_failed(
+                summary="Failed to query DSS for operational intents",
+                severity=Severity.High,
+                details=f"Received status code {query.status_code} from the DSS",
+                query_timestamps=[query.request.timestamp],
+            )
+            return False
+
+    matching_op_intent_refs = [
+        op_intent_ref
+        for op_intent_ref in op_intent_refs
+        if op_intent_ref.id == op_intent_id
+    ]
+    with scenario.check(
+        "Operational intent shared correctly", [scenario.uss1.participant_id]
+    ) as check:
+        if not matching_op_intent_refs:
+            check.record_failed(
+                summary="Operational intent reference not found in DSS",
+                severity=Severity.High,
+                details=f"USS {scenario.uss1.participant_id} indicated that it created an operational intent with ID {op_intent_id}, but no operational intent references with that ID were found in the DSS in the area of the flight intent",
+                query_timestamps=[query.request.timestamp],
+            )
+            return False
+    op_intent_ref = matching_op_intent_refs[0]
+
+    op_intent, query = scenario.dss.get_full_op_intent(op_intent_ref)
+    with scenario.check(
+        "Operational intent shared correctly", [scenario.uss1.participant_id]
+    ) as check:
+        if query.status_code != 200:
+            check.record_failed(
+                summary="Operational intent details could not be retrieved from USS",
+                severity=Severity.High,
+                details=f"Received status code {query.status_code} from {scenario.uss1.participant_id} when querying for details of operational intent {op_intent_id}",
+                query_timestamps=[query.request.timestamp],
+            )
+            return False
+
+    error_text = validate_op_intent_details(op_intent, extent)
+    with scenario.check(
+        "Correct operational intent details", [scenario.uss1.participant_id]
+    ) as check:
+        if error_text:
+            check.record_failed(
+                summary="Operational intent details do not match user flight intent",
+                severity=Severity.High,
+                details=error_text,
+                query_timestamps=[query.request.timestamp],
+            )
+            return False
+
+    scenario.end_test_step()
+    return True

--- a/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
@@ -1,0 +1,15 @@
+# Validate flight sharing test step
+
+This step verifies that a created flight is shared properly per ASTM F3548-21 by querying the DSS for flights in the area of the flight intent, and then retrieving the details from the USS if the operational intent reference is found.  See `validate_shared_operational_intent` in [test_steps.py](test_steps.py).
+
+## DSS response check
+
+If the DSS does not respond properly to the query that should yield the planned flight, this check will fail.
+
+## Operational intent shared correctly check
+
+If a reference to the operational intent for the flight is not found in the DSS or the details cannot be retrieved from the USS, this check will fail and one of the requirements **astm.f3548.v21.USS0005** or **astm.f3548.v21.USS0105** were not met.
+
+## Correct operational intent details check
+
+If the operational intent details reported by the USS do not match the user's flight intent, this check will fail.

--- a/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
@@ -4,12 +4,24 @@ This step verifies that a created flight is shared properly per ASTM F3548-21 by
 
 ## DSS response check
 
-If the DSS does not respond properly to the query that should yield the planned flight, this check will fail.
+**astm.f3548.v21.DSS0005**
 
 ## Operational intent shared correctly check
 
-If a reference to the operational intent for the flight is not found in the DSS or the details cannot be retrieved from the USS, this check will fail and one of the requirements **astm.f3548.v21.USS0005** or **astm.f3548.v21.USS0105** were not met.
+If a reference to the operational intent for the flight is not found in the DSS, this check will fail per **astm.f3548.v21.USS0005** and **astm.f3548.v21.OPIN0030**.
+
+## Operational intent details retrievable check
+
+If the operational intent details for the flight cannot be retrieved from the USS, this check will fail per **astm.f3548.v21.USS0105**.
 
 ## Correct operational intent details check
 
-If the operational intent details reported by the USS do not match the user's flight intent, this check will fail.
+If the operational intent details reported by the USS do not match the user's flight intent, this check will fail per **interuss.automated_testing.flight_planning.ExpectedBehavior**.
+
+## Off-nominal volumes check
+
+**astm.f3548.v21.OPIN0015**
+
+## Vertices check
+
+**astm.f3548.v21.OPIN0020**

--- a/monitoring/uss_qualifier/scenarios/flight_planning/inject_successful_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/inject_successful_flight_intent.md
@@ -1,0 +1,7 @@
+# Plan valid flight test step
+
+This page describes the content of a common test case where a valid user flight intent should be successfully planned by a flight planner.  See `inject_successful_flight_intent` in [test_steps.py](test_steps.py).
+
+## Successful planning check
+
+All flight intent data provided is correct and valid and free of conflict in space and time, therefore it should have been planned by the USS.  If the USS indicates a conflict, this check will fail.  If the USS indicates that the flight was rejected, this check will fail.  If the USS indicates that the injection attempt failed, this check will fail.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/inject_successful_flight_intent.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/inject_successful_flight_intent.md
@@ -4,4 +4,4 @@ This page describes the content of a common test case where a valid user flight 
 
 ## Successful planning check
 
-All flight intent data provided is correct and valid and free of conflict in space and time, therefore it should have been planned by the USS.  If the USS indicates a conflict, this check will fail.  If the USS indicates that the flight was rejected, this check will fail.  If the USS indicates that the injection attempt failed, this check will fail.
+All flight intent data provided is correct and valid and free of conflict in space and time, therefore it should have been planned by the USS per **interuss.automated_testing.flight_planning.ExpectedBehavior**.  If the USS indicates a conflict, this check will fail.  If the USS indicates that the flight was rejected, this check will fail.  If the USS indicates that the injection attempt failed, this check will fail.

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -273,6 +273,7 @@ def cleanup_flights(
                 else:
                     check.record_failed(
                         summary="Failed to delete flight",
+                        details=f"USS indicated: {resp.notes}",
                         severity=Severity.Medium,
                         query_timestamps=[query.request.timestamp],
                     )

--- a/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/test_steps.py
@@ -211,10 +211,8 @@ def inject_successful_flight_intent(
 ) -> Optional[InjectFlightResponse]:
     """Inject a flight intent that should result in success.
 
-    This function assumes:
-    * `scenario` is currently ready to execute a test step
-    * "Successful planning" check is declared for specified test step in `scenario`'s documentation
-
+    This function implements the test step described in
+    inject_successful_flight_intent.md.
 
     Returns: None if a check failed, otherwise the injection response.
     """
@@ -250,88 +248,6 @@ def inject_successful_flight_intent(
             return None
     scenario.end_test_step()
     return resp
-
-
-def validate_shared_operational_intent(
-    scenario: TestScenarioType,
-    test_step: str,
-    flight_intent: InjectFlightRequest,
-    op_intent_id: str,
-) -> bool:
-    """Validate that operational intent information was correctly shared for a flight intent.
-
-    This function assumes:
-    * `scenario` is ready to execute a test step
-    * "DSS response" check declared for specified test step in `scenario`'s documentation
-    * "Operational intent shared correctly" check declared for specified test step in `scenario`'s documentation
-    * "Correct operational intent details" check declared for specified test in step`scenario`'s documentation
-
-    Returns:
-      False if the scenario should stop, True otherwise.
-    """
-    scenario.begin_test_step(test_step)
-    extent = bounding_vol4(
-        flight_intent.operational_intent.volumes
-        + flight_intent.operational_intent.off_nominal_volumes
-    )
-    op_intent_refs, query = scenario.dss.find_op_intent(extent)
-    scenario.record_query(query)
-    with scenario.check("DSS response", [scenario.dss.participant_id]) as check:
-        if query.status_code != 200:
-            check.record_failed(
-                summary="Failed to query DSS for operational intents",
-                severity=Severity.High,
-                details=f"Received status code {query.status_code} from the DSS",
-                query_timestamps=[query.request.timestamp],
-            )
-            return False
-
-    matching_op_intent_refs = [
-        op_intent_ref
-        for op_intent_ref in op_intent_refs
-        if op_intent_ref.id == op_intent_id
-    ]
-    with scenario.check(
-        "Operational intent shared correctly", [scenario.uss1.participant_id]
-    ) as check:
-        if not matching_op_intent_refs:
-            check.record_failed(
-                summary="Operational intent reference not found in DSS",
-                severity=Severity.High,
-                details=f"USS {scenario.uss1.participant_id} indicated that it created an operational intent with ID {op_intent_id}, but no operational intent references with that ID were found in the DSS in the area of the flight intent",
-                query_timestamps=[query.request.timestamp],
-            )
-            return False
-    op_intent_ref = matching_op_intent_refs[0]
-
-    op_intent, query = scenario.dss.get_full_op_intent(op_intent_ref)
-    with scenario.check(
-        "Operational intent shared correctly", [scenario.uss1.participant_id]
-    ) as check:
-        if query.status_code != 200:
-            check.record_failed(
-                summary="Operational intent details could not be retrieved from USS",
-                severity=Severity.High,
-                details=f"Received status code {query.status_code} from {scenario.uss1.participant_id} when querying for details of operational intent {op_intent_id}",
-                query_timestamps=[query.request.timestamp],
-            )
-            return False
-
-    error_text = validate_op_intent_details(op_intent, extent)
-    with scenario.check(
-        "Correct operational intent details", [scenario.uss1.participant_id]
-    ) as check:
-        if error_text:
-            check.record_failed(
-                summary="Operational intent details do not match user flight intent",
-                severity=Severity.High,
-                details=error_text,
-                query_timestamps=[query.request.timestamp],
-            )
-            return False
-
-    scenario.end_test_step()
-    return True
 
 
 def cleanup_flights(

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
@@ -66,26 +66,6 @@ uss_qualifier indicates to the flight planner a user intent to create a valid fl
 
 All flight intent data provided is correct and valid and free of conflict in space and time, therefore it should have been planned by the USS.  If the USSP indicates a conflict, this check will fail.  If the USSP indicates that the flight was rejected, this check will fail.  If the USSP indicates that the injection attempt failed, this check will fail.
 
-### Validate flight creation test step
-
-TODO: uss_qualifier should verify that the flight actually planned is not too different from the flight request
-
-### Validate flight sharing test step
-
-This step verifies that the created flight is shared properly per ASTM F3548-21 by querying the DSS for flights in the area of the flight intent, and then retrieving the details from the USS if the operational intent reference is found.
-
-#### DSS response check
-
-If the DSS does not respond properly to the query that should yield the planned flight, this check will fail.
-
-#### Operational intent shared correctly check
-
-If a reference to the operational intent for the flight is not found in the DSS or the details cannot be retrieved from the USS, this check will fail and one of the requirements **ASTM F3548-21::USS0005** or **ASTM F3548-21::USS0105** were not met.
-
-#### Correct operational intent details check
-
-If the operational intent details reported by the USS do not match the user's flight intent, this check will fail.
-
 ## Cleanup
 
 ### Successful flight deletion check


### PR DESCRIPTION
This PR cleans up and adds requirements for all of the checks in our currently-defined test scenarios.  In preparation for a more formal programmatic definition of requirements, a package-style format is adopted for requirement IDs.  Links to reference material relating to requirements are removed with the assumption that the requirements will be more explicitly defined (in a single place) in a future PR.

To avoid duplication and better align documentation with implementation, this PR also adds a feature where a test scenario documentation file may link to another file defining a test step -- this corresponds with calling a shared function to perform a common test step.  The two `test_steps.py` files contain examples of these shared test steps.

The `validate_shared_operational_intent` common test step is moved from the original single `test_steps.py` file into a `test_steps.py` in the `astm.utm` package since that test step is only valid for ASTM F3548 tests whereas the other functions in the original `test_steps.py` are suitable for any flight planning test (e.g., U-space Flight Authorisation validation).