### PR TITLE
[uss_qualifier] Add activation to priority planning scenario

### DIFF
--- a/monitoring/mock_uss/scdsc/database.py
+++ b/monitoring/mock_uss/scdsc/database.py
@@ -19,7 +19,7 @@ class FlightRecord(ImplicitDict):
 class Database(ImplicitDict):
     """Simple in-memory pseudo-database tracking the state of the mock system"""
 
-    flights: Dict[str, FlightRecord] = {}
+    flights: Dict[str, Optional[FlightRecord]] = {}
     cached_operations: Dict[str, scd.OperationalIntent] = {}
 
 

--- a/monitoring/mock_uss/scdsc/database.py
+++ b/monitoring/mock_uss/scdsc/database.py
@@ -13,6 +13,7 @@ class FlightRecord(ImplicitDict):
     op_intent_injection: scd_injection_api.OperationalIntentTestInjection
     flight_authorisation: scd_injection_api.FlightAuthorisationData
     op_intent_reference: scd.OperationalIntentReference
+    locked: bool = False
 
 
 class Database(ImplicitDict):

--- a/monitoring/mock_uss/scdsc/routes.py
+++ b/monitoring/mock_uss/scdsc/routes.py
@@ -1,12 +1,4 @@
-from typing import List, Tuple
-
-import flask
-
-from monitoring.monitorlib import scd
-from monitoring.monitorlib.clients import scd as scd_client
-from implicitdict import ImplicitDict
-from monitoring.mock_uss import resources, webapp
-from monitoring.mock_uss.scdsc.database import db
+from monitoring.mock_uss import webapp
 
 
 @webapp.route("/scdsc/status")

--- a/monitoring/mock_uss/scdsc/routes_injection.py
+++ b/monitoring/mock_uss/scdsc/routes_injection.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import time
 from typing import List, Tuple
 import uuid
 
@@ -92,6 +93,7 @@ def scd_capabilities() -> Tuple[str, int]:
 @requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
 def inject_flight(flight_id: str) -> Tuple[str, int]:
     """Implements flight injection in SCD automated testing injection API."""
+    print(f"[inject_flight:{flight_id}] Starting handler")
     try:
         json = flask.request.json
         if json is None:
@@ -103,6 +105,7 @@ def inject_flight(flight_id: str) -> Tuple[str, int]:
 
     if webapp.config[config.KEY_BEHAVIOR_LOCALITY].is_uspace_applicable:
         # Validate flight authorisation
+        print(f"[inject_flight:{flight_id}] Validating flight authorisation")
         problems = problems_with_flight_authorisation(req_body.flight_authorisation)
         if problems:
             return flask.jsonify(
@@ -111,105 +114,162 @@ def inject_flight(flight_id: str) -> Tuple[str, int]:
                 )
             )
 
-    # Check for operational intents in the DSS
-    start_time = scd.start_of(req_body.operational_intent.volumes)
-    end_time = scd.end_of(req_body.operational_intent.volumes)
-    area = scd.rect_bounds_of(req_body.operational_intent.volumes)
-    alt_lo, alt_hi = scd.meter_altitude_bounds_of(req_body.operational_intent.volumes)
-    vol4 = scd.make_vol4(
-        start_time, end_time, alt_lo, alt_hi, polygon=scd.make_polygon(latlngrect=area)
-    )
-    try:
-        op_intents = query_operational_intents(vol4)
-    except (
-        ValueError,
-        scd_client.OperationError,
-        requests.exceptions.ConnectionError,
-        ConnectionError,
-    ) as e:
-        notes = "Error querying operational intents: {}".format(e)
-        return (
-            flask.jsonify(
-                InjectFlightResponse(result=InjectFlightResult.Failed, notes=notes)
-            ),
-            200,
-        )
+    # Check if this is an existing flight being modified
+    while True:
+        with db as tx:
+            if flight_id in tx.flights:
+                # This is an existing flight being modified
+                existing_flight = tx.flights[flight_id]
+                if not existing_flight.locked:
+                    print(
+                        f"[inject_flight:{flight_id}] Existing flight locked for update"
+                    )
+                    existing_flight.locked = True
+                    break
+            else:
+                print(f"[inject_flight:{flight_id}] Request is for a new flight")
+                existing_flight = None
+                break
+        # We found an existing flight but it was locked; wait for it to become
+        # available
+        time.sleep(0.5)
 
-    # Check for intersections
-    v1 = req_body.operational_intent.volumes
-    for op_intent in op_intents:
-        if req_body.operational_intent.priority > op_intent.details.priority:
-            continue
-        if webapp.config[
-            config.KEY_BEHAVIOR_LOCALITY
-        ].allow_same_priority_intersections:
-            continue
-        v2a = op_intent.details.volumes
-        v2b = op_intent.details.off_nominal_volumes
-        if scd.vol4s_intersect(v1, v2a) or scd.vol4s_intersect(v1, v2b):
-            notes = "Requested flight intersected {}'s operational intent {}".format(
-                op_intent.reference.manager, op_intent.reference.id
-            )
+    try:
+        # Check for operational intents in the DSS
+        print(
+            f"[inject_flight:{flight_id}] Checking for operational intents in the DSS"
+        )
+        start_time = scd.start_of(req_body.operational_intent.volumes)
+        end_time = scd.end_of(req_body.operational_intent.volumes)
+        area = scd.rect_bounds_of(req_body.operational_intent.volumes)
+        alt_lo, alt_hi = scd.meter_altitude_bounds_of(
+            req_body.operational_intent.volumes
+        )
+        vol4 = scd.make_vol4(
+            start_time,
+            end_time,
+            alt_lo,
+            alt_hi,
+            polygon=scd.make_polygon(latlngrect=area),
+        )
+        try:
+            op_intents = query_operational_intents(vol4)
+        except (
+            ValueError,
+            scd_client.OperationError,
+            requests.exceptions.ConnectionError,
+            ConnectionError,
+        ) as e:
+            notes = "Error querying operational intents: {}".format(e)
             return (
                 flask.jsonify(
-                    InjectFlightResponse(
-                        result=InjectFlightResult.ConflictWithFlight, notes=notes
-                    )
+                    InjectFlightResponse(result=InjectFlightResult.Failed, notes=notes)
                 ),
                 200,
             )
 
-    # Create operational intent in DSS
-    base_url = "{}/mock/scd".format(webapp.config[config.KEY_BASE_URL])
-    req = scd.PutOperationalIntentReferenceParameters(
-        extents=req_body.operational_intent.volumes,
-        key=[op.reference.ovn for op in op_intents],
-        state=req_body.operational_intent.state,
-        uss_base_url=base_url,
-        new_subscription=scd.ImplicitSubscriptionParameters(uss_base_url=base_url),
-    )
-    id = str(uuid.uuid4())
-    try:
-        result = scd_client.create_operational_intent_reference(
-            resources.utm_client, id, req
+        # Check for intersections
+        print(
+            f"[inject_flight:{flight_id}] Checking for intersections with {', '.join(op_intent.reference.id for op_intent in op_intents)}"
         )
-    except (
-        ValueError,
-        scd_client.OperationError,
-        requests.exceptions.ConnectionError,
-        ConnectionError,
-    ) as e:
-        notes = "Error creating operational intent: {}".format(e)
-        return (
-            flask.jsonify(
-                InjectFlightResponse(result=InjectFlightResult.Failed, notes=notes)
+        v1 = req_body.operational_intent.volumes
+        for op_intent in op_intents:
+            if (
+                existing_flight
+                and existing_flight.op_intent_reference.id == op_intent.reference.id
+            ):
+                continue
+            if req_body.operational_intent.priority > op_intent.details.priority:
+                continue
+            if webapp.config[
+                config.KEY_BEHAVIOR_LOCALITY
+            ].allow_same_priority_intersections:
+                continue
+            v2a = op_intent.details.volumes
+            v2b = op_intent.details.off_nominal_volumes
+            if scd.vol4s_intersect(v1, v2a) or scd.vol4s_intersect(v1, v2b):
+                notes = f"Requested flight (priority {req_body.operational_intent.priority}) intersected {op_intent.reference.manager}'s operational intent {op_intent.reference.id} (priority {op_intent.details.priority})"
+                return (
+                    flask.jsonify(
+                        InjectFlightResponse(
+                            result=InjectFlightResult.ConflictWithFlight, notes=notes
+                        )
+                    ),
+                    200,
+                )
+
+        # Create operational intent in DSS
+        print(f"[inject_flight:{flight_id}] Sharing operational intent with DSS")
+        base_url = "{}/mock/scd".format(webapp.config[config.KEY_BASE_URL])
+        req = scd.PutOperationalIntentReferenceParameters(
+            extents=req_body.operational_intent.volumes,
+            key=[op.reference.ovn for op in op_intents],
+            state=req_body.operational_intent.state,
+            uss_base_url=base_url,
+            new_subscription=scd.ImplicitSubscriptionParameters(uss_base_url=base_url),
+        )
+        try:
+            if existing_flight:
+                id = existing_flight.op_intent_reference.id
+                result = scd_client.update_operational_intent_reference(
+                    resources.utm_client,
+                    id,
+                    existing_flight.op_intent_reference.ovn,
+                    req,
+                )
+            else:
+                id = str(uuid.uuid4())
+                result = scd_client.create_operational_intent_reference(
+                    resources.utm_client, id, req
+                )
+        except (
+            ValueError,
+            scd_client.OperationError,
+            requests.exceptions.ConnectionError,
+            ConnectionError,
+        ) as e:
+            notes = "Error creating operational intent: {}".format(e)
+            print(f"[inject_flight:{flight_id}] {notes}")
+            return (
+                flask.jsonify(
+                    InjectFlightResponse(result=InjectFlightResult.Failed, notes=notes)
+                ),
+                200,
+            )
+        print(
+            f"[inject_flight:{flight_id}] Notifying subscribers {', '.join(s.uss_base_url for s in result.subscribers)}"
+        )
+        scd_client.notify_subscribers(
+            resources.utm_client,
+            result.operational_intent_reference.id,
+            scd.OperationalIntent(
+                reference=result.operational_intent_reference,
+                details=req_body.operational_intent,
             ),
-            200,
+            result.subscribers,
         )
-    scd_client.notify_subscribers(
-        resources.utm_client,
-        result.operational_intent_reference.id,
-        scd.OperationalIntent(
-            reference=result.operational_intent_reference,
-            details=req_body.operational_intent,
-        ),
-        result.subscribers,
-    )
 
-    # Store flight in database
-    record = database.FlightRecord(
-        op_intent_reference=result.operational_intent_reference,
-        op_intent_injection=req_body.operational_intent,
-        flight_authorisation=req_body.flight_authorisation,
-    )
-    with db as tx:
-        tx.flights[flight_id] = record
-
-    return flask.jsonify(
-        InjectFlightResponse(
-            result=InjectFlightResult.Planned, operational_intent_id=id
+        # Store flight in database
+        print(f"[inject_flight:{flight_id}] Storing flight in database")
+        record = database.FlightRecord(
+            op_intent_reference=result.operational_intent_reference,
+            op_intent_injection=req_body.operational_intent,
+            flight_authorisation=req_body.flight_authorisation,
         )
-    )
+        with db as tx:
+            tx.flights[flight_id] = record
+
+        print(f"[inject_flight:{flight_id}] Complete.")
+        return flask.jsonify(
+            InjectFlightResponse(
+                result=InjectFlightResult.Planned, operational_intent_id=id
+            )
+        )
+    finally:
+        if existing_flight:
+            print(f"[inject_flight] Releasing lock on flight_id {flight_id}")
+            with db as tx:
+                tx.flights[flight_id].locked = False
 
 
 @webapp.route("/scdsc/v1/flights/<flight_id>", methods=["DELETE"])

--- a/monitoring/mock_uss/start.sh
+++ b/monitoring/mock_uss/start.sh
@@ -18,6 +18,7 @@ cd "${BASEDIR}" || exit 1
 cp health_check.sh /app
 
 # Start mock_uss server on port 5000
+export PYTHONUNBUFFERED=TRUE
 gunicorn \
     --preload \
     --workers=4 \

--- a/monitoring/monitorlib/clients/scd.py
+++ b/monitoring/monitorlib/clients/scd.py
@@ -41,15 +41,29 @@ def create_operational_intent_reference(
     id: str,
     req: scd.PutOperationalIntentReferenceParameters,
 ) -> scd.ChangeOperationalIntentReferenceResponse:
-    resp = utm_client.put(
-        "/dss/v1/operational_intent_references/{}".format(id),
-        json=req,
-        scope=scd.SCOPE_SC,
-    )
+    url = "/dss/v1/operational_intent_references/{}".format(id)
+    resp = utm_client.put(url, json=req, scope=scd.SCOPE_SC)
     if resp.status_code != 200 and resp.status_code != 201:
         raise OperationError(
-            "createOperationalIntentReference failed {}:\n{}".format(
-                resp.status_code, resp.content.decode("utf-8")
+            "createOperationalIntentReference failed {} to {}:\n{}".format(
+                resp.status_code, url, resp.content.decode("utf-8")
+            )
+        )
+    return ImplicitDict.parse(resp.json(), scd.ChangeOperationalIntentReferenceResponse)
+
+
+def update_operational_intent_reference(
+    utm_client: UTMClientSession,
+    id: str,
+    ovn: str,
+    req: scd.PutOperationalIntentReferenceParameters,
+) -> scd.ChangeOperationalIntentReferenceResponse:
+    url = "/dss/v1/operational_intent_references/{}/{}".format(id, ovn)
+    resp = utm_client.put(url, json=req, scope=scd.SCOPE_SC)
+    if resp.status_code != 200 and resp.status_code != 201:
+        raise OperationError(
+            "updateOperationalIntentReference failed {} to {}:\n{}".format(
+                resp.status_code, url, resp.content.decode("utf-8")
             )
         )
     return ImplicitDict.parse(resp.json(), scd.ChangeOperationalIntentReferenceResponse)

--- a/monitoring/monitorlib/clients/scd_automated_testing.py
+++ b/monitoring/monitorlib/clients/scd_automated_testing.py
@@ -29,10 +29,14 @@ class QueryError(OperationError):
         self.query = query
 
 
-def create_flight(
-    utm_client: UTMClientSession, uss_base_url: str, flight_request: InjectFlightRequest
+def put_flight(
+    utm_client: UTMClientSession,
+    uss_base_url: str,
+    flight_request: InjectFlightRequest,
+    flight_id: Optional[str] = None,
 ) -> Tuple[str, InjectFlightResponse, fetch.Query]:
-    flight_id = str(uuid.uuid4())
+    if not flight_id:
+        flight_id = str(uuid.uuid4())
     url = "{}/v1/flights/{}".format(uss_base_url, flight_id)
 
     initiated_at = datetime.utcnow()

--- a/monitoring/uss_qualifier/configurations/configuration.py
+++ b/monitoring/uss_qualifier/configurations/configuration.py
@@ -6,7 +6,6 @@ from monitoring.uss_qualifier.fileio import load_dict_with_references
 from monitoring.uss_qualifier.requirements.documentation import RequirementSetID
 from monitoring.uss_qualifier.resources.definitions import ResourceCollection
 from monitoring.uss_qualifier.suites.definitions import (
-    TestSuiteDeclaration,
     TestSuiteActionDeclaration,
 )
 

--- a/monitoring/uss_qualifier/configurations/dev/f3548/nominal_planning_priority.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/f3548/nominal_planning_priority.yaml
@@ -1,0 +1,23 @@
+v1:
+  test_run:
+    resources:
+      resource_declarations:
+        "$ref": ../resources.yaml#/f3548_single_scenario
+    action:
+      test_scenario:
+        scenario_type: scenarios.astm.utm.NominalPlanningPriority
+        resources:
+          uss1: uss1
+          uss2: uss2
+          flight_intents: priority_preemption_flights
+          dss: dss
+  artifacts:
+    tested_roles:
+      report_path: tested_requirements.html
+      roles:
+      - name: Strategic Coordination role
+        requirement_set: astm.f3548.v21.scd
+        participants:
+        - uss1
+        - uss2
+    "$ref": ../artifacts.yaml#/relative

--- a/monitoring/uss_qualifier/configurations/dev/resources.yaml
+++ b/monitoring/uss_qualifier/configurations/dev/resources.yaml
@@ -99,6 +99,25 @@ f3548:
       participant_id: uss1
       base_url: http://host.docker.internal:8082
 
+f3548_single_scenario:
+  $ref: '#/f3548'
+  uss1:
+    resource_type: resources.flight_planning.FlightPlannerResource
+    dependencies:
+      auth_adapter: utm_auth
+    specification:
+      flight_planner:
+        participant_id: uss1
+        injection_base_url: http://host.docker.internal:8074/scdsc
+  uss2:
+    resource_type: resources.flight_planning.FlightPlannerResource
+    dependencies:
+      auth_adapter: utm_auth
+    specification:
+      flight_planner:
+        participant_id: uss2
+        injection_base_url: http://host.docker.internal:8074/scdsc
+
 common:
   utm_auth:
     resource_type: resources.communications.AuthAdapterResource

--- a/monitoring/uss_qualifier/reports/graphs.py
+++ b/monitoring/uss_qualifier/reports/graphs.py
@@ -276,18 +276,31 @@ def make_graph(report: TestRunReport) -> graphviz.Digraph:
     # Make nodes for resources
     nodes, nodes_by_id = _make_resource_nodes(report.configuration.resources, namer)
 
-    if report.configuration.action.get_action_type() != ActionType.TestSuite:
+    action_type = report.configuration.action.get_action_type()
+    if action_type == ActionType.TestSuite:
+        test_suite = report.configuration.action.test_suite
+        test_suite_report = report.report.test_suite
+
+        # Translate resource names into the action frame
+        suite_nodes_by_id = _translate_ids(nodes_by_id, test_suite.resources)
+
+        # Make nodes for the suite
+        nodes.extend(
+            _make_test_suite_nodes(
+                test_suite, test_suite_report, suite_nodes_by_id, namer
+            )
+        )
+    elif action_type == ActionType.TestScenario:
+        test_scenario = report.configuration.action.test_scenario
+        test_scenario_report = report.report.test_scenario
+        scenario_nodes_by_id = _translate_ids(nodes_by_id, test_scenario.resources)
+        nodes.extend(
+            _make_test_scenario_nodes(
+                test_scenario, test_scenario_report, scenario_nodes_by_id, namer
+            )
+        )
+    else:
         raise NotImplementedError()
-    test_suite = report.configuration.action.test_suite
-    test_suite_report = report.report.test_suite
-
-    # Translate resource names into the action frame
-    suite_nodes_by_id = _translate_ids(nodes_by_id, test_suite.resources)
-
-    # Make nodes for the suite
-    nodes.extend(
-        _make_test_suite_nodes(test_suite, test_suite_report, suite_nodes_by_id, namer)
-    )
 
     # Translate nodes into GraphViz
     dot = graphviz.Digraph(node_attr={"shape": "box"})

--- a/monitoring/uss_qualifier/resources/flight_planning/__init__.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/__init__.py
@@ -1,4 +1,5 @@
 from .flight_planners import (
+    FlightPlannerResource,
     FlightPlannersResource,
     FlightPlannerCombinationSelectorResource,
 )

--- a/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py
+++ b/monitoring/uss_qualifier/resources/flight_planning/flight_planner.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Tuple, List
+from typing import Tuple, List, Optional, Set
 from urllib.parse import urlparse
 
 from implicitdict import ImplicitDict
@@ -7,7 +7,7 @@ from implicitdict import ImplicitDict
 from monitoring.monitorlib import infrastructure, fetch
 from monitoring.monitorlib.clients.scd_automated_testing import (
     clear_area,
-    create_flight,
+    put_flight,
     delete_flight,
     get_version,
     get_capabilities,
@@ -63,7 +63,7 @@ class FlightPlanner:
         )
 
         # Flights injected by this target.
-        self.created_flight_ids: List[str] = []
+        self.created_flight_ids: Set[str] = set()
 
     def __repr__(self):
         return "FlightPlanner({}, {})".format(
@@ -79,13 +79,15 @@ class FlightPlanner:
         return self.config.participant_id
 
     def request_flight(
-        self, request: InjectFlightRequest
+        self,
+        request: InjectFlightRequest,
+        flight_id: Optional[str] = None,
     ) -> Tuple[InjectFlightResponse, fetch.Query, str]:
-        flight_id, resp, query = create_flight(
-            self.client, self.config.injection_base_url, request
+        flight_id, resp, query = put_flight(
+            self.client, self.config.injection_base_url, request, flight_id
         )
         if resp.result == InjectFlightResult.Planned:
-            self.created_flight_ids.append(flight_id)
+            self.created_flight_ids.add(flight_id)
 
         return resp, query, flight_id
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning/nominal_planning.py
@@ -93,18 +93,17 @@ class NominalPlanning(TestScenario):
         ):
             return False
 
-        if not clear_area(
+        clear_area(
             self,
             "Area clearing",
             [self.first_flight, self.conflicting_flight],
             [self.uss1, self.uss2],
-        ):
-            return False
+        )
 
         return True
 
     def _plan_first_flight(self) -> bool:
-        resp = inject_successful_flight_intent(
+        resp, _ = inject_successful_flight_intent(
             self, "Inject flight intent", self.uss1, self.first_flight
         )
         if resp is None:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/nominal_planning_priority/nominal_planning_priority.md
@@ -73,7 +73,11 @@ The first flight intent should be successfully planned by the first flight plann
 
 In this step, the second USS successfully executes a user intent to activate the priority flight.
 
-TODO: Complete this test case
+### [Activate priority flight test step](../../../flight_planning/successfully_activate_flight.md)
+
+The high-priority flight intent should be successfully activated by the first flight planner.
+
+### [Validate flight sharing test step](../validate_shared_operational_intent.md)
 
 ## Attempt to activate first flight test case
 

--- a/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/test_steps.py
@@ -61,6 +61,7 @@ def validate_shared_operational_intent(
     op_intent_ref = matching_op_intent_refs[0]
 
     op_intent, query = scenario.dss.get_full_op_intent(op_intent_ref)
+    scenario.record_query(query)
     with scenario.check(
         "Operational intent details retrievable", [scenario.uss1.participant_id]
     ) as check:

--- a/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
+++ b/monitoring/uss_qualifier/scenarios/astm/utm/validate_shared_operational_intent.md
@@ -8,7 +8,7 @@ This step verifies that a created flight is shared properly per ASTM F3548-21 by
 
 ## Operational intent shared correctly check
 
-If a reference to the operational intent for the flight is not found in the DSS, this check will fail per **astm.f3548.v21.USS0005** and **astm.f3548.v21.OPIN0030**.
+If a reference to the operational intent for the flight is not found in the DSS, this check will fail per **astm.f3548.v21.USS0005**.
 
 ## Operational intent details retrievable check
 

--- a/monitoring/uss_qualifier/scenarios/definitions.py
+++ b/monitoring/uss_qualifier/scenarios/definitions.py
@@ -1,11 +1,18 @@
+from types import MappingProxyType
 from typing import Dict
 
 from implicitdict import ImplicitDict
+from monitoring.uss_qualifier.fileio import FileReference
+from monitoring.uss_qualifier.resources.definitions import ResourceID
 
 
 class TestScenarioDeclaration(ImplicitDict):
-    scenario_type: str
-    """Type of test scenario, expressed as a Python class name qualified relative to this `scenarios` module"""
+    scenario_type: FileReference
+    """Type/location of test scenario.  Usually expressed as the class name of the scenario module-qualified relative to the `uss_qualifier` folder"""
 
-    resources: Dict[str, str] = {}
-    """Mapping of resource parameter (additional argument to concrete test scenario constructor) to ID of resource to use"""
+    # Note: MappingProxyType effectively creates a read-only dict.
+    resources: Dict[ResourceID, ResourceID] = MappingProxyType({})
+    """Mapping of the ID a resource in the test scenario -> the ID a resource is known by in the parent test suite.
+    
+    The additional argument to concrete test scenario constructor <key> is supplied by the parent suite resource <value>.
+    """

--- a/monitoring/uss_qualifier/scenarios/documentation/requirements.py
+++ b/monitoring/uss_qualifier/scenarios/documentation/requirements.py
@@ -180,11 +180,9 @@ def _evaluate_requirements_in_suite(
 
 
 def evaluate_requirements(report: TestRunReport) -> List[TestedRequirement]:
-    if report.configuration.action.get_action_type() != ActionType.TestSuite:
-        raise NotImplementedError()
     import_submodules(scenarios_module)
     reqs = {}
-    _evaluate_requirements_in_suite(report.report.test_suite, "$.report", reqs)
+    _evaluate_requirements_in_action(report.report, "$.report", reqs)
     sorted_ids = list(reqs.keys())
     sorted_ids.sort()
     return [reqs[k] for k in sorted_ids]

--- a/monitoring/uss_qualifier/scenarios/flight_planning/successfully_activate_flight.md
+++ b/monitoring/uss_qualifier/scenarios/flight_planning/successfully_activate_flight.md
@@ -1,0 +1,7 @@
+# Activate valid flight test step
+
+This page describes the content of a common test step where a valid user flight intent should be successfully activated by a flight planner.  See `activate_valid_flight_intent` in [test_steps.py](test_steps.py).
+
+## Successful activation check
+
+All flight intent data provided is correct and valid and free of conflict in space and time, therefore it should have been activated by the USS per **interuss.automated_testing.flight_planning.ExpectedBehavior**.  If the USS indicates a conflict, this check will fail.  If the USS indicates that the flight was rejected, this check will fail.  If the USS indicates that the injection attempt failed, this check will fail.

--- a/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
+++ b/monitoring/uss_qualifier/scenarios/uspace/flight_auth/validation.py
@@ -91,13 +91,12 @@ class Validation(TestScenario):
         ):
             return False
 
-        if not clear_area(
+        clear_area(
             self,
             "Area clearing",
             self.flight_intents,
             [self.ussp],
-        ):
-            return False
+        )
 
         return True
 
@@ -134,7 +133,7 @@ class Validation(TestScenario):
         return True
 
     def _plan_valid_flight(self) -> bool:
-        resp = inject_successful_flight_intent(
+        resp, _ = inject_successful_flight_intent(
             self, "Inject valid flight intent", self.ussp, self.flight_intents[-1]
         )
         if resp is None:


### PR DESCRIPTION
This PR partially completes the unfinished nominal planning priority test scenario by activating the high-priority flight.

This required behavioral changes in mock_uss's scd functionality, and some logging was added to help troubleshoot, though it should be helpful in the future as well.  The changes to the inject_flight handler appear very large if whitespace is not omitted because most of the routine is placed into a try/finally block to ensure that the locked flight is always released.  Flight locking is added in order to mutate the flight in a process-safe way.

A single nominal_planning_priority configuration is added to run just that one scenario without the need for a suite.  This was useful for debugging behavior, but it will also serve as the first example of how to run a single scenario without a test suite.

Also, some conditional-continue logic is removed because now test scenarios will automatically stop if a High or Critical Severity failed check occurs, so that behavior doesn't need to be written into each individual scenario.

A few additional smaller cleanups are also included.