### PR TITLE
[monitoring/atproxy] Add SCD injection endpoints to atproxy

### DIFF
--- a/monitoring/atproxy/atproxy.postman_collection.json
+++ b/monitoring/atproxy/atproxy.postman_collection.json
@@ -24,7 +24,7 @@
 						}
 					],
 					"request": {
-						"method": "POST",
+						"method": "GET",
 						"header": [],
 						"url": {
 							"raw": "http://localhost:8085/token?grant_type=client_credentials&scope=rid.display_provider&intended_audience=localhost&issuer=localhost",
@@ -74,7 +74,7 @@
 						}
 					],
 					"request": {
-						"method": "POST",
+						"method": "GET",
 						"header": [],
 						"url": {
 							"raw": "http://localhost:8085/token?grant_type=client_credentials&scope=rid.inject_test_data&intended_audience=localhost&issuer=localhost",
@@ -94,6 +94,56 @@
 								{
 									"key": "scope",
 									"value": "rid.inject_test_data"
+								},
+								{
+									"key": "intended_audience",
+									"value": "localhost"
+								},
+								{
+									"key": "issuer",
+									"value": "localhost"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get SCD injection token from dummy OAuth",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var data = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"scd_inject_access_token\", data.access_token);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8085/token?grant_type=client_credentials&scope=utm.inject_test_data&intended_audience=localhost&issuer=localhost",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8085",
+							"path": [
+								"token"
+							],
+							"query": [
+								{
+									"key": "grant_type",
+									"value": "client_credentials"
+								},
+								{
+									"key": "scope",
+									"value": "utm.inject_test_data"
 								},
 								{
 									"key": "intended_audience",
@@ -256,6 +306,186 @@
 								"tests",
 								"702255ac-22b5-4be9-ba10-c68411724280",
 								"asdf"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "SCD Injection",
+			"item": [
+				{
+					"name": "Status",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{scd_inject_access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8075/scd/v1/status",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8075",
+							"path": [
+								"scd",
+								"v1",
+								"status"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Capabilities",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{scd_inject_access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8075/scd/v1/capabilities",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8075",
+							"path": [
+								"scd",
+								"v1",
+								"capabilities"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Flights",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{scd_inject_access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"operational_intent\": {\n        \"state\": \"Accepted\",\n        \"priority\": 0,\n        \"volumes\": [],\n        \"off_nominal_volumes\": []\n    },\n    \"flight_authorisation\": {\n        \"uas_serial_number\": \"\",\n        \"operation_mode\": \"Undeclared\",\n        \"uas_class\": \"Other\",\n        \"identification_technologies\": [],\n        \"operator_id\": \"\",\n        \"operation_category\": \"Unknown\",\n        \"connectivity_methods\": [],\n        \"endurance_minutes\": 0,\n        \"emergency_procedure_url\": \"\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8075/scd/v1/flights/c320b2ee-d944-418b-baad-dcdfb61ef0d6",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8075",
+							"path": [
+								"scd",
+								"v1",
+								"flights",
+								"c320b2ee-d944-418b-baad-dcdfb61ef0d6"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Flights",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{scd_inject_access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8075/scd/v1/flights/c320b2ee-d944-418b-baad-dcdfb61ef0d6",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8075",
+							"path": [
+								"scd",
+								"v1",
+								"flights",
+								"c320b2ee-d944-418b-baad-dcdfb61ef0d6"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Clear area",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{scd_inject_access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"request_id\": \"f49191cb-202d-4555-8bb3-4da25b1b17f7\",\n    \"extent\": {\n        \"volume\": {}\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8075/scd/v1/clear_area_requests",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8075",
+							"path": [
+								"scd",
+								"v1",
+								"clear_area_requests"
 							]
 						}
 					},
@@ -502,6 +732,261 @@
 								"body": {
 									"mode": "raw",
 									"raw": "{\"return_code\":200,\"response\":{\"injected_flights\":[]}}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8075/handler/queries/{{handler_request_id}}",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8075",
+									"path": [
+										"handler",
+										"queries",
+										"{{handler_request_id}}"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "SCD Injection",
+					"item": [
+						{
+							"name": "Status response",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "local_client",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "local_client",
+											"type": "string"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"return_code\":200,\"response\":{\"status\":\"Ready\"}}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8075/handler/queries/{{handler_request_id}}",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8075",
+									"path": [
+										"handler",
+										"queries",
+										"{{handler_request_id}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Capabilities response",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "local_client",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "local_client",
+											"type": "string"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"return_code\":200,\"response\":{\"capabilities\":[\"FlightAuthorisationValidation\",\"BasicStrategicConflictDetection\",\"HighPriorityFlights\"]}}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8075/handler/queries/{{handler_request_id}}",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8075",
+									"path": [
+										"handler",
+										"queries",
+										"{{handler_request_id}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "(PUT) Flights response",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "local_client",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "local_client",
+											"type": "string"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"return_code\":200,\"response\":{\"response_example_not_complete\": true}}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8075/handler/queries/{{handler_request_id}}",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8075",
+									"path": [
+										"handler",
+										"queries",
+										"{{handler_request_id}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "(DELETE) Flights response",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "local_client",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "local_client",
+											"type": "string"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"return_code\":200,\"response\":{\"response_example_not_complete\": true}}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8075/handler/queries/{{handler_request_id}}",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8075",
+									"path": [
+										"handler",
+										"queries",
+										"{{handler_request_id}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Clear area response",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "local_client",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "local_client",
+											"type": "string"
+										},
+										{
+											"key": "showPassword",
+											"value": false,
+											"type": "boolean"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"return_code\":200,\"response\":{\"outcome\":{\"timestamp\":\"2022-12-12T00:00.00Z\",\"success\":true}}}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/monitoring/atproxy/requests.py
+++ b/monitoring/atproxy/requests.py
@@ -1,5 +1,8 @@
 from monitoring.monitorlib.rid_automated_testing import injection_api
 from implicitdict import ImplicitDict
+from uas_standards.interuss.automated_testing.flight_planning.v1.api import \
+    InjectFlightRequest, ClearAreaRequest
+
 
 # Each request descriptor in this file is expected to implement a static
 # request_type_name() method which indicates the type of request corresponding
@@ -40,3 +43,41 @@ class RIDInjectionDeleteTestRequest(ImplicitDict):
 
     test_id: str
     version: str
+
+
+# --- SCD injection (interfaces/automated_testing/scd/v1/scd.yaml) ---
+class SCDInjectionStatusRequest(ImplicitDict):
+    @staticmethod
+    def request_type_name() -> str:
+        return 'scd.getStatus'
+
+
+class SCDInjectionCapabilitiesRequest(ImplicitDict):
+    @staticmethod
+    def request_type_name() -> str:
+        return 'scd.getCapabilities'
+
+
+class SCDInjectionPutFlightRequest(ImplicitDict):
+    @staticmethod
+    def request_type_name() -> str:
+        return 'scd.putFlight'
+
+    flight_id: str
+    request_body: InjectFlightRequest
+
+
+class SCDInjectionDeleteFlightRequest(ImplicitDict):
+    @staticmethod
+    def request_type_name() -> str:
+        return 'scd.deleteFlight'
+
+    flight_id: str
+
+
+class SCDInjectionClearAreaRequest(ImplicitDict):
+    @staticmethod
+    def request_type_name() -> str:
+        return 'scd.createClearAreaRequest'
+
+    request_body: ClearAreaRequest

--- a/monitoring/atproxy/routes.py
+++ b/monitoring/atproxy/routes.py
@@ -57,3 +57,4 @@ def verify_password(username, password):
 from . import routes_handler
 from . import routes_rid_observation
 from . import routes_rid_injection
+from . import routes_scd

--- a/monitoring/atproxy/routes_rid_injection.py
+++ b/monitoring/atproxy/routes_rid_injection.py
@@ -17,7 +17,7 @@ _logger.setLevel(logging.DEBUG)
 
 @webapp.route('/ridsp/injection/tests/<test_id>', methods=['PUT'])
 @requires_scope([injection_api.SCOPE_RID_QUALIFIER_INJECT])
-def create_test(test_id: str) -> Tuple[str, int]:
+def rid_injection_create_test(test_id: str) -> Tuple[str, int]:
     """Implements test creation in RID automated testing injection API."""
     try:
         json = flask.request.json
@@ -33,6 +33,6 @@ def create_test(test_id: str) -> Tuple[str, int]:
 
 @webapp.route('/ridsp/injection/tests/<test_id>/<version>', methods=['DELETE'])
 @requires_scope([injection_api.SCOPE_RID_QUALIFIER_INJECT])
-def delete_test(test_id: str, version: str) -> Tuple[str, int]:
+def rid_injection_delete_test(test_id: str, version: str) -> Tuple[str, int]:
     """Implements test deletion in RID automated testing injection API."""
     return handling.fulfill_query(RIDInjectionDeleteTestRequest(test_id=test_id, version=version), _logger)

--- a/monitoring/atproxy/routes_rid_observation.py
+++ b/monitoring/atproxy/routes_rid_observation.py
@@ -16,13 +16,13 @@ _logger.setLevel(logging.DEBUG)
 
 @webapp.route('/riddp/observation/display_data', methods=['GET'])
 @requires_scope([rid_v2.SCOPE_DP])
-def display_data() -> Tuple[str, int]:
+def rid_observation_display_data() -> Tuple[str, int]:
     """Implements retrieval of current display data per automated testing API."""
     return handling.fulfill_query(RIDObservationGetDisplayDataRequest(view=flask.request.args['view']), _logger)
 
 
 @webapp.route('/riddp/observation/display_data/<flight_id>', methods=['GET'])
 @requires_scope([rid_v2.SCOPE_DP])
-def flight_details(flight_id: str) -> Tuple[str, int]:
+def rid_observation_flight_details(flight_id: str) -> Tuple[str, int]:
     """Implements get flight details endpoint per automated testing API."""
     return handling.fulfill_query(RIDObservationGetDetailsRequest(id=flight_id), _logger)

--- a/monitoring/atproxy/routes_scd.py
+++ b/monitoring/atproxy/routes_scd.py
@@ -1,0 +1,72 @@
+import logging
+from typing import Tuple
+
+import flask
+
+from uas_standards.interuss.automated_testing.flight_planning.v1.api import \
+    InjectFlightRequest, ClearAreaRequest
+from . import webapp, handling
+from .oauth import requires_scope
+from .requests import SCDInjectionStatusRequest, \
+    SCDInjectionCapabilitiesRequest, SCDInjectionPutFlightRequest, \
+    SCDInjectionDeleteFlightRequest, SCDInjectionClearAreaRequest
+from monitoring.monitorlib.scd_automated_testing.scd_injection_api import SCOPE_SCD_QUALIFIER_INJECT
+from implicitdict import ImplicitDict
+
+
+logging.basicConfig()
+_logger = logging.getLogger('atproxy.rid_injection')
+_logger.setLevel(logging.DEBUG)
+
+
+@webapp.route('/scd/v1/status', methods=['GET'])
+@requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
+def scd_injection_status() -> Tuple[str, int]:
+    """Implements status in SCD automated testing injection API."""
+    return handling.fulfill_query(SCDInjectionStatusRequest(), _logger)
+
+
+@webapp.route('/scd/v1/capabilities', methods=['GET'])
+@requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
+def scd_injection_capabilities() -> Tuple[str, int]:
+    """Implements capabilities in SCD automated testing injection API."""
+    return handling.fulfill_query(SCDInjectionCapabilitiesRequest(), _logger)
+
+
+@webapp.route('/scd/v1/flights/<flight_id>', methods=['PUT'])
+@requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
+def scd_injection_put_flight(flight_id: str) -> Tuple[str, int]:
+    """Implements PUT flight in SCD automated testing injection API."""
+    try:
+        json = flask.request.json
+        if json is None:
+            raise ValueError('Request did not contain a JSON payload')
+        req_body: InjectFlightRequest = ImplicitDict.parse(json, InjectFlightRequest)
+    except ValueError as e:
+        msg = 'Upsert flight {} unable to parse JSON: {}'.format(flight_id, e)
+        return msg, 400
+
+    return handling.fulfill_query(SCDInjectionPutFlightRequest(flight_id=flight_id, request_body=req_body), _logger)
+
+
+@webapp.route('/scd/v1/flights/<flight_id>', methods=['DELETE'])
+@requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
+def scd_injection_delete_flight(flight_id: str) -> Tuple[str, int]:
+    """Implements flight deletion in SCD automated testing injection API."""
+    return handling.fulfill_query(SCDInjectionDeleteFlightRequest(flight_id=flight_id), _logger)
+
+
+@webapp.route('/scd/v1/clear_area_requests', methods=['POST'])
+@requires_scope([SCOPE_SCD_QUALIFIER_INJECT])
+def scd_injection_clear_area() -> Tuple[str, int]:
+    """Implements area clearing in RID automated testing injection API."""
+    try:
+        json = flask.request.json
+        if json is None:
+            raise ValueError('Request did not contain a JSON payload')
+        req_body: ClearAreaRequest = ImplicitDict.parse(json, ClearAreaRequest)
+    except ValueError as e:
+        msg = 'Clear area request unable to parse JSON: {}'.format(e)
+        return msg, 400
+
+    return handling.fulfill_query(SCDInjectionClearAreaRequest(request_body=req_body), _logger)

--- a/monitoring/atproxy/run_locally.sh
+++ b/monitoring/atproxy/run_locally.sh
@@ -30,6 +30,7 @@ docker run ${docker_args} --name atproxy \
   -e ATPROXY_CLIENT_BASIC_AUTH="${CLIENT_BASIC_AUTH}" \
   -e ATPROXY_PUBLIC_KEY="${PUBLIC_KEY}" \
   -e ATPROXY_TOKEN_AUDIENCE="${AUD}" \
+  -e PYTHONUNBUFFERED=TRUE \
   -p ${PORT}:5000 \
   -v "$(pwd)/build/test-certs:/var/test-certs:ro" \
   "$@" \


### PR DESCRIPTION
This PR adds support for SCD injection endpoints to atproxy, as well as entries in the Postman collection to verify behavior.  All SCD injection endpoints in this PR were tested successfully using the Postman collection.

Note that atproxy is mostly not included in continuous integration tests.  I've added #925 to address this eventually.