### PR TITLE
[uss_qualifier] Add requirement declarations

### DIFF
--- a/monitoring/uss_qualifier/Makefile
+++ b/monitoring/uss_qualifier/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test
-test: validate_documentation lint
+test: lint
 	./scripts/test_docker_fully_mocked.sh
 
 .PHONY: validate_documentation
@@ -7,7 +7,7 @@ validate_documentation:
 	./scripts/validate_test_definitions.sh
 
 .PHONY: lint
-lint:
+lint: validate_documentation
 	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:latest_release black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
 	find . -name '*.sh' | xargs docker run --rm -v $(CURDIR):/code -w /code koalaman/shellcheck
 

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -8,13 +8,10 @@ import sys
 from implicitdict import ImplicitDict
 from monitoring.monitorlib.versioning import get_code_version
 from monitoring.uss_qualifier.configurations.configuration import TestConfiguration
-from monitoring.uss_qualifier.reports.documents import render_requirement_table
+from monitoring.uss_qualifier.reports.documents import generate_tested_requirements
 from monitoring.uss_qualifier.reports.graphs import make_graph
 from monitoring.uss_qualifier.reports.report import TestRunReport
 from monitoring.uss_qualifier.resources.resource import create_resources
-from monitoring.uss_qualifier.scenarios.documentation.requirements import (
-    evaluate_requirements,
-)
 from monitoring.uss_qualifier.suites.suite import (
     TestSuite,
 )
@@ -41,6 +38,11 @@ def parseArgs() -> argparse.Namespace:
     parser.add_argument(
         "--tested_requirements",
         help="File name to create for a tested requirements HTML summary",
+    )
+    parser.add_argument(
+        "--role_requirements",
+        action="append",
+        help="Specification of a role to include in the tested_requirements summary for the specified participants, in the form of <PARTICIPANT_ID>[,<PARTICIPANT_ID>,...]=<REQUIREMENT_SET_ID>",
     )
 
     return parser.parse_args()
@@ -84,9 +86,8 @@ def main() -> int:
 
     if args.tested_requirements is not None:
         print(f"Writing tested requirements summary to {args.tested_requirements}")
-        requirements = evaluate_requirements(report)
         with open(args.tested_requirements, "w") as f:
-            f.write(render_requirement_table(requirements))
+            f.write(generate_tested_requirements(report, args.role_requirements))
 
     return os.EX_OK
 

--- a/monitoring/uss_qualifier/reports/documents.py
+++ b/monitoring/uss_qualifier/reports/documents.py
@@ -1,12 +1,21 @@
-from typing import List
+from dataclasses import dataclass
+from typing import List, Dict
 
 from jinja2 import Environment, PackageLoader
 
-from monitoring.uss_qualifier.reports.report import ParticipantID
-from monitoring.uss_qualifier.scenarios.documentation.requirements import Requirement
+from monitoring.uss_qualifier.reports.report import ParticipantID, TestRunReport
+from monitoring.uss_qualifier.requirements.documentation import (
+    RequirementSet,
+    RequirementSetID,
+    get_requirement_set,
+)
+from monitoring.uss_qualifier.scenarios.documentation.requirements import (
+    TestedRequirement,
+    evaluate_requirements,
+)
 
 
-def _all_participants(requirements: List[Requirement]) -> List[ParticipantID]:
+def _all_participants(requirements: List[TestedRequirement]) -> List[ParticipantID]:
     participants = set()
     for requirement in requirements:
         for participant_id in requirement.participant_performance:
@@ -16,12 +25,16 @@ def _all_participants(requirements: List[Requirement]) -> List[ParticipantID]:
     return result
 
 
-def render_requirement_table(requirements: List[Requirement]) -> str:
-    all_participants = _all_participants(requirements)
-    rows = [["Requirement"] + all_participants]
+def _render_requirement_table(
+    env,
+    requirements: List[TestedRequirement],
+    participants: List[ParticipantID],
+    requirement_set_title: str,
+) -> str:
+    rows = [["Requirement"] + participants]
     for requirement in requirements:
         cols = [requirement.requirement_id]
-        for participant in all_participants:
+        for participant in participants:
             performance = requirement.participant_performance.get(participant, None)
             if performance is None:
                 cols.append("")
@@ -31,6 +44,73 @@ def render_requirement_table(requirements: List[Requirement]) -> str:
                 cols.append("{:.0f}%".format(percentage_successful))
         rows.append(cols)
 
+    template = env.get_template("tested_requirement_set.html")
+    return template.render(rows=rows, requirement_set_title=requirement_set_title)
+
+
+@dataclass
+class TestedRequirementsTable(object):
+    participants: List[ParticipantID]
+    requirement_set: RequirementSet
+
+
+def _parse_role_arguments(args: List[str]) -> List[TestedRequirementsTable]:
+    tables: Dict[RequirementSetID, List[ParticipantID]] = {}
+    for arg in args:
+        cols = arg.split("=")
+        if len(cols) != 2:
+            raise ValueError(
+                f'Argument "{arg}" is invalid; arguments must be in the form of <PARTICIPANT_ID>[,<PARTICIPANT_ID>,...]=<REQUIREMENT_SET_ID>'
+            )
+        req_set_id = cols[1]
+        if req_set_id not in tables:
+            tables[req_set_id] = []
+        tables[req_set_id].extend(ParticipantID(s.strip()) for s in cols[0].split(","))
+    return [
+        TestedRequirementsTable(
+            requirement_set=get_requirement_set(RequirementSetID(k)), participants=v
+        )
+        for k, v in tables.items()
+    ]
+
+
+def generate_tested_requirements(
+    report: TestRunReport, role_arguments: List[str]
+) -> str:
     env = Environment(loader=PackageLoader(__name__))
+    tables = _parse_role_arguments(role_arguments)
+    requirements = evaluate_requirements(report)
+    tested_reqs_by_id = {tr.requirement_id: tr for tr in requirements}
+    unclassified_reqs = set(tr.requirement_id for tr in requirements)
+
+    content = ""
+    for table in tables:
+        table_reqs = []
+        for r in table.requirement_set.requirement_ids:
+            if r in tested_reqs_by_id:
+                table_reqs.append(tested_reqs_by_id[r])
+                if r in unclassified_reqs:
+                    unclassified_reqs.remove(r)
+            else:
+                table_reqs.append(
+                    TestedRequirement(requirement_id=r, participant_performance={})
+                )
+        content += _render_requirement_table(
+            env,
+            table_reqs,
+            table.participants,
+            table.requirement_set.name,
+        )
+
+    unclassified_tested_requirements = [
+        tr for tr in requirements if tr.requirement_id in unclassified_reqs
+    ]
+    content += _render_requirement_table(
+        env,
+        unclassified_tested_requirements,
+        _all_participants(unclassified_tested_requirements),
+        "Unclassified requirements",
+    )
+
     template = env.get_template("tested_requirements.html")
-    return template.render(rows=rows)
+    return template.render(content=content)

--- a/monitoring/uss_qualifier/reports/templates/tested_requirement_set.html
+++ b/monitoring/uss_qualifier/reports/templates/tested_requirement_set.html
@@ -1,0 +1,14 @@
+    <div>
+        <h2>{{ requirement_set_title }}</h2>
+        <table>
+            {% for row in rows %}
+            <tr>
+                {% for cell in row %}
+                <td>
+                    {{ cell }}
+                </td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </table>
+    </div>

--- a/monitoring/uss_qualifier/reports/templates/tested_requirements.html
+++ b/monitoring/uss_qualifier/reports/templates/tested_requirements.html
@@ -1,16 +1,5 @@
 <html>
 <body>
-    Note: Only requirements that were tested appear in the table below.  If checks are skipped or otherwise not performed, they may not appear below.
-    <table>
-    {% for row in rows %}
-        <tr>
-        {% for cell in row %}
-            <td>
-                {{ cell }}
-            </td>
-        {% endfor %}
-        </tr>
-    {% endfor %}
-    </table>
+{{ content }}
 </body>
 </html>

--- a/monitoring/uss_qualifier/requirements/README.md
+++ b/monitoring/uss_qualifier/requirements/README.md
@@ -1,0 +1,13 @@
+# Requirements
+
+## Overview
+
+The primary purpose of uss_qualifier is to identify the requirements with which a test participant complies and does not comply.  The existence of these requirements should be documented within this folder.
+
+## Documentation format
+
+A requirement's identifier is `<PACKAGE>.<NAME>` where `<PACKAGE>` is a Python-style package reference to a .md file (without extension) relative to this folder (`uss_qualifier/requirements`).  For instance, the `<PACKAGE>` for the file located at `./astm/f3548/v21.md` would be `astm.f3548.v21`.  `<NAME>` is an identifier defined in the file described by `<PACKAGE>` by enclosing it in a `<tt>` tag; for instance: `<tt>USS0105</tt>`.
+
+## Usage
+
+Requirements tested by a scenario should be defined in that [scenario's documentation](../scenarios/README.md).

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v19.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v19.md
@@ -1,0 +1,87 @@
+# ASTM F3411-19
+
+_Standard Specification for Remote ID and Tracking_
+
+For information on these requirements, refer to [the ASTM standard F3411-19](https://www.astm.org/f3411-19.html).
+
+## Network Compliance Matrix
+
+### UAS to Network Remote ID Service Provider Requirements
+
+* <tt>NET0010</tt>
+* <tt>NET0020</tt>
+* <tt>NET0030</tt>
+* <tt>NET0040</tt>
+
+### Operator of Non-Equipped Network Participant to Net-RID Service Provider Requirements
+
+* <tt>NET0110</tt>
+* <tt>NET0120</tt>
+* <tt>NET0130</tt>
+
+### Net-RID Service Provider to Net-RID Display Provider Requirements
+
+* <tt>NET0210</tt>
+* <tt>NET0220</tt>
+* <tt>NET0230</tt>
+* <tt>NET0240</tt>
+* <tt>NET0250</tt>
+* <tt>NET0260</tt>
+* <tt>NET0270</tt>
+* <tt>NET0280</tt>
+* <tt>NET0290</tt>
+* <tt>NET0300</tt>
+* <tt>NET0310</tt>
+* <tt>NET0320</tt>
+* <tt>NET0330</tt>
+* <tt>NET0340</tt>
+
+### Net-RID Display Provider to Display Application Requirements
+
+* <tt>NET0410</tt>
+* <tt>NET0420</tt>
+* <tt>NET0430</tt>
+* <tt>NET0440</tt>
+* <tt>NET0450</tt>
+* <tt>NET0460</tt>
+* <tt>NET0470</tt>
+* <tt>NET0480</tt>
+* <tt>NET0490</tt>
+
+### Test Methods
+
+* <tt>NET0500</tt>
+
+### USS Requirements Related to the DSS
+
+* <tt>NET0610</tt>
+* <tt>NET0620</tt>
+* <tt>NET0630</tt>
+
+### USS-USS Interfaces
+
+* <tt>NET0710</tt>
+* <tt>NET0720</tt>
+* <tt>NET0730</tt>
+
+## DSS Compliance Matrix
+
+### DSS Implementation Requirements
+
+* <tt>DSS0010</tt>
+* <tt>DSS0020</tt>
+* <tt>DSS0030</tt>
+* <tt>DSS0040</tt>
+* <tt>DSS0050</tt>
+* <tt>DSS0060</tt>
+* <tt>DSS0070</tt>
+
+### Data Synchronization Requirements
+
+* <tt>DSS0110</tt>
+* <tt>DSS0120</tt>
+* <tt>DSS0130</tt>
+
+### Test Environment Requirements
+
+* <tt>DSS0210</tt>

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v19/display_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v19/display_provider.md
@@ -1,0 +1,44 @@
+# ASTM F3411-19: Display Provider Role
+
+This file describes the set of ASTM F3411-19 requirements with which a USS fulfilling the Display Provider role must comply.
+
+## Manual verification
+
+### Network Compliance Matrix
+
+#### Net-RID Service Provider to Net-RID Display Provider Requirements
+
+* **astm.f3411.v19.NET0330**
+
+## Automated verification
+
+### Network Compliance Matrix
+
+#### Net-RID Service Provider to Net-RID Display Provider Requirements
+
+* **astm.f3411.v19.NET0210**
+* **astm.f3411.v19.NET0220**
+* **astm.f3411.v19.NET0230**
+* **astm.f3411.v19.NET0240**
+* **astm.f3411.v19.NET0340**
+
+#### Net-RID Display Provider to Display Application Requirements
+
+* **astm.f3411.v19.NET0410**
+* **astm.f3411.v19.NET0420**
+* **astm.f3411.v19.NET0430**
+* **astm.f3411.v19.NET0440**
+* **astm.f3411.v19.NET0450**
+* **astm.f3411.v19.NET0460**
+* **astm.f3411.v19.NET0470**
+* **astm.f3411.v19.NET0480**
+* **astm.f3411.v19.NET0490**
+
+#### USS Requirements Related to the DSS
+
+* **astm.f3411.v19.NET0630**
+
+#### USS-USS Interfaces
+
+* **astm.f3411.v19.NET0720**
+* **astm.f3411.v19.NET0730**

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v19/display_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v19/display_provider.md
@@ -1,4 +1,4 @@
-# ASTM F3411-19: Display Provider Role
+# ASTM F3411-19: Display Provider Role requirement set
 
 This file describes the set of ASTM F3411-19 requirements with which a USS fulfilling the Display Provider role must comply.
 

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v19/dss_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v19/dss_provider.md
@@ -1,0 +1,31 @@
+# ASTM F3411-19: DSS Provider
+
+This file describes the set of ASTM F3411-19 requirements with which a USS providing a DSS instance must comply.
+
+## Manual verification
+
+All DSS instance provider requirements can be verified by automation.
+
+## Automated verification
+
+### DSS Compliance Matrix
+
+#### DSS Implementation Requirements
+
+* **astm.f3411.v19.DSS0010**
+* **astm.f3411.v19.DSS0020**
+* **astm.f3411.v19.DSS0030**
+* **astm.f3411.v19.DSS0040**
+* **astm.f3411.v19.DSS0050**
+* **astm.f3411.v19.DSS0060**
+* **astm.f3411.v19.DSS0070**
+
+#### Data Synchronization Requirements
+
+* **astm.f3411.v19.DSS0110**
+* **astm.f3411.v19.DSS0120**
+* **astm.f3411.v19.DSS0130**
+
+#### Test Environment Requirements
+
+* **astm.f3411.v19.DSS0210**

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v19/dss_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v19/dss_provider.md
@@ -1,4 +1,4 @@
-# ASTM F3411-19: DSS Provider
+# ASTM F3411-19: DSS Provider requirement set
 
 This file describes the set of ASTM F3411-19 requirements with which a USS providing a DSS instance must comply.
 

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v19/service_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v19/service_provider.md
@@ -1,0 +1,49 @@
+# ASTM F3411-19: Service Provider Role
+
+This file describes the set of ASTM F3411-19 requirements with which a USS fulfilling the Service Provider role must comply.
+
+## Not tested by automated tests
+
+## Tested by automated tests
+
+### Network Compliance Matrix
+
+#### UAS to Network Remote ID Service Provider Requirements
+
+* **astm.f3411.v19.NET0010**
+* **astm.f3411.v19.NET0020**
+* **astm.f3411.v19.NET0030**
+* **astm.f3411.v19.NET0040**
+
+#### Operator of Non-Equipped Network Participant to Net-RID Service Provider Requirements
+
+* **astm.f3411.v19.NET0110**
+* **astm.f3411.v19.NET0120**
+* **astm.f3411.v19.NET0130**
+
+#### Net-RID Service Provider to Net-RID Display Provider Requirements
+
+* **astm.f3411.v19.NET0210**
+* **astm.f3411.v19.NET0220**
+* **astm.f3411.v19.NET0250**
+* **astm.f3411.v19.NET0260**
+* **astm.f3411.v19.NET0270**
+* **astm.f3411.v19.NET0280**
+* **astm.f3411.v19.NET0290**
+* **astm.f3411.v19.NET0300**
+* **astm.f3411.v19.NET0310**
+* **astm.f3411.v19.NET0320**
+* **astm.f3411.v19.NET0340**
+
+#### Test Methods
+
+* **astm.f3411.v19.NET0500**
+
+#### USS Requirements Related to the DSS
+
+* **astm.f3411.v19.NET0610**
+* **astm.f3411.v19.NET0620**
+
+#### USS-USS Interfaces
+
+* **astm.f3411.v19.NET0710**

--- a/monitoring/uss_qualifier/requirements/astm/f3411/v19/service_provider.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3411/v19/service_provider.md
@@ -1,4 +1,4 @@
-# ASTM F3411-19: Service Provider Role
+# ASTM F3411-19: Service Provider Role requirement set
 
 This file describes the set of ASTM F3411-19 requirements with which a USS fulfilling the Service Provider role must comply.
 

--- a/monitoring/uss_qualifier/requirements/astm/f3548/v21.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3548/v21.md
@@ -1,0 +1,167 @@
+# ASTM F3548-21
+
+_Standard Specification for UAS Traffic Management (UTM) UAS Service Supplier (USS) Interoperability_
+
+For information on these requirements, refer to [the ASTM standard F3548-21](https://www.astm.org/f3548-21.html).
+
+## Common Requirements
+
+* <tt>GEN0005</tt>
+* <tt>GEN0010</tt>
+* <tt>GEN0015</tt>
+* <tt>GEN0100</tt>
+* <tt>GEN0105</tt>
+* <tt>GEN0200</tt>
+* <tt>GEN0300</tt>
+* <tt>GEN0305</tt>
+* <tt>GEN0310</tt>
+* <tt>GEN0400</tt>
+* <tt>GEN0405</tt>
+* <tt>GEN0500</tt>
+
+## Operational Intent Creation and Modification
+
+* <tt>OPIN0005</tt>
+* <tt>OPIN0010</tt>
+* <tt>OPIN0015</tt>
+* <tt>OPIN0020</tt>
+* <tt>OPIN0025</tt>
+* <tt>OPIN0030</tt>
+* <tt>OPIN0035</tt>
+* <tt>OPIN0040</tt>
+* <tt>USS0005</tt>
+
+## Strategic Conflict Detection Service
+
+* <tt>SCD0005</tt>
+* <tt>SCD0010</tt>
+* <tt>SCD0015</tt>
+* <tt>SCD0020</tt>
+* <tt>SCD0025</tt>
+* <tt>SCD0030</tt>
+* <tt>SCD0035</tt>
+* <tt>SCD0040</tt>
+* <tt>SCD0045</tt>
+* <tt>SCD0050</tt>
+* <tt>SCD0055</tt>
+* <tt>SCD0060</tt>
+* <tt>SCD0065</tt>
+* <tt>SCD0070</tt>
+* <tt>SCD0075</tt>
+* <tt>SCD0080</tt>
+* <tt>SCD0085</tt>
+* <tt>SCD0090</tt>
+* <tt>SCD0095</tt>
+* <tt>SCD0100</tt>
+* <tt>GEN0500</tt>
+* <tt>USS0105</tt>
+
+## Aggregate Operational Intent Conformance Monitoring Service
+
+* <tt>ACM0005</tt>
+* <tt>ACM0010</tt>
+* <tt>ACM0015</tt>
+
+## Conformance Monitoring for Situational Awareness Service
+
+* <tt>CMSA0005</tt>
+* <tt>CMSA0010</tt>
+* <tt>CMSA0015</tt>
+* <tt>CMSA0020</tt>
+* <tt>CMSA0025</tt>
+* <tt>CMSA0030</tt>
+* <tt>CMSA0035</tt>
+* <tt>CMSA0040</tt>
+* <tt>CMSA0100</tt>
+* <tt>CMSA0105</tt>
+* <tt>CMSA0110</tt>
+* <tt>CMSA0115</tt>
+* <tt>CMSA0200</tt>
+* <tt>CMSA0205</tt>
+* <tt>CMSA0210</tt>
+* <tt>CMSA0215</tt>
+* <tt>CMSA0300</tt>
+* <tt>CMSA0305</tt>
+* <tt>CMSA0310</tt>
+* <tt>CMSA0315</tt>
+* <tt>CMSA0320</tt>
+* <tt>CMSA0325</tt>
+* <tt>CMSA0330</tt>
+* <tt>USS0105</tt>
+* <tt>USS0105</tt>
+
+## Constraint Management Service
+
+* <tt>CSTM0005</tt>
+* <tt>CSTM0010</tt>
+* <tt>CSTM0015</tt>
+* <tt>CSTM0020</tt>
+* <tt>CSTM0025</tt>
+* <tt>CSTM0030</tt>
+* <tt>CSTM0035</tt>
+* <tt>CSTM0040</tt>
+* <tt>CSTM0045</tt>
+* <tt>CSTM0050</tt>
+* <tt>CSTM0055</tt>
+* <tt>CSTM0060</tt>
+* <tt>CSTM0065</tt>
+* <tt>CSTM0070</tt>
+* <tt>CSTM0075</tt>
+* <tt>CSTM0080</tt>
+* <tt>CSTM0085</tt>
+* <tt>CSTM0090</tt>
+* <tt>CSTM0095</tt>
+* <tt>USS0005</tt>
+* <tt>USS0105</tt>
+* <tt>USS0110</tt>
+
+## Constraint Processing Service
+
+* <tt>CSTP0005</tt>
+* <tt>CSTP0010</tt>
+* <tt>CSTP0015</tt>
+* <tt>CSTP0020</tt>
+* <tt>CSTP0025</tt>
+* <tt>CSTP0030</tt>
+* <tt>CSTP0035</tt>
+* <tt>GEN0500</tt>
+* <tt>USS0110</tt>
+* <tt>USS0110</tt>
+
+## Logging
+
+### General Logging Requirements Applicable To All Roles
+
+* <tt>LOG0005</tt>
+* <tt>LOG0010</tt>
+* <tt>LOG0015</tt>
+* <tt>LOG0020</tt>
+* <tt>LOG0025</tt>
+* <tt>LOG0030</tt>
+* <tt>LOG0035</tt>
+
+### Logging Associated with Operational Intents, Applicable to Strategic Coordination Role
+
+* <tt>LOG0040</tt>
+* <tt>LOG0045</tt>
+
+### Logging Associated with Conformance Monitoring, Applicable to Strategic Coordination Role
+
+* <tt>LOG0050</tt>
+
+### Logging Associated with Constraint Management, Applicable to Constraint Management Role
+
+* <tt>LOG0055</tt>
+
+## Discovery and Synchronization Service
+
+* <tt>DSS0005</tt>
+* <tt>DSS0010</tt>
+* <tt>DSS0015</tt>
+* <tt>DSS0020</tt>
+* <tt>DSS0100</tt>
+* <tt>DSS0200</tt>
+* <tt>DSS0205</tt>
+* <tt>DSS0210</tt>
+* <tt>DSS0215</tt>
+* <tt>DSS0300</tt>

--- a/monitoring/uss_qualifier/requirements/astm/f3548/v21.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3548/v21.md
@@ -18,6 +18,7 @@ For information on these requirements, refer to [the ASTM standard F3548-21](htt
 * <tt>GEN0400</tt>
 * <tt>GEN0405</tt>
 * <tt>GEN0500</tt>
+* <tt>USS0005</tt>
 
 ## Operational Intent Creation and Modification
 
@@ -29,7 +30,6 @@ For information on these requirements, refer to [the ASTM standard F3548-21](htt
 * <tt>OPIN0030</tt>
 * <tt>OPIN0035</tt>
 * <tt>OPIN0040</tt>
-* <tt>USS0005</tt>
 
 ## Strategic Conflict Detection Service
 
@@ -53,7 +53,6 @@ For information on these requirements, refer to [the ASTM standard F3548-21](htt
 * <tt>SCD0090</tt>
 * <tt>SCD0095</tt>
 * <tt>SCD0100</tt>
-* <tt>GEN0500</tt>
 * <tt>USS0105</tt>
 
 ## Aggregate Operational Intent Conformance Monitoring Service
@@ -87,8 +86,6 @@ For information on these requirements, refer to [the ASTM standard F3548-21](htt
 * <tt>CMSA0320</tt>
 * <tt>CMSA0325</tt>
 * <tt>CMSA0330</tt>
-* <tt>USS0105</tt>
-* <tt>USS0105</tt>
 
 ## Constraint Management Service
 
@@ -111,8 +108,6 @@ For information on these requirements, refer to [the ASTM standard F3548-21](htt
 * <tt>CSTM0085</tt>
 * <tt>CSTM0090</tt>
 * <tt>CSTM0095</tt>
-* <tt>USS0005</tt>
-* <tt>USS0105</tt>
 * <tt>USS0110</tt>
 
 ## Constraint Processing Service
@@ -124,9 +119,6 @@ For information on these requirements, refer to [the ASTM standard F3548-21](htt
 * <tt>CSTP0025</tt>
 * <tt>CSTP0030</tt>
 * <tt>CSTP0035</tt>
-* <tt>GEN0500</tt>
-* <tt>USS0110</tt>
-* <tt>USS0110</tt>
 
 ## Logging
 

--- a/monitoring/uss_qualifier/requirements/astm/f3548/v21/scd.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3548/v21/scd.md
@@ -1,4 +1,4 @@
-# ASTM F3548-21: Strategic Conflict Detection Service
+# ASTM F3548-21: Strategic Conflict Detection Service requirement set
 
 This file describes the set of ASTM F3548-21 requirements with which a USS providing the strategic conflict detection service must comply.
 

--- a/monitoring/uss_qualifier/requirements/astm/f3548/v21/scd.md
+++ b/monitoring/uss_qualifier/requirements/astm/f3548/v21/scd.md
@@ -1,0 +1,91 @@
+# ASTM F3548-21: Strategic Conflict Detection Service
+
+This file describes the set of ASTM F3548-21 requirements with which a USS providing the strategic conflict detection service must comply.
+
+## Manual verification
+
+### Common Requirements
+
+* **astm.f3548.v21.GEN0005**
+* **astm.f3548.v21.GEN0010**
+* **astm.f3548.v21.GEN0015**
+* **astm.f3548.v21.GEN0200**
+
+### Operational Intent Creation and Modification
+
+* **astm.f3548.v21.OPIN0005**
+* **astm.f3548.v21.OPIN0010**
+
+### Aggregate Operational Intent Conformance Monitoring Service
+
+* **astm.f3548.v21.ACM0005**
+* **astm.f3548.v21.ACM0010**
+* **astm.f3548.v21.ACM0015**
+
+## Automated verification
+
+### Common Requirements
+
+* **astm.f3548.v21.GEN0100**
+* **astm.f3548.v21.GEN0105**
+* **astm.f3548.v21.GEN0300**
+* **astm.f3548.v21.GEN0305**
+* **astm.f3548.v21.GEN0310**
+* **astm.f3548.v21.GEN0400**
+* **astm.f3548.v21.GEN0405**
+* **astm.f3548.v21.GEN0500**
+
+### Operational Intent Creation and Modification
+
+* **astm.f3548.v21.OPIN0015**
+* **astm.f3548.v21.OPIN0020**
+* **astm.f3548.v21.OPIN0025**
+* **astm.f3548.v21.OPIN0030**
+* **astm.f3548.v21.OPIN0035**
+* **astm.f3548.v21.OPIN0040**
+* **astm.f3548.v21.USS0005**
+
+### Strategic Conflict Detection Service
+
+* **astm.f3548.v21.SCD0005**
+* **astm.f3548.v21.SCD0010**
+* **astm.f3548.v21.SCD0015**
+* **astm.f3548.v21.SCD0020**
+* **astm.f3548.v21.SCD0025**
+* **astm.f3548.v21.SCD0030**
+* **astm.f3548.v21.SCD0035**
+* **astm.f3548.v21.SCD0040**
+* **astm.f3548.v21.SCD0045**
+* **astm.f3548.v21.SCD0050**
+* **astm.f3548.v21.SCD0055**
+* **astm.f3548.v21.SCD0060**
+* **astm.f3548.v21.SCD0065**
+* **astm.f3548.v21.SCD0070**
+* **astm.f3548.v21.SCD0075**
+* **astm.f3548.v21.SCD0080**
+* **astm.f3548.v21.SCD0085**
+* **astm.f3548.v21.SCD0090**
+* **astm.f3548.v21.SCD0095**
+* **astm.f3548.v21.SCD0100**
+* **astm.f3548.v21.USS0105**
+
+### Logging
+
+#### General Logging Requirements Applicable To All Roles
+
+* **astm.f3548.v21.LOG0005**
+* **astm.f3548.v21.LOG0010**
+* **astm.f3548.v21.LOG0015**
+* **astm.f3548.v21.LOG0020**
+* **astm.f3548.v21.LOG0025**
+* **astm.f3548.v21.LOG0030**
+* **astm.f3548.v21.LOG0035**
+
+#### Logging Associated with Operational Intents, Applicable to Strategic Coordination Role
+
+* **astm.f3548.v21.LOG0040**
+* **astm.f3548.v21.LOG0045**
+
+#### Logging Associated with Conformance Monitoring, Applicable to Strategic Coordination Role
+
+* **astm.f3548.v21.LOG0050**

--- a/monitoring/uss_qualifier/requirements/documentation.py
+++ b/monitoring/uss_qualifier/requirements/documentation.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Set
+from typing import Dict, Set, List
 
 from implicitdict import ImplicitDict
 import marko
@@ -25,11 +25,6 @@ in a <tt> tag; for instance: `<tt>USS0105</tt>`.
 class Requirement(object):
     def __init__(self, requirement_id: RequirementID):
         self.requirement_id = requirement_id
-
-
-class RequirementSet(ImplicitDict):
-    name: str
-    requirement_ids: RequirementID
 
 
 _verified_requirements: Set[RequirementID] = set()
@@ -61,12 +56,16 @@ def _verify_requirements(parent: marko.element.Element, package: str) -> None:
                 _verify_requirements(child, package)
 
 
-def _load_requirement(requirement_id: RequirementID) -> None:
+def _ensure_valid_id(req_id: str, subject: str) -> None:
     illegal_characters = "#%&{}\\<>*?/ $!'\":@+`|="
-    if any(c in requirement_id for c in illegal_characters):
+    if any(c in req_id for c in illegal_characters):
         raise ValueError(
-            f'Requirement ID "{requirement_id}" may not contain any of these characters: {illegal_characters}'
+            f'{subject} "{req_id}" may not contain any of these characters: {illegal_characters}'
         )
+
+
+def _load_requirement(requirement_id: RequirementID) -> None:
+    _ensure_valid_id(requirement_id, "Requirement ID")
     parts = requirement_id.split(".")
     name = parts[-1]
     package = ".".join(parts[:-1])
@@ -90,3 +89,81 @@ def get_requirement(requirement_id: RequirementID) -> Requirement:
     if requirement_id not in _verified_requirements:
         _load_requirement(requirement_id)
     return Requirement(requirement_id)
+
+
+RequirementSetID = str
+"""Identifier for a set of requirements.
+
+The form of a value is a Python-style package reference to a .md file (without
+extension) relative to uss_qualifier/requirements.  For instance, the set of
+requirements described in uss_qualifier/requirements/astm/f3548/v21/scd.md would
+have a RequirementSetID of astm.f3548.v21.scd.
+"""
+
+
+class RequirementSet(ImplicitDict):
+    name: str
+    requirement_ids: List[RequirementID]
+
+
+REQUIREMENT_SET_SUFFIX = " requirement set"
+
+
+_requirement_sets: Dict[RequirementSetID, RequirementSet] = {}
+
+
+def _parse_requirements(parent: marko.element.Element) -> List[RequirementID]:
+    reqs = []
+    if hasattr(parent, "children") and not isinstance(parent.children, str):
+        for i, child in enumerate(parent.children):
+            if isinstance(child, str):
+                continue
+            if isinstance(child, marko.inline.StrongEmphasis):
+                req_id = _text_of(parent.children[i])
+                reqs.append(RequirementID(req_id))
+            else:
+                reqs.extend(_parse_requirements(child))
+    return reqs
+
+
+def _load_requirement_set(requirement_set_id: RequirementSetID) -> RequirementSet:
+    _ensure_valid_id(requirement_set_id, "Requirement set ID")
+    parts = requirement_set_id.split(".")
+    md_filename = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), os.path.join(*parts) + ".md")
+    )
+    if not os.path.exists(md_filename):
+        raise ValueError(
+            f'Could not load requirement set "{requirement_set_id}" because the file "{md_filename}" does not exist'
+        )
+    with open(md_filename, "r") as f:
+        doc = marko.parse(f.read())
+
+    # Extract the requirement set name from the first top-level header
+    if (
+        not isinstance(doc.children[0], marko.block.Heading)
+        or doc.children[0].level != 1
+        or not _text_of(doc.children[0]).lower().endswith(REQUIREMENT_SET_SUFFIX)
+    ):
+        raise ValueError(
+            f'The first line of {md_filename} must be a level-1 heading with the name of the scenario + "{REQUIREMENT_SET_SUFFIX}" (e.g., "# ASTM F3411-19 Service Provider requirement set")'
+        )
+    requirement_set_name = _text_of(doc.children[0])[0 : -len(REQUIREMENT_SET_SUFFIX)]
+
+    reqs = _parse_requirements(doc)
+    for req in reqs:
+        try:
+            get_requirement(req)
+        except ValueError as e:
+            raise ValueError(
+                f'Error loading requirement set "{requirement_set_id}" from {md_filename}: {str(e)}'
+            )
+    return RequirementSet(name=requirement_set_name, requirement_ids=reqs)
+
+
+def get_requirement_set(requirement_set_id: RequirementSetID) -> RequirementSet:
+    if requirement_set_id not in _requirement_sets:
+        _requirement_sets[requirement_set_id] = _load_requirement_set(
+            requirement_set_id
+        )
+    return _requirement_sets[requirement_set_id]

--- a/monitoring/uss_qualifier/requirements/documentation.py
+++ b/monitoring/uss_qualifier/requirements/documentation.py
@@ -1,0 +1,92 @@
+import os
+from typing import Dict, Set
+
+from implicitdict import ImplicitDict
+import marko
+import marko.element
+import marko.inline
+
+
+RequirementID = str
+"""Identifier for a requirement.
+
+Form: <PACKAGE>.<NAME>
+
+PACKAGE is a Python-style package reference to a .md file (without extension)
+relative to uss_qualifier/requirements.  For instance, the PACKAGE for the file
+located at uss_qualifier/requirements/astm/f3548/v21.md would be
+`astm.f3548.v21`.
+
+NAME is an identifier defined in the file described by PACKAGE by enclosing it
+in a <tt> tag; for instance: `<tt>USS0105</tt>`.
+"""
+
+
+class Requirement(object):
+    def __init__(self, requirement_id: RequirementID):
+        self.requirement_id = requirement_id
+
+
+class RequirementSet(ImplicitDict):
+    name: str
+    requirement_ids: RequirementID
+
+
+_verified_requirements: Set[RequirementID] = set()
+
+
+def _text_of(parent: marko.element.Element) -> str:
+    if not hasattr(parent, "children"):
+        return ""
+    if isinstance(parent.children, str):
+        return parent.children
+    return "".join(_text_of(c) for c in parent.children)
+
+
+def _verify_requirements(parent: marko.element.Element, package: str) -> None:
+    if hasattr(parent, "children") and not isinstance(parent.children, str):
+        for i, child in enumerate(parent.children):
+            if isinstance(child, str):
+                continue
+            if (
+                i < len(parent.children) - 2
+                and isinstance(child, marko.inline.InlineHTML)
+                and child.children == "<tt>"
+                and isinstance(parent.children[i + 2], marko.inline.InlineHTML)
+                and parent.children[i + 2].children == "</tt>"
+            ):
+                name = _text_of(parent.children[i + 1])
+                _verified_requirements.add(package + "." + name)
+            else:
+                _verify_requirements(child, package)
+
+
+def _load_requirement(requirement_id: RequirementID) -> None:
+    illegal_characters = "#%&{}\\<>*?/ $!'\":@+`|="
+    if any(c in requirement_id for c in illegal_characters):
+        raise ValueError(
+            f'Requirement ID "{requirement_id}" may not contain any of these characters: {illegal_characters}'
+        )
+    parts = requirement_id.split(".")
+    name = parts[-1]
+    package = ".".join(parts[:-1])
+    md_filename = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), os.path.join(*parts[0:-1]) + ".md")
+    )
+    if not os.path.exists(md_filename):
+        raise ValueError(
+            f'Could not load requirement "{requirement_id}" because the file "{md_filename}" does not exist'
+        )
+    with open(md_filename, "r") as f:
+        doc = marko.parse(f.read())
+    _verify_requirements(doc, package)
+    if requirement_id not in _verified_requirements:
+        raise ValueError(
+            f'Requirement "{name}" could not be found in "{md_filename}", so the requirement {requirement_id} could not be loaded (the file must contain `<tt>{name}</tt>` somewhere in it, but does not)'
+        )
+
+
+def get_requirement(requirement_id: RequirementID) -> Requirement:
+    if requirement_id not in _verified_requirements:
+        _load_requirement(requirement_id)
+    return Requirement(requirement_id)

--- a/monitoring/uss_qualifier/requirements/interuss/automated_testing/flight_planning.md
+++ b/monitoring/uss_qualifier/requirements/interuss/automated_testing/flight_planning.md
@@ -1,0 +1,15 @@
+# InterUSS Flight Planning Interface Requirements
+
+## Overview
+
+TODO: Link to API YAML and provide overview
+
+## Requirements
+
+TODO: Describe requirements
+
+### <tt>ClearArea</tt>
+
+### <tt>ExpectedBehavior</tt>
+
+### <tt>DeleteFlightSuccess</tt>

--- a/monitoring/uss_qualifier/requirements/interuss/automated_testing/rid.md
+++ b/monitoring/uss_qualifier/requirements/interuss/automated_testing/rid.md
@@ -1,0 +1,11 @@
+# InterUSS RemoteID Testing Requirements
+
+## Overview
+
+TODO: Describe overall approach, link to injection & observation
+
+## Requirements
+
+TODO: Describe requirements
+
+### <tt>ObservationFlightID</tt>

--- a/monitoring/uss_qualifier/requirements/interuss/automated_testing/rid/injection.md
+++ b/monitoring/uss_qualifier/requirements/interuss/automated_testing/rid/injection.md
@@ -1,0 +1,17 @@
+# InterUSS RemoteID Injection Interface Requirements
+
+## Overview
+
+TODO: Link to API YAML and provide overview
+
+## Requirements
+
+TODO: Describe requirements
+
+### <tt>UpsertTestSuccess</tt>
+
+### <tt>UpsertTestResult</tt>
+
+### <tt>ExpectedBehavior</tt>
+
+### <tt>DeleteTestSuccess</tt>

--- a/monitoring/uss_qualifier/requirements/interuss/automated_testing/rid/observation.md
+++ b/monitoring/uss_qualifier/requirements/interuss/automated_testing/rid/observation.md
@@ -1,0 +1,11 @@
+# InterUSS RemoteID Observation Interface Requirements
+
+## Overview
+
+TODO: Link to API YAML and provide overview
+
+## Requirements
+
+TODO: Describe requirements
+
+### <tt>ObservationSuccess</tt>

--- a/monitoring/uss_qualifier/run_locally.sh
+++ b/monitoring/uss_qualifier/run_locally.sh
@@ -60,4 +60,7 @@ docker run ${docker_args} --name uss_qualifier \
   python main.py $QUALIFIER_OPTIONS \
   --report report.json \
   --tested_requirements tested_requirements.html \
+  --role_requirements uss1,uss2=astm.f3548.v21.scd \
+  --role_requirements uss1=astm.f3411.v19.service_provider \
+  --role_requirements uss2=astm.f3411.v19.display_provider \
   --dot report.gv

--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -62,6 +62,8 @@ Each check a test step performs that may result in a finding/issue must be docum
 
 A check should document the requirement(s) violated if the check fails.  Requirements are identified by putting a strong emphasis/bold style around the requirement ID (example: `**astm.f3411.v19.NET0420**`).  The description of a check should generally explain why the relevant requirement would fail when that information is useful, but the requirement itself should generally not be re-iterated in this description.  If the check is self-evident from the requirement, the requirement can be noted without further explanation.
 
+Any requirements identified (e.g., `**astm.f3411.v19.NET0420**`) must be documented as well.  See [the requirements documentation](../requirements/README.md) for more information.
+
 ### Cleanup phase
 
 If a test scenario wants to perform a cleanup procedure follow any non-error termination of the rest of the scenario, it must:

--- a/monitoring/uss_qualifier/scenarios/documentation/requirements.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/requirements.py
@@ -39,7 +39,7 @@ class ParticipantRequirementPerformance(ImplicitDict):
     """List of failed checks involving the requirement"""
 
 
-class Requirement(ImplicitDict):
+class TestedRequirement(ImplicitDict):
     requirement_id: RequirementID
     """Identity of the requirement"""
 
@@ -53,7 +53,7 @@ def _add_check(
     scenario_docs: TestScenarioDocumentation,
     case_docs: TestCaseDocumentation,
     step_docs: TestStepDocumentation,
-    requirements: Dict[RequirementID, Requirement],
+    requirements: Dict[RequirementID, TestedRequirement],
 ):
     if not check.requirements:
         # Generate an implied requirement ID
@@ -66,7 +66,7 @@ def _add_check(
         tested_requirements = check.requirements
     for requirement_id in tested_requirements:
         if requirement_id not in requirements:
-            requirements[requirement_id] = Requirement(
+            requirements[requirement_id] = TestedRequirement(
                 requirement_id=requirement_id, participant_performance={}
             )
         requirement = requirements[requirement_id]
@@ -91,7 +91,7 @@ def _evaluate_requirements_in_step(
     scenario_docs: TestScenarioDocumentation,
     case_docs: TestCaseDocumentation,
     path: JSONPath,
-    requirements: Dict[RequirementID, Requirement],
+    requirements: Dict[RequirementID, TestedRequirement],
 ) -> None:
     step_docs = case_docs.get_step_by_name(report.name)
     for i, check in enumerate(report.passed_checks):
@@ -118,7 +118,7 @@ def _evaluate_requirements_in_case(
     report: TestCaseReport,
     scenario_docs: TestScenarioDocumentation,
     path: JSONPath,
-    requirements: Dict[RequirementID, Requirement],
+    requirements: Dict[RequirementID, TestedRequirement],
 ) -> None:
     case_docs = scenario_docs.get_case_by_name(report.name)
     for i, step in enumerate(report.steps):
@@ -130,7 +130,7 @@ def _evaluate_requirements_in_case(
 def _evaluate_requirements_in_scenario(
     report: TestScenarioReport,
     path: JSONPath,
-    requirements: Dict[RequirementID, Requirement],
+    requirements: Dict[RequirementID, TestedRequirement],
 ) -> None:
     scenario_docs = get_documentation_by_name(report.scenario_type)
     for i, case in enumerate(report.cases):
@@ -142,7 +142,7 @@ def _evaluate_requirements_in_scenario(
 def _evaluate_requirements_in_action(
     report: TestSuiteActionReport,
     path: JSONPath,
-    requirements: Dict[RequirementID, Requirement],
+    requirements: Dict[RequirementID, TestedRequirement],
 ) -> None:
     if "test_suite" in report:
         _evaluate_requirements_in_suite(
@@ -163,7 +163,7 @@ def _evaluate_requirements_in_action(
 def _evaluate_requirements_in_generator(
     report: ActionGeneratorReport,
     path: JSONPath,
-    requirements: Dict[RequirementID, Requirement],
+    requirements: Dict[RequirementID, TestedRequirement],
 ) -> None:
     for i, action in enumerate(report.actions):
         _evaluate_requirements_in_action(action, path + f".action[{i}]", requirements)
@@ -172,13 +172,13 @@ def _evaluate_requirements_in_generator(
 def _evaluate_requirements_in_suite(
     report: TestSuiteReport,
     path: JSONPath,
-    requirements: Dict[RequirementID, Requirement],
+    requirements: Dict[RequirementID, TestedRequirement],
 ) -> None:
     for i, action in enumerate(report.actions):
         _evaluate_requirements_in_action(action, path + f".action[{i}]", requirements)
 
 
-def evaluate_requirements(report: TestRunReport) -> List[Requirement]:
+def evaluate_requirements(report: TestRunReport) -> List[TestedRequirement]:
     import_submodules(scenarios_module)
     reqs = {}
     _evaluate_requirements_in_suite(report.report, "$.report", reqs)

--- a/monitoring/uss_qualifier/scenarios/documentation/validation.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/validation.py
@@ -2,6 +2,7 @@ import inspect
 from typing import List
 
 from monitoring.monitorlib.inspection import fullname
+from monitoring.uss_qualifier.requirements.documentation import get_requirement
 from monitoring.uss_qualifier.scenarios import documentation
 from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
 
@@ -31,3 +32,24 @@ def validate(test_scenarios: List[TestScenarioType]):
                 raise ValueError(
                     f"Documentation for test scenario {fullname(test_scenario)} specifies a resource named {documented_resource}, but this resource is not declared as a resource in the constructor"
                 )
+
+        # Verify that all requirements are documented
+        for case in docs.cases:
+            for step in case.steps:
+                for check in step.checks:
+                    for req in check.applicable_requirements:
+                        try:
+                            get_requirement(req)
+                        except ValueError as e:
+                            raise ValueError(
+                                f'Error verifying documentation for requirement "{req}" in check "{check.name}" of step "{step.name}" for case "{case.name}" in scenario "{fullname(test_scenario)}": {str(e)}'
+                            )
+        if "cleanup" in docs:
+            for check in docs.cleanup.checks:
+                for req in check.applicable_requirements:
+                    try:
+                        get_requirement(req)
+                    except ValueError as e:
+                        raise ValueError(
+                            f'Error verifying documentation for requirement "{req}" in check "{check.name}" of cleanup phase in scenario "{fullname(test_scenario)}": {str(e)}'
+                        )

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
@@ -70,4 +70,4 @@ All flight intent data provided is correct and valid and free of conflict in spa
 
 ### Successful flight deletion check
 
-Per **[scd.yaml::DeleteFlightSuccess](../../../../../interfaces/automated-testing/scd/scd.yaml)**, the deletion attempt of the previously-created flight should succeed for every flight planner under test.
+**interuss.automated_testing.flight_planning.DeleteFlightSuccess**


### PR DESCRIPTION
This PR adds programmatically-verified requirement documentation.

When a test scenario performs a check, it should generally specify a requirement that is not met when that check fails.  (Though specifying such a requirement is not currently mandatory).  If a check fails, the impacted USS should be able to clearly determine what requirement they have not fulfilled.  This PR ensures that each referenced requirement is documented to enable that discovery (even though the content of the requirements imposed by InterUSS is not populated in this PR).

These documentation requirements are documented in requirements/README.md and noted in and linked from scenarios documentation (scenarios/README.md).

In the second commit of this PR, the output of tested_requirements.html is grouped by requirement set (`--role_requirements`), and untested requirements for that requirement set are listed as well.