### PR TITLE
Adding start and stop triggers for recording message signing report 

### DIFF
--- a/monitoring/uss_qualifier/configurations/dev/faa/uft/local_message_signing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/faa/uft/local_message_signing.yaml
@@ -8,9 +8,7 @@ resources:
       specification:
         flight_planners:
         - participant_id: uss1
-          injection_base_url: http://host.docker.internal:8074/scdsc
-        - participant_id: uss2
-          injection_base_url: http://host.docker.internal:8074/scdsc
+          injection_base_url: http://host.docker.internal:10230/ussq
         - participant_id: mock_uss
           injection_base_url: http://host.docker.internal:8074/scdsc
     combination_selector:

--- a/monitoring/uss_qualifier/configurations/dev/faa/uft/local_message_signing.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/faa/uft/local_message_signing.yaml
@@ -8,7 +8,8 @@ resources:
       specification:
         flight_planners:
         - participant_id: uss1
-          injection_base_url: http://host.docker.internal:10230/ussq
+          # Set injection_base_url to USS-under-test interface url. Eg - http://host.docker.internal:10230/ussq
+          injection_base_url: http://host.docker.internal:8074/scdsc
         - participant_id: mock_uss
           injection_base_url: http://host.docker.internal:8074/scdsc
     combination_selector:

--- a/monitoring/uss_qualifier/resources/interuss/mock_uss.py
+++ b/monitoring/uss_qualifier/resources/interuss/mock_uss.py
@@ -28,7 +28,6 @@ class MockUSSClient(object):
         resp = self.session.get("/scdsc/v1/status", scope=SCOPE_SCD_QUALIFIER_INJECT)
         return fetch.describe_query(resp, initiated_at)
 
-    # TODO: Add other methods to interact with the mock USS in other ways (like starting/stopping message signing data collection)
     def start_msg_sign_recording(self) -> fetch.Query:
         initiated_at = arrow.utcnow().datetime
         resp = self.session.post("/scdsc/v1/startreport", scope=SCOPE_SCD_QUALIFIER_INJECT)

--- a/monitoring/uss_qualifier/resources/interuss/mock_uss.py
+++ b/monitoring/uss_qualifier/resources/interuss/mock_uss.py
@@ -29,12 +29,20 @@ class MockUSSClient(object):
         return fetch.describe_query(resp, initiated_at)
 
     # TODO: Add other methods to interact with the mock USS in other ways (like starting/stopping message signing data collection)
+    def start_msg_sign_recording(self) -> fetch.Query:
+        initiated_at = arrow.utcnow().datetime
+        resp = self.session.post("/scdsc/v1/startreport", scope=SCOPE_SCD_QUALIFIER_INJECT)
+        return fetch.describe_query(resp, initiated_at)
 
+    def stop_msg_sign_recording(self) -> fetch.Query:
+        initiated_at = arrow.utcnow().datetime
+        resp = self.session.post("/scdsc/v1/endreport", scope=SCOPE_SCD_QUALIFIER_INJECT)
+        return fetch.describe_query(resp, initiated_at)
 
 class MockUSSSpecification(ImplicitDict):
     mock_uss_base_url: str
     """The base URL for the mock USS.
-    
+
     If the mock USS had scdsc enabled, for instance, then these URLs would be
     valid:
       * <mock_uss_base_url>/mock/scd/uss/v1/reports

--- a/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_finalize.py
+++ b/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_finalize.py
@@ -21,15 +21,18 @@ class FinalizeMessageSigningReport(TestScenario):
         self.begin_test_step("Signal mock USS")
 
         # TODO: Add call to mock USS to finalize message signing report
+        query = self._mock_uss.stop_msg_sign_recording()
+        self.record_query(query)
+
         with self.check(
             "Successful finalization", participants=[self._mock_uss.participant_id]
         ) as check:
-            if False:  # TODO: Insert appropriate check
+            if query.status_code != 200:  # TODO: Insert appropriate check
                 check.record_failed(
                     summary="Failed to finalize message signing report",
-                    details="TODO",
+                    details="Status code {query.status_code}",
                     severity=Severity.High,
-                    query_timestamps=[],
+                    query_timestamps=[query.request.timestamp],
                 )
                 return
 

--- a/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_finalize.py
+++ b/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_finalize.py
@@ -20,14 +20,13 @@ class FinalizeMessageSigningReport(TestScenario):
 
         self.begin_test_step("Signal mock USS")
 
-        # TODO: Add call to mock USS to finalize message signing report
         query = self._mock_uss.stop_msg_sign_recording()
         self.record_query(query)
 
         with self.check(
             "Successful finalization", participants=[self._mock_uss.participant_id]
         ) as check:
-            if query.status_code != 200:  # TODO: Insert appropriate check
+            if query.status_code != 200:
                 check.record_failed(
                     summary="Failed to finalize message signing report",
                     details="Status code {query.status_code}",

--- a/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_start.py
+++ b/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_start.py
@@ -50,13 +50,12 @@ class StartMessageSigningReport(TestScenario):
 
         self.begin_test_step("Signal mock USS")
 
-        # TODO: Add call to mock USS to start message signing report
         start_query = self._mock_uss.start_msg_sign_recording()
         self.record_query(start_query)
         with self.check(
             "Successful start", participants=[self._mock_uss.participant_id]
         ) as check:
-            if start_query.status_code != 200:  # TODO: Insert appropriate check
+            if start_query.status_code != 200:
                 check.record_failed(
                     summary="Failed to start message signing report",
                     details="Status code {start_query.status_code}",

--- a/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_start.py
+++ b/monitoring/uss_qualifier/scenarios/faa/uft/message_signing_start.py
@@ -51,15 +51,17 @@ class StartMessageSigningReport(TestScenario):
         self.begin_test_step("Signal mock USS")
 
         # TODO: Add call to mock USS to start message signing report
+        start_query = self._mock_uss.start_msg_sign_recording()
+        self.record_query(start_query)
         with self.check(
             "Successful start", participants=[self._mock_uss.participant_id]
         ) as check:
-            if False:  # TODO: Insert appropriate check
+            if start_query.status_code != 200:  # TODO: Insert appropriate check
                 check.record_failed(
                     summary="Failed to start message signing report",
-                    details="TODO",
+                    details="Status code {start_query.status_code}",
                     severity=Severity.High,
-                    query_timestamps=[],
+                    query_timestamps=[query.request.timestamp],
                 )
                 return
 


### PR DESCRIPTION
As part of UFT, the uss _qualifier SCD flow will need to test for message signing headers in requests and responses sent to Mock Uss. Uss_qualifier needs to provide triggers to Mock USS to start and stop recording message signing reports for a SCD flow test suite. These triggers for starting and stopping reports in mock uss have been added as scenarios to the test suite.