### PR TITLE
#822 gRPC layer removal: use time.RFC3339Nano and add omitempty to JSON

### DIFF
--- a/cmds/dummy-oauth/api/dummyoauth/types.gen.go
+++ b/cmds/dummy-oauth/api/dummyoauth/types.gen.go
@@ -8,5 +8,5 @@ type TokenResponse struct {
 
 type BadRequestResponse struct {
 	// Human-readable message describing problem with request
-	Message *string `json:"message"`
+	Message *string `json:"message,omitempty"`
 }

--- a/interfaces/openapi-to-go-server/example/api/rid/types.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/rid/types.gen.go
@@ -7,10 +7,10 @@ type Volume3D struct {
 	Footprint GeoPolygon `json:"footprint"`
 
 	// Minimum bounding altitude of this volume.
-	AltitudeLo *Altitude `json:"altitude_lo"`
+	AltitudeLo *Altitude `json:"altitude_lo,omitempty"`
 
 	// Maximum bounding altitude of this volume.
-	AltitudeHi *Altitude `json:"altitude_hi"`
+	AltitudeHi *Altitude `json:"altitude_hi,omitempty"`
 }
 
 // Contiguous block of geographic spacetime.
@@ -19,10 +19,10 @@ type Volume4D struct {
 	SpatialVolume Volume3D `json:"spatial_volume"`
 
 	// Beginning time of this volume.  RFC 3339 format, per OpenAPI specification.
-	TimeStart *string `json:"time_start"`
+	TimeStart *string `json:"time_start,omitempty"`
 
 	// End time of this volume.  RFC 3339 format, per OpenAPI specification.
-	TimeEnd *string `json:"time_end"`
+	TimeEnd *string `json:"time_end,omitempty"`
 }
 
 // Response to DSS request for the subscription with the given id.
@@ -44,9 +44,9 @@ type SubscriptionNotificationIndex int32
 
 // State of AreaSubscription which is causing a notification to be sent.
 type SubscriptionState struct {
-	SubscriptionId *SubscriptionUUID `json:"subscription_id"`
+	SubscriptionId *SubscriptionUUID `json:"subscription_id,omitempty"`
 
-	NotificationIndex *SubscriptionNotificationIndex `json:"notification_index"`
+	NotificationIndex *SubscriptionNotificationIndex `json:"notification_index,omitempty"`
 }
 
 // UUID v4.
@@ -64,7 +64,7 @@ type SubscriptionUUID UUIDv4
 // Data provided when an off-nominal condition was encountered.
 type ErrorResponse struct {
 	// Human-readable message indicating what error occurred and/or why.
-	Message *string `json:"message"`
+	Message *string `json:"message,omitempty"`
 }
 
 // Response for a successful request to delete an Subscription.
@@ -143,13 +143,13 @@ type IdentificationServiceAreaURL string
 // Endpoints that should be called when an applicable event occurs.  At least one field must be specified.
 type SubscriptionCallbacks struct {
 	// If specified, other clients will be instructed by the DSS to call this endpoint when an Identification Service Area relevant to this Subscription is created, modified, or deleted.  Must implement PUT and DELETE according to the `/uss/identification_service_areas/{id}` path API.
-	IdentificationServiceAreaUrl *IdentificationServiceAreaURL `json:"identification_service_area_url"`
+	IdentificationServiceAreaUrl *IdentificationServiceAreaURL `json:"identification_service_area_url,omitempty"`
 }
 
 // Response for a request to create or update a subscription.
 type PutSubscriptionResponse struct {
 	// Identification Service Areas in or near the subscription area at the time of creation/update, if `identification_service_area_url` callback was specified.
-	ServiceAreas *[]IdentificationServiceArea `json:"service_areas"`
+	ServiceAreas *[]IdentificationServiceArea `json:"service_areas,omitempty"`
 
 	// Result of the operation on the subscription.
 	Subscription Subscription `json:"subscription"`
@@ -217,10 +217,10 @@ type Subscription struct {
 	NotificationIndex SubscriptionNotificationIndex `json:"notification_index"`
 
 	// If set, this subscription will be automatically removed after this time.  RFC 3339 format, per OpenAPI specification.
-	TimeEnd *string `json:"time_end"`
+	TimeEnd *string `json:"time_end,omitempty"`
 
 	// If set, this Subscription will not generate any notifications before this time.  RFC 3339 format, per OpenAPI specification.
-	TimeStart *string `json:"time_start"`
+	TimeStart *string `json:"time_start,omitempty"`
 
 	Version Version `json:"version"`
 }

--- a/interfaces/openapi-to-go-server/example/api/scd/types.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/scd/types.gen.go
@@ -62,24 +62,24 @@ type LatLngPoint struct {
 
 // A circular area on the surface of the earth.
 type Circle struct {
-	Center *LatLngPoint `json:"center"`
+	Center *LatLngPoint `json:"center,omitempty"`
 
-	Radius *Radius `json:"radius"`
+	Radius *Radius `json:"radius,omitempty"`
 }
 
 // A three-dimensional geographic volume consisting of a vertically-extruded shape. Exactly one outline must be specified.
 type Volume3D struct {
 	// A circular geographic shape on the surface of the earth.
-	OutlineCircle *Circle `json:"outline_circle"`
+	OutlineCircle *Circle `json:"outline_circle,omitempty"`
 
 	// A polygonal geographic shape on the surface of the earth.
-	OutlinePolygon *Polygon `json:"outline_polygon"`
+	OutlinePolygon *Polygon `json:"outline_polygon,omitempty"`
 
 	// Minimum bounding altitude of this volume. Must be less than altitude_upper, if specified.
-	AltitudeLower *Altitude `json:"altitude_lower"`
+	AltitudeLower *Altitude `json:"altitude_lower,omitempty"`
 
 	// Maximum bounding altitude of this volume. Must be greater than altitude_lower, if specified.
-	AltitudeUpper *Altitude `json:"altitude_upper"`
+	AltitudeUpper *Altitude `json:"altitude_upper,omitempty"`
 }
 
 // Contiguous block of geographic spacetime.
@@ -87,16 +87,16 @@ type Volume4D struct {
 	Volume Volume3D `json:"volume"`
 
 	// Beginning time of this volume. Must be before time_end.
-	TimeStart *Time `json:"time_start"`
+	TimeStart *Time `json:"time_start,omitempty"`
 
 	// End time of this volume. Must be after time_start.
-	TimeEnd *Time `json:"time_end"`
+	TimeEnd *Time `json:"time_end,omitempty"`
 }
 
 // Human-readable string returned when an error occurs as a result of a USS - DSS transaction.
 type ErrorResponse struct {
 	// Human-readable message indicating what error occurred and/or why.
-	Message *string `json:"message"`
+	Message *string `json:"message,omitempty"`
 }
 
 // State of subscription which is causing a notification to be sent.
@@ -124,24 +124,24 @@ type Subscription struct {
 	NotificationIndex SubscriptionNotificationIndex `json:"notification_index"`
 
 	// If set, this subscription will not receive notifications involving airspace changes entirely before this time.
-	TimeStart *Time `json:"time_start"`
+	TimeStart *Time `json:"time_start,omitempty"`
 
 	// If set, this subscription will not receive notifications involving airspace changes entirely after this time.
-	TimeEnd *Time `json:"time_end"`
+	TimeEnd *Time `json:"time_end,omitempty"`
 
 	UssBaseUrl SubscriptionUssBaseURL `json:"uss_base_url"`
 
 	// If true, trigger notifications when operational intents are created, updated, or deleted.  Otherwise, changes in operational intents should not trigger notifications.  The scope utm.strategic_coordination is required to set this flag true.
-	NotifyForOperationalIntents *bool `json:"notify_for_operational_intents"`
+	NotifyForOperationalIntents *bool `json:"notify_for_operational_intents,omitempty"`
 
 	// If true, trigger notifications when constraints are created, updated, or deleted.  Otherwise, changes in constraints should not trigger notifications.  The scope utm.constraint_processing is required to set this flag true.
-	NotifyForConstraints *bool `json:"notify_for_constraints"`
+	NotifyForConstraints *bool `json:"notify_for_constraints,omitempty"`
 
 	// True if this subscription was implicitly created by the DSS via the creation of an operational intent, and should therefore be deleted by the DSS when that operational intent is deleted.
-	ImplicitSubscription *bool `json:"implicit_subscription"`
+	ImplicitSubscription *bool `json:"implicit_subscription,omitempty"`
 
 	// List of IDs for operational intents that are dependent on this subscription.
-	DependentOperationalIntents *[]EntityID `json:"dependent_operational_intents"`
+	DependentOperationalIntents *[]EntityID `json:"dependent_operational_intents,omitempty"`
 }
 
 // Tracks the notifications sent for a subscription so the subscriber can detect missed notifications more easily.
@@ -149,7 +149,7 @@ type SubscriptionNotificationIndex int32
 
 // Parameters for a request to find subscriptions matching the provided criteria.
 type QuerySubscriptionParameters struct {
-	AreaOfInterest *Volume4D `json:"area_of_interest"`
+	AreaOfInterest *Volume4D `json:"area_of_interest,omitempty"`
 }
 
 // Response to DSS query for subscriptions in a particular geographic area.
@@ -173,10 +173,10 @@ type PutSubscriptionParameters struct {
 	UssBaseUrl SubscriptionUssBaseURL `json:"uss_base_url"`
 
 	// If true, trigger notifications when operational intents are created, updated, or deleted.  Otherwise, changes in operational intents should not trigger notifications.  The scope utm.strategic_coordination is required to set this flag true.
-	NotifyForOperationalIntents *bool `json:"notify_for_operational_intents"`
+	NotifyForOperationalIntents *bool `json:"notify_for_operational_intents,omitempty"`
 
 	// If true, trigger notifications when constraints are created, updated, or deleted.  Otherwise, changes in constraints should not trigger notifications.  The scope utm.constraint_processing is required to set this flag true.
-	NotifyForConstraints *bool `json:"notify_for_constraints"`
+	NotifyForConstraints *bool `json:"notify_for_constraints,omitempty"`
 }
 
 // The base URL of a USS implementation of the parts of the USS-USS API necessary for receiving the notifications requested by this subscription.
@@ -187,10 +187,10 @@ type PutSubscriptionResponse struct {
 	Subscription Subscription `json:"subscription"`
 
 	// Operational intents in or near the subscription area at the time of creation/update, if `notify_for_operational_intents` is true.
-	OperationalIntentReferences *[]OperationalIntentReference `json:"operational_intent_references"`
+	OperationalIntentReferences *[]OperationalIntentReference `json:"operational_intent_references,omitempty"`
 
 	// Constraints in or near the subscription area at the time of creation/update, if `notify_for_constraints` is true.
-	ConstraintReferences *[]ConstraintReference `json:"constraint_references"`
+	ConstraintReferences *[]ConstraintReference `json:"constraint_references,omitempty"`
 }
 
 // Response for a successful request to delete a subscription.
@@ -234,7 +234,7 @@ type OperationalIntentReference struct {
 	State OperationalIntentState `json:"state"`
 
 	// Opaque version number of this operational intent.  Populated only when the OperationalIntentReference is managed by the USS retrieving or providing it.  Not populated when the OperationalIntentReference is not managed by the USS retrieving or providing it (instead, the USS must obtain the OVN from the details retrieved from the managing USS).
-	Ovn *EntityOVN `json:"ovn"`
+	Ovn *EntityOVN `json:"ovn,omitempty"`
 
 	// Beginning time of operational intent.
 	TimeStart Time `json:"time_start"`
@@ -258,17 +258,17 @@ type PutOperationalIntentReferenceParameters struct {
 	Extents []Volume4D `json:"extents"`
 
 	// Proof that the USS creating or mutating this operational intent was aware of the current state of the airspace, with the expectation that this operational intent is therefore deconflicted from all relevant features in the airspace.  This field is not required when declaring an operational intent Nonconforming or Contingent, or when there are no relevant Entities in the airspace, but is otherwise required. OVNs for constraints are required if and only if the USS managing this operational intent is performing the constraint processing role, which is indicated by whether the subscription associated with this operational intent triggers notifications for constraints.  The key does not need to contain the OVN for the operational intent being updated.
-	Key *Key `json:"key"`
+	Key *Key `json:"key,omitempty"`
 
 	State OperationalIntentState `json:"state"`
 
 	UssBaseUrl OperationalIntentUssBaseURL `json:"uss_base_url"`
 
 	// The ID of an existing subscription that the USS will use to keep the operator informed about updates to relevant airspace information. If this field is not provided when the operational intent is in the Activated, Nonconforming, or Contingent state, then the `new_subscription` field must be provided in order to provide notification capability for the operational intent.  The subscription specified by this ID must cover at least the area over which this operational intent is conducted, and it must provide notifications for operational intents.
-	SubscriptionId *EntityID `json:"subscription_id"`
+	SubscriptionId *EntityID `json:"subscription_id,omitempty"`
 
 	// If an existing subscription is not specified in `subscription_id`, and the operational intent is in the Activated, Nonconforming, or Contingent state, then this field must be populated.  When this field is populated, an implicit subscription will be created and associated with this operational intent, and will generally be deleted automatically upon the deletion of this operational intent.
-	NewSubscription *ImplicitSubscriptionParameters `json:"new_subscription"`
+	NewSubscription *ImplicitSubscriptionParameters `json:"new_subscription,omitempty"`
 }
 
 // Information necessary to create a subscription to serve a single operational intent's notification needs.
@@ -277,7 +277,7 @@ type ImplicitSubscriptionParameters struct {
 	UssBaseUrl SubscriptionUssBaseURL `json:"uss_base_url"`
 
 	// True if this operational intent's subscription should trigger notifications when constraints change. Otherwise, changes in constraints should not trigger notifications.  The scope utm.constraint_processing is required to set this flag true, and a USS performing the constraint processing role should set this flag true.
-	NotifyForConstraints *bool `json:"notify_for_constraints"`
+	NotifyForConstraints *bool `json:"notify_for_constraints,omitempty"`
 }
 
 // Response to DSS request for the OperationalIntentReference with the given ID.
@@ -295,7 +295,7 @@ type ChangeOperationalIntentReferenceResponse struct {
 
 // Parameters for a request to find OperationalIntentReferences matching the provided criteria.
 type QueryOperationalIntentReferenceParameters struct {
-	AreaOfInterest *Volume4D `json:"area_of_interest"`
+	AreaOfInterest *Volume4D `json:"area_of_interest,omitempty"`
 }
 
 // Response to DSS query for OperationalIntentReferences in an area of interest.
@@ -317,7 +317,7 @@ type ConstraintReference struct {
 	Version int32 `json:"version"`
 
 	// Opaque version number of this constraint.  Populated only when the ConstraintReference is managed by the USS retrieving or providing it.  Not populated when the ConstraintReference is not managed by the USS retrieving or providing it (instead, the USS must obtain the OVN from the details retrieved from the managing USS).
-	Ovn *EntityOVN `json:"ovn"`
+	Ovn *EntityOVN `json:"ovn,omitempty"`
 
 	TimeStart Time `json:"time_start"`
 
@@ -354,7 +354,7 @@ type ChangeConstraintReferenceResponse struct {
 
 // Parameters for a request to find ConstraintReferences matching the provided criteria.
 type QueryConstraintReferenceParameters struct {
-	AreaOfInterest *Volume4D `json:"area_of_interest"`
+	AreaOfInterest *Volume4D `json:"area_of_interest,omitempty"`
 }
 
 // Response to DSS query for ConstraintReferences in an area of interest.
@@ -366,13 +366,13 @@ type QueryConstraintReferencesResponse struct {
 // Data provided when an airspace conflict was encountered.
 type AirspaceConflictResponse struct {
 	// Human-readable message indicating what error occurred and/or why.
-	Message *string `json:"message"`
+	Message *string `json:"message,omitempty"`
 
 	// List of operational intent references for which current proof of knowledge was not provided.  If this field is present and contains elements, the calling USS should query the details URLs for these operational intents to obtain their details and correct OVNs.  The OVNs can be used to update the key, at which point the USS may retry this call.
-	MissingOperationalIntents *[]OperationalIntentReference `json:"missing_operational_intents"`
+	MissingOperationalIntents *[]OperationalIntentReference `json:"missing_operational_intents,omitempty"`
 
 	// List of constraint references for which current proof of knowledge was not provided.  If this field is present and contains elements, the calling USS should query the details URLs for these constraints to obtain their details and correct OVNs.  The OVNs can be used to update the key, at which point the USS may retry this call.
-	MissingConstraints *[]ConstraintReference `json:"missing_constraints"`
+	MissingConstraints *[]ConstraintReference `json:"missing_constraints,omitempty"`
 }
 
 type UssAvailabilityStatus struct {
@@ -418,7 +418,7 @@ type ExchangeRecord struct {
 	Method string `json:"method"`
 
 	// Set of headers associated with request or response. Requires 'Authorization:' field (at a minimum)
-	Headers *[]string `json:"headers"`
+	Headers *[]string `json:"headers,omitempty"`
 
 	// A coded value that indicates the role of the logging USS: 'Client' (initiating a request to a remote USS) or 'Server' (handling a request from a remote USS)
 	RecorderRole string `json:"recorder_role"`
@@ -427,25 +427,25 @@ type ExchangeRecord struct {
 	RequestTime Time `json:"request_time"`
 
 	// Base64-encoded body content sent/received as a request.
-	RequestBody *string `json:"request_body"`
+	RequestBody *string `json:"request_body,omitempty"`
 
 	// The time at which the response was sent/received.
-	ResponseTime *Time `json:"response_time"`
+	ResponseTime *Time `json:"response_time,omitempty"`
 
 	// Base64-encoded body content sent/received in response to request.
-	ResponseBody *string `json:"response_body"`
+	ResponseBody *string `json:"response_body,omitempty"`
 
 	// HTTP response code sent/received in response to request.
-	ResponseCode *int32 `json:"response_code"`
+	ResponseCode *int32 `json:"response_code,omitempty"`
 
 	// 'Human-readable description of the problem with the exchange, if any.'
-	Problem *string `json:"problem"`
+	Problem *string `json:"problem,omitempty"`
 }
 
 // A report informing a server of a communication problem.
 type ErrorReport struct {
 	// ID assigned by the server receiving the report.  Not populated when submitting a report.
-	ReportId *string `json:"report_id"`
+	ReportId *string `json:"report_id,omitempty"`
 
 	// The request (by this USS) and response associated with the error.
 	Exchange ExchangeRecord `json:"exchange"`

--- a/interfaces/openapi-to-go-server/rendering.py
+++ b/interfaces/openapi-to-go-server/rendering.py
@@ -86,9 +86,10 @@ def _object_field(field: data_types.ObjectField) -> List[str]:
     :return: Lines of Go code defining the provided field
     """
     lines = comment(field.description.split('\n')) if field.description else []
-    lines.append('{} {}{} `json:"{}"`'.format(field.go_name,
+    lines.append('{} {}{} `json:"{}{}"`'.format(field.go_name,
                                               '*' if not field.required else '',
-                                              field.go_type, field.api_name))
+                                              field.go_type, field.api_name,
+                                              ',omitempty' if not field.required else ''))
     return lines
 
 

--- a/pkg/api/auxv1/types.gen.go
+++ b/pkg/api/auxv1/types.gen.go
@@ -8,5 +8,5 @@ type VersionResponse struct {
 
 type ErrorResponse struct {
 	// Human-readable message indicating what error occurred and/or why.
-	Message *string `json:"message"`
+	Message *string `json:"message,omitempty"`
 }

--- a/pkg/api/ridv1/types.gen.go
+++ b/pkg/api/ridv1/types.gen.go
@@ -7,10 +7,10 @@ type Volume3D struct {
 	Footprint GeoPolygon `json:"footprint"`
 
 	// Minimum bounding altitude of this volume.
-	AltitudeLo *Altitude `json:"altitude_lo"`
+	AltitudeLo *Altitude `json:"altitude_lo,omitempty"`
 
 	// Maximum bounding altitude of this volume.
-	AltitudeHi *Altitude `json:"altitude_hi"`
+	AltitudeHi *Altitude `json:"altitude_hi,omitempty"`
 }
 
 // Contiguous block of geographic spacetime.
@@ -19,10 +19,10 @@ type Volume4D struct {
 	SpatialVolume Volume3D `json:"spatial_volume"`
 
 	// Beginning time of this volume.  RFC 3339 format, per OpenAPI specification.
-	TimeStart *string `json:"time_start"`
+	TimeStart *string `json:"time_start,omitempty"`
 
 	// End time of this volume.  RFC 3339 format, per OpenAPI specification.
-	TimeEnd *string `json:"time_end"`
+	TimeEnd *string `json:"time_end,omitempty"`
 }
 
 // Response to DSS request for the subscription with the given id.
@@ -44,9 +44,9 @@ type SubscriptionNotificationIndex int32
 
 // State of AreaSubscription which is causing a notification to be sent.
 type SubscriptionState struct {
-	SubscriptionId *SubscriptionUUID `json:"subscription_id"`
+	SubscriptionId *SubscriptionUUID `json:"subscription_id,omitempty"`
 
-	NotificationIndex *SubscriptionNotificationIndex `json:"notification_index"`
+	NotificationIndex *SubscriptionNotificationIndex `json:"notification_index,omitempty"`
 }
 
 // UUID v4.
@@ -64,7 +64,7 @@ type SubscriptionUUID UUIDv4
 // Data provided when an off-nominal condition was encountered.
 type ErrorResponse struct {
 	// Human-readable message indicating what error occurred and/or why.
-	Message *string `json:"message"`
+	Message *string `json:"message,omitempty"`
 }
 
 // Response for a successful request to delete an Subscription.
@@ -143,13 +143,13 @@ type IdentificationServiceAreaURL string
 // Endpoints that should be called when an applicable event occurs.  At least one field must be specified.
 type SubscriptionCallbacks struct {
 	// If specified, other clients will be instructed by the DSS to call this endpoint when an Identification Service Area relevant to this Subscription is created, modified, or deleted.  Must implement PUT and DELETE according to the `/uss/identification_service_areas/{id}` path API.
-	IdentificationServiceAreaUrl *IdentificationServiceAreaURL `json:"identification_service_area_url"`
+	IdentificationServiceAreaUrl *IdentificationServiceAreaURL `json:"identification_service_area_url,omitempty"`
 }
 
 // Response for a request to create or update a subscription.
 type PutSubscriptionResponse struct {
 	// Identification Service Areas in or near the subscription area at the time of creation/update, if `identification_service_area_url` callback was specified.
-	ServiceAreas *[]IdentificationServiceArea `json:"service_areas"`
+	ServiceAreas *[]IdentificationServiceArea `json:"service_areas,omitempty"`
 
 	// Result of the operation on the subscription.
 	Subscription Subscription `json:"subscription"`
@@ -217,10 +217,10 @@ type Subscription struct {
 	NotificationIndex SubscriptionNotificationIndex `json:"notification_index"`
 
 	// If set, this subscription will be automatically removed after this time.  RFC 3339 format, per OpenAPI specification.
-	TimeEnd *string `json:"time_end"`
+	TimeEnd *string `json:"time_end,omitempty"`
 
 	// If set, this Subscription will not generate any notifications before this time.  RFC 3339 format, per OpenAPI specification.
-	TimeStart *string `json:"time_start"`
+	TimeStart *string `json:"time_start,omitempty"`
 
 	Version Version `json:"version"`
 }

--- a/pkg/api/ridv2/types.gen.go
+++ b/pkg/api/ridv2/types.gen.go
@@ -18,24 +18,24 @@ type Radius struct {
 
 // A circular area on the surface of the earth.
 type Circle struct {
-	Center *LatLngPoint `json:"center"`
+	Center *LatLngPoint `json:"center,omitempty"`
 
-	Radius *Radius `json:"radius"`
+	Radius *Radius `json:"radius,omitempty"`
 }
 
 // A three-dimensional geographic volume consisting of a vertically-extruded shape. Exactly one outline must be specified.
 type Volume3D struct {
 	// A circular geographic shape on the surface of the earth.
-	OutlineCircle *Circle `json:"outline_circle"`
+	OutlineCircle *Circle `json:"outline_circle,omitempty"`
 
 	// A polygonal geographic shape on the surface of the earth.
-	OutlinePolygon *Polygon `json:"outline_polygon"`
+	OutlinePolygon *Polygon `json:"outline_polygon,omitempty"`
 
 	// Minimum bounding altitude of this volume. Must be less than altitude_upper, if specified.
-	AltitudeLower *Altitude `json:"altitude_lower"`
+	AltitudeLower *Altitude `json:"altitude_lower,omitempty"`
 
 	// Maximum bounding altitude of this volume. Must be greater than altitude_lower, if specified.
-	AltitudeUpper *Altitude `json:"altitude_upper"`
+	AltitudeUpper *Altitude `json:"altitude_upper,omitempty"`
 }
 
 // Contiguous block of geographic spacetime.
@@ -43,10 +43,10 @@ type Volume4D struct {
 	Volume Volume3D `json:"volume"`
 
 	// Beginning time of this volume. Must be before time_end.
-	TimeStart *Time `json:"time_start"`
+	TimeStart *Time `json:"time_start,omitempty"`
 
 	// End time of this volume. Must be after time_start.
-	TimeEnd *Time `json:"time_end"`
+	TimeEnd *Time `json:"time_end,omitempty"`
 }
 
 // Response to DSS request for the subscription with the given id.
@@ -57,7 +57,7 @@ type GetSubscriptionResponse struct {
 // Response to DSS query for subscriptions in a particular area.
 type SearchSubscriptionsResponse struct {
 	// Subscriptions that overlap the specified area.
-	Subscriptions *[]Subscription `json:"subscriptions"`
+	Subscriptions *[]Subscription `json:"subscriptions,omitempty"`
 }
 
 // Valid http or https URL.
@@ -70,7 +70,7 @@ type SubscriptionNotificationIndex int32
 type SubscriptionState struct {
 	SubscriptionId SubscriptionUUID `json:"subscription_id"`
 
-	NotificationIndex *SubscriptionNotificationIndex `json:"notification_index"`
+	NotificationIndex *SubscriptionNotificationIndex `json:"notification_index,omitempty"`
 }
 
 // UUID v4.
@@ -88,7 +88,7 @@ type SubscriptionUUID UUIDv4
 // Data provided when an off-nominal condition was encountered.
 type ErrorResponse struct {
 	// Human-readable message indicating what error occurred and/or why.
-	Message *string `json:"message"`
+	Message *string `json:"message,omitempty"`
 }
 
 // Response for a successful request to delete an Subscription.
@@ -138,7 +138,7 @@ type Polygon struct {
 // Response to a request to create or update a reference to an Identification Service Area in the DSS.
 type PutIdentificationServiceAreaResponse struct {
 	// DSS subscribers that this client now has the obligation to notify of the Identification Service Area changes just made.  This client must call POST for each provided URL according to the `/uss/identification_service_areas/{id}` path API.
-	Subscribers *[]SubscriberToNotify `json:"subscribers"`
+	Subscribers *[]SubscriberToNotify `json:"subscribers,omitempty"`
 
 	// Resulting service area stored in DSS.
 	ServiceArea IdentificationServiceArea `json:"service_area"`
@@ -147,7 +147,7 @@ type PutIdentificationServiceAreaResponse struct {
 // Response to DSS query for Identification Service Areas in an area of interest.
 type SearchIdentificationServiceAreasResponse struct {
 	// Identification Service Areas in the area of interest.
-	ServiceAreas *[]IdentificationServiceArea `json:"service_areas"`
+	ServiceAreas *[]IdentificationServiceArea `json:"service_areas,omitempty"`
 }
 
 // Subscriber to notify of a creation/change/deletion of a change in the airspace.  This is provided by the DSS to a client changing the airspace, and it is the responsibility of the client changing the airspace (they will receive a set of these notification requests) to send a notification to each specified `url`.
@@ -165,13 +165,13 @@ type DeleteIdentificationServiceAreaResponse struct {
 	ServiceArea IdentificationServiceArea `json:"service_area"`
 
 	// DSS subscribers that this client now has the obligation to notify of the Identification Service Area just deleted.  This client must call POST for each provided URL according to the `/uss/identification_service_areas` path API.
-	Subscribers *[]SubscriberToNotify `json:"subscribers"`
+	Subscribers *[]SubscriberToNotify `json:"subscribers,omitempty"`
 }
 
 // Response for a request to create or update a subscription.
 type PutSubscriptionResponse struct {
 	// Identification Service Areas in or near the subscription area at the time of creation/update, if `identification_service_area_url` callback was specified.
-	ServiceAreas *[]IdentificationServiceArea `json:"service_areas"`
+	ServiceAreas *[]IdentificationServiceArea `json:"service_areas,omitempty"`
 
 	// Result of the operation on the subscription.
 	Subscription Subscription `json:"subscription"`
@@ -236,13 +236,13 @@ type Subscription struct {
 	// Assigned by the DSS based on creating client’s ID (via access token).  Used for restricting mutation and deletion operations to owner.
 	Owner string `json:"owner"`
 
-	NotificationIndex *SubscriptionNotificationIndex `json:"notification_index"`
+	NotificationIndex *SubscriptionNotificationIndex `json:"notification_index,omitempty"`
 
 	// If set, this subscription will be automatically removed after this time.
-	TimeEnd *Time `json:"time_end"`
+	TimeEnd *Time `json:"time_end,omitempty"`
 
 	// If set, this Subscription will not generate any notifications before this time.
-	TimeStart *Time `json:"time_start"`
+	TimeStart *Time `json:"time_start,omitempty"`
 
 	Version Version `json:"version"`
 }

--- a/pkg/api/scdv1/types.gen.go
+++ b/pkg/api/scdv1/types.gen.go
@@ -62,24 +62,24 @@ type LatLngPoint struct {
 
 // A circular area on the surface of the earth.
 type Circle struct {
-	Center *LatLngPoint `json:"center"`
+	Center *LatLngPoint `json:"center,omitempty"`
 
-	Radius *Radius `json:"radius"`
+	Radius *Radius `json:"radius,omitempty"`
 }
 
 // A three-dimensional geographic volume consisting of a vertically-extruded shape. Exactly one outline must be specified.
 type Volume3D struct {
 	// A circular geographic shape on the surface of the earth.
-	OutlineCircle *Circle `json:"outline_circle"`
+	OutlineCircle *Circle `json:"outline_circle,omitempty"`
 
 	// A polygonal geographic shape on the surface of the earth.
-	OutlinePolygon *Polygon `json:"outline_polygon"`
+	OutlinePolygon *Polygon `json:"outline_polygon,omitempty"`
 
 	// Minimum bounding altitude of this volume. Must be less than altitude_upper, if specified.
-	AltitudeLower *Altitude `json:"altitude_lower"`
+	AltitudeLower *Altitude `json:"altitude_lower,omitempty"`
 
 	// Maximum bounding altitude of this volume. Must be greater than altitude_lower, if specified.
-	AltitudeUpper *Altitude `json:"altitude_upper"`
+	AltitudeUpper *Altitude `json:"altitude_upper,omitempty"`
 }
 
 // Contiguous block of geographic spacetime.
@@ -87,16 +87,16 @@ type Volume4D struct {
 	Volume Volume3D `json:"volume"`
 
 	// Beginning time of this volume. Must be before time_end.
-	TimeStart *Time `json:"time_start"`
+	TimeStart *Time `json:"time_start,omitempty"`
 
 	// End time of this volume. Must be after time_start.
-	TimeEnd *Time `json:"time_end"`
+	TimeEnd *Time `json:"time_end,omitempty"`
 }
 
 // Human-readable string returned when an error occurs as a result of a USS - DSS transaction.
 type ErrorResponse struct {
 	// Human-readable message indicating what error occurred and/or why.
-	Message *string `json:"message"`
+	Message *string `json:"message,omitempty"`
 }
 
 // State of subscription which is causing a notification to be sent.
@@ -124,24 +124,24 @@ type Subscription struct {
 	NotificationIndex SubscriptionNotificationIndex `json:"notification_index"`
 
 	// If set, this subscription will not receive notifications involving airspace changes entirely before this time.
-	TimeStart *Time `json:"time_start"`
+	TimeStart *Time `json:"time_start,omitempty"`
 
 	// If set, this subscription will not receive notifications involving airspace changes entirely after this time.
-	TimeEnd *Time `json:"time_end"`
+	TimeEnd *Time `json:"time_end,omitempty"`
 
 	UssBaseUrl SubscriptionUssBaseURL `json:"uss_base_url"`
 
 	// If true, trigger notifications when operational intents are created, updated, or deleted.  Otherwise, changes in operational intents should not trigger notifications.  The scope utm.strategic_coordination is required to set this flag true.
-	NotifyForOperationalIntents *bool `json:"notify_for_operational_intents"`
+	NotifyForOperationalIntents *bool `json:"notify_for_operational_intents,omitempty"`
 
 	// If true, trigger notifications when constraints are created, updated, or deleted.  Otherwise, changes in constraints should not trigger notifications.  The scope utm.constraint_processing is required to set this flag true.
-	NotifyForConstraints *bool `json:"notify_for_constraints"`
+	NotifyForConstraints *bool `json:"notify_for_constraints,omitempty"`
 
 	// True if this subscription was implicitly created by the DSS via the creation of an operational intent, and should therefore be deleted by the DSS when that operational intent is deleted.
-	ImplicitSubscription *bool `json:"implicit_subscription"`
+	ImplicitSubscription *bool `json:"implicit_subscription,omitempty"`
 
 	// List of IDs for operational intents that are dependent on this subscription.
-	DependentOperationalIntents *[]EntityID `json:"dependent_operational_intents"`
+	DependentOperationalIntents *[]EntityID `json:"dependent_operational_intents,omitempty"`
 }
 
 // Tracks the notifications sent for a subscription so the subscriber can detect missed notifications more easily.
@@ -149,7 +149,7 @@ type SubscriptionNotificationIndex int32
 
 // Parameters for a request to find subscriptions matching the provided criteria.
 type QuerySubscriptionParameters struct {
-	AreaOfInterest *Volume4D `json:"area_of_interest"`
+	AreaOfInterest *Volume4D `json:"area_of_interest,omitempty"`
 }
 
 // Response to DSS query for subscriptions in a particular geographic area.
@@ -173,10 +173,10 @@ type PutSubscriptionParameters struct {
 	UssBaseUrl SubscriptionUssBaseURL `json:"uss_base_url"`
 
 	// If true, trigger notifications when operational intents are created, updated, or deleted.  Otherwise, changes in operational intents should not trigger notifications.  The scope utm.strategic_coordination is required to set this flag true.
-	NotifyForOperationalIntents *bool `json:"notify_for_operational_intents"`
+	NotifyForOperationalIntents *bool `json:"notify_for_operational_intents,omitempty"`
 
 	// If true, trigger notifications when constraints are created, updated, or deleted.  Otherwise, changes in constraints should not trigger notifications.  The scope utm.constraint_processing is required to set this flag true.
-	NotifyForConstraints *bool `json:"notify_for_constraints"`
+	NotifyForConstraints *bool `json:"notify_for_constraints,omitempty"`
 }
 
 // The base URL of a USS implementation of the parts of the USS-USS API necessary for receiving the notifications requested by this subscription.
@@ -187,10 +187,10 @@ type PutSubscriptionResponse struct {
 	Subscription Subscription `json:"subscription"`
 
 	// Operational intents in or near the subscription area at the time of creation/update, if `notify_for_operational_intents` is true.
-	OperationalIntentReferences *[]OperationalIntentReference `json:"operational_intent_references"`
+	OperationalIntentReferences *[]OperationalIntentReference `json:"operational_intent_references,omitempty"`
 
 	// Constraints in or near the subscription area at the time of creation/update, if `notify_for_constraints` is true.
-	ConstraintReferences *[]ConstraintReference `json:"constraint_references"`
+	ConstraintReferences *[]ConstraintReference `json:"constraint_references,omitempty"`
 }
 
 // Response for a successful request to delete a subscription.
@@ -234,7 +234,7 @@ type OperationalIntentReference struct {
 	State OperationalIntentState `json:"state"`
 
 	// Opaque version number of this operational intent.  Populated only when the OperationalIntentReference is managed by the USS retrieving or providing it.  Not populated when the OperationalIntentReference is not managed by the USS retrieving or providing it (instead, the USS must obtain the OVN from the details retrieved from the managing USS).
-	Ovn *EntityOVN `json:"ovn"`
+	Ovn *EntityOVN `json:"ovn,omitempty"`
 
 	// Beginning time of operational intent.
 	TimeStart Time `json:"time_start"`
@@ -258,17 +258,17 @@ type PutOperationalIntentReferenceParameters struct {
 	Extents []Volume4D `json:"extents"`
 
 	// Proof that the USS creating or mutating this operational intent was aware of the current state of the airspace, with the expectation that this operational intent is therefore deconflicted from all relevant features in the airspace.  This field is not required when declaring an operational intent Nonconforming or Contingent, or when there are no relevant Entities in the airspace, but is otherwise required. OVNs for constraints are required if and only if the USS managing this operational intent is performing the constraint processing role, which is indicated by whether the subscription associated with this operational intent triggers notifications for constraints.  The key does not need to contain the OVN for the operational intent being updated.
-	Key *Key `json:"key"`
+	Key *Key `json:"key,omitempty"`
 
 	State OperationalIntentState `json:"state"`
 
 	UssBaseUrl OperationalIntentUssBaseURL `json:"uss_base_url"`
 
 	// The ID of an existing subscription that the USS will use to keep the operator informed about updates to relevant airspace information. If this field is not provided when the operational intent is in the Activated, Nonconforming, or Contingent state, then the `new_subscription` field must be provided in order to provide notification capability for the operational intent.  The subscription specified by this ID must cover at least the area over which this operational intent is conducted, and it must provide notifications for operational intents.
-	SubscriptionId *EntityID `json:"subscription_id"`
+	SubscriptionId *EntityID `json:"subscription_id,omitempty"`
 
 	// If an existing subscription is not specified in `subscription_id`, and the operational intent is in the Activated, Nonconforming, or Contingent state, then this field must be populated.  When this field is populated, an implicit subscription will be created and associated with this operational intent, and will generally be deleted automatically upon the deletion of this operational intent.
-	NewSubscription *ImplicitSubscriptionParameters `json:"new_subscription"`
+	NewSubscription *ImplicitSubscriptionParameters `json:"new_subscription,omitempty"`
 }
 
 // Information necessary to create a subscription to serve a single operational intent's notification needs.
@@ -277,7 +277,7 @@ type ImplicitSubscriptionParameters struct {
 	UssBaseUrl SubscriptionUssBaseURL `json:"uss_base_url"`
 
 	// True if this operational intent's subscription should trigger notifications when constraints change. Otherwise, changes in constraints should not trigger notifications.  The scope utm.constraint_processing is required to set this flag true, and a USS performing the constraint processing role should set this flag true.
-	NotifyForConstraints *bool `json:"notify_for_constraints"`
+	NotifyForConstraints *bool `json:"notify_for_constraints,omitempty"`
 }
 
 // Response to DSS request for the OperationalIntentReference with the given ID.
@@ -295,7 +295,7 @@ type ChangeOperationalIntentReferenceResponse struct {
 
 // Parameters for a request to find OperationalIntentReferences matching the provided criteria.
 type QueryOperationalIntentReferenceParameters struct {
-	AreaOfInterest *Volume4D `json:"area_of_interest"`
+	AreaOfInterest *Volume4D `json:"area_of_interest,omitempty"`
 }
 
 // Response to DSS query for OperationalIntentReferences in an area of interest.
@@ -317,7 +317,7 @@ type ConstraintReference struct {
 	Version int32 `json:"version"`
 
 	// Opaque version number of this constraint.  Populated only when the ConstraintReference is managed by the USS retrieving or providing it.  Not populated when the ConstraintReference is not managed by the USS retrieving or providing it (instead, the USS must obtain the OVN from the details retrieved from the managing USS).
-	Ovn *EntityOVN `json:"ovn"`
+	Ovn *EntityOVN `json:"ovn,omitempty"`
 
 	TimeStart Time `json:"time_start"`
 
@@ -354,7 +354,7 @@ type ChangeConstraintReferenceResponse struct {
 
 // Parameters for a request to find ConstraintReferences matching the provided criteria.
 type QueryConstraintReferenceParameters struct {
-	AreaOfInterest *Volume4D `json:"area_of_interest"`
+	AreaOfInterest *Volume4D `json:"area_of_interest,omitempty"`
 }
 
 // Response to DSS query for ConstraintReferences in an area of interest.
@@ -366,13 +366,13 @@ type QueryConstraintReferencesResponse struct {
 // Data provided when an airspace conflict was encountered.
 type AirspaceConflictResponse struct {
 	// Human-readable message indicating what error occurred and/or why.
-	Message *string `json:"message"`
+	Message *string `json:"message,omitempty"`
 
 	// List of operational intent references for which current proof of knowledge was not provided.  If this field is present and contains elements, the calling USS should query the details URLs for these operational intents to obtain their details and correct OVNs.  The OVNs can be used to update the key, at which point the USS may retry this call.
-	MissingOperationalIntents *[]OperationalIntentReference `json:"missing_operational_intents"`
+	MissingOperationalIntents *[]OperationalIntentReference `json:"missing_operational_intents,omitempty"`
 
 	// List of constraint references for which current proof of knowledge was not provided.  If this field is present and contains elements, the calling USS should query the details URLs for these constraints to obtain their details and correct OVNs.  The OVNs can be used to update the key, at which point the USS may retry this call.
-	MissingConstraints *[]ConstraintReference `json:"missing_constraints"`
+	MissingConstraints *[]ConstraintReference `json:"missing_constraints,omitempty"`
 }
 
 type UssAvailabilityStatus struct {
@@ -418,7 +418,7 @@ type ExchangeRecord struct {
 	Method string `json:"method"`
 
 	// Set of headers associated with request or response. Requires 'Authorization:' field (at a minimum)
-	Headers *[]string `json:"headers"`
+	Headers *[]string `json:"headers,omitempty"`
 
 	// A coded value that indicates the role of the logging USS: 'Client' (initiating a request to a remote USS) or 'Server' (handling a request from a remote USS)
 	RecorderRole string `json:"recorder_role"`
@@ -427,25 +427,25 @@ type ExchangeRecord struct {
 	RequestTime Time `json:"request_time"`
 
 	// Base64-encoded body content sent/received as a request.
-	RequestBody *string `json:"request_body"`
+	RequestBody *string `json:"request_body,omitempty"`
 
 	// The time at which the response was sent/received.
-	ResponseTime *Time `json:"response_time"`
+	ResponseTime *Time `json:"response_time,omitempty"`
 
 	// Base64-encoded body content sent/received in response to request.
-	ResponseBody *string `json:"response_body"`
+	ResponseBody *string `json:"response_body,omitempty"`
 
 	// HTTP response code sent/received in response to request.
-	ResponseCode *int32 `json:"response_code"`
+	ResponseCode *int32 `json:"response_code,omitempty"`
 
 	// 'Human-readable description of the problem with the exchange, if any.'
-	Problem *string `json:"problem"`
+	Problem *string `json:"problem,omitempty"`
 }
 
 // A report informing a server of a communication problem.
 type ErrorReport struct {
 	// ID assigned by the server receiving the report.  Not populated when submitting a report.
-	ReportId *string `json:"report_id"`
+	ReportId *string `json:"report_id,omitempty"`
 
 	// The request (by this USS) and response associated with the error.
 	Exchange ExchangeRecord `json:"exchange"`

--- a/pkg/rid/models/api/v1/conversions.go
+++ b/pkg/rid/models/api/v1/conversions.go
@@ -18,17 +18,17 @@ func FromVolume4D(vol4 *restapi.Volume4D) (*dssmodels.Volume4D, error) {
 	}
 
 	if vol4.TimeStart != nil {
-		ts, err := time.Parse(time.RFC3339, *vol4.TimeStart)
+		ts, err := time.Parse(time.RFC3339Nano, *vol4.TimeStart)
 		if err != nil {
-			return nil, stacktrace.Propagate(err, "Error converting start time from proto")
+			return nil, stacktrace.Propagate(err, "Error converting start time")
 		}
 		result.StartTime = &ts
 	}
 
 	if vol4.TimeEnd != nil {
-		ts, err := time.Parse(time.RFC3339, *vol4.TimeEnd)
+		ts, err := time.Parse(time.RFC3339Nano, *vol4.TimeEnd)
 		if err != nil {
-			return nil, stacktrace.Propagate(err, "Error converting end time from proto")
+			return nil, stacktrace.Propagate(err, "Error converting end time")
 		}
 		result.EndTime = &ts
 	}
@@ -78,12 +78,12 @@ func ToVolume4D(vol4 *dssmodels.Volume4D) (*restapi.Volume4D, error) {
 	}
 
 	if vol4.StartTime != nil {
-		ts := vol4.StartTime.Format(time.RFC3339)
+		ts := vol4.StartTime.Format(time.RFC3339Nano)
 		result.TimeStart = &ts
 	}
 
 	if vol4.EndTime != nil {
-		ts := vol4.EndTime.Format(time.RFC3339)
+		ts := vol4.EndTime.Format(time.RFC3339Nano)
 		result.TimeEnd = &ts
 	}
 
@@ -154,11 +154,11 @@ func ToIdentificationServiceArea(i *ridmodels.IdentificationServiceArea) *restap
 	}
 
 	if i.StartTime != nil {
-		result.TimeStart = i.StartTime.Format(time.RFC3339)
+		result.TimeStart = i.StartTime.Format(time.RFC3339Nano)
 	}
 
 	if i.EndTime != nil {
-		result.TimeEnd = i.EndTime.Format(time.RFC3339)
+		result.TimeEnd = i.EndTime.Format(time.RFC3339Nano)
 	}
 	return result
 }
@@ -193,12 +193,12 @@ func ToSubscription(s *ridmodels.Subscription) *restapi.Subscription {
 	}
 
 	if s.StartTime != nil {
-		ts := s.StartTime.Format(time.RFC3339)
+		ts := s.StartTime.Format(time.RFC3339Nano)
 		result.TimeStart = &ts
 	}
 
 	if s.EndTime != nil {
-		ts := s.EndTime.Format(time.RFC3339)
+		ts := s.EndTime.Format(time.RFC3339Nano)
 		result.TimeEnd = &ts
 	}
 	return result

--- a/pkg/rid/models/api/v2/conversions.go
+++ b/pkg/rid/models/api/v2/conversions.go
@@ -22,7 +22,7 @@ func FromTime(t *restapi.Time) (*time.Time, error) {
 	if t.Value == "" {
 		return nil, stacktrace.NewError("Time structure specified, but `value` was missing")
 	}
-	ts, err := time.Parse(time.RFC3339, t.Value)
+	ts, err := time.Parse(time.RFC3339Nano, t.Value)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "Error converting time")
 	}
@@ -158,7 +158,7 @@ func ToTime(t *time.Time) *restapi.Time {
 
 	result := &restapi.Time{
 		Format: "RFC3339",
-		Value:  t.Format(time.RFC3339),
+		Value:  t.Format(time.RFC3339Nano),
 	}
 
 	return result

--- a/pkg/rid/server/v2/isa_handler.go
+++ b/pkg/rid/server/v2/isa_handler.go
@@ -293,7 +293,7 @@ func (s *Server) SearchIdentificationServiceAreas(ctx context.Context, req *rest
 	)
 
 	if req.EarliestTime != nil {
-		ts, err := time.Parse(time.RFC3339, *req.EarliestTime)
+		ts, err := time.Parse(time.RFC3339Nano, *req.EarliestTime)
 		if err != nil {
 			return restapi.SearchIdentificationServiceAreasResponseSet{Response400: &restapi.ErrorResponse{
 				Message: dsserr.Handle(ctx, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Unable to convert earliest timestamp"))}}
@@ -302,7 +302,7 @@ func (s *Server) SearchIdentificationServiceAreas(ctx context.Context, req *rest
 	}
 
 	if req.LatestTime != nil {
-		ts, err := time.Parse(time.RFC3339, *req.LatestTime)
+		ts, err := time.Parse(time.RFC3339Nano, *req.LatestTime)
 		if err != nil {
 			return restapi.SearchIdentificationServiceAreasResponseSet{Response400: &restapi.ErrorResponse{
 				Message: dsserr.Handle(ctx, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Unable to convert latest timestamp"))}}


### PR DESCRIPTION
Sixth batch of mofifications:

- In handlers of RID v1 and v2 (and their models conversion functions): replace the use of layout `time.RFC3339` to `time.RFC3339Nano`. Why:
  The layout `time.RFC3339` only resolves times up to the second, fragments of seconds are ignored. This means that if a client submits a time with fragments of seconds, those will be ignored. I did not notice this issue up until testing the handlers of the SCD API, because only the test cases of the SCD APIs make use of fragments of seconds.
- Add to the OpenAPI generation tool the ability to set the option `omitempty` of the Go JSON Marshalling library (and update the generated APIs and examples). Why:
  Before this change the fields that were empty (notably arrays) were marshalled as a JSON `null` value. This would confuse the prober in some instances, and was not the same behavior as before with the gateway. 