### PR TITLE
#822 gRPC layer removal: adaptations of the prober tests

### DIFF
--- a/monitoring/monitorlib/auth.py
+++ b/monitoring/monitorlib/auth.py
@@ -95,7 +95,7 @@ class DummyOAuth(AuthAdapter):
             urllib.parse.quote(intended_audience),
             self._sub,
         )
-        response = self._oauth_session.post(url)
+        response = self._oauth_session.get(url)
         if response.status_code != 200:
             raise AccessTokenError(
                 'Request to get DummyOAuth access token returned {} "{}" at {}'.format(

--- a/monitoring/prober/aux_/test_version.py
+++ b/monitoring/prober/aux_/test_version.py
@@ -5,6 +5,6 @@ from monitoring.monitorlib import rid
 def test_version(aux_session):
   resp = aux_session.get('/version', scope=rid.SCOPE_READ)
   assert resp.status_code == 200
-  version = resp.json()['version']['as_string']
+  version = resp.json()['version']
   assert version
   assert 'undefined' not in version, version

--- a/monitoring/prober/rid/v1/test_isa_validation.py
+++ b/monitoring/prober/rid/v1/test_isa_validation.py
@@ -78,7 +78,7 @@ def test_isa_empty_vertices(ids, session_ridv1):
           'flights_url': 'https://example.com/uss/flights',
       })
   assert resp.status_code == 400, resp.content
-  assert 'Not enough points in polygon' in resp.json()['message']
+  assert 'Missing or malformed required extents' in resp.json()['message']
 
 
 @default_scope(SCOPE_WRITE)
@@ -100,7 +100,7 @@ def test_isa_missing_footprint(ids, session_ridv1):
           'flights_url': 'https://example.com/uss/flights',
       })
   assert resp.status_code == 400, resp.content
-  assert 'Error parsing Volume4D' in resp.json()['message']
+  assert 'Missing or malformed required extents' in resp.json()['message']
 
 
 @default_scope(SCOPE_WRITE)
@@ -118,7 +118,7 @@ def test_isa_missing_spatial_volume(ids, session_ridv1):
           'flights_url': 'https://example.com/uss/flights',
       })
   assert resp.status_code == 400, resp.content
-  assert 'Error parsing Volume4D' in resp.json()['message']
+  assert 'Missing or malformed required extents' in resp.json()['message']
 
 
 @default_scope(SCOPE_WRITE)
@@ -129,7 +129,7 @@ def test_isa_missing_extents(ids, session_ridv1):
           'flights_url': 'https://example.com/uss/flights',
       })
   assert resp.status_code == 400, resp.content
-  assert resp.json()['message'] == 'Missing required extents'
+  assert 'Missing or malformed required extents' in resp.json()['message']
 
 
 @default_scope(SCOPE_WRITE)
@@ -154,7 +154,7 @@ def test_isa_start_time_in_past(ids, session_ridv1):
           'flights_url': 'https://example.com/uss/flights',
       })
   assert resp.status_code == 400, resp.content
-  assert resp.json()['message'] == 'IdentificationServiceArea time_start must not be in the past'
+  assert 'IdentificationServiceArea time_start must not be in the past' in resp.json()['message']
 
 
 @default_scope(SCOPE_WRITE)
@@ -179,7 +179,7 @@ def test_isa_start_time_after_time_end(ids, session_ridv1):
           'flights_url': 'https://example.com/uss/flights',
       })
   assert resp.status_code == 400, resp.content
-  assert resp.json()['message'] == 'IdentificationServiceArea time_end must be after time_start'
+  assert 'IdentificationServiceArea time_end must be after time_start' in resp.json()['message']
 
 
 @default_scope(SCOPE_WRITE)

--- a/monitoring/prober/rid/v1/test_token_validation.py
+++ b/monitoring/prober/rid/v1/test_token_validation.py
@@ -81,14 +81,14 @@ def test_create_isa(ids, session_ridv1):
 def test_get_isa_without_token(ids, no_auth_session_ridv1):
   resp = no_auth_session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 401, resp.content
-  assert resp.json()['message'] == 'Missing access token'
+  assert 'Missing access token' in resp.json()['message']
 
 
 def test_get_isa_with_fake_token(ids, no_auth_session_ridv1):
   no_auth_session_ridv1.headers['Authorization'] = 'Bearer fake_token'
   resp = no_auth_session_ridv1.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 401, resp.content
-  assert resp.json()['message'] == 'token contains an invalid number of segments'
+  assert 'token contains an invalid number of segments' in resp.json()['message']
 
 
 def test_delete(ids, session_ridv1):

--- a/monitoring/prober/rid/v2/test_isa_expiry.py
+++ b/monitoring/prober/rid/v2/test_isa_expiry.py
@@ -14,7 +14,7 @@ ISA_TYPE = register_resource_type(347, 'ISA')
 
 
 def test_ensure_clean_workspace_v2(ids, session_ridv2):
-  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_SP)
+  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_DP)
   if resp.status_code == 200:
     version = resp.json()['service_area']['version']
     resp = session_ridv2.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_SP)

--- a/monitoring/prober/rid/v2/test_isa_expiry.py
+++ b/monitoring/prober/rid/v2/test_isa_expiry.py
@@ -14,7 +14,7 @@ ISA_TYPE = register_resource_type(347, 'ISA')
 
 
 def test_ensure_clean_workspace_v2(ids, session_ridv2):
-  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_DP)
+  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_SP)
   if resp.status_code == 200:
     version = resp.json()['service_area']['version']
     resp = session_ridv2.delete('{}/{}/{}'.format(ISA_PATH, ids(ISA_TYPE), version), scope=SCOPE_SP)

--- a/monitoring/prober/rid/v2/test_isa_simple.py
+++ b/monitoring/prober/rid/v2/test_isa_simple.py
@@ -80,7 +80,7 @@ def test_get_isa_by_id(ids, session_ridv2):
 
 @default_scope(SCOPE_SP)
 def test_update_isa(ids, session_ridv2):
-  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_DP)
+  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 200, resp.content
   version = resp.json()['service_area']['version']
 

--- a/monitoring/prober/rid/v2/test_isa_simple.py
+++ b/monitoring/prober/rid/v2/test_isa_simple.py
@@ -80,7 +80,8 @@ def test_get_isa_by_id(ids, session_ridv2):
 
 @default_scope(SCOPE_SP)
 def test_update_isa(ids, session_ridv2):
-  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
+  resp = session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)), scope=SCOPE_DP)
+  assert resp.status_code == 200, resp.content
   version = resp.json()['service_area']['version']
 
   resp = session_ridv2.put(

--- a/monitoring/prober/rid/v2/test_isa_validation.py
+++ b/monitoring/prober/rid/v2/test_isa_validation.py
@@ -130,7 +130,7 @@ def test_isa_missing_extents(ids, session_ridv2):
           'uss_base_url': BASE_URL,
       })
   assert resp.status_code == 400, resp.content
-  assert resp.json()['message'] == 'Missing required extents'
+  assert 'Error parsing Volume4D: Neither outline_polygon nor outline_circle were specified in volume' in resp.json()['message']
 
 
 @default_scope(SCOPE_SP)
@@ -155,7 +155,7 @@ def test_isa_start_time_in_past(ids, session_ridv2):
           'uss_base_url': BASE_URL,
       })
   assert resp.status_code == 400, resp.content
-  assert resp.json()['message'] == 'IdentificationServiceArea time_start must not be in the past'
+  assert 'IdentificationServiceArea time_start must not be in the past' in resp.json()['message']
 
 
 @default_scope(SCOPE_SP)
@@ -180,7 +180,7 @@ def test_isa_start_time_after_time_end(ids, session_ridv2):
           'uss_base_url': BASE_URL,
       })
   assert resp.status_code == 400, resp.content
-  assert resp.json()['message'] == 'IdentificationServiceArea time_end must be after time_start'
+  assert 'IdentificationServiceArea time_end must be after time_start' in resp.json()['message']
 
 
 @default_scope(SCOPE_SP)

--- a/monitoring/prober/rid/v2/test_token_validation.py
+++ b/monitoring/prober/rid/v2/test_token_validation.py
@@ -82,14 +82,14 @@ def test_create_isa(ids, session_ridv2):
 def test_get_isa_without_token(ids, no_auth_session_ridv2):
   resp = no_auth_session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 401, resp.content
-  assert resp.json()['message'] == 'Missing access token'
+  assert 'Missing access token' in resp.json()['message']
 
 
 def test_get_isa_with_fake_token(ids, no_auth_session_ridv2):
   no_auth_session_ridv2.headers['Authorization'] = 'Bearer fake_token'
   resp = no_auth_session_ridv2.get('{}/{}'.format(ISA_PATH, ids(ISA_TYPE)))
   assert resp.status_code == 401, resp.content
-  assert resp.json()['message'] == 'token contains an invalid number of segments'
+  assert 'token contains an invalid number of segments' in resp.json()['message']
 
 
 def test_delete(ids, session_ridv2):

--- a/monitoring/prober/scd/test_constraint_simple.py
+++ b/monitoring/prober/scd/test_constraint_simple.py
@@ -108,7 +108,7 @@ def test_create_constraint(ids, scd_api, scd_session):
   assert resp.status_code == 403, resp.content
 
   resp = scd_session.put('/constraint_references/{}'.format(id), json=req, scope=SCOPE_CM)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
 
   data = resp.json()
   constraint = data['constraint_reference']

--- a/monitoring/prober/scd/test_constraints_with_subscriptions.py
+++ b/monitoring/prober/scd/test_constraints_with_subscriptions.py
@@ -135,7 +135,7 @@ def test_constraint_does_not_exist(ids, scd_api, scd_session, scd_session2):
 def test_create_constraint(ids, scd_api, scd_session, scd_session2):
   req = _make_c1_request()
   resp = scd_session.put('/constraint_references/{}'.format(ids(CONSTRAINT_TYPE)), json=req)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
 
   data = resp.json()
   subscribers = data['subscribers']

--- a/monitoring/prober/scd/test_operation_references_error_cases.py
+++ b/monitoring/prober/scd/test_operation_references_error_cases.py
@@ -116,7 +116,7 @@ def test_op_already_exists(ids, scd_api, scd_session):
   with open('./scd/resources/op_request_1.json', 'r') as f:
     req = json.load(f)
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
   ovn = resp.json()['operational_intent_reference']['ovn']
 
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req)
@@ -190,7 +190,7 @@ def test_op_repeated_requests(ids, scd_api, scd_session):
   with open('./scd/resources/op_request_1.json', 'r') as f:
     req = json.load(f)
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
   ovn = resp.json()['operational_intent_reference']['ovn']
 
   print(resp.json()['operational_intent_reference']['ovn'])
@@ -226,7 +226,7 @@ def test_missing_conflicted_operation(ids, scd_api, scd_session):
   dt = datetime.datetime.utcnow() - scd.start_of(req['extents'])
   req['extents'] = scd.offset_time(req['extents'], dt)
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
   ovn1a = resp.json()['operational_intent_reference']['ovn']
   sub_id = resp.json()['operational_intent_reference']['subscription_id']
 
@@ -236,7 +236,7 @@ def test_missing_conflicted_operation(ids, scd_api, scd_session):
   req['extents'] = scd.offset_time(req['extents'], dt)
   req['key'] = [ovn1a]
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE2)), json=req)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
 
   # Attempt to update Operation 1 without OVN for the pre-existing Operation
   with open('./scd/resources/op_missing_update.json', 'r') as f:

--- a/monitoring/prober/scd/test_operation_references_state_transition.py
+++ b/monitoring/prober/scd/test_operation_references_state_transition.py
@@ -25,7 +25,7 @@ def test_op_accepted(ids, scd_api, scd_session):
   with open('./scd/resources/op_request_1.json', 'r') as f:
     req = json.load(f)
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
 
 
 @for_api_versions(scd.API_0_3_17)

--- a/monitoring/prober/scd/test_operation_simple.py
+++ b/monitoring/prober/scd/test_operation_simple.py
@@ -114,7 +114,7 @@ def test_create_op(ids, scd_api, scd_session, scd_session_cp, scd_session_cm):
     assert resp.status_code == 403, resp.content
 
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP_TYPE)), json=req, scope=SCOPE_SC)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
 
   data = resp.json()
   op = data['operational_intent_reference']

--- a/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
+++ b/monitoring/prober/scd/test_operation_simple_heavy_traffic.py
@@ -85,7 +85,7 @@ def test_create_ops(ids, scd_api, scd_session):
 
     resp = scd_session.put(
       '/operational_intent_references/{}'.format(op_id), json=req, scope=SCOPE_SC)
-    assert resp.status_code == 200, resp.content
+    assert resp.status_code == 201, resp.content
 
     data = resp.json()
     op = data['operational_intent_reference']

--- a/monitoring/prober/scd/test_operation_simple_heavy_traffic_concurrent.py
+++ b/monitoring/prober/scd/test_operation_simple_heavy_traffic_concurrent.py
@@ -92,7 +92,7 @@ def _make_op_request_differ_in_time(idx, time_gap):
 
 # Generate request with non-overlapping operations in volume4d.
 # 1/3 operations will be generated with different 2d areas, altitude ranges and time windows respectively
-# additional_time_gap is given to keep a time gap between `create` operational_content and `mutate` operational content 
+# additional_time_gap is given to keep a time gap between `create` operational_content and `mutate` operational content
 # requests, so these two types of requests do not overlap at any time.
 def _make_op_request(idx, additional_time_gap=0):
   if idx < GROUP_SIZE:
@@ -214,7 +214,7 @@ def test_create_ops_concurrent(ids, scd_api, scd_session_async):
     op_resp_map[op_id]['status_code'] = resp[0][0]
     op_resp_map[op_id]['content'] = resp[0][1]
   for op_id, resp in op_resp_map.items():
-    if resp['status_code'] != 200:
+    if resp['status_code'] != 201:
         try:
             owner_name, id_code = IDFactory.decode(op_id)
         except ValueError:
@@ -239,7 +239,7 @@ def test_create_ops_concurrent(ids, scd_api, scd_session_async):
                 print(json.dumps(op_req_map[missing_id]))
                 print('--- Response:')
                 print(json.dumps(op_resp_map[missing_id]))
-    assert resp['status_code'] == 200, resp['content']
+    assert resp['status_code'] == 201, resp['content']
     req = op_req_map[op_id]
     data = resp['content']
     op = data['operational_intent_reference']
@@ -297,7 +297,7 @@ def test_get_ops_by_search_concurrent(ids, scd_api, scd_session_async):
   loop = asyncio.get_event_loop()
   results = loop.run_until_complete(
     asyncio.gather(*[_query_operation_async(idx, scd_session_async, scd_api) for idx in range(len(OP_TYPES))]))
-  
+
   for idx, resp in zip(range(len(OP_TYPES)), results):
     op_resp_map[idx] = {}
     op_resp_map[idx]['status_code'] = resp[0]

--- a/monitoring/prober/scd/test_operation_special_cases.py
+++ b/monitoring/prober/scd/test_operation_special_cases.py
@@ -38,7 +38,7 @@ def test_op_request_1(ids, scd_api, scd_session):
   with open('./scd/resources/op_request_1.json', 'r') as f:
     req = json.load(f)
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP1_TYPE)), json=req)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
   data = resp.json()
   assert 'operational_intent_reference'  in data, data
   assert 'ovn' in resp.json()['operational_intent_reference'], data

--- a/monitoring/prober/scd/test_operations_simple.py
+++ b/monitoring/prober/scd/test_operations_simple.py
@@ -153,7 +153,7 @@ def test_op1_does_not_exist_query_2(ids, scd_api, scd_session, scd_session2):
 def test_create_op1(ids, scd_api, scd_session, scd_session2):
   req = _make_op1_request()
   resp = scd_session.put('/operational_intent_references/{}'.format(ids(OP1_TYPE)), json=req)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
 
   data = resp.json()
   op = data['operational_intent_reference']
@@ -280,7 +280,7 @@ def test_create_op2(ids, scd_api, scd_session, scd_session2):
   req['subscription_id'] = ids(SUB2_TYPE)
   req['key'] = [op1_ovn]
   resp = scd_session2.put('/operational_intent_references/{}'.format(ids(OP2_TYPE)), json=req)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
 
   data = resp.json()
   op = data['operational_intent_reference']

--- a/monitoring/prober/scd/test_subscription_update_validation.py
+++ b/monitoring/prober/scd/test_subscription_update_validation.py
@@ -66,7 +66,7 @@ def test_create_op(ids, scd_api, scd_session):
   entity_name = 'operational_intent_reference'
   req = _make_op_req()
   resp = scd_session.put('/{}s/{}'.format(entity_name, ids(OP_TYPE)), json=req)
-  assert resp.status_code == 200, resp.content
+  assert resp.status_code == 201, resp.content
 
   data = resp.json()
   op = data[entity_name]

--- a/pkg/api/ridv2/interface.gen.go
+++ b/pkg/api/ridv2/interface.gen.go
@@ -16,6 +16,9 @@ var (
 		{
 			"Authority": {"rid.display_provider"},
 		},
+		{
+			"Authority": {"rid.service_provider"},
+		},
 	}
 	CreateIdentificationServiceAreaSecurity = []api.AuthorizationOption{
 		{


### PR DESCRIPTION
Seventh batch of modifications, those changes enable all tests to be validated with the new implementation.

- change from POST to GET the method to retrieve the token: because the generated code used to not check for the HTTP method, the POST call used to work, while this was actually not according to the OpenAPI definition of the dummy oauth provider
- aux API: do not retrieve anymore the version through the `as_string` subfield, which is a construct inherited from gRPC
- in all APIs: remove the error message exact comparison: now we have an error ID embedded, so we only do a substring check
- in all APIs: some validation messages changed due to the fact that it is not possible anymore for some fields to be missing (when they are specified as required they will be present but empty in the go models)
- in SCD API: some calls for creating resources used to return 200 when success, while the specs specify 201
- in RID v2 API: adapt scopes used in some endpoints, which were not implemented as per specs in the previous implementation (please check that this is indeed correct and not something that was intended as such but not specified properly like the scope issue for RID v1 API we has discussed)

After this, 2 more upcoming PRs before everything is done (modulo if I forget something): 1. fix for the path prefix; 2. cleanup and documentation