### PR TITLE
#822 gRPC layer removal: add option for path prefix and use it for RID v2 API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,14 +169,14 @@ dss_apis: openapi-to-go-server
       	-v "$(CURDIR)/interfaces/aux/aux.yaml:/resources/auxv1.yaml" \
       	-v "$(CURDIR)/interfaces/astm-utm/Protocol/utm.yaml:/resources/scdv1.yaml" \
       	-v "$(CURDIR)/interfaces/rid/v1/remoteid/augmented.yaml:/resources/ridv1.yaml" \
-        -v "$(CURDIR)/interfaces/rid/v2/remoteid/canonical.yaml:/resources/ridv2.yaml" \
+        -v "$(CURDIR)/interfaces/rid/v2/remoteid/updated.yaml:/resources/ridv2.yaml" \
 	    -v "$(CURDIR)/:/resources/src" \
 			interuss/openapi-to-go-server \
 		  		--api_import github.com/interuss/dss/pkg/api \
     	      	--api /resources/auxv1.yaml#dss \
     	      	--api /resources/scdv1.yaml#dss \
 				--api /resources/ridv1.yaml#dss \
-              	--api /resources/ridv2.yaml#dss \
+              	--api /resources/ridv2.yaml#dss@ridv2/rid/v2 \
     	      	--api_folder /resources/src/pkg/api
 
 example_apis: openapi-to-go-server

--- a/interfaces/openapi-to-go-server/generate.py
+++ b/interfaces/openapi-to-go-server/generate.py
@@ -16,7 +16,7 @@ def _parse_args():
 
     # Input/output specifications
     parser.add_argument('--api', dest='apis', type=str, action='append',
-                        help='Source YAML to preprocess along with tags (if applicable) and the name of the API.  Form of --api PATH_TO_YAML#TAG1,TAG2@API_NAME')
+                        help='Source YAML to preprocess along with tags (if applicable) and the name of the API.  Form of --api PATH_TO_YAML#TAG1,TAG2@API_NAME[/PATH_PREFIX]')
     parser.add_argument('--api_folder', dest='api_folder', type=str,
                         default=None,
                         help='Folder that will hold the generated output for APIs')
@@ -132,7 +132,10 @@ def main():
     for api_declaration in args.apis:
         if '@' in api_declaration:
             input_yaml, package = api_declaration.split('@')
-            api_path = package
+            if '/' in package:
+                package, api_path = package.split('/', 1)
+            else:
+                api_path = package
         else:
             input_yaml = api_declaration
             package = os.path.split(api_declaration)[-1].split('.')[0]

--- a/pkg/api/ridv2/server.gen.go
+++ b/pkg/api/ridv2/server.gen.go
@@ -523,34 +523,34 @@ func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter
 func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {
 	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 10)}
 
-	pattern := regexp.MustCompile("^/dss/identification_service_areas$")
+	pattern := regexp.MustCompile("^/rid/v2/dss/identification_service_areas$")
 	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchIdentificationServiceAreas}
 
-	pattern = regexp.MustCompile("^/dss/identification_service_areas/(?P<id>[^/]*)$")
+	pattern = regexp.MustCompile("^/rid/v2/dss/identification_service_areas/(?P<id>[^/]*)$")
 	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetIdentificationServiceArea}
 
-	pattern = regexp.MustCompile("^/dss/identification_service_areas/(?P<id>[^/]*)$")
+	pattern = regexp.MustCompile("^/rid/v2/dss/identification_service_areas/(?P<id>[^/]*)$")
 	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateIdentificationServiceArea}
 
-	pattern = regexp.MustCompile("^/dss/identification_service_areas/(?P<id>[^/]*)/(?P<version>[^/]*)$")
+	pattern = regexp.MustCompile("^/rid/v2/dss/identification_service_areas/(?P<id>[^/]*)/(?P<version>[^/]*)$")
 	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateIdentificationServiceArea}
 
-	pattern = regexp.MustCompile("^/dss/identification_service_areas/(?P<id>[^/]*)/(?P<version>[^/]*)$")
+	pattern = regexp.MustCompile("^/rid/v2/dss/identification_service_areas/(?P<id>[^/]*)/(?P<version>[^/]*)$")
 	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteIdentificationServiceArea}
 
-	pattern = regexp.MustCompile("^/dss/subscriptions$")
+	pattern = regexp.MustCompile("^/rid/v2/dss/subscriptions$")
 	router.Routes[5] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchSubscriptions}
 
-	pattern = regexp.MustCompile("^/dss/subscriptions/(?P<id>[^/]*)$")
+	pattern = regexp.MustCompile("^/rid/v2/dss/subscriptions/(?P<id>[^/]*)$")
 	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription}
 
-	pattern = regexp.MustCompile("^/dss/subscriptions/(?P<id>[^/]*)$")
+	pattern = regexp.MustCompile("^/rid/v2/dss/subscriptions/(?P<id>[^/]*)$")
 	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription}
 
-	pattern = regexp.MustCompile("^/dss/subscriptions/(?P<id>[^/]*)/(?P<version>[^/]*)$")
+	pattern = regexp.MustCompile("^/rid/v2/dss/subscriptions/(?P<id>[^/]*)/(?P<version>[^/]*)$")
 	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription}
 
-	pattern = regexp.MustCompile("^/dss/subscriptions/(?P<id>[^/]*)/(?P<version>[^/]*)$")
+	pattern = regexp.MustCompile("^/rid/v2/dss/subscriptions/(?P<id>[^/]*)/(?P<version>[^/]*)$")
 	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription}
 
 	return router


### PR DESCRIPTION
Batch 8, a PR that is normally-sized for once.
This adds an option to the OpenAPI generation tool to add a prefix to the paths of the endpoints. This is useful for the RID v2 API. This is achieved by adding an optional syntax on the CLI.
