### PR TITLE
[dss/dev] Clean up local checks

### DIFF
--- a/build/dev/check_dss.sh
+++ b/build/dev/check_dss.sh
@@ -6,18 +6,10 @@ set -eo pipefail
 # DSS instance using any of the deployment methods described in
 # standalone_instance.md.
 
-if [[ -z $(command -v jq) ]]; then
-  echo "This script requires the jq utility.  On Debian Linux, install with"
-  echo "  sudo apt-get install jq"
-  echo "With homebrew, install with"
-  echo "  brew install jq"
-  exit 1
-fi
-
 # Retrieve token from dummy OAuth server
-ACCESS_TOKEN=$(curl --silent -X POST \
+ACCESS_TOKEN=$(curl --silent \
   "http://localhost:8085/token?grant_type=client_credentials&scope=dss.read.identification_service_areas&intended_audience=localhost&issuer=localhost" \
-  | jq -r '.access_token')
+  | python extract_json_field.py access_token)
 
 # Retrieve Identification Service Areas currently active on Mauna Loa
 echo "DSS response to Mauna Loa ISA query:"

--- a/build/dev/check_scd_clear.sh
+++ b/build/dev/check_scd_clear.sh
@@ -15,15 +15,15 @@ fi
 cd "${BASEDIR}" || exit 1
 
 # Retrieve token from dummy OAuth server
-ACCESS_TOKEN=$(curl --silent -X POST \
+ACCESS_TOKEN=$(curl --silent \
     "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination%20utm.constraint_management&intended_audience=localhost&issuer=localhost&sub=check_scd" \
-| jq -r '.access_token')
+| python extract_json_field.py access_token)
 
 
 echo "DSS response to [SCD] DELETE subscription query:"
 echo "============="
 
-VERSION=$(./read_scd_subscription.sh 00000158-9aba-4026-bbef-bad6cde80000 | jq -r '.subscription.version')
+VERSION=$(./read_scd_subscription.sh 00000158-9aba-4026-bbef-bad6cde80000 | python extract_json_field.py 'subscription.version')
 
 curl --silent -X DELETE  \
 "http://localhost:8082/dss/v1/subscriptions/00000158-9aba-4026-bbef-bad6cde80000/${VERSION}" \
@@ -34,7 +34,7 @@ echo
 echo "DSS response to [SCD] DELETE constraint reference query:"
 echo "============="
 
-VERSION=$(./read_scd_constraint_reference.sh 00000159-9aba-4026-bbef-bad6cde80000 | jq -r '.constraint_reference.version')
+VERSION=$(./read_scd_constraint_reference.sh 00000159-9aba-4026-bbef-bad6cde80000 | python extract_json_field.py 'constraint_reference.version')
 
 curl --silent -X DELETE  "http://localhost:8082/dss/v1/constraint_references/00000159-9aba-4026-bbef-bad6cde80000/${VERSION}"  \
 -H "Authorization: Bearer ${ACCESS_TOKEN}"  \
@@ -45,7 +45,7 @@ echo
 echo "DSS response to [SCD] DELETE operational intent reference query:"
 echo "=========="
 
-VERSION=$(./read_scd_operational_intent_reference.sh 0000015a-9aba-4026-bbef-bad6cde80000 | jq -r '.operational_intent_reference.version')
+VERSION=$(./read_scd_operational_intent_reference.sh 0000015a-9aba-4026-bbef-bad6cde80000 | python extract_json_field.py 'operational_intent_reference.version')
 
 curl --silent -X DELETE  "http://localhost:8082/dss/v1/operational_intent_references/0000015a-9aba-4026-bbef-bad6cde80000/${VERSION}"  \
  -H "Authorization: Bearer ${ACCESS_TOKEN}"  \

--- a/build/dev/check_scd_write.sh
+++ b/build/dev/check_scd_write.sh
@@ -5,9 +5,9 @@ set -eo pipefail
 # This script is to perform simple write operations on SCD database for testing.
 
 # Retrieve token from dummy OAuth server
-ACCESS_TOKEN=$(curl --silent -X POST \
+ACCESS_TOKEN=$(curl --silent \
     "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination%20utm.constraint_management&intended_audience=localhost&issuer=localhost&sub=check_scd" \
-| jq -r '.access_token')
+| python extract_json_field.py 'access_token')
 
 
 echo "DSS response to [SCD] PUT subscription query:"

--- a/build/dev/check_subs.sh
+++ b/build/dev/check_subs.sh
@@ -6,18 +6,10 @@ set -eo pipefail
 # DSS instance using any of the deployment method described in
 # standalone_instance.md.
 
-if jq --version > /dev/null; then
-  echo "This script requires the jq utility.  On Debian Linux, install with"
-  echo "  sudo apt-get install jq"
-  echo "With homebrew, install with"
-  echo "  brew install jq"
-  exit 1
-fi
-
 # Retrieve token from dummy OAuth server
-ACCESS_TOKEN=$(curl --silent -X POST \
+ACCESS_TOKEN=$(curl --silent \
   "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination&intended_audience=localhost&issuer=localhost" \
-  | jq -r '.access_token')
+  | python extract_json_field.py 'access_token')
 
 echo "DSS response to [SCD] PUT Subscriptions query:"
 echo "============="

--- a/build/dev/extract_json_field.py
+++ b/build/dev/extract_json_field.py
@@ -1,0 +1,20 @@
+"""Simple script to extract a field from a JSON representation on stdin."""
+
+import json
+import sys
+
+s = ""
+try:
+    for line in sys.stdin:
+        s += line + "\n"
+except KeyboardInterrupt:
+    pass
+
+try:
+    obj = json.loads(s)
+except ValueError as e:
+    raise ValueError(str(e) + "\nvvvvv Unable to decode JSON: vvvvv\n" + s + "^^^^^ Unable to decode JSON: ^^^^^")
+fields = sys.argv[1].split(".")
+for field in fields:
+    obj = obj[field]
+print(obj)

--- a/build/dev/read_scd_constraint_reference.sh
+++ b/build/dev/read_scd_constraint_reference.sh
@@ -8,9 +8,9 @@ constraint_id=$1
 [[ -z "$constraint_id" ]] && { echo "Error: Constraint ID not provided."; exit 1; }
 
 # Retrieve token from dummy OAuth server
-ACCESS_TOKEN=$(curl --silent -X POST \
+ACCESS_TOKEN=$(curl --silent \
     "http://localhost:8085/token?grant_type=client_credentials&scope=utm.constraint_processing&intended_audience=localhost&issuer=localhost&sub=check_scd" \
-| jq -r '.access_token')
+| python extract_json_field.py 'access_token')
 
 curl --silent -X GET  "http://localhost:8082/dss/v1/constraint_references/$constraint_id"  \
 -H "Authorization: Bearer ${ACCESS_TOKEN}"  \

--- a/build/dev/read_scd_operational_intent_reference.sh
+++ b/build/dev/read_scd_operational_intent_reference.sh
@@ -8,9 +8,9 @@ operation_id=$1
 [[ -z "$operation_id" ]] && { echo "Error: Operation ID not provided"; exit 1; }
 
 # Retrieve token from dummy OAuth server
-ACCESS_TOKEN=$(curl --silent -X POST \
+ACCESS_TOKEN=$(curl --silent \
     "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination&intended_audience=localhost&issuer=localhost&sub=check_scd" \
-| jq -r '.access_token')
+| python extract_json_field.py 'access_token')
 
 curl --silent -X GET  "http://localhost:8082/dss/v1/operational_intent_references/$operation_id"  \
 -H "Authorization: Bearer ${ACCESS_TOKEN}"  \

--- a/build/dev/read_scd_subscription.sh
+++ b/build/dev/read_scd_subscription.sh
@@ -8,9 +8,9 @@ subscription_id=$1
 [[ -z "$subscription_id" ]] && { echo "Error: Subscription ID not provided"; exit 1; }
 
 # Retrieve token from dummy OAuth server
-ACCESS_TOKEN=$(curl --silent -X POST \
+ACCESS_TOKEN=$(curl --silent \
     "http://localhost:8085/token?grant_type=client_credentials&scope=utm.strategic_coordination&intended_audience=localhost&issuer=localhost&sub=check_scd" \
-| jq -r '.access_token')
+| python extract_json_field.py 'access_token')
 
 curl --silent -X GET  \
 "http://localhost:8082/dss/v1/subscriptions/$subscription_id" \


### PR DESCRIPTION
Currently, some check scripts for a local DSS deployment are broken (due to #901 correcting the HTTP method for dummy auth), and the `jq` dependency is unnecessary.  This PR corrects those two issues in preparation for incorporating these checks into an additional step in the CI (in another PR).