### PR TITLE
[monitorlib] Use uas_standards for RID injection API

### DIFF
--- a/monitoring/mock_uss/ridsp/routes_injection.py
+++ b/monitoring/mock_uss/ridsp/routes_injection.py
@@ -11,6 +11,7 @@ from implicitdict import ImplicitDict
 from monitoring.mock_uss import webapp
 from monitoring.mock_uss.auth import requires_scope
 from monitoring.mock_uss import config, resources
+from uas_standards.interuss.automated_testing.rid.v1.injection import ChangeTestResponse
 from . import database
 from .database import db
 
@@ -62,9 +63,7 @@ def create_test(test_id: str) -> Tuple[str, int]:
     with db as tx:
         tx.tests[test_id] = record
     return flask.jsonify(
-        injection_api.ChangeTestResponse(
-            version=record.version, injected_flights=record.flights
-        )
+        ChangeTestResponse(version=record.version, injected_flights=record.flights)
     )
 
 
@@ -94,7 +93,5 @@ def delete_test(test_id: str) -> Tuple[str, int]:
     with db as tx:
         del tx.tests[test_id]
     return flask.jsonify(
-        injection_api.ChangeTestResponse(
-            version=record.version, injected_flights=record.flights
-        )
+        ChangeTestResponse(version=record.version, injected_flights=record.flights)
     )

--- a/monitoring/uss_qualifier/resources/netrid/flight_data.py
+++ b/monitoring/uss_qualifier/resources/netrid/flight_data.py
@@ -2,8 +2,8 @@ from typing import List, Optional
 
 from implicitdict import ImplicitDict, StringBasedDateTime, StringBasedTimeDelta
 
-from monitoring.monitorlib.rid import RIDAircraftState, RIDFlightDetails
 from monitoring.uss_qualifier.fileio import FileReference
+from uas_standards.astm.f3411.v19.api import RIDAircraftState, RIDFlightDetails
 
 
 class FullFlightRecord(ImplicitDict):

--- a/monitoring/uss_qualifier/resources/netrid/flight_data_resources.py
+++ b/monitoring/uss_qualifier/resources/netrid/flight_data_resources.py
@@ -4,10 +4,10 @@ import uuid
 
 import arrow
 from implicitdict import ImplicitDict, StringBasedDateTime
+from uas_standards.interuss.automated_testing.rid.v1.injection import TestFlightDetails
 
 from monitoring.monitorlib.rid import RIDAircraftState
 from monitoring.monitorlib.rid_automated_testing.injection_api import (
-    TestFlightDetails,
     TestFlight,
 )
 from monitoring.uss_qualifier.fileio import load_dict_with_references, load_content

--- a/monitoring/uss_qualifier/resources/netrid/simulation/adjacent_circular_flights_simulator.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/adjacent_circular_flights_simulator.py
@@ -8,12 +8,6 @@ import shapely.geometry
 from shapely.geometry import Point, Polygon
 
 from implicitdict import ImplicitDict
-from monitoring.monitorlib.rid import (
-    RIDHeight,
-    RIDAircraftState,
-    RIDAircraftPosition,
-    RIDFlightDetails,
-)
 from monitoring.uss_qualifier.resources.netrid.flight_data import (
     FullFlightRecord,
     FlightRecordCollection,
@@ -21,6 +15,14 @@ from monitoring.uss_qualifier.resources.netrid.flight_data import (
 )
 from monitoring.uss_qualifier.resources.netrid.simulation import (
     operator_flight_details,
+)
+from uas_standards.astm.f3411.v19.api import (
+    HorizontalAccuracy,
+    VerticalAccuracy,
+    RIDAircraftPosition,
+    RIDAircraftState,
+    RIDHeight,
+    RIDFlightDetails,
 )
 from .utils import (
     QueryBoundingBox,
@@ -140,8 +142,8 @@ class AdjacentCircularFlightsSimulator:
                 QueryBoundingBox(
                     name=box_diagonals[box_id]["name"],
                     shape=buffered_box,
-                    timestamp_after=box_diagonals[box_id]["timestamp_after"],
-                    timestamp_before=box_diagonals[box_id]["timestamp_before"],
+                    timestamp_after=box_diagonals[box_id]["timestamp_after"].datetime,
+                    timestamp_before=box_diagonals[box_id]["timestamp_before"].datetime,
                 )
             )
 
@@ -320,8 +322,8 @@ class AdjacentCircularFlightsSimulator:
                         lat=flight_point.lat,
                         lng=flight_point.lng,
                         alt=flight_point.alt,
-                        accuracy_h="HAUnkown",
-                        accuracy_v="VAUnknown",
+                        accuracy_h=HorizontalAccuracy.HAUnknown,
+                        accuracy_v=VerticalAccuracy.VAUnknown,
                         extrapolated=False,
                     )
                     aircraft_height = RIDHeight(

--- a/monitoring/uss_qualifier/resources/netrid/simulation/operator_flight_details.py
+++ b/monitoring/uss_qualifier/resources/netrid/simulation/operator_flight_details.py
@@ -3,7 +3,7 @@ import string
 import random
 import uuid
 
-from monitoring.monitorlib.rid_automated_testing.injection_api import OperatorLocation
+from uas_standards.astm.f3411.v19.api import LatLngPoint
 
 
 class OperatorFlightDataGenerator:
@@ -37,7 +37,7 @@ class OperatorFlightDataGenerator:
         return self.random.choice(operation_description)
 
     def generate_operator_location(self, centroid):
-        operator_location = OperatorLocation(lat=centroid.y, lng=centroid.x)
+        operator_location = LatLngPoint(lat=centroid.y, lng=centroid.x)
         return operator_location
 
     def generate_operator_id(self, prefix="OP-"):

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.py
@@ -9,7 +9,6 @@ from requests.exceptions import RequestException
 
 from monitoring.monitorlib.rid_automated_testing.injection_api import (
     CreateTestParameters,
-    ChangeTestResponse,
 )
 from monitoring.monitorlib.rid_common import RIDVersion
 from monitoring.uss_qualifier.common_data_definitions import Severity
@@ -28,6 +27,7 @@ from monitoring.uss_qualifier.scenarios.astm.netrid.virtual_observer import (
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.scenarios.astm.netrid import display_data_evaluator
 from monitoring.uss_qualifier.scenarios.astm.netrid.injection import InjectedFlight
+from uas_standards.interuss.automated_testing.rid.v1.injection import ChangeTestResponse
 
 
 class NominalBehavior(TestScenario):

--- a/monitoring/uss_qualifier/test_data/che/netrid/circular_flights.json
+++ b/monitoring/uss_qualifier/test_data/che/netrid/circular_flights.json
@@ -10,7 +10,7 @@
             "lat": 46.9754225199202,
             "lng": 7.475076017275803,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -31,7 +31,7 @@
             "lat": 46.97537839156561,
             "lng": 7.475074106522959,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -52,7 +52,7 @@
             "lat": 46.97533460388938,
             "lng": 7.475065885577716,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -73,7 +73,7 @@
             "lat": 46.97529157858963,
             "lng": 7.4750514336274,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -94,7 +94,7 @@
             "lat": 46.97524973002137,
             "lng": 7.475030889866306,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -115,7 +115,7 @@
             "lat": 46.975209461206134,
             "lng": 7.475004452154652,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -136,7 +136,7 @@
             "lat": 46.97517115995081,
             "lng": 7.474972375112586,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -157,7 +157,7 @@
             "lat": 46.97513519511295,
             "lng": 7.474934967667648,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -178,7 +178,7 @@
             "lat": 46.97510191304869,
             "lng": 7.47489259007933,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -199,7 +199,7 @@
             "lat": 46.9750716342773,
             "lng": 7.474845650469361,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -220,7 +220,7 @@
             "lat": 46.97504465039461,
             "lng": 7.474794600891187,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -241,7 +241,7 @@
             "lat": 46.97502122126502,
             "lng": 7.474739932976472,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -262,7 +262,7 @@
             "lat": 46.97500157251901,
             "lng": 7.474682173200564,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -283,7 +283,7 @@
             "lat": 46.974985893380456,
             "lng": 7.4746218778124875,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -304,7 +304,7 @@
             "lat": 46.974974334844354,
             "lng": 7.474559627478333,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -325,7 +325,7 @@
             "lat": 46.97496700822293,
             "lng": 7.474496021689548,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -346,7 +346,7 @@
             "lat": 46.97496398407367,
             "lng": 7.474431672990031,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -367,7 +367,7 @@
             "lat": 46.97496529151983,
             "lng": 7.474367201077551,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -388,7 +388,7 @@
             "lat": 46.974970917970175,
             "lng": 7.474303226836321,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -409,7 +409,7 @@
             "lat": 46.97498080924005,
             "lng": 7.474240366358126,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -430,7 +430,7 @@
             "lat": 46.97499487007325,
             "lng": 7.47417922500962,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -451,7 +451,7 @@
             "lat": 46.97501296505933,
             "lng": 7.474120391602846,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -472,7 +472,7 @@
             "lat": 46.9750349199375,
             "lng": 7.47406443272514,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -493,7 +493,7 @@
             "lat": 46.975060523274735,
             "lng": 7.47401188728299,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -514,7 +514,7 @@
             "lat": 46.975089528501826,
             "lng": 7.473963261312384,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -535,7 +535,7 @@
             "lat": 46.975121656287804,
             "lng": 7.47391902310561,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -556,7 +556,7 @@
             "lat": 46.9751565972298,
             "lng": 7.473879598701442,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -577,7 +577,7 @@
             "lat": 46.97519401483258,
             "lng": 7.4738453677821175,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -598,7 +598,7 @@
             "lat": 46.975233548749024,
             "lng": 7.473816660016666,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -619,7 +619,7 @@
             "lat": 46.975274818250206,
             "lng": 7.473793751885744,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -657,7 +657,7 @@
             "lat": 46.97690122350781,
             "lng": 7.47507603539103,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -678,7 +678,7 @@
             "lat": 46.976857095163645,
             "lng": 7.475074124615693,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -699,7 +699,7 @@
             "lat": 46.97681330749575,
             "lng": 7.475065903473716,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -720,7 +720,7 @@
             "lat": 46.976770282202125,
             "lng": 7.475051451154319,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -741,7 +741,7 @@
             "lat": 46.97672843363776,
             "lng": 7.475030906855352,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -762,7 +762,7 @@
             "lat": 46.976688164824125,
             "lng": 7.475004468442217,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -783,7 +783,7 @@
             "lat": 46.9766498635681,
             "lng": 7.474972390541814,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -804,7 +804,7 @@
             "lat": 46.97661389872726,
             "lng": 7.474934982089958,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -825,7 +825,7 @@
             "lat": 46.97658061665774,
             "lng": 7.474892603355829,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -846,7 +846,7 @@
             "lat": 46.97655033787888,
             "lng": 7.474845662472196,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -867,7 +867,7 @@
             "lat": 46.97652335398656,
             "lng": 7.474794611504771,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -888,7 +888,7 @@
             "lat": 46.97649992484531,
             "lng": 7.474739942098597,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -909,7 +909,7 @@
             "lat": 46.976480276085674,
             "lng": 7.474682180743383,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -930,7 +930,7 @@
             "lat": 46.976464596931706,
             "lng": 7.474621883703365,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -951,7 +951,7 @@
             "lat": 46.97645303837853,
             "lng": 7.474559631660539,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -972,7 +972,7 @@
             "lat": 46.97644571173855,
             "lng": 7.47449602412281,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -993,7 +993,7 @@
             "lat": 46.976442687569374,
             "lng": 7.474431673650915,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1014,7 +1014,7 @@
             "lat": 46.97644399499454,
             "lng": 7.474367199959694,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1035,7 +1035,7 @@
             "lat": 46.97644962142294,
             "lng": 7.4743032239504865,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1056,7 +1056,7 @@
             "lat": 46.97645951267017,
             "lng": 7.474240361732105,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1077,7 +1077,7 @@
             "lat": 46.97647357348022,
             "lng": 7.4741792186879605,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1098,7 +1098,7 @@
             "lat": 46.97649166844289,
             "lng": 7.474120383646425,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1119,7 +1119,7 @@
             "lat": 46.976513623297585,
             "lng": 7.474064423210576,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1140,7 +1140,7 @@
             "lat": 46.97653922661156,
             "lng": 7.474011876301907,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1161,7 +1161,7 @@
             "lat": 46.976568231815776,
             "lng": 7.4739632489705325,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1182,7 +1182,7 @@
             "lat": 46.976600359579514,
             "lng": 7.473919009521841,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1203,7 +1203,7 @@
             "lat": 46.9766353005001,
             "lng": 7.473879584006569,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1224,7 +1224,7 @@
             "lat": 46.97667271808253,
             "lng": 7.473845352117653,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1245,7 +1245,7 @@
             "lat": 46.976712251979855,
             "lng": 7.473816643533461,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1266,7 +1266,7 @@
             "lat": 46.976753521463344,
             "lng": 7.473793734742539,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1304,7 +1304,7 @@
             "lat": 46.97542251027387,
             "lng": 7.476756868772192,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1325,7 +1325,7 @@
             "lat": 46.97537838193127,
             "lng": 7.476754956635472,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1346,7 +1346,7 @@
             "lat": 46.975334594359815,
             "lng": 7.476746734314739,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1367,7 +1367,7 @@
             "lat": 46.97529156925661,
             "lng": 7.476732281010565,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1388,7 +1388,7 @@
             "lat": 46.97524972097478,
             "lng": 7.476711735930281,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1409,7 +1409,7 @@
             "lat": 46.97520945253309,
             "lng": 7.476685296946811,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1430,7 +1430,7 @@
             "lat": 46.975171151734834,
             "lng": 7.476653218692547,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1451,7 +1451,7 @@
             "lat": 46.975135187433175,
             "lng": 7.4766158101067095,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1472,7 +1472,7 @@
             "lat": 46.97510190597907,
             "lng": 7.47657343145977,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1493,7 +1493,7 @@
             "lat": 46.975071627885924,
             "lng": 7.476526490883654,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1514,7 +1514,7 @@
             "lat": 46.975044644743015,
             "lng": 7.476475440441114,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1535,7 +1535,7 @@
             "lat": 46.97502121640763,
             "lng": 7.476420771772134,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1556,7 +1556,7 @@
             "lat": 46.97500156850261,
             "lng": 7.476363011359325,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1577,7 +1577,7 @@
             "lat": 46.97498589024373,
             "lng": 7.476302715457846,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1598,7 +1598,7 @@
             "lat": 46.974974332617506,
             "lng": 7.47624046473873,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1619,7 +1619,7 @@
             "lat": 46.974967006927415,
             "lng": 7.476176858697133,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1640,7 +1640,7 @@
             "lat": 46.97496398372193,
             "lng": 7.476112509879386,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1661,7 +1661,7 @@
             "lat": 46.97496529211529,
             "lng": 7.4760480379844,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1682,7 +1682,7 @@
             "lat": 46.97497091950708,
             "lng": 7.475984063896213,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1703,7 +1703,7 @@
             "lat": 46.97498081170361,
             "lng": 7.475921203705144,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1724,7 +1724,7 @@
             "lat": 46.974994873439734,
             "lng": 7.475860062775077,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1745,7 +1745,7 @@
             "lat": 46.9750129692963,
             "lng": 7.475801229914025,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1766,7 +1766,7 @@
             "lat": 46.975034925004174,
             "lng": 7.475745271704076,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1787,7 +1787,7 @@
             "lat": 46.975060529122324,
             "lng": 7.47569272704528,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1808,7 +1808,7 @@
             "lat": 46.975089535074005,
             "lng": 7.475644101966086,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1829,7 +1829,7 @@
             "lat": 46.9751216635213,
             "lng": 7.475599864750197,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1850,7 +1850,7 @@
             "lat": 46.97515660505494,
             "lng": 7.475560441426847,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1871,7 +1871,7 @@
             "lat": 46.97519402317401,
             "lng": 7.475526211667861,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1892,7 +1892,7 @@
             "lat": 46.97523355752641,
             "lng": 7.4754975051310995,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1913,7 +1913,7 @@
             "lat": 46.97527482737902,
             "lng": 7.475474598285385,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1951,7 +1951,7 @@
             "lat": 46.97690121386124,
             "lng": 7.4767568868874354,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1972,7 +1972,7 @@
             "lat": 46.976857085529076,
             "lng": 7.476754974728151,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -1993,7 +1993,7 @@
             "lat": 46.97681329796595,
             "lng": 7.476746752210612,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2014,7 +2014,7 @@
             "lat": 46.976770272868876,
             "lng": 7.476732298537285,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2035,7 +2035,7 @@
             "lat": 46.976728424590945,
             "lng": 7.476711752919061,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2056,7 +2056,7 @@
             "lat": 46.97668815615087,
             "lng": 7.476685313234045,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2077,7 +2077,7 @@
             "lat": 46.97664985535192,
             "lng": 7.476653234121385,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2098,7 +2098,7 @@
             "lat": 46.97661389104729,
             "lng": 7.476615824528567,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2119,7 +2119,7 @@
             "lat": 46.97658060958795,
             "lng": 7.476573444735765,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2140,7 +2140,7 @@
             "lat": 46.97655033148734,
             "lng": 7.476526502885938,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2161,7 +2161,7 @@
             "lat": 46.97652334833483,
             "lng": 7.4764754510541005,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2182,7 +2182,7 @@
             "lat": 46.9764999199878,
             "lng": 7.4764207808936245,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2203,7 +2203,7 @@
             "lat": 46.97648027206919,
             "lng": 7.476363018901478,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2224,7 +2224,7 @@
             "lat": 46.9764645937949,
             "lng": 7.4763027213480315,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2245,7 +2245,7 @@
             "lat": 46.97645303615162,
             "lng": 7.476240468920227,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2266,7 +2266,7 @@
             "lat": 46.97644571044297,
             "lng": 7.476176861129674,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2287,7 +2287,7 @@
             "lat": 46.976442687217634,
             "lng": 7.476112510539544,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2308,7 +2308,7 @@
             "lat": 46.976443995589996,
             "lng": 7.4760480368658175,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2329,7 +2329,7 @@
             "lat": 46.976449622959876,
             "lng": 7.475984061009664,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2350,7 +2350,7 @@
             "lat": 46.976459515133776,
             "lng": 7.475921199078423,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2371,7 +2371,7 @@
             "lat": 46.97647357684678,
             "lng": 7.47586005645274,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2392,7 +2392,7 @@
             "lat": 46.97649167267996,
             "lng": 7.4758012219569565,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2413,7 +2413,7 @@
             "lat": 46.976513628364394,
             "lng": 7.475745262188898,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2434,7 +2434,7 @@
             "lat": 46.97653923245929,
             "lng": 7.475692716063627,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2455,7 +2455,7 @@
             "lat": 46.97656823838812,
             "lng": 7.47564408962371,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2476,7 +2476,7 @@
             "lat": 46.976600366813166,
             "lng": 7.475599851165955,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2497,7 +2497,7 @@
             "lat": 46.97663530832542,
             "lng": 7.4755604267315565,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2518,7 +2518,7 @@
             "lat": 46.97667272642415,
             "lng": 7.475526196003043,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2539,7 +2539,7 @@
             "lat": 46.976712260757445,
             "lng": 7.475497488647604,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2560,7 +2560,7 @@
             "lat": 46.97675353059237,
             "lng": 7.475474581141957,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2598,7 +2598,7 @@
             "lat": 46.97542250062755,
             "lng": 7.478437720268015,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2619,7 +2619,7 @@
             "lat": 46.97537837229697,
             "lng": 7.47843580674742,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2640,7 +2640,7 @@
             "lat": 46.97533458483033,
             "lng": 7.478427583051206,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2661,7 +2661,7 @@
             "lat": 46.97529155992369,
             "lng": 7.478413128393184,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2682,7 +2682,7 @@
             "lat": 46.97524971192833,
             "lng": 7.478392581993727,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2703,7 +2703,7 @@
             "lat": 46.97520944386022,
             "lng": 7.478366141738464,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2724,7 +2724,7 @@
             "lat": 46.975171143519084,
             "lng": 7.478334062272031,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2745,7 +2745,7 @@
             "lat": 46.97513517975364,
             "lng": 7.478296652545325,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2766,7 +2766,7 @@
             "lat": 46.975101898909735,
             "lng": 7.478254272839801,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2787,7 +2787,7 @@
             "lat": 46.97507162149484,
             "lng": 7.478207331297581,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2808,7 +2808,7 @@
             "lat": 46.97504463909175,
             "lng": 7.478156279990716,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2829,7 +2829,7 @@
             "lat": 46.97502121155059,
             "lng": 7.47810161056752,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2850,7 +2850,7 @@
             "lat": 46.975001564486575,
             "lng": 7.478043849517858,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2871,7 +2871,7 @@
             "lat": 46.97498588710737,
             "lng": 7.47798355310303,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2892,7 +2892,7 @@
             "lat": 46.974974330391035,
             "lng": 7.477921301999006,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2913,7 +2913,7 @@
             "lat": 46.974967005632266,
             "lng": 7.477857695704652,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2934,7 +2934,7 @@
             "lat": 46.974963983370586,
             "lng": 7.47779334676873,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2955,7 +2955,7 @@
             "lat": 46.974965292711126,
             "lng": 7.477728874891291,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2976,7 +2976,7 @@
             "lat": 46.97497092104437,
             "lng": 7.4776649009562055,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -2997,7 +2997,7 @@
             "lat": 46.97498081416754,
             "lng": 7.477602041052314,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3018,7 +3018,7 @@
             "lat": 46.97499487680657,
             "lng": 7.477540900540738,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3039,7 +3039,7 @@
             "lat": 46.97501297353365,
             "lng": 7.477482068225463,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3060,7 +3060,7 @@
             "lat": 46.97503493007119,
             "lng": 7.477426110683315,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3081,7 +3081,7 @@
             "lat": 46.975060534970225,
             "lng": 7.47737356680792,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3102,7 +3102,7 @@
             "lat": 46.97508954164649,
             "lng": 7.4773249426201795,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3123,7 +3123,7 @@
             "lat": 46.975121670755044,
             "lng": 7.477280706395215,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3144,7 +3144,7 @@
             "lat": 46.97515661288031,
             "lng": 7.477241284152714,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3165,7 +3165,7 @@
             "lat": 46.97519403151563,
             "lng": 7.4772070555541,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3186,7 +3186,7 @@
             "lat": 46.975233566303956,
             "lng": 7.477178350246053,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3207,7 +3207,7 @@
             "lat": 46.975274836507936,
             "lng": 7.477155444685566,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3245,7 +3245,7 @@
             "lat": 46.97690120421468,
             "lng": 7.4784377383832705,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3266,7 +3266,7 @@
             "lat": 46.976857075894536,
             "lng": 7.478435824840042,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3287,7 +3287,7 @@
             "lat": 46.976813288436226,
             "lng": 7.478427600946948,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3308,7 +3308,7 @@
             "lat": 46.976770263535755,
             "lng": 7.478413145919705,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3329,7 +3329,7 @@
             "lat": 46.97672841554428,
             "lng": 7.478392598982242,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3350,7 +3350,7 @@
             "lat": 46.9766881474778,
             "lng": 7.4783661580253655,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3371,7 +3371,7 @@
             "lat": 46.97664984713598,
             "lng": 7.478334077700476,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3392,7 +3392,7 @@
             "lat": 46.97661388336759,
             "lng": 7.478296666966733,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3413,7 +3413,7 @@
             "lat": 46.976580602518446,
             "lng": 7.47825428611529,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3434,7 +3434,7 @@
             "lat": 46.9765503250961,
             "lng": 7.47820734329931,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3455,7 +3455,7 @@
             "lat": 46.976523342683436,
             "lng": 7.478156290603106,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3476,7 +3476,7 @@
             "lat": 46.97649991513066,
             "lng": 7.478101619688374,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3497,7 +3497,7 @@
             "lat": 46.97648026805306,
             "lng": 7.478043857059343,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3518,7 +3518,7 @@
             "lat": 46.97646459065849,
             "lng": 7.4779835589925225,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3539,7 +3539,7 @@
             "lat": 46.97645303392511,
             "lng": 7.477921306179789,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3560,7 +3560,7 @@
             "lat": 46.97644570914782,
             "lng": 7.477857698136468,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3581,7 +3581,7 @@
             "lat": 46.976442686866285,
             "lng": 7.477793347428159,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3602,7 +3602,7 @@
             "lat": 46.976443996185864,
             "lng": 7.477728873771983,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3623,7 +3623,7 @@
             "lat": 46.97644962449721,
             "lng": 7.477664898068939,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3644,7 +3644,7 @@
             "lat": 46.97645951759776,
             "lng": 7.4776020364248925,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3665,7 +3665,7 @@
             "lat": 46.97647358021371,
             "lng": 7.477540894217724,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3686,7 +3686,7 @@
             "lat": 46.97649167691741,
             "lng": 7.477482060267744,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3707,7 +3707,7 @@
             "lat": 46.97651363343155,
             "lng": 7.4774261011675245,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3728,7 +3728,7 @@
             "lat": 46.976539238307325,
             "lng": 7.477373555825696,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3749,7 +3749,7 @@
             "lat": 46.97656824496077,
             "lng": 7.477324930277279,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3770,7 +3770,7 @@
             "lat": 46.9766003740471,
             "lng": 7.477280692810501,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3791,7 +3791,7 @@
             "lat": 46.97663531615098,
             "lng": 7.477241269457007,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3812,7 +3812,7 @@
             "lat": 46.97667273476598,
             "lng": 7.477207039888923,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3833,7 +3833,7 @@
             "lat": 46.97671226953519,
             "lng": 7.477178333762265,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },
@@ -3854,7 +3854,7 @@
             "lat": 46.97675353972152,
             "lng": 7.477155427541912,
             "alt": 620.0,
-            "accuracy_h": "HAUnkown",
+            "accuracy_h": "HAUnknown",
             "accuracy_v": "VAUnknown",
             "extrapolated": false
           },


### PR DESCRIPTION
This PR switches from using monitorlib's manual RID injection API data objects to using the same objects from uas_standards.