### PR TITLE
[CI] Fix cloudbuild.yaml Go lint to match Makefile

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,21 +7,21 @@ steps:
   - name: 'go-vol'
     path: '/go'
 - id: 'Lint: Formatting'
-  name: golangci/golangci-lint:v1.23.8
+  name: golangci/golangci-lint:v1.26.0
   # Disable staticcheck since http-gateway doesn't use DialContext
   args: ['golangci-lint', 'run', '--timeout', '5m', '-v', '-E', 'gofmt,bodyclose,rowserrcheck,misspell,golint', '-D', 'staticcheck,vet']
   volumes:
   - name: 'go-vol'
     path: '/go'
 - id: 'Lint: Formatting: vet'
-  name: golangci/golangci-lint:v1.23.8
+  name: golangci/golangci-lint:v1.26.0
   # Run vet separately to try and fix https://github.com/golangci/golangci-lint/issues/896
   args: ['golangci-lint', 'run', '-v', '--disable-all',  '-E', 'vet', '--timeout', '5m']
   volumes:
   - name: 'go-vol'
     path: '/go'
 - id: 'Lint: Formatting staticcheck'
-  name: golangci/golangci-lint:v1.24.0
+  name: golangci/golangci-lint:v1.26.0
   # Run staticcheck everywhere but the http-gateway
   args: ['golangci-lint', 'run', '-v', '--disable-all',  '-E', 'staticcheck', '--skip-dirs', '^cmds/http-gateway,^pkg/logging', '--timeout', '5m']
   volumes:


### PR DESCRIPTION
In the longer term, we should harmonize our CI per #894, but in the mean time, our Cloud CI should at least match the operations developers would perform locally.  [In our Makefile](https://github.com/interuss/dss/blob/b36e2988b4567d5392f84b4abfd5d1e5b0d22387/Makefile#L52), `go_lint` uses version 1.26.0 of the golangci-lint image whereas cloudbuild.yaml uses older versions.  This PR updates cloudbuild.yaml to match our Makefile, though hopefully this change will be made obsolete in the near future by the resolution of #894.