### PR TITLE
Removing ClearAreaRequest field from ClearAreaResponse as per given api

### DIFF
--- a/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
+++ b/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
@@ -111,7 +111,6 @@ class ClearAreaOutcome(ImplicitDict):
 
 
 class ClearAreaResponse(ImplicitDict):
-    request: ClearAreaRequest
     outcome: ClearAreaOutcome
 
 

--- a/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
+++ b/monitoring/monitorlib/scd_automated_testing/scd_injection_api.py
@@ -111,6 +111,7 @@ class ClearAreaOutcome(ImplicitDict):
 
 
 class ClearAreaResponse(ImplicitDict):
+    request: Optional[ClearAreaRequest]
     outcome: ClearAreaOutcome
 
 


### PR DESCRIPTION
ClearAreaRequest needs to be removed from ClearAreaResponse, as per the yaml spec.