### PR TITLE
[uss_qualifier] Add single FlightPlannerResource

### DIFF
--- a/monitoring/uss_qualifier/action_generators/flight_planning/README.md
+++ b/monitoring/uss_qualifier/action_generators/flight_planning/README.md
@@ -1,0 +1,21 @@
+# Flight planning action generators
+
+This folder contains action generators related to USSs capable of flight planning.
+
+## [FlightPlannerCombinations](planner_combinations.py) action generator
+
+This action generator accepts a [FlightPlannersResource](../../resources/flight_planning/flight_planners.py) (note the plural) containing multiple USSs capable of flight planning and generates a specified action with combinations of flight planners from that resource provided as multiple [FlightPlannerResource](../../resources/flight_planning/flight_planners.py)s (note the singular) according to ResourceIDs specified as `roles`.  For instance, if a particular test scenario required two flight planners for the roles of `uss1` and `uss2`, a test designing might use a FlightPlannerCombinations to run that scenario multiple times according to a set of flight planner USSs to be tested.  If a `FlightPlannersResource` included {`ussA`, `ussB`, `ussC`} and the `FlightPlannerCombinations` action generator was configured to produce `ExampleTestScenario` actions from flight planner combinations for the roles `uss1` and `uss2`, then the scenarios below (or a subset, depending on configuration) would be produced as actions:
+
+| `uss1` resource | `uss2` resource | Action                |
+|-----------------|-----------------|-----------------------|
+| `ussA`          | `ussA`          | `ExampleTestScenario` |
+| `ussA`          | `ussB`          | `ExampleTestScenario` |
+| `ussA`          | `ussC`          | `ExampleTestScenario` |
+| `ussB`          | `ussA`          | `ExampleTestScenario` |
+| `ussB`          | `ussB`          | `ExampleTestScenario` |
+| `ussB`          | `ussC`          | `ExampleTestScenario` |
+| `ussC`          | `ussA`          | `ExampleTestScenario` |
+| `ussC`          | `ussB`          | `ExampleTestScenario` |
+| `ussC`          | `ussC`          | `ExampleTestScenario` |
+
+The usage intent for this action generator is to enable design of simple test scenarios with a small number of participants, but to automatically repeat that simple scenario with all applicable role assignment combinations given a list of flight planner USSs to test.

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Dict, Tuple, List, Optional
+from typing import Tuple, List
 from urllib.parse import urlparse
 
 from implicitdict import ImplicitDict
@@ -9,7 +9,6 @@ from monitoring.monitorlib.clients.scd_automated_testing import (
     clear_area,
     create_flight,
     delete_flight,
-    QueryError,
     get_version,
     get_capabilities,
 )
@@ -23,9 +22,6 @@ from monitoring.monitorlib.scd_automated_testing.scd_injection_api import (
     Capability,
     ClearAreaResponse,
     ClearAreaRequest,
-)
-from monitoring.uss_qualifier.resources.flight_planning.automated_test import (
-    FlightInjectionAttempt,
 )
 
 

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_planners.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_planners.py
@@ -1,7 +1,8 @@
-from typing import List, Iterable, Dict
+from typing import List, Iterable, Dict, Optional
 
 from implicitdict import ImplicitDict
 from monitoring.uss_qualifier.reports.report import ParticipantID
+from monitoring.uss_qualifier.resources.definitions import ResourceID
 
 from monitoring.uss_qualifier.resources.resource import Resource
 from monitoring.uss_qualifier.resources.communications import AuthAdapterResource
@@ -11,35 +12,53 @@ from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
 )
 
 
+class FlightPlannerSpecification(ImplicitDict):
+    flight_planner: FlightPlannerConfiguration
+
+
+class FlightPlannerResource(Resource[FlightPlannerSpecification]):
+    flight_planner: FlightPlanner
+
+    def __init__(
+        self,
+        specification: FlightPlannerSpecification,
+        auth_adapter: AuthAdapterResource,
+    ):
+        self.flight_planner = FlightPlanner(
+            specification.flight_planner, auth_adapter.adapter
+        )
+
+
 class FlightPlannersSpecification(ImplicitDict):
     flight_planners: List[FlightPlannerConfiguration]
 
 
 class FlightPlannersResource(Resource[FlightPlannersSpecification]):
-    flight_planners: List[FlightPlanner]
+    flight_planners: List[FlightPlannerResource]
 
     def __init__(
         self,
         specification: FlightPlannersSpecification,
         auth_adapter: AuthAdapterResource,
     ):
+        self._specification = specification
+        self._auth_adapter = auth_adapter
         self.flight_planners = [
-            FlightPlanner(p, auth_adapter.adapter)
+            FlightPlannerResource(
+                FlightPlannerSpecification(flight_planner=p), auth_adapter
+            )
             for p in specification.flight_planners
         ]
 
-    def make_subset(self, select_indices: Iterable[int]) -> "FlightPlannersResource":
-        subset = [self.flight_planners[i] for i in select_indices]
-        subset_resource = FlightPlannersResource.__new__(FlightPlannersResource)
-        subset_resource.flight_planners = subset
-        return subset_resource
+    def make_subset(self, select_indices: Iterable[int]) -> List[FlightPlannerResource]:
+        return [self.flight_planners[i] for i in select_indices]
 
 
 class FlightPlannerCombinationSelectorSpecification(ImplicitDict):
-    must_include: List[ParticipantID]
+    must_include: Optional[List[ParticipantID]]
     """The set of flight planners which must be included in every combination"""
 
-    maximum_roles: Dict[ParticipantID, int]
+    maximum_roles: Optional[Dict[ParticipantID, int]]
     """Maximum number of roles a particular participant may fill in any given combination"""
 
 
@@ -51,25 +70,30 @@ class FlightPlannerCombinationSelectorResource(
     def __init__(self, specification: FlightPlannerCombinationSelectorSpecification):
         self._specification = specification
 
-    def is_valid_combination(self, flight_planners: FlightPlannersResource):
-        participants = [p.participant_id for p in flight_planners.flight_planners]
-
-        accept_combination = True
+    def is_valid_combination(
+        self, flight_planners: Dict[ResourceID, FlightPlannerResource]
+    ):
+        participants = [
+            p.flight_planner.participant_id for p in flight_planners.values()
+        ]
 
         # Apply must_include criteria
-        for required_participant in self._specification.must_include:
-            if required_participant not in participants:
-                accept_combination = False
-                break
+        if "must_include" in self._specification:
+            for required_participant in self._specification.must_include:
+                if required_participant not in participants:
+                    return False
 
         # Apply maximum_roles criteria
-        for limited_participant, max_count in self._specification.maximum_roles.items():
-            count = sum(
-                (1 if participant == limited_participant else 0)
-                for participant in participants
-            )
-            if count > max_count:
-                accept_combination = False
-                break
+        if "maximum_roles" in self._specification:
+            for (
+                limited_participant,
+                max_count,
+            ) in self._specification.maximum_roles.items():
+                count = sum(
+                    (1 if participant == limited_participant else 0)
+                    for participant in participants
+                )
+                if count > max_count:
+                    return False
 
-        return accept_combination
+        return True

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.md
@@ -17,9 +17,13 @@ intent.
 
 FlightIntentsResource that provides at least 2 flight intents.  The first flight intent will be used for the successfully-planned flight and the second flight will be used for the failed flight.  Therefore, the second flight must intersect the first flight.
 
-### flight_planners
+### uss1
 
-FlightPlannersResource that provides exactly 2 flight planners (USSs).  The first flight planner will successfully plan the first flight.  The second flight planner will unsuccessfully attempt to plan the second flight.
+FlightPlannerResource that will successfully plan the first flight.
+
+### uss2
+
+FlightPlannerResource that will unsuccessfully attempt to plan the second flight.
 
 ### dss
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
@@ -8,10 +8,12 @@ from monitoring.uss_qualifier.resources.astm.f3548.v21 import DSSInstanceResourc
 from monitoring.uss_qualifier.resources.astm.f3548.v21.dss import DSSInstance
 from monitoring.uss_qualifier.resources.flight_planning import (
     FlightIntentsResource,
-    FlightPlannersResource,
 )
 from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
     FlightPlanner,
+)
+from monitoring.uss_qualifier.resources.flight_planning.flight_planners import (
+    FlightPlannerResource,
 )
 from monitoring.uss_qualifier.scenarios.astm.utm.test_steps import (
     validate_shared_operational_intent,
@@ -35,15 +37,13 @@ class NominalPlanning(TestScenario):
     def __init__(
         self,
         flight_intents: FlightIntentsResource,
-        flight_planners: FlightPlannersResource,
+        uss1: FlightPlannerResource,
+        uss2: FlightPlannerResource,
         dss: DSSInstanceResource,
     ):
         super().__init__()
-        if len(flight_planners.flight_planners) != 2:
-            raise ValueError(
-                f"`{self.me()}` TestScenario requires exactly 2 flight_planners; found {len(flight_planners.flight_planners)}"
-            )
-        self.uss1, self.uss2 = flight_planners.flight_planners
+        self.uss1 = uss1.flight_planner
+        self.uss2 = uss2.flight_planner
 
         flight_intents = flight_intents.get_flight_intents()
         if len(flight_intents) < 2:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
@@ -17,9 +17,13 @@ with higher priority.
 
 FlightIntentsResource that provides at least 2 flight intents.  The first flight intent will be planned normally and then the second flight will be planned on top of the first flight.  Therefore, the second flight must intersect the first flight, and the second flight must have higher priority than the first flight.
 
-### flight_planners
+### uss1
 
-FlightPlannersResource that provides exactly 2 flight planners (USSs).  The first flight planner will successfully plan the first flight.  The second flight planner successfully plan the second, higher-priority flight over the first one.
+FlightPlannerResource that will successfully plan the first flight.
+
+### uss2
+
+FlightPlannerResouce that will successfully plan the second, higher-priority flight over the first one.
 
 ### dss
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.py
@@ -11,6 +11,9 @@ from monitoring.uss_qualifier.resources.flight_planning import (
 from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
     FlightPlanner,
 )
+from monitoring.uss_qualifier.resources.flight_planning.flight_planners import (
+    FlightPlannerResource,
+)
 from monitoring.uss_qualifier.scenarios.astm.utm.test_steps import (
     validate_shared_operational_intent,
 )
@@ -33,15 +36,13 @@ class NominalPlanningPriority(TestScenario):
     def __init__(
         self,
         flight_intents: FlightIntentsResource,
-        flight_planners: FlightPlannersResource,
+        uss1: FlightPlannerResource,
+        uss2: FlightPlannerResource,
         dss: DSSInstanceResource,
     ):
         super().__init__()
-        if len(flight_planners.flight_planners) != 2:
-            raise ValueError(
-                f"`{self.me()}` TestScenario requires exactly 2 flight_planners; found {len(flight_planners.flight_planners)}"
-            )
-        self.uss1, self.uss2 = flight_planners.flight_planners
+        self.uss1 = uss1.flight_planner
+        self.uss2 = uss2.flight_planner
 
         flight_intents = flight_intents.get_flight_intents()
         if len(flight_intents) < 2:

--- a/monitoring/uss_qualifier/scenarios/scenario.py
+++ b/monitoring/uss_qualifier/scenarios/scenario.py
@@ -173,7 +173,7 @@ class TestScenario(ABC):
             if arg_name not in resource_pool:
                 available_pool = ", ".join(resource_pool)
                 raise ValueError(
-                    f'Resource to populate test scenario argument "{arg_name}" was not found in the resource pool when trying to create {self.scenario_type} test scenario (resource pool: {available_pool})'
+                    f'Resource to populate test scenario argument "{arg_name}" was not found in the resource pool when trying to create {declaration.scenario_type} test scenario (resource pool: {available_pool})'
                 )
             constructor_args[arg_name] = resource_pool[arg_name]
 

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.md
@@ -16,9 +16,9 @@ creation when all fields are valid.
 
 FlightIntentsResource that provides at least two flight intents.  The last flight intent is expected to be valid and should be planned successfully.  All preceding flight intents must have some problem with the flight authorisation data such that they should be rejected.
 
-### flight_planners
+### flight_planner
 
-FlightPlannersResource that provides exactly one flight planner (USSP) which should be tested.
+FlightPlannerResource that provides the flight planner (USSP) which should be tested.
 
 ## Setup test case
 

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
@@ -14,6 +14,9 @@ from monitoring.uss_qualifier.resources.flight_planning import (
 from monitoring.uss_qualifier.resources.flight_planning.flight_planner import (
     FlightPlanner,
 )
+from monitoring.uss_qualifier.resources.flight_planning.flight_planners import (
+    FlightPlannerResource,
+)
 from monitoring.uss_qualifier.scenarios.scenario import TestScenario
 from monitoring.uss_qualifier.scenarios.flight_planning.test_steps import (
     clear_area,
@@ -30,14 +33,10 @@ class Validation(TestScenario):
     def __init__(
         self,
         flight_intents: FlightIntentsResource,
-        flight_planners: FlightPlannersResource,
+        flight_planner: FlightPlannerResource,
     ):
         super().__init__()
-        if len(flight_planners.flight_planners) != 1:
-            raise ValueError(
-                f"`{self.me()}` TestScenario requires exactly 1 flight_planner; found {len(flight_planners.flight_planners)}"
-            )
-        self.ussp = flight_planners.flight_planners[0]
+        self.ussp = flight_planner.flight_planner
 
         intents = flight_intents.get_flight_intents()
         if len(intents) < 2:

--- a/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
+++ b/monitoring/uss_qualifier/suites/astm/utm/f3548_21.yaml
@@ -20,12 +20,15 @@ actions:
           scenario_type: scenarios.astm.utm.NominalPlanning
           resources:
             flight_intents: conflicting_flights
-            flight_planners: flight_planners
+            uss1: uss1
+            uss2: uss2
             dss: dss
         on_failure: Continue
       combination_selector_source: nominal_planning_selector
       flight_planners_source: flight_planners
-      roles: 2
+      roles:
+      - uss1
+      - uss2
   on_failure: Continue
 - action_generator:
     generator_type: action_generators.flight_planning.FlightPlannerCombinations
@@ -40,10 +43,13 @@ actions:
           scenario_type: scenarios.astm.utm.NominalPlanningPriority
           resources:
             flight_intents: priority_preemption_flights
-            flight_planners: flight_planners
+            uss1: uss1
+            uss2: uss2
             dss: dss
         on_failure: Continue
       combination_selector_source: priority_planning_selector
       flight_planners_source: flight_planners
-      roles: 2
+      roles:
+      - uss1
+      - uss2
   on_failure: Continue

--- a/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
+++ b/monitoring/uss_qualifier/suites/uspace/flight_auth.yaml
@@ -29,8 +29,9 @@ actions:
           scenario_type: scenarios.uspace.flight_auth.Validation
           resources:
             flight_intents: invalid_flight_auth_flights
-            flight_planners: flight_planners
+            flight_planner: flight_planner
         on_failure: Continue
       flight_planners_source: flight_planners
-      roles: 1
+      roles:
+      - flight_planner
   on_failure: Continue


### PR DESCRIPTION
Currently, the only test resource available to test scenarios for defining USSs that support flight planning (scd.yaml) is `FlightPlannersResource`, which specifies a list of flight planning USSs (flight planners).  This PR adds an alternate resource type: the singular `FlightPlannerResource` specifying exactly one flight planner.  This makes simple test scenario definitions clearer (each individual role can be defined explicitly), and it makes the FlightPlannerCombinations action generator much clearer: it produces multiple sets of FlightPlannerResources from a single FlightPlannersResource.  The latter behavior is now more clearly documented in a README.md, added in this PR.