### PR TITLE
[release] Support full semantic version in release tags

### DIFF
--- a/.github/workflows/dss-publish.yml
+++ b/.github/workflows/dss-publish.yml
@@ -9,7 +9,11 @@ on:
   push:
     tags:
       # To modify to trigger the job for fork's releases
-      - "interuss/dss/v[0-9]+.[0-9]+.[0-9]+"
+      # Note: GitHub's filter pattern capabilities are limited[1], so this
+      # pattern matches more often than it should.  A more correct regex would
+      # be the one found in scripts/tag.sh.
+      # [1] https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      - "interuss/dss/v[0-9]+.[0-9]+.[0-9]+-?*"
 jobs:
   docker-hub-push:
     name: DSS Build and Push to Docker Hub

--- a/Makefile
+++ b/Makefile
@@ -212,10 +212,8 @@ test-e2e:
 hygiene:
 	test/repo_hygiene/repo_hygiene.sh
 
-tag: VERSION = v$(MAJOR).$(MINOR).$(PATCH)
-
 tag:
-	scripts/tag.sh $(UPSTREAM_OWNER)/dss/$(VERSION)
+	scripts/tag.sh $(UPSTREAM_OWNER)/dss/v$(VERSION)
 
 start-locally:
 	build/dev/run_locally.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,20 @@
 # Release Management
 
-Releases of the DSS are based on git tags in the format `interuss/dss/v[0-9]+\.[0-9]+\.[0-9]+`. When either an executable or image is built from a `git` checkout of the source, the most recent tag is used as the version tag. If no such tag exists, the build system defaults to v0.0.0-[commit_hash]. If commits have been added to the tag, the commit hash is appended to the version. If the workspace is not clean, `-dirty` is appended to it. The version tag is computed by `scripts/git/version.sh`.
+Releases of the DSS are based on git tags in the format `interuss/dss/v[0-9]+\.[0-9]+\.[0-9]+`, optionally suffixed with `-[0-9A-Za-z-.]+`.  This tag form follows the pattern `[owner]/[component]/[semantic version]`; see [semantic version](https://semver.org) for more information.
 
-With that, releasing a DSS version in the canonical interuss fork requires the following steps:
-- Create a release tag on master using `make tag MAJOR=X MINOR=Y PATCH=Z`. The script will push a tag (`release tag`) to the remote origin under the form of `[owner]/dss/vX.Y.Z` where `[owner]` is either the organization name or the username of the origin remote url. Official releases are `interuss/dss/v#.#.#`.
-- The github workflow ([.github/workflows/dss-publish.yml](.github/workflows/dss-publish.yml)) is triggered for every new release tag. It builds and publishes the DSS image to the [official docker registry](https://hub.docker.com/repository/docker/interuss/dss).
+When either an executable or image is built from a `git` checkout of the source, the most recent tag is used as the version tag. If no such tag exists, the build system defaults to v0.0.0-[commit_hash]. If commits have been added to the tag, the commit hash is appended to the version. If the workspace is not clean, `-dirty` is appended to it. The version tag is computed by [`scripts/git/version.sh`](scripts/git/version.sh).
+
+Releasing a DSS version requires the following steps:
+- Create a release tag on master using `make tag VERSION=X.Y.Z[-W]`. The script will push a tag (`release tag`) to the remote origin under the form of `[owner]/dss/vX.Y.Z[-W]`, where
+    - `[owner]` is either the organization name or the username of the origin remote url
+    - `X` is the major release number
+    - `Y` is the minor release number
+    - `Z` is the patch number
+    - (optionally) `W` is the prerelease
+    - `X.Y.Z[-W]` is according to [semantic versioning](https://semver.org)
+        - Note that valid examples of this form include `0.1.0`, `20.0.0`, `0.5.0-rc`, `0.5.0-1.2`
+    - Official releases are `interuss/dss/v#.#.#`.
+- The github workflow ([.github/workflows/dss-publish.yml](.github/workflows/dss-publish.yml)) is triggered for every new release tag. On the canonical interuss fork, it builds and publishes the DSS image to the [official docker registry](https://hub.docker.com/repository/docker/interuss/dss).
 
 To enable releases of DSS version in a fork, the following steps are required:
   1. Set the remote origin url of the repository of the target fork. (ie git@github.com:[owner]/dss.git)
@@ -14,10 +24,6 @@ To enable releases of DSS version in a fork, the following steps are required:
 
 Optionally, you can manually build the DSS docker image using [build/build.sh](build/build.sh), tag accordingly the image `interuss-local/dss` and push it out to an image registry of your choice.
 
-# CockroachDB Version
+# Historical CockroachDB version note
 
-When possible we try to use the latest version major and minor of CockroachDB (v 20.2.x). CRDB 20.2.0 comes with upgrades to the underlying storage of CRDB itself using a branched version of RocksDB called Pebble.
-
-## Backwards Compatibility
-
-20.2.x is backwards compatible with the files written by 20.1.x and upgrades are simple. However you CANNOT downgrade back to 20.1.x as the new version updates the metadata and prevents the older version of the CRDB to be started on same files. Although 20.2.x is compatible with 20.1.x in the same cluster; it was recommended that you quickly upgrade all the remianing nodes to 20.2.x and reduce the version drift as much as possible. The possible negative effect of running a mixed cluster is the difference in features available between the nodes, you must be sure that you are not leveraging the new or deprecated features as this could negatively affect your queries.
+We try to use the latest version major and minor of CockroachDB.  For a legacy deployment with CRDB prior to v20.2.0, know that CRDB 20.2.0 comes with upgrades to the underlying storage of CRDB itself using a branched version of RocksDB called Pebble.  20.2.x is backwards compatible with the files written by 20.1.x and upgrades are simple. However you CANNOT downgrade back to 20.1.x as the new version updates the metadata and prevents the older version of the CRDB to be started on same files. Although 20.2.x is compatible with 20.1.x in the same cluster, operators should quickly upgrade all the remaining nodes to 20.2.x and reduce the version drift as much as possible. The possible negative effect of running a mixed cluster is the difference in features available between the nodes, the operator must be sure not to leverage the new or deprecated features as this could negatively affect queries.

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -2,24 +2,26 @@
 
 # We only enable -o pipefail after having verified that
 # the command line argument satisfies format requirements.
-version=$(echo "$1" | grep -E '.+/.+/v[0-9]+\.[0-9]+\.[0-9]+')
+# Semantic versioning regex (suffixed below) from:
+# https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+tag_regex='^[^/]+/[^/]+/v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+tag=$(echo "$1" | grep -E ${tag_regex})
 
 set -e
+
+if test -z "${tag}"; then
+  echo "requested tag \"${1}\" does not match expected tag format [owner]/[component]/[semantic version] using the pattern ${tag_regex}" && false
+fi
 
 branch=$(git rev-parse --abbrev-ref HEAD)
 
 if test "${branch}" != "master"; then
-  echo "releases are only supported on master" && false
+  echo "releases are only supported on master branch (currently on ${branch})" && false
 fi
 
 if test -n "$(git status -s)"; then
-  echo "releases are only supported on clean workspace" && false
+  echo "releases are only supported in a clean git workspace" && false
 fi
 
-if test -z "${version}"; then
-  echo "${1} does not match .+/.+/v[0-9]+\.[0-9]+\.[0-9]+" && false
-fi
-
-git tag -a "${version}"
-git push origin "${version}"
-
+git tag -a "${tag}"
+git push origin "${tag}"

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -5,7 +5,7 @@
 # Semantic versioning regex (suffixed below) from:
 # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 tag_regex='^[^/]+/[^/]+/v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
-tag=$(echo "$1" | grep -E ${tag_regex})
+tag=$(echo "$1" | grep -E "${tag_regex}")
 
 set -e
 


### PR DESCRIPTION
This PR adds the ability to specify a full semantic version (including a "pre-release" suffix) for a desired DSS release tag, per [semantic versioning](https://semver.org).  The format for `make tag` is correspondingly updated, as is the documentation in RELEASE.md (also including cleanup of unrelated content at the bottom).