### PR TITLE
[uss_qualifier] Set timeout to uss qualifier client requests

### DIFF
--- a/monitoring/monitorlib/infrastructure.py
+++ b/monitoring/monitorlib/infrastructure.py
@@ -18,7 +18,7 @@ ALL_SCOPES = [
 
 EPOCH = datetime.datetime.utcfromtimestamp(0)
 TOKEN_REFRESH_MARGIN = datetime.timedelta(seconds=15)
-
+CLIENT_TIMEOUT = 15 # seconds
 
 class AuthAdapter(object):
     """Base class for an adapter that add JWTs to requests."""
@@ -112,6 +112,7 @@ class UTMClientSession(requests.Session):
                 return prepared_request
 
             kwargs["auth"] = auth
+        kwargs["timeout"] = CLIENT_TIMEOUT
         return kwargs
 
     def request(self, method, url, **kwargs):
@@ -166,6 +167,8 @@ class AsyncUTMTestSession:
             if method == "PUT" and kwargs.get("data"):
                 kwargs["json"] = kwargs["data"]
                 del kwargs["data"]
+
+        kwargs["timeout"] = CLIENT_TIMEOUT
         return kwargs
 
     async def put(self, url, **kwargs):

--- a/monitoring/monitorlib/infrastructure.py
+++ b/monitoring/monitorlib/infrastructure.py
@@ -18,7 +18,7 @@ ALL_SCOPES = [
 
 EPOCH = datetime.datetime.utcfromtimestamp(0)
 TOKEN_REFRESH_MARGIN = datetime.timedelta(seconds=15)
-CLIENT_TIMEOUT = 15  # seconds
+CLIENT_TIMEOUT = 60  # seconds
 
 
 class AuthAdapter(object):

--- a/monitoring/monitorlib/infrastructure.py
+++ b/monitoring/monitorlib/infrastructure.py
@@ -18,7 +18,8 @@ ALL_SCOPES = [
 
 EPOCH = datetime.datetime.utcfromtimestamp(0)
 TOKEN_REFRESH_MARGIN = datetime.timedelta(seconds=15)
-CLIENT_TIMEOUT = 15 # seconds
+CLIENT_TIMEOUT = 15  # seconds
+
 
 class AuthAdapter(object):
     """Base class for an adapter that add JWTs to requests."""


### PR DESCRIPTION
When the uss_qualifier runs inside a container, connection to missing host may hang forever. This PR adds a default timeout to the test client to catch this use case. 15 seconds seemed reasonable in our context.