### PR TITLE
[uss_qualifier] Add documentation autoformatting

### DIFF
--- a/monitoring/uss_qualifier/Makefile
+++ b/monitoring/uss_qualifier/Makefile
@@ -11,6 +11,10 @@ lint: validate_documentation
 	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:latest_release black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
 	find . -name '*.sh' | xargs docker run --rm -v $(CURDIR):/code -w /code koalaman/shellcheck
 
+.PHONY: format_documentation
+format_documentation:
+	./scripts/format_test_documentation.sh
+
 .PHONY: format
-format:
+format: format_documentation
 	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:latest_release black .

--- a/monitoring/uss_qualifier/documentation.py
+++ b/monitoring/uss_qualifier/documentation.py
@@ -1,0 +1,9 @@
+import marko.element
+
+
+def text_of(parent: marko.element.Element) -> str:
+    if not hasattr(parent, "children"):
+        return ""
+    if isinstance(parent.children, str):
+        return parent.children
+    return "".join(text_of(c) for c in parent.children)

--- a/monitoring/uss_qualifier/reports/documents.py
+++ b/monitoring/uss_qualifier/reports/documents.py
@@ -62,14 +62,12 @@ def _parse_role_arguments(args: List[str]) -> List[TestedRequirementsTable]:
             raise ValueError(
                 f'Argument "{arg}" is invalid; arguments must be in the form of <PARTICIPANT_ID>[,<PARTICIPANT_ID>,...]=<REQUIREMENT_SET_ID>'
             )
-        req_set_id = cols[1]
+        req_set_id = RequirementSetID(cols[1])
         if req_set_id not in tables:
             tables[req_set_id] = []
         tables[req_set_id].extend(ParticipantID(s.strip()) for s in cols[0].split(","))
     return [
-        TestedRequirementsTable(
-            requirement_set=get_requirement_set(RequirementSetID(k)), participants=v
-        )
+        TestedRequirementsTable(requirement_set=get_requirement_set(k), participants=v)
         for k, v in tables.items()
     ]
 

--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -13,7 +13,7 @@ ParticipantID = str
 """String that refers to a participant being qualified by uss_qualifier"""
 
 
-RequirementID = str
+RequirementID = str  # TODO: Use uss_qualifier.requirements.documentation.RequirementID
 
 
 class FailedCheck(ImplicitDict):

--- a/monitoring/uss_qualifier/requirements/documentation.py
+++ b/monitoring/uss_qualifier/requirements/documentation.py
@@ -6,20 +6,46 @@ import marko
 import marko.element
 import marko.inline
 
+from monitoring.uss_qualifier.documentation import text_of
 
-RequirementID = str
-"""Identifier for a requirement.
 
-Form: <PACKAGE>.<NAME>
+class RequirementID(str):
+    """Identifier for a requirement.
 
-PACKAGE is a Python-style package reference to a .md file (without extension)
-relative to uss_qualifier/requirements.  For instance, the PACKAGE for the file
-located at uss_qualifier/requirements/astm/f3548/v21.md would be
-`astm.f3548.v21`.
+    Form: <PACKAGE>.<NAME>
 
-NAME is an identifier defined in the file described by PACKAGE by enclosing it
-in a <tt> tag; for instance: `<tt>USS0105</tt>`.
-"""
+    PACKAGE is a Python-style package reference to a .md file (without extension)
+    relative to uss_qualifier/requirements.  For instance, the PACKAGE for the file
+    located at uss_qualifier/requirements/astm/f3548/v21.md would be
+    `astm.f3548.v21`.
+
+    NAME is an identifier defined in the file described by PACKAGE by enclosing it
+    in a <tt> tag; for instance: `<tt>USS0105</tt>`.
+    """
+
+    def __new__(cls, value):
+        illegal_characters = "#%&{}\\<>*?/ $!'\":@+`|="
+        if any(c in value for c in illegal_characters):
+            raise ValueError(
+                f'RequirementID "{value}" may not contain any of these characters: {illegal_characters}'
+            )
+        str_value = str.__new__(cls, value)
+        return str_value
+
+    def md_file_path(self) -> str:
+        parts = self.split(".")
+        md_filename = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), os.path.join(*parts[0:-1]) + ".md")
+        )
+        return md_filename
+
+    def requirement_name(self) -> str:
+        parts = self.split(".")
+        return parts[-1]
+
+    def package(self) -> str:
+        parts = self.split(".")
+        return ".".join(parts[:-1])
 
 
 class Requirement(object):
@@ -28,14 +54,6 @@ class Requirement(object):
 
 
 _verified_requirements: Set[RequirementID] = set()
-
-
-def _text_of(parent: marko.element.Element) -> str:
-    if not hasattr(parent, "children"):
-        return ""
-    if isinstance(parent.children, str):
-        return parent.children
-    return "".join(_text_of(c) for c in parent.children)
 
 
 def _verify_requirements(parent: marko.element.Element, package: str) -> None:
@@ -50,38 +68,24 @@ def _verify_requirements(parent: marko.element.Element, package: str) -> None:
                 and isinstance(parent.children[i + 2], marko.inline.InlineHTML)
                 and parent.children[i + 2].children == "</tt>"
             ):
-                name = _text_of(parent.children[i + 1])
-                _verified_requirements.add(package + "." + name)
+                name = text_of(parent.children[i + 1])
+                _verified_requirements.add(RequirementID(package + "." + name))
             else:
                 _verify_requirements(child, package)
 
 
-def _ensure_valid_id(req_id: str, subject: str) -> None:
-    illegal_characters = "#%&{}\\<>*?/ $!'\":@+`|="
-    if any(c in req_id for c in illegal_characters):
-        raise ValueError(
-            f'{subject} "{req_id}" may not contain any of these characters: {illegal_characters}'
-        )
-
-
 def _load_requirement(requirement_id: RequirementID) -> None:
-    _ensure_valid_id(requirement_id, "Requirement ID")
-    parts = requirement_id.split(".")
-    name = parts[-1]
-    package = ".".join(parts[:-1])
-    md_filename = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), os.path.join(*parts[0:-1]) + ".md")
-    )
+    md_filename = requirement_id.md_file_path()
     if not os.path.exists(md_filename):
         raise ValueError(
             f'Could not load requirement "{requirement_id}" because the file "{md_filename}" does not exist'
         )
     with open(md_filename, "r") as f:
         doc = marko.parse(f.read())
-    _verify_requirements(doc, package)
+    _verify_requirements(doc, requirement_id.package())
     if requirement_id not in _verified_requirements:
         raise ValueError(
-            f'Requirement "{name}" could not be found in "{md_filename}", so the requirement {requirement_id} could not be loaded (the file must contain `<tt>{name}</tt>` somewhere in it, but does not)'
+            f'Requirement "{requirement_id.requirement_name()}" could not be found in "{md_filename}", so the requirement {requirement_id} could not be loaded (the file must contain `<tt>{requirement_id.requirement_name()}</tt>` somewhere in it, but does not)'
         )
 
 
@@ -91,14 +95,23 @@ def get_requirement(requirement_id: RequirementID) -> Requirement:
     return Requirement(requirement_id)
 
 
-RequirementSetID = str
-"""Identifier for a set of requirements.
+class RequirementSetID(str):
+    """Identifier for a set of requirements.
 
-The form of a value is a Python-style package reference to a .md file (without
-extension) relative to uss_qualifier/requirements.  For instance, the set of
-requirements described in uss_qualifier/requirements/astm/f3548/v21/scd.md would
-have a RequirementSetID of astm.f3548.v21.scd.
-"""
+    The form of a value is a Python-style package reference to a .md file (without
+    extension) relative to uss_qualifier/requirements.  For instance, the set of
+    requirements described in uss_qualifier/requirements/astm/f3548/v21/scd.md would
+    have a RequirementSetID of astm.f3548.v21.scd.
+    """
+
+    def __new__(cls, value):
+        illegal_characters = "#%&{}\\<>*?/ $!'\":@+`|="
+        if any(c in value for c in illegal_characters):
+            raise ValueError(
+                f'RequirementSetID "{value}" may not contain any of these characters: {illegal_characters}'
+            )
+        str_value = str.__new__(cls, value)
+        return str_value
 
 
 class RequirementSet(ImplicitDict):
@@ -119,7 +132,7 @@ def _parse_requirements(parent: marko.element.Element) -> List[RequirementID]:
             if isinstance(child, str):
                 continue
             if isinstance(child, marko.inline.StrongEmphasis):
-                req_id = _text_of(parent.children[i])
+                req_id = text_of(parent.children[i])
                 reqs.append(RequirementID(req_id))
             else:
                 reqs.extend(_parse_requirements(child))
@@ -127,7 +140,6 @@ def _parse_requirements(parent: marko.element.Element) -> List[RequirementID]:
 
 
 def _load_requirement_set(requirement_set_id: RequirementSetID) -> RequirementSet:
-    _ensure_valid_id(requirement_set_id, "Requirement set ID")
     parts = requirement_set_id.split(".")
     md_filename = os.path.abspath(
         os.path.join(os.path.dirname(__file__), os.path.join(*parts) + ".md")
@@ -143,12 +155,12 @@ def _load_requirement_set(requirement_set_id: RequirementSetID) -> RequirementSe
     if (
         not isinstance(doc.children[0], marko.block.Heading)
         or doc.children[0].level != 1
-        or not _text_of(doc.children[0]).lower().endswith(REQUIREMENT_SET_SUFFIX)
+        or not text_of(doc.children[0]).lower().endswith(REQUIREMENT_SET_SUFFIX)
     ):
         raise ValueError(
             f'The first line of {md_filename} must be a level-1 heading with the name of the scenario + "{REQUIREMENT_SET_SUFFIX}" (e.g., "# ASTM F3411-19 Service Provider requirement set")'
         )
-    requirement_set_name = _text_of(doc.children[0])[0 : -len(REQUIREMENT_SET_SUFFIX)]
+    requirement_set_name = text_of(doc.children[0])[0 : -len(REQUIREMENT_SET_SUFFIX)]
 
     reqs = _parse_requirements(doc)
     for req in reqs:

--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -72,3 +72,9 @@ If a test scenario wants to perform a cleanup procedure follow any non-error ter
 2) Include a main section in the documentation named "Cleanup" that is documented like a test step (including, e.g., test checks when appropriate).
 
 The `cleanup()` method may not be overridden unless the cleanup phase is documented for that test scenario.  If the cleanup phase is documented for the test scenario, the `cleanup()` method must be overridden.
+
+### Reserved stylings
+
+#### Strong emphasis
+
+The strong emphasis styling (`**example**`) may only be used to identify requirement IDs (see "Test checks" section).  Requirement IDs must also link to the document in which they are defined, but this can be performed automatically with `make format` (which transforms, e.g., `**example.req.ID**` into `**[example.req.ID](path/to/example/req.md)`).

--- a/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
+++ b/monitoring/uss_qualifier/scenarios/astm/netrid/nominal_behavior.md
@@ -30,11 +30,11 @@ In this step, uss_qualifier injects a single nominal flight into each SP under t
 
 #### Successful injection check
 
-Per **interuss.automated_testing.rid.injection.UpsertTestSuccess**, the injection attempt of the valid flight should succeed for every NetRID Service Provider under test.
+Per **[interuss.automated_testing.rid.injection.UpsertTestSuccess](../../../requirements/interuss/automated_testing/rid/injection.md)**, the injection attempt of the valid flight should succeed for every NetRID Service Provider under test.
 
 #### Valid flight check
 
-Per **interuss.automated_testing.rid.injection.UpsertTestResult**, the NetRID Service Provider under test should only make valid modifications to the injected flights.  This includes:
+Per **[interuss.automated_testing.rid.injection.UpsertTestResult](../../../requirements/interuss/automated_testing/rid/injection.md)**, the NetRID Service Provider under test should only make valid modifications to the injected flights.  This includes:
 * A flight with the specified injection ID must be returned.
 
 ### Polling test step
@@ -43,29 +43,29 @@ In this step, all observers are periodically queried for the flights they observ
 
 #### Successful observation check
 
-Per **interuss.automated_testing.rid.observation.ObservationSuccess**, the call to each observer is expected to succeed since a valid view was provided by uss_qualifier.
+Per **[interuss.automated_testing.rid.observation.ObservationSuccess](../../../requirements/interuss/automated_testing/rid/observation.md)**, the call to each observer is expected to succeed since a valid view was provided by uss_qualifier.
 
 #### Duplicate flights check
 
-An assumption (**interuss.automated_testing.rid.ObservationFlightID**) this test scenario currently makes is that the flight ID reported by the SP the flight was injected into is the same flight ID that each observer will report.  This is probably not a robust assumption and should be adjusted.
+An assumption (**[interuss.automated_testing.rid.ObservationFlightID](../../../requirements/interuss/automated_testing/rid.md)**) this test scenario currently makes is that the flight ID reported by the SP the flight was injected into is the same flight ID that each observer will report.  This is probably not a robust assumption and should be adjusted.
 
 This check will fail if an observation contains two flights with the same ID.
 
 #### Premature flight check
 
-The timestamps of the injected telemetry usually start in the future.  If a flight with injected telemetry only in the future is observed prior to the timestamp of the first telemetry point, this check will fail because the SP does not satisfy **interuss.automated_testing.rid.injection.ExpectedBehavior**.
+The timestamps of the injected telemetry usually start in the future.  If a flight with injected telemetry only in the future is observed prior to the timestamp of the first telemetry point, this check will fail because the SP does not satisfy **[interuss.automated_testing.rid.injection.ExpectedBehavior](../../../requirements/interuss/automated_testing/rid/injection.md)**.
 
 #### Lingering flight check
 
-**astm.f3411.v19.NET0260** requires a SP to provide flights up to *NetMaxNearRealTimeDataPeriod* in the past, but an SP should preserve privacy and ensure relevancy by not sharing flights that are further in the past than this window.
+**[astm.f3411.v19.NET0260](../../../requirements/astm/f3411/v19.md)** requires a SP to provide flights up to *NetMaxNearRealTimeDataPeriod* in the past, but an SP should preserve privacy and ensure relevancy by not sharing flights that are further in the past than this window.
 
 #### Missing flight check
 
-**astm.f3411.v19.NET0610** require that SPs make all UAS operations discoverable over the duration of the flight plus *NetMaxNearRealTimeDataPeriod*, so each injected flight should be observable during this time.  If one of the flights is not observed during its appropriate time period, this check will fail.
+**[astm.f3411.v19.NET0610](../../../requirements/astm/f3411/v19.md)** require that SPs make all UAS operations discoverable over the duration of the flight plus *NetMaxNearRealTimeDataPeriod*, so each injected flight should be observable during this time.  If one of the flights is not observed during its appropriate time period, this check will fail.
 
 #### Area too large check
 
-**astm.f3411.v19.NET0430** require that a NetRID Display Provider reject a request for a very large view area with a diagonal greater than *NetMaxDisplayAreaDiagonal*.  If such a large view is requested and a 413 error code is not received, then this check will fail.
+**[astm.f3411.v19.NET0430](../../../requirements/astm/f3411/v19.md)** require that a NetRID Display Provider reject a request for a very large view area with a diagonal greater than *NetMaxDisplayAreaDiagonal*.  If such a large view is requested and a 413 error code is not received, then this check will fail.
 
 ## Cleanup
 
@@ -73,4 +73,4 @@ The cleanup phase of this test scenario attempts to remove injected data from al
 
 ### Successful test deletion check
 
-**interuss.automated_testing.rid.injection.DeleteTestSuccess**
+**[interuss.automated_testing.rid.injection.DeleteTestSuccess](../../../requirements/interuss/automated_testing/rid/injection.md)**

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.md
@@ -37,7 +37,7 @@ If either USS does not respond appropriately to the endpoint queried to determin
 
 #### Support BasicStrategicConflictDetection check
 
-If either USS does not support BasicStrategicConflictDetection, then this check will fail per **astm.f3548.v21.GEN0310** as the USS does not support the InterUSS implementation of that requirement.
+If either USS does not support BasicStrategicConflictDetection, then this check will fail per **[astm.f3548.v21.GEN0310](../../../../requirements/astm/f3548/v21.md)** as the USS does not support the InterUSS implementation of that requirement.
 
 ### Area clearing test step
 
@@ -45,7 +45,7 @@ Both USSs are requested to remove all flights from the area under test.
 
 #### Area cleared successfully check
 
-**interuss.automated_testing.flight_planning.ClearArea**
+**[interuss.automated_testing.flight_planning.ClearArea](../../../../requirements/interuss/automated_testing/flight_planning.md)**
 
 ## Plan first flight test case
 
@@ -61,14 +61,14 @@ The first flight intent should be successfully planned by the first flight plann
 
 #### Incorrectly planned check
 
-The second flight intent conflicts with the first flight that was already planned.  If the USS successfully plans the flight, it means they failed to detect the conflict with the pre-existing flight.  Therefore, this check will fail if the second USS indicates success in creating the flight from the user flight intent, per **astm.f3548.v21.SCD0035**.
+The second flight intent conflicts with the first flight that was already planned.  If the USS successfully plans the flight, it means they failed to detect the conflict with the pre-existing flight.  Therefore, this check will fail if the second USS indicates success in creating the flight from the user flight intent, per **[astm.f3548.v21.SCD0035](../../../../requirements/astm/f3548/v21.md)**.
 
 #### Failure check
 
-All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS to reject or accept the flight.  If the USS indicates that the injection attempt failed, this check will fail per **interuss.automated_testing.flight_planning.ExpectedBehavior**.
+All flight intent data provided was complete and correct. It should have been processed successfully, allowing the USS to reject or accept the flight.  If the USS indicates that the injection attempt failed, this check will fail per **[interuss.automated_testing.flight_planning.ExpectedBehavior](../../../../requirements/interuss/automated_testing/flight_planning.md)**.
 
 ## Cleanup
 
 ### Successful flight deletion check
 
-**interuss.automated_testing.flight_planning.DeleteFlightSuccess**
+**[interuss.automated_testing.flight_planning.DeleteFlightSuccess](../../../../requirements/interuss/automated_testing/flight_planning.md)**

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
@@ -37,7 +37,7 @@ If either USS does not respond appropriately to the endpoint queried to determin
 
 #### Support BasicStrategicConflictDetection check
 
-This check will fail if the first flight planner does not support BasicStrategicConflictDetection per **astm.f3548.v21.GEN0310** as the USS does not support the InterUSS implementation of that requirement.  If the second flight planner does not support HighPriorityFlights, this scenario will end normally at this point.
+This check will fail if the first flight planner does not support BasicStrategicConflictDetection per **[astm.f3548.v21.GEN0310](../../../../requirements/astm/f3548/v21.md)** as the USS does not support the InterUSS implementation of that requirement.  If the second flight planner does not support HighPriorityFlights, this scenario will end normally at this point.
 
 ### Area clearing test step
 
@@ -45,7 +45,7 @@ Both USSs are requested to remove all flights from the area under test.
 
 #### Area cleared successfully check
 
-**interuss.automated_testing.flight_planning.ClearArea**
+**[interuss.automated_testing.flight_planning.ClearArea](../../../../requirements/interuss/automated_testing/flight_planning.md)**
 
 ## Plan first flight test case
 
@@ -77,10 +77,10 @@ In this step, the first USS fails to activate the flight it previously created.
 
 TODO: Complete this test case
 
-**astm.f3548.v21.SCD0015**
+**[astm.f3548.v21.SCD0015](../../../../requirements/astm/f3548/v21.md)**
 
 ## Cleanup
 
 ### Successful flight deletion check
 
-**interuss.automated_testing.flight_planning.DeleteFlightSuccess**
+**[interuss.automated_testing.flight_planning.DeleteFlightSuccess](../../../../requirements/interuss/automated_testing/flight_planning.md)**

--- a/monitoring/uss_qualifier/scenarios/documentation/autoformat.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/autoformat.py
@@ -92,6 +92,5 @@ def _add_requirement_links(parent: marko.element.Element, doc_path: str) -> None
                     raise ValueError(
                         f"Found a {child.children[0].__class__.__name__} content element in a bolded (**strong emphasis**) section of documentation, but expected either a Link or RawText"
                     )
-                x = parent.children[i]
             else:
                 _add_requirement_links(child, doc_path)

--- a/monitoring/uss_qualifier/scenarios/documentation/autoformat.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/autoformat.py
@@ -1,0 +1,97 @@
+import os
+from typing import Iterable, Dict
+
+import marko.block
+import marko.element
+import marko.inline
+from marko.md_renderer import MarkdownRenderer
+
+from monitoring.uss_qualifier.documentation import text_of
+from monitoring.uss_qualifier.requirements.documentation import RequirementID
+from monitoring.uss_qualifier.scenarios.documentation.parsing import (
+    get_documentation_filename,
+)
+from monitoring.uss_qualifier.scenarios.scenario import TestScenarioType
+
+
+def format_scenario_documentation(
+    test_scenarios: Iterable[TestScenarioType],
+) -> Dict[str, str]:
+    """Get new documentation content after autoformatting Scenario docs.
+
+    Returns:
+        Mapping from .md filename to content that file should contain (which is
+        different from what it currently contains).
+    """
+    new_versions: Dict[str, str] = {}
+    for test_scenario in test_scenarios:
+        md = marko.Markdown(renderer=MarkdownRenderer)
+        # Load the .md file if it exists
+        doc_filename = get_documentation_filename(test_scenario)
+        if not os.path.exists(doc_filename):
+            continue
+        with open(doc_filename, "r") as f:
+            original = f.read()
+        doc = md.parse(original)
+        original = md.render(doc)
+
+        _add_requirement_links(doc, doc_filename)
+
+        # Return the formatted version
+        formatted = md.render(doc)
+        if formatted != original:
+            new_versions[doc_filename] = formatted
+    return new_versions
+
+
+def _add_requirement_links(parent: marko.element.Element, doc_path: str) -> None:
+    if hasattr(parent, "children") and not isinstance(parent.children, str):
+        for i, child in enumerate(parent.children):
+            if isinstance(child, str):
+                continue
+            if isinstance(child, marko.inline.StrongEmphasis):
+                if not child.children:
+                    raise ValueError(
+                        "No content found in bolded (**strong emphasis**) section of documentation"
+                    )
+                if len(child.children) != 1:
+                    content_types = ", ".join(
+                        c.__class__.__name__ for c in child.children
+                    )
+                    raise ValueError(
+                        f"Expected exactly 1 content element in bolded (**strong emphasis**) section of documentation, but instead found {len(child.children)} content elements ({content_types})"
+                    )
+                if isinstance(child.children[0], marko.inline.Link):
+                    # Requirement already has link; ensure validity
+                    req_id = RequirementID(text_of(child.children[0]))
+                    if not os.path.exists(req_id.md_file_path()):
+                        raise ValueError(
+                            f'Requirement ID "{req_id}" implies that {req_id.md_file_path()} should exist, but it does not exist'
+                        )
+                    href = child.children[0].dest
+                    doc_dir = os.path.dirname(doc_path)
+                    linked_path = os.path.normpath(os.path.join(doc_dir, href))
+                    if linked_path != req_id.md_file_path():
+                        href = os.path.relpath(req_id.md_file_path(), doc_dir)
+                        child.children[0].dest = href
+
+                elif isinstance(child.children[0], marko.inline.RawText):
+                    # Replace plaintext with link to requirement definition
+                    req_id = RequirementID(text_of(child.children[0]))
+                    if not os.path.exists(req_id.md_file_path()):
+                        raise ValueError(
+                            f'Requirement ID "{req_id}" implies that {req_id.md_file_path()} should exist, but it does not exist'
+                        )
+                    href = os.path.relpath(
+                        req_id.md_file_path(), os.path.dirname(doc_path)
+                    )
+                    del child.children[0]
+                    link = marko.parse(f"[{req_id}]({href})").children[0].children[0]
+                    child.children.append(link)
+                else:
+                    raise ValueError(
+                        f"Found a {child.children[0].__class__.__name__} content element in a bolded (**strong emphasis**) section of documentation, but expected either a Link or RawText"
+                    )
+                x = parent.children[i]
+            else:
+                _add_requirement_links(child, doc_path)

--- a/monitoring/uss_qualifier/scenarios/documentation/definitions.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/definitions.py
@@ -1,0 +1,42 @@
+from typing import Optional, List
+
+from implicitdict import ImplicitDict
+from monitoring.uss_qualifier.reports.report import RequirementID
+
+
+class TestCheckDocumentation(ImplicitDict):
+    name: str
+    url: Optional[str] = None
+    applicable_requirements: List[RequirementID]
+
+
+class TestStepDocumentation(ImplicitDict):
+    name: str
+    url: Optional[str] = None
+    checks: List[TestCheckDocumentation]
+
+
+class TestCaseDocumentation(ImplicitDict):
+    name: str
+    url: Optional[str] = None
+    steps: List[TestStepDocumentation]
+
+    def get_step_by_name(self, step_name: str) -> Optional[TestStepDocumentation]:
+        for step in self.steps:
+            if step.name == step_name:
+                return step
+        return None
+
+
+class TestScenarioDocumentation(ImplicitDict):
+    name: str
+    url: Optional[str] = None
+    resources: Optional[List[str]]
+    cases: List[TestCaseDocumentation]
+    cleanup: Optional[TestStepDocumentation]
+
+    def get_case_by_name(self, case_name: str) -> Optional[TestCaseDocumentation]:
+        for case in self.cases:
+            if case.name == case_name:
+                return case
+        return None

--- a/monitoring/uss_qualifier/scenarios/documentation/format_documentation.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/format_documentation.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+from monitoring.monitorlib import inspection
+from monitoring.uss_qualifier import scenarios
+from monitoring.uss_qualifier.scenarios.documentation.autoformat import (
+    format_scenario_documentation,
+)
+from monitoring.uss_qualifier.scenarios.scenario import find_test_scenarios
+
+
+def main() -> int:
+    inspection.import_submodules(scenarios)
+    test_scenarios = find_test_scenarios(scenarios)
+    changes = format_scenario_documentation(list(test_scenarios))
+    for filename, content in changes.items():
+        with open(filename, "w") as f:
+            f.write(content)
+        print(f"Reformatted documentation in {filename}")
+    if not changes:
+        print("No scenario documentation needs to be reformatted.")
+    return os.EX_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/monitoring/uss_qualifier/scenarios/documentation/requirements.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/requirements.py
@@ -21,11 +21,13 @@ from monitoring.uss_qualifier.reports.report import (
     PassedCheck,
     FailedCheck,
 )
-from monitoring.uss_qualifier.scenarios.documentation import (
-    get_documentation_by_name,
+from monitoring.uss_qualifier.scenarios.documentation.definitions import (
     TestScenarioDocumentation,
     TestCaseDocumentation,
     TestStepDocumentation,
+)
+from monitoring.uss_qualifier.scenarios.documentation.parsing import (
+    get_documentation_by_name,
 )
 
 JSONPath = str

--- a/monitoring/uss_qualifier/scenarios/documentation/validate_documentation.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/validate_documentation.py
@@ -11,6 +11,7 @@ def main() -> int:
     inspection.import_submodules(scenarios)
     test_scenarios = find_test_scenarios(scenarios)
     validation.validate(list(test_scenarios))
+    print("Test documentation is valid.")
     return os.EX_OK
 
 

--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -10,6 +10,7 @@ from implicitdict import StringBasedDateTime
 
 from monitoring import uss_qualifier as uss_qualifier_module
 from monitoring.monitorlib import fetch, inspection
+from monitoring.monitorlib.inspection import fullname
 from monitoring.uss_qualifier import scenarios as scenarios_module
 from monitoring.uss_qualifier.common_data_definitions import Severity
 from monitoring.uss_qualifier.reports.report import (
@@ -23,14 +24,14 @@ from monitoring.uss_qualifier.reports.report import (
     PassedCheck,
 )
 from monitoring.uss_qualifier.scenarios.definitions import TestScenarioDeclaration
-from monitoring.uss_qualifier.scenarios.documentation import (
-    get_documentation,
+from monitoring.uss_qualifier.scenarios.documentation.definitions import (
     TestScenarioDocumentation,
     TestCaseDocumentation,
     TestStepDocumentation,
     TestCheckDocumentation,
 )
 from monitoring.uss_qualifier.resources.definitions import ResourceTypeName, ResourceID
+from monitoring.uss_qualifier.scenarios.documentation.parsing import get_documentation
 
 
 class ScenarioPhase(str, Enum):
@@ -415,7 +416,7 @@ TestScenarioType = TypeVar("TestScenarioType", bound=TestScenario)
 
 def find_test_scenarios(
     module, already_checked: Optional[Set[str]] = None
-) -> Set[TestScenarioType]:
+) -> List[TestScenarioType]:
     if already_checked is None:
         already_checked = set()
     already_checked.add(module.__name__)
@@ -434,4 +435,6 @@ def find_test_scenarios(
             if issubclass(member, TestScenario):
                 if member not in test_scenarios:
                     test_scenarios.add(member)
-    return test_scenarios
+    result = list(test_scenarios)
+    result.sort(key=lambda s: fullname(s))
+    return result

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
@@ -70,4 +70,4 @@ All flight intent data provided is correct and valid and free of conflict in spa
 
 ### Successful flight deletion check
 
-**interuss.automated_testing.flight_planning.DeleteFlightSuccess**
+**[interuss.automated_testing.flight_planning.DeleteFlightSuccess](../../../requirements/interuss/automated_testing/flight_planning.md)**

--- a/monitoring/uss_qualifier/scripts/format_test_documentation.sh
+++ b/monitoring/uss_qualifier/scripts/format_test_documentation.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -o xtrace
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../../.." || exit 1
+
+monitoring/build.sh || exit 1
+
+# shellcheck disable=SC2086
+docker run --name test_documentation_formatter \
+  --rm \
+  -v "$(pwd):/app" \
+  interuss/monitoring \
+  uss_qualifier/scripts/in_container/format_test_documentation.sh

--- a/monitoring/uss_qualifier/scripts/in_container/format_test_documentation.sh
+++ b/monitoring/uss_qualifier/scripts/in_container/format_test_documentation.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script is intended to be called from within a Docker container running
+# mock_uss via the interuss/monitoring image.  In that context, this script is
+# the entrypoint into the test documentation formatting tool.
+
+# Ensure uss_qualifier is the working directory
+OS=$(uname)
+if [[ $OS == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../.." || exit 1
+
+# Run validation
+python scenarios/documentation/format_documentation.py


### PR DESCRIPTION
The PR adds auto-formatting capability for test scenario documentation that is invoked with `make format` and verified in `make lint`.  The one auto-formatting operation implemented in this PR is automatically linking requirement references in test scenario documentation to the definition of the specified requirements (and this auto-formatting is applied to existing test scenario documentation).

To wrangle some dependencies, uss_qualifier/scenarios/documentation/__init__.py is split into uss_qualifier/scenarios/documentation/definitions.py and uss_qualifier/scenarios/documentation/parsing.py.  Note that git has a hard time showing a good diff when a file is both moved and then a new file added in its place, so please see just the first commit of this PR for a more accurate diff of the __init__.py split.

The `RequirementID` and `RequirementSetID` types are enhanced to have more capabilities than simply aliasing a `str`, which enforces validity more consistently.