### PR TITLE
[uss_qualifier/docs] Improve uss_qualifier documentation

### DIFF
--- a/monitoring/uss_qualifier/README.md
+++ b/monitoring/uss_qualifier/README.md
@@ -2,54 +2,36 @@
 
 ## Introduction
 
-The USS Qualifier automates testing compliance to requirements and interoperability of multiple USS/USSPs.
+The uss_qualifier tool in this folder automates verifying compliance to requirements and interoperability of multiple USS/USSPs.
+
+## Usage
+
+The `uss_qualifier` tool is a synchronous executable built into the `interuss/monitoring` Docker image.  To use the `interuss/monitoring` image to run uss_qualifier, specify a working directory of `/app/monitoring/uss_qualifier` and a command of `python main.py ${OPTIONS}` -- see [`run_locally.sh`](run_locally.sh) for an example that can be run on any local system that is running the required prerequisites (documented in message printed by run_locally.sh).
+
+The primary input accepted by uss_qualifier is the "configuration" specified with the `--config` option.  This option should be a [reference to a configuration file](configurations/README.md) that the user has constructed or been provided to test the desired system for the desired characteristics.  If testing a standard local system (DSS + dummy auth + mock USSs), the user can specify an alternate configuration reference as a single argument to `run_locally.sh` (the default configuration is `configurations.dev.local_test`).
+
+When building a custom configuration file, consider starting from [`configurations.dev.self_contained_f3548`](configurations/dev/self_contained_f3548.yaml), as it contains all information necessary to run the test without the usage of sometimes-configuring `$ref`s and `allOf`s.  See [configurations documentation](configurations/README.md) for more information.
+
+### Quick start
+
+This section provides a specific set of commands to execute uss_qualifier for demonstration purposes.
+
+1. Check out this repository: `git clone https://github.com/interuss/dss`
+2. Go to repository root: `cd dss`
+3. Bring up a local UTM ecosystem (DSS + dummy auth): `build/dev/run_locally.sh`
+4. In a separate window, bring up a mock RID Service Provider USS: `monitoring/mock_uss/run_locally_ridsp.sh`
+5. In a separate window, bring up a mock RID Display Provider USS: `monitoring/mock_uss/run_locally_riddp.sh`
+6. In a separate window, bring up a mock strategic conflict detection USS: `monitoring/mock_uss/run_locally_scdsc.sh`
+7. Wait until all 4 windows above stop printing new text (should take 1-2 minutes usually, or up to 15 minutes the first time)
+8. In a separate window, run uss_qualifier explicitly specifying a configuration to use: `monitoring/uss_qualifier/run_locally.sh configurations.dev.local_test`
+
+After building, uss_qualifier should take a few minutes to run and then `report.json` should appear in [monitoring/uss_qualifier](.)
+
+At this point, uss_qualifier can be run again with a different configuration targeted at the development resources brought up in steps 3-6; for instance: `monitoring/uss_qualifier/run_locally.sh configurations.dev.self_contained_f3548`
 
 ## Architecture
 
-Note: We are currently in the process of migrating the technical implementation of uss_qualifier to the architecture described here; the architecture today is different from this.
-
-### Test suites
-
-1. A test suite is a set of tests that establish compliance to the thing they're named after.
-    * Example: Passing the "ASTM F3548-21" test suite should indicate the systems under test are compliant with ASTM F3548-21.
-2. A test suite is composed of a list of {test suite|test scenario}.
-    * Each element on the list is executed sequentially.
-
-### [Test scenarios](scenarios/README.md)
-
-### Test cases
-
-1. A test case is a single wholistic operation or action performed as part of a larger test scenario.
-    * Test cases are like acts in the "play" of the test scenario they are a part of.
-    * Test cases are typically the "gray headers” of the overview sequence diagrams.
-2. A given test case belongs to exactly one test scenario.
-3. A test case is composed of a list of test steps.
-    * Each test step on the list is executed sequentially.
-
-### Test steps
-
-1. A test step is a single task that must be performed in order to accomplish its associated test case.
-   * Test steps are like scenes in the "play/act" of the test scenario/test case they are a part of.
-2. A given test step belongs to exactly one test case.
-3. A test step may have a list of checks associated with it.
-
-### Checks
-
-1. A check is the lowest-level thing automated testing does – it is a single pass/fail evaluation of a single criterion for a requirement.
-2. A check evaluates information collected during the actions performed for a test step.
-3. A given check belongs to exactly one test step.
-4. Each check defines which requirement is not met if the check fails.
-
-### Test configurations
-
-1. Even though all the scenarios, cases, steps and checks are fully defined for a particular test suite, the scenarios require data customized for a particular ecosystem – this data is provided as "test resources" which are created from the specifications in a "test configuration".
-2. A test configuration is associated with exactly one test suite, and contains descriptions for how to create each of the set of required test resources.
-    * The resources required for a particular test definition depend on which test scenarios are included in the test suite.
-3. One resource can be used by many different test scenarios.
-4. One test scenario may use multiple resources.
-5. One class of resources is resources that describe the systems under test and how to interact with them; e.g., "Display Providers under test".
-    * This means that a complete test configuration can't be tracked in the InterUSS repository because it wouldn't make sense to list, e.g., Display Provider observation endpoint URLs in the SUSI qual-partners environment.
-    * Partial test configurations, including RID telemetry to inject, operational intents to inject, etc, can be tracked in the InterUSS repository, but they could not be used without specifying the missing resources describing systems under test.
-
-### [Test resources](resources/README.md)
-
+* [Test suites](suites/README.md)
+* [Test scenarios](scenarios/README.md) (includes test case, test step, check breakdown)
+* [Test configurations](configurations/README.md)
+* [Test resources](resources/README.md)

--- a/monitoring/uss_qualifier/configurations/README.md
+++ b/monitoring/uss_qualifier/configurations/README.md
@@ -1,9 +1,79 @@
 # uss_qualifier configurations
 
+## Usage
+
 To execute a test run with uss_qualifier, a test configuration must be provided.  This configuration consists of the test suite to run, along with definitions for all resources needed by that test suite.  See [`TestConfiguration`](configuration.py) for the exact schema.
 
-When referring to a configuration, three methods may be used:
+### Specifying
 
-* **Package-based**: refer to the .json file located in a subfolder of this `configurations` folder using the Python module style, omitting the extension of the file name.  For instance, `dev.local_test` would refer to [monitoring/uss_qualifier/configurations/dev/local_test.json](dev/local_test.json).
+When referring to a configuration, three methods may be used; see [`FileReference` documentation](../fileio.py) for more details.
+
+* **Package-based**: refer to a dictionary (*.json, *.yaml) file located in a subfolder of the `uss_qualifier` folder using the Python module style, omitting the extension of the file name.  For instance, `configurations.dev.local_test` would refer to [uss_qualifier/configurations/dev/local_test.json](dev/local_test.json).
 * **Local file**: when a configuration reference is prefixed with `file://`, it refers to a local file using the path syntax of the host operating system.
 * **Web file**: when a configuration reference is prefixed with `http://` or `https://`, it refers to a file accessible at the specified URL.
+
+### Building
+
+A valid configuration file must provide a single instance of the [`TestConfiguration` schema](configuration.py) in the format chosen (JSON or YAML), as indicated by the file extension (.json or .yaml).
+
+#### Personalization
+
+When designing personalized/custom configuration files for specific, non-standard systems, the configuration files should generally be stored in either [uss_qualifier/configurations/personal](personal), or in an external repository and provided via `file://` prefix or `http(s)://` prefix.
+
+#### References
+
+To reduce repetition in similar configurations, the configuration parser supports the inclusion of all or parts of other files by using a `$ref` notation similar to (but not the same as) OpenAPI.
+
+When a `$ref` key is encountered, the keys and values of the referenced content are used to overwrite any keys at the same level of the `$ref`.  For instance:
+
+_x.json_:
+```json
+{"a": 1, "$ref": "y.json", "b": 2}
+```
+
+_y.json_:
+```json
+{"b": 3, "c": 4}
+```
+
+Loading _x.json_ results in the object:
+
+```json
+{"a": 1, "b": 3, "c": 4}
+```
+
+To combine the contents from multiple `$ref` sources, use `allOf`.  For instance:
+
+_q.json_:
+```json
+{"a": 1, "b": 2, "allOf": [{"$ref": "r.json"}, {"$ref": "s.json"}], "c": 3, "d":  4}
+```
+
+_r.json_:
+```json
+{"b": 5, "c": 6, "e":  7}
+```
+
+_s.json_:
+```json
+{"b": 8, "d": 9, "f": 10}
+```
+
+Loading _q.json_ results in the object:
+
+```json
+{"a": 1, "b": 8, "c": 6, "d": 9, "e": 7, "f": 10}
+```
+
+More details may be found in [`fileio.py`](../fileio.py).
+
+## Design notes
+
+1. Even though all the scenarios, cases, steps and checks are fully defined for a particular test suite, the scenarios require data customized for a particular ecosystem – this data is provided as "test resources" which are created from the specifications in a "test configuration".
+2. A test configuration is associated with exactly one test suite, and contains descriptions for how to create each of the set of required test resources.
+    * The resources required for a particular test definition depend on which test scenarios are included in the test suite.
+3. One resource can be used by many different test scenarios.
+4. One test scenario may use multiple resources.
+5. One class of resources is resources that describe the systems under test and how to interact with them; e.g., "Display Providers under test".
+    * This means that a complete test configuration can't be tracked in the InterUSS repository because it wouldn't make sense to list, e.g., Display Provider observation endpoint URLs in the SUSI qual-partners environment.
+    * Partial test configurations, including RID telemetry to inject, operational intents to inject, etc, can be tracked in the InterUSS repository, but they could not be used without specifying the missing resources describing systems under test.

--- a/monitoring/uss_qualifier/configurations/dev/self_contained_f3548.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/self_contained_f3548.yaml
@@ -1,0 +1,61 @@
+# This block defines which test suite uss_qualifier should run, and what resources from the pool should be used
+test_suite:
+  # suite_type is a FileReference (defined in uss_qualifier/file_io.py) to a test suite definition (see uss_qualifier/suites/README.md)
+  suite_type: suites.astm.utm.f3548_21
+
+  # Mapping of <resource name in test suite> to <resource name in resource pool>
+  resources:
+    flight_planners: flight_planners
+    conflicting_flights: conflicting_flights
+    priority_preemption_flights: priority_preemption_flights
+    dss: dss
+
+# This block defines all the resources available in the resource pool.
+# Presumably all resources defined below would be used either
+#   1) directly in the test suite or
+#   2) to create another resource in the pool (see, e.g., `utm_auth` as it relates to `dss` below)
+resources:
+  resource_declarations:
+    # Means by which uss_qualifier can obtain authorization to make requests in an ASTM USS ecosystem
+    utm_auth:
+      # resource_type is a ResourceTypeName (defined in uss_qualifier/resources/definitions.py)
+      resource_type: resources.communications.AuthAdapterResource
+      specification:
+        # To avoid putting secrets in configuration files, the auth spec (including sensitive information) will be read from the AUTH_SPEC environment variable
+        environment_variable_containing_auth_spec: AUTH_SPEC
+
+    # Set of USSs capable of being tested as flight planners
+    flight_planners:
+      resource_type: resources.flight_planning.FlightPlannersResource
+      dependencies:
+        auth_adapter: utm_auth
+      specification:
+        flight_planners:
+        - participant_id: uss1
+          injection_base_url: http://host.docker.internal:8074/scdsc
+        - participant_id: uss2
+          injection_base_url: http://host.docker.internal:8074/scdsc
+
+    # Details of conflicting flights (used in nominal planning scenario)
+    conflicting_flights:
+      resource_type: resources.flight_planning.FlightIntentsResource
+      specification:
+        planning_time: '0:05:00'
+        file_source: file://./test_data/che/flight_intents/conflicting_flights.json
+
+    # Details of priority-preemption flights (used in nominal planning priority scenario)
+    priority_preemption_flights:
+      resource_type: resources.flight_planning.FlightIntentsResource
+      specification:
+        planning_time: '0:05:00'
+        file_source: test_data.che.flight_intents.priority_preemption
+
+    # Location of DSS instance that can be used to verify flight planning outcomes
+    dss:
+      resource_type: resources.astm.f3548.v21.DSSInstanceResource
+      dependencies:
+        auth_adapter: utm_auth
+      specification:
+        # A USS that hosts a DSS instance is also a participant in the test, even if they don't fulfill any other roles
+        participant_id: uss1
+        base_url: http://host.docker.internal:8082

--- a/monitoring/uss_qualifier/configurations/personal/.gitignore
+++ b/monitoring/uss_qualifier/configurations/personal/.gitignore
@@ -1,1 +1,2 @@
 *.json
+*.yaml

--- a/monitoring/uss_qualifier/configurations/personal/README.md
+++ b/monitoring/uss_qualifier/configurations/personal/README.md
@@ -1,3 +1,3 @@
-# uss_qualifier.configurations.personal
+# configurations.personal
 
 Use this folder to store your personal configurations; they will be ignored when committing changes to git.

--- a/monitoring/uss_qualifier/scenarios/README.md
+++ b/monitoring/uss_qualifier/scenarios/README.md
@@ -6,7 +6,30 @@ A test scenario is a logical, self-contained scenario designed to test specific 
 
 ## Structure
 
-A test scenario is separated into of a list of test cases.  Each test case on the list is executed sequentially.  A test case is like an act in a play.
+A test scenario is separated into of a list of test cases, each of which are separated into a list of test steps, each of which have a set of checks that may be performed.  A test scenario is implemented as [`TestScenario`](scenario.py) subclass, and the context of current test case and test step is controlled by a state machine build into `TestScenario`, as is the performance of checks.
+
+### Test cases
+
+1. A test case is a single wholistic operation or action performed as part of a larger test scenario.
+    * Test cases are like acts in the "play" of the test scenario they are a part of.
+    * Test cases are typically the "gray headers” of the overview sequence diagrams.
+2. A given test case belongs to exactly one test scenario.
+3. A test case is composed of a list of test steps.
+    * Each test step on the list is executed sequentially.
+
+### Test steps
+
+1. A test step is a single task that must be performed in order to accomplish its associated test case.
+    * Test steps are like scenes in the "play/act" of the test scenario/test case they are a part of.
+2. A given test step belongs to exactly one test case.
+3. A test step may have a list of checks associated with it.
+
+### Checks
+
+1. A check is the lowest-level thing automated testing does – it is a single pass/fail evaluation of a single criterion for a requirement.
+2. A check evaluates information collected during the actions performed for a test step.
+3. A given check belongs to exactly one test step.
+4. Each check defines which requirement(s) are not met if the check fails.
 
 ## Creation
 

--- a/monitoring/uss_qualifier/suites/README.md
+++ b/monitoring/uss_qualifier/suites/README.md
@@ -1,0 +1,7 @@
+# USS Qualifier test suites
+
+A test suite is a set of tests that establish compliance to the thing they're named after.  Example: Passing the "ASTM F3548-21" test suite should indicate the systems under test are compliant with ASTM F3548-21.
+
+A test suite is composed of a list of {test suite|test scenario}; each element on the list is executed sequentially.
+
+A test suite is defined with a YAML file following the [`TestSuiteDefinition` schema](definitions.py).


### PR DESCRIPTION
This PR improves uss_qualifier documentation by

1. Providing actionable usage instructions on the main uss_qualifier page
2. Moving architecture details into individual architecture components' (suite, scenario, resource, configuration) pages
3. Adding a complete, commented sample configuration (self_contained_f3548) for users to base their custom configurations off of 