### PR TITLE
[docs] Add reference to Python style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ In order to maximize the quality of contributions while keeping the time and ene
 
 1. Before your PR can be accepted, you must submit a Contributor License Agreement (CLA). See [here](https://github.com/interuss/tsc/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) for more details.
 
+1. Contributions involving Python code should generally follow the [InterUSS Python style guide](https://github.com/interuss/tsc/blob/main/python_style_guide.md). 
+
 1. The size of individual PRs is a key factor with respect to the quality and efficiency of the reviews. When [Large Contributions](#large-contributions) are required, they should be structured as a series of small and focused PRs. Here are some helpful references:
     - [Strategies For Small, Focused Pull Requests, Steve Hicks](https://artsy.github.io/blog/2021/03/09/strategies-for-small-focused-pull-requests/)
     - [The Art of Small Pull Requests, David Wilson](https://essenceofcode.com/2019/10/29/the-art-of-small-pull-requests/)

--- a/monitoring/mock_uss/Makefile
+++ b/monitoring/mock_uss/Makefile
@@ -4,7 +4,7 @@ lint: python-lint shell-lint
 
 .PHONY: python-lint
 python-lint:
-	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:latest_release black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
+	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:22.10.0 black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
 
 .PHONY: shell-lint
 shell-lint:
@@ -12,7 +12,7 @@ shell-lint:
 
 .PHONY: format
 format:
-	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:latest_release black .
+	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:22.10.0 black .
 
 .PHONY: test
 test: lint

--- a/monitoring/monitorlib/Makefile
+++ b/monitoring/monitorlib/Makefile
@@ -3,11 +3,11 @@ lint: python-lint
 
 .PHONY: python-lint
 python-lint:
-	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:latest_release black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
+	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:22.10.0 black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
 
 .PHONY: format
 format:
-	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:latest_release black .
+	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:22.10.0 black .
 
 .PHONY: test
 test: lint

--- a/monitoring/uss_qualifier/Makefile
+++ b/monitoring/uss_qualifier/Makefile
@@ -7,7 +7,7 @@ validate-docs:
 
 .PHONY: python-lint
 python-lint:
-	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:latest_release black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
+	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:22.10.0 black --check . || (echo "Linter didn't succeed. You can use the following command to fix python linter issues: make format" && exit 1)
 
 .PHONY: shell-lint
 shell-lint:
@@ -15,7 +15,7 @@ shell-lint:
 
 .PHONY: format
 format: format-documentation
-	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:latest_release black .
+	docker run --rm -v $(CURDIR):/code -w /code pyfound/black:22.10.0 black .
 
 .PHONY: format-documentation
 format-documentation:


### PR DESCRIPTION
In addition to adding the style guide, this PR also explicitly pins the version of the Black formatter for Python as initially this PR (which changes one line of a .md file) was failing Python formatting checks because the `latest_version` tag of `pyfound/black` was rev'd to a version that detects problems with the current repo content.  We should explicitly move between `pyfound/black` versions in the future.  Added #932 to track this.