### PR TITLE
[monitoring/mock_uss] Improve management capabilities of local USS mocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,14 @@ start-locally:
 probe-locally:
 	monitoring/prober/run_locally.sh
 
+.PHONY: start-uss-mocks
+start-uss-mocks:
+	monitoring/mock_uss/start_all_local_mocks.sh
+
+.PHONY: stop-uss-mocks
+stop-uss-mocks:
+	monitoring/mock_uss/stop_all_local_mocks.sh
+
 .PHONY: collect-local-logs
 collect-local-logs:
 	docker logs dss_sandbox_local-dss-core-service_1 2> core-service-for-testing.log

--- a/build/dev/wait_for_local_dss.sh
+++ b/build/dev/wait_for_local_dss.sh
@@ -14,7 +14,7 @@ for container_name in "${localhost_containers[@]}"; do
     if [ "${new_message}" = "${last_message}" ]; then
       printf "."
     else
-      printf '..%s..' "${new_message}"
+      printf '%s' "${new_message}"
       last_message="${new_message}"
     fi
     sleep 3
@@ -34,7 +34,7 @@ while true; do
       if [ "${new_message}" = "${last_message}" ]; then
         printf "."
       else
-        printf '..%s..' "${new_message}"
+        printf '%s' "${new_message}"
         last_message="${new_message}"
       fi
       sleep 3

--- a/monitoring/mock_uss/run_locally_base.sh
+++ b/monitoring/mock_uss/run_locally_base.sh
@@ -15,4 +15,6 @@ echo '## NOTE: Prerequisite to run this command is:                          ##'
 echo '## Local DSS instance + Dummy OAuth server (/build/dev/run_locally.sh) ##'
 echo '#########################################################################'
 
-monitoring/build.sh || exit 1
+if [ -z "${DO_NOT_BUILD_MONITORING}" ]; then
+  monitoring/build.sh || exit 1
+fi

--- a/monitoring/mock_uss/run_locally_geoawareness.sh
+++ b/monitoring/mock_uss/run_locally_geoawareness.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-"${SCRIPT_DIR}/../build.sh" || exit 1
+if [ -z "${DO_NOT_BUILD_MONITORING}" ]; then
+  "${SCRIPT_DIR}/../build.sh" || exit 1
+fi
 
 PUBLIC_KEY="/var/test-certs/auth2.pem"
 AUD=${MOCK_USS_TOKEN_AUDIENCE:-localhost,host.docker.internal}
@@ -19,6 +21,8 @@ if [ "$TEST" == "true" ]; then
   AUD="localhost"
   docker_command="mock_uss/test.sh"
 fi
+
+docker container rm -f mock_uss_geoawareness || echo "mock_uss_geoawareness container was not already running"
 
 # shellcheck disable=SC2086
 docker run ${docker_args} --name mock_uss_geoawareness \

--- a/monitoring/mock_uss/start_all_local_mocks.sh
+++ b/monitoring/mock_uss/start_all_local_mocks.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../.." || exit 1
+
+monitoring/mock_uss/run_locally_scdsc.sh -d
+export DO_NOT_BUILD_MONITORING=true
+monitoring/mock_uss/run_locally_ridsp.sh -d
+monitoring/mock_uss/run_locally_riddp.sh -d
+monitoring/mock_uss/run_locally_geoawareness.sh -d
+monitoring/mock_uss/wait_for_mock_uss.sh mock_uss_scdsc
+monitoring/mock_uss/wait_for_mock_uss.sh mock_uss_ridsp
+monitoring/mock_uss/wait_for_mock_uss.sh mock_uss_riddp
+monitoring/mock_uss/wait_for_mock_uss.sh mock_uss_geoawareness

--- a/monitoring/mock_uss/stop_all_local_mocks.sh
+++ b/monitoring/mock_uss/stop_all_local_mocks.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../.." || exit 1
+
+docker container rm -f mock_uss_scdsc mock_uss_ridsp mock_uss_riddp mock_uss_geoawareness

--- a/monitoring/mock_uss/wait_for_mock_uss.sh
+++ b/monitoring/mock_uss/wait_for_mock_uss.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+MOCK_USS_CONTAINER="${1:?The mock_uss container name must be specified (e.g., wait_for_mock_uss.sh mock_uss_scdsc)}"
+
+# Check that container is running
+last_message=""
+while true; do
+  if [ "$( docker container inspect -f '{{.State.Status}}' "${MOCK_USS_CONTAINER}" 2>/dev/null)" = "running" ]; then
+    break
+  fi
+  new_message="Waiting for ${MOCK_USS_CONTAINER} container to start..."
+  if [ "${new_message}" = "${last_message}" ]; then
+    printf "."
+  else
+    printf '%s' "${new_message}"
+    last_message="${new_message}"
+  fi
+  sleep 3
+done
+if [ -n "${last_message}" ]; then
+  echo ""
+fi
+
+last_message=""
+while true; do
+  health_status="$( docker container inspect -f '{{.State.Health.Status}}' "${MOCK_USS_CONTAINER}" )"
+    if [ "${health_status}" = "healthy" ]; then
+      break
+    else
+      new_message="Waiting for ${MOCK_USS_CONTAINER} to be available (currently ${health_status})..."
+      if [ "${new_message}" = "${last_message}" ]; then
+        printf "."
+      else
+        printf '%s' "${new_message}"
+        last_message="${new_message}"
+      fi
+      sleep 3
+    fi
+done
+if [ -n "${last_message}" ]; then
+  echo ""
+fi
+
+echo "Mock USS ${MOCK_USS_CONTAINER} is now available."

--- a/monitoring/mock_uss/wait_for_mock_uss.sh
+++ b/monitoring/mock_uss/wait_for_mock_uss.sh
@@ -2,6 +2,9 @@
 
 MOCK_USS_CONTAINER="${1:?The mock_uss container name must be specified (e.g., wait_for_mock_uss.sh mock_uss_scdsc)}"
 
+n_delays=0
+max_delays=20
+
 # Check that container is running
 last_message=""
 while true; do
@@ -16,6 +19,12 @@ while true; do
     last_message="${new_message}"
   fi
   sleep 3
+  ((n_delays=n_delays+1))
+  if [ $n_delays -gt $max_delays ]; then
+    echo ""
+    echo "Mock USS container ${MOCK_USS_CONTAINER} did not start in a reasonable amount of time"
+    exit 1
+  fi
 done
 if [ -n "${last_message}" ]; then
   echo ""
@@ -35,6 +44,12 @@ while true; do
         last_message="${new_message}"
       fi
       sleep 3
+      ((n_delays=n_delays+1))
+      if [ $n_delays -gt $max_delays ]; then
+        echo ""
+        echo "Mock USS container ${MOCK_USS_CONTAINER} did not become healthy in a reasonable amount of time"
+        exit 1
+      fi
     fi
 done
 if [ -n "${last_message}" ]; then

--- a/monitoring/uss_qualifier/scripts/test_docker_fully_mocked.sh
+++ b/monitoring/uss_qualifier/scripts/test_docker_fully_mocked.sh
@@ -13,23 +13,16 @@ else
 fi
 cd "${BASEDIR}/../../.." || exit 1
 
-containers=(mock_uss_ridsp mock_uss_riddp mock_uss_scdsc dss_sandbox_local-dss-core-service_1)
-
 echo "Ensure the environment is clean"
 echo "============="
-build/dev/run_locally.sh down
-for container_name in "${containers[@]}"; do
-  docker container kill "$container_name" || echo "No pre-existing $container_name"
-done
+make down-locally
+make stop-uss-mocks
 
 function cleanup() {
   echo "Clean up"
   echo "============="
-  for container_name in "${containers[@]}"; do
-    docker container kill "$container_name"
-  done
-
-  build/dev/run_locally.sh down
+  make stop-uss-mocks
+  make down-locally
 }
 
 function on_exit() {
@@ -46,28 +39,18 @@ trap on_sigint SIGINT
 
 echo "Start mock system"
 echo "============="
-build/dev/run_locally.sh up -d
-monitoring/mock_uss/run_locally_ridsp.sh -d
-monitoring/mock_uss/run_locally_riddp.sh -d
-monitoring/mock_uss/run_locally_scdsc.sh -d
-
-echo "Wait for system to be healthy"
-echo "============="
-for container_name in "${containers[@]}"; do
-    retry=0
-    max_retry=6
-    until [ "$(docker inspect -f \{\{.State.Health.Status\}\} "${container_name}")" == "healthy" ]; do
-        if [ "$retry" -gt "$max_retry" ]; then
-            echo "$container_name logs:"
-            docker logs "$container_name"
-            echo "$container_name didn't properly start. Exit." && exit 1
-        fi
-        echo "Waiting for $container_name to become healthy..."
-        sleep 10
-        retry=$((retry+1))
-    done
-done
+make start-locally
+make start-uss-mocks
 
 echo "Run the standard local tests."
 echo "============="
 monitoring/uss_qualifier/run_locally.sh
+
+# Ensure all tests passed
+successful=$(python build/dev/extract_json_field.py report.test_suite.successful < monitoring/uss_qualifier/report.json)
+if echo "${successful}" | grep -iqF true; then
+  echo "All uss_qualifier tests passed."
+else
+  echo "Could not establish that all uss_qualifier tests passed."
+  exit 1
+fi


### PR DESCRIPTION
Currently, a user is required to run a number of separate commands to bring up various pieces of a local system that can be tested by uss_qualifier's standard local test.  This PR adds two commands to easily bring up the mock_uss instances required by the standard local uss_qualifier test (`make start-uss-mocks` and `make stop-uss-mocks`) and harmonizes approaches to managing these mocks.

It also adds a small check at the end of uss_qualifier's standard automated tests (used in CI) to verify that the uss_qualifier report indicated successs.