### PR TITLE
Adding mock uss report recording feature

### DIFF
--- a/monitoring/mock_uss/report/.gitignore
+++ b/monitoring/mock_uss/report/.gitignore
@@ -1,0 +1,1 @@
+report_*.json

--- a/monitoring/mock_uss/run_locally_scdsc.sh
+++ b/monitoring/mock_uss/run_locally_scdsc.sh
@@ -28,6 +28,7 @@ docker run ${docker_args} --name mock_uss_scdsc \
   -e MOCK_USS_SERVICES="scdsc" \
   -p ${PORT}:5000 \
   -v "${SCRIPT_DIR}/../../build/test-certs:/var/test-certs:ro" \
+  -v "${PWD}/report:/app/monitoring/mock_uss/report" \
   "$@" \
   interuss/monitoring \
   mock_uss/start.sh

--- a/monitoring/mock_uss/scdsc/muss_report_recorder.py
+++ b/monitoring/mock_uss/scdsc/muss_report_recorder.py
@@ -1,0 +1,31 @@
+import uuid
+from monitoring.monitorlib import fetch
+from monitoring.mock_uss.scdsc.muss_reports import (
+    Interaction,
+    MussReport,
+    Issue,
+    InteractionID,
+    MockUssTestContext,
+)
+
+class MussReportRecorder:
+    """Class providing helper to capture interactions and issues in a report"""
+
+    def __init__(self, report: MussReport):
+        self.reprt = report
+
+    def capture_interaction(
+        self, query: fetch.Query, purpose: str, test_context=None
+    ) -> InteractionID:
+        interaction_id = str(uuid.uuid4())
+        interaction = Interaction(
+            interaction_id=interaction_id,
+            purpose=purpose,
+            query=query,
+            context=test_context
+        )
+        self.reprt.findings.add_interaction(interaction)
+        return interaction_id
+
+    def capture_issue(self, issue: Issue):
+        self.reprt.findings.add_issue(issue)

--- a/monitoring/mock_uss/scdsc/muss_reports.py
+++ b/monitoring/mock_uss/scdsc/muss_reports.py
@@ -1,0 +1,90 @@
+import datetime, json
+from typing import Dict, List, Optional
+from implicitdict import ImplicitDict
+from monitoring.monitorlib import fetch
+from pathlib import Path
+
+InteractionID = str
+
+
+class MockUssTestContext(ImplicitDict):
+    test_name: str
+    """Name of the test"""
+
+    test_case: str
+    """Testcase describing the received request, action and the expected result"""
+
+
+class Issue(ImplicitDict):
+    timestamp: Optional[str]
+    """Time the issue was discovered"""
+
+    context: MockUssTestContext
+    """The context describing what is being tested"""
+
+    uss_role: str
+    """Role USS was performing in the test when the issue occurred"""
+
+    target: str
+    """Issue is related to this USS/DSS"""
+
+    summary: str
+    """Human-readable summary of the issue"""
+
+    details: str
+    """Human-readable description of the issue"""
+
+    interactions: List[InteractionID]
+    """Description of interactions relevant to this issue"""
+
+    def __init__(self, **kwargs):
+        super(Issue, self).__init__(**kwargs)
+        if "timestamp" not in kwargs:
+            self.timestamp = datetime.datetime.utcnow().isoformat()
+
+
+class Interaction(ImplicitDict):
+    interaction_id: InteractionID
+    """ID of this interaction (used to refer to this interaction from an issue)"""
+
+    purpose: str
+    """Intended purpose of the interaction - eg. to return the appropriate response"""
+
+    context: MockUssTestContext
+    """The context describing what is being tested"""
+
+    query: fetch.Query
+    """Interaction performed (flight injection, DSS query, USS query, etc)"""
+
+
+class Findings(ImplicitDict):
+    issues: List[Issue] = []
+    interactions: List[Interaction] = []
+
+    def add_interaction(self, interaction: Interaction):
+        self.interactions.append(interaction)
+
+    def add_issue(self, issue: Issue):
+        self.issues.append(issue)
+
+    def critical_issues(self) -> List[Issue]:
+        return list(filter(lambda issue: issue.severity.Critical, self.issues))
+
+    def __repr__(self):
+        return "[{} issues in {} interactions]".format(
+            len(self.issues), len(self.interactions)
+        )
+
+class MussReport(ImplicitDict):
+    findings: Findings = Findings()
+
+    def save(self):
+        filepath = "./report/report_mock_uss_scdsc_messagesigning.json"
+        with open(filepath, "w") as f:
+            f.write(json.dumps(self, indent=4, default=str))
+        print("[Mock USS] Report saved to {}".format(filepath))
+
+
+    def reset(self):
+        self.findings.issues = []
+        self.findings.interactions = []

--- a/monitoring/mock_uss/scdsc/report_settings.py
+++ b/monitoring/mock_uss/scdsc/report_settings.py
@@ -1,0 +1,9 @@
+from monitoring.mock_uss.scdsc.muss_reports import MussReport
+from monitoring.mock_uss.scdsc.muss_report_recorder import MussReportRecorder
+
+reprt = MussReport()
+reprt_recorder = MussReportRecorder(reprt)
+
+def reset():
+    global reprt
+    reprt.reset()

--- a/monitoring/mock_uss/scdsc/routes.py
+++ b/monitoring/mock_uss/scdsc/routes.py
@@ -16,3 +16,6 @@ def scdsc_status():
 
 from . import routes_scdsc
 from . import routes_injection
+from . import report_settings
+from . import muss_report_recorder
+from . import muss_reports

--- a/monitoring/mock_uss/start.sh
+++ b/monitoring/mock_uss/start.sh
@@ -20,6 +20,6 @@ cp health_check.sh /app
 # Start mock_uss server on port 5000
 gunicorn \
     --preload \
-    --workers=4 \
+    --workers=1 \
     --bind=0.0.0.0:5000 \
     monitoring.mock_uss:webapp


### PR DESCRIPTION
1. Added report recording feature in mock uss.
2. Added report start and end endpoints in mock uss, to be used by uss_qualifier tests while running faa aft message signing tests.
3. Had to reduce gunicorn workers to 1, as report (global reprt) is used as a global variable for report recording in report_settings.py file. With multiple gunicorn workers, seems like the global variable was not being passed correctly, and we couldn't record all interactions. Not sure how to solve it at the moment. But, we can open an issue to resolve it later. Or, if somebody could help resolve it. Thanks