### PR TITLE
[mock_uss] Prepare mock_uss for backend implementation client functionality

### DIFF
--- a/monitoring/mock_uss/config.py
+++ b/monitoring/mock_uss/config.py
@@ -1,4 +1,3 @@
-from enum import Enum
 import os
 
 from monitoring.monitorlib import auth_validation

--- a/monitoring/mock_uss/geoawareness/routes_geoawareness.py
+++ b/monitoring/mock_uss/geoawareness/routes_geoawareness.py
@@ -25,7 +25,7 @@ from monitoring.monitorlib.geoawareness_automated_testing.api import (
     methods=["GET"],
 )
 @requires_scope([SCOPE_GEOAWARENESS_TEST])
-def get_geozone_sources(geozone_source_id: str) -> Tuple[str, int]:
+def geoawareness_get_geozone_sources(geozone_source_id: str) -> Tuple[str, int]:
     return get_geozone_source(geozone_source_id)
 
 
@@ -34,7 +34,7 @@ def get_geozone_sources(geozone_source_id: str) -> Tuple[str, int]:
     methods=["PUT"],
 )
 @requires_scope([SCOPE_GEOAWARENESS_TEST])
-def put_geozone_sources(geozone_source_id: str) -> Tuple[str, int]:
+def geoawareness_put_geozone_sources(geozone_source_id: str) -> Tuple[str, int]:
     try:
         json = flask.request.json
         if json is None:
@@ -56,13 +56,13 @@ def put_geozone_sources(geozone_source_id: str) -> Tuple[str, int]:
     methods=["DELETE"],
 )
 @requires_scope([SCOPE_GEOAWARENESS_TEST])
-def delete_geozone_sources(geozone_source_id: str) -> Tuple[str, int]:
+def geoawareness_delete_geozone_sources(geozone_source_id: str) -> Tuple[str, int]:
     return delete_geozone_source(geozone_source_id)
 
 
 @webapp.route("/geoawareness/check", methods=["POST"])
 @requires_scope([SCOPE_GEOAWARENESS_TEST])
-def check():
+def geoawareness_check():
     try:
         json = flask.request.json
         if json is None:

--- a/monitoring/mock_uss/riddp/routes_behavior.py
+++ b/monitoring/mock_uss/riddp/routes_behavior.py
@@ -9,7 +9,7 @@ from .database import db
 
 
 @webapp.route("/riddp/behavior", methods=["PUT"])
-def set_dp_behavior() -> Tuple[str, int]:
+def riddp_set_dp_behavior() -> Tuple[str, int]:
     """Set the behavior of the mock Display Provider."""
     try:
         json = flask.request.json
@@ -27,6 +27,6 @@ def set_dp_behavior() -> Tuple[str, int]:
 
 
 @webapp.route("/riddp/behavior", methods=["GET"])
-def get_dp_behavior() -> Tuple[str, int]:
+def riddp_get_dp_behavior() -> Tuple[str, int]:
     """Get the behavior of the mock Display Provider."""
     return flask.jsonify(db.value.behavior)

--- a/monitoring/mock_uss/riddp/routes_observation.py
+++ b/monitoring/mock_uss/riddp/routes_observation.py
@@ -64,7 +64,7 @@ def _make_flight_observation(
 
 @webapp.route("/riddp/observation/display_data", methods=["GET"])
 @requires_scope([rid.SCOPE_READ])
-def display_data() -> Tuple[str, int]:
+def riddp_display_data() -> Tuple[str, int]:
     """Implements retrieval of current display data per automated testing API."""
 
     if "view" not in flask.request.args:
@@ -155,7 +155,7 @@ def display_data() -> Tuple[str, int]:
 
 @webapp.route("/riddp/observation/display_data/<flight_id>", methods=["GET"])
 @requires_scope([rid.SCOPE_READ])
-def flight_details(flight_id: str) -> Tuple[str, int]:
+def riddp_flight_details(flight_id: str) -> Tuple[str, int]:
     """Implements get flight details endpoint per automated testing API."""
 
     tx = db.value

--- a/monitoring/mock_uss/ridsp/routes_behavior.py
+++ b/monitoring/mock_uss/ridsp/routes_behavior.py
@@ -9,7 +9,7 @@ from .database import db
 
 
 @webapp.route("/ridsp/behavior", methods=["PUT"])
-def set_dp_behavior() -> Tuple[str, int]:
+def ridsp_set_dp_behavior() -> Tuple[str, int]:
     """Set the behavior of the mock Display Provider."""
     try:
         json = flask.request.json
@@ -27,6 +27,6 @@ def set_dp_behavior() -> Tuple[str, int]:
 
 
 @webapp.route("/ridsp/behavior", methods=["GET"])
-def get_dp_behavior() -> Tuple[str, int]:
+def ridsp_get_dp_behavior() -> Tuple[str, int]:
     """Get the behavior of the mock Display Provider."""
     return flask.jsonify(db.value.behavior)

--- a/monitoring/mock_uss/ridsp/routes_injection.py
+++ b/monitoring/mock_uss/ridsp/routes_injection.py
@@ -23,7 +23,7 @@ RECENT_POSITIONS_BUFFER = datetime.timedelta(seconds=60.2)
 
 @webapp.route("/ridsp/injection/tests/<test_id>", methods=["PUT"])
 @requires_scope([injection_api.SCOPE_RID_QUALIFIER_INJECT])
-def create_test(test_id: str) -> Tuple[str, int]:
+def ridsp_create_test(test_id: str) -> Tuple[str, int]:
     """Implements test creation in RID automated testing injection API."""
 
     try:
@@ -69,7 +69,7 @@ def create_test(test_id: str) -> Tuple[str, int]:
 
 @webapp.route("/ridsp/injection/tests/<test_id>", methods=["DELETE"])
 @requires_scope([injection_api.SCOPE_RID_QUALIFIER_INJECT])
-def delete_test(test_id: str) -> Tuple[str, int]:
+def ridsp_delete_test(test_id: str) -> Tuple[str, int]:
     """Implements test deletion in RID automated testing injection API."""
 
     record = db.value.tests.get(test_id, None)

--- a/monitoring/mock_uss/ridsp/routes_ridsp.py
+++ b/monitoring/mock_uss/ridsp/routes_ridsp.py
@@ -52,7 +52,7 @@ def _get_report(
 
 @webapp.route("/mock/ridsp/v1/uss/identification_service_areas/<id>", methods=["POST"])
 @requires_scope([rid.SCOPE_WRITE])
-def notify_isa(id: str):
+def ridsp_notify_isa(id: str):
     return (
         flask.jsonify(
             {"message": "mock_ridsp never solicits subscription notifications"}
@@ -63,7 +63,7 @@ def notify_isa(id: str):
 
 @webapp.route("/mock/ridsp/v1/uss/flights", methods=["GET"])
 @requires_scope([rid.SCOPE_READ])
-def flights():
+def ridsp_flights():
     if "view" not in flask.request.args:
         return (
             flask.jsonify(
@@ -115,7 +115,7 @@ def flights():
 
 @webapp.route("/mock/ridsp/v1/uss/flights/<id>/details", methods=["GET"])
 @requires_scope([rid.SCOPE_READ])
-def flight_details(id: str):
+def ridsp_flight_details(id: str):
     now = arrow.utcnow().datetime
     tx = db.value
     for test_id, record in tx.tests.items():

--- a/monitoring/mock_uss/scdsc/routes_scdsc.py
+++ b/monitoring/mock_uss/scdsc/routes_scdsc.py
@@ -8,7 +8,7 @@ from monitoring.mock_uss.scdsc.database import db
 
 @webapp.route("/mock/scd/uss/v1/operational_intents/<entityid>", methods=["GET"])
 @requires_scope([scd.SCOPE_SC])
-def get_operational_intent_details(entityid: str):
+def scdsc_get_operational_intent_details(entityid: str):
     """Implements getOperationalIntentDetails in ASTM SCD API."""
 
     # Look up entityid in database
@@ -48,7 +48,7 @@ def get_operational_intent_details(entityid: str):
 
 @webapp.route("/mock/scd/uss/v1/operational_intents", methods=["POST"])
 @requires_scope([scd.SCOPE_SC])
-def notify_operational_intent_details_changed():
+def scdsc_notify_operational_intent_details_changed():
     """Implements notifyOperationalIntentDetailsChanged in ASTM SCD API."""
 
     # Do nothing because this USS is unsophisticated and polls the DSS for every
@@ -60,7 +60,7 @@ def notify_operational_intent_details_changed():
 @requires_scope(
     [scd.SCOPE_SC, scd.SCOPE_CP, scd.SCOPE_CM, scd.SCOPE_CM_SA, scd.SCOPE_AA]
 )
-def make_uss_report():
+def scdsc_make_uss_report():
     """Implements makeUssReport in ASTM SCD API."""
 
     return flask.jsonify({"message": "Not yet implemented"}), 500

--- a/monitoring/monitorlib/clients/scd.py
+++ b/monitoring/monitorlib/clients/scd.py
@@ -116,8 +116,8 @@ def notify_operational_intent_details_changed(
     )
     if resp.status_code != 204 and resp.status_code != 200:
         raise OperationError(
-            "notifyOperationalIntentDetailsChanged failed {}:\n{}".format(
-                resp.status_code, resp.content.decode("utf-8")
+            "notifyOperationalIntentDetailsChanged failed {} to {}:\n{}".format(
+                resp.status_code, resp.request.url, resp.content.decode("utf-8")
             )
         )
 

--- a/monitoring/monitorlib/scd.py
+++ b/monitoring/monitorlib/scd.py
@@ -326,18 +326,24 @@ def meter_altitude_bounds_of(vol4s: List[Volume4D]) -> Tuple[float, float]:
         for vol4 in vol4s
         if "altitude_upper" in vol4.volume
     )
-    if not all(
-        vol4.volume.altitude_lower.units == "M"
+    units = [
+        vol4.volume.altitude_lower.units
         for vol4 in vol4s
-        if "altitude_lower" in vol4.volume
-    ):
-        raise ValueError("altitude_lower units must always be M")
-    if not all(
-        vol4.volume.altitude_upper.units == "M"
+        if "altitude_lower" in vol4.volume and vol4.volume.altitude_lower.units != "M"
+    ]
+    if units:
+        raise ValueError(
+            f"altitude_lower units must always be M; found instead {', '.join(units)}"
+        )
+    units = [
+        vol4.volume.altitude_upper.units
         for vol4 in vol4s
-        if "altitude_upper" in vol4.volume
-    ):
-        raise ValueError("altitude_upper units must always be M")
+        if "altitude_upper" in vol4.volume and vol4.volume.altitude_upper.units != "M"
+    ]
+    if units:
+        raise ValueError(
+            f"altitude_upper units must always be M; found instead {', '.join(units)}"
+        )
     return alt_lo, alt_hi
 
 

--- a/monitoring/uss_qualifier/main.py
+++ b/monitoring/uss_qualifier/main.py
@@ -41,7 +41,7 @@ def execute_test_run(config: TestConfiguration):
     resources = create_resources(config.resources.resource_declarations)
     action = TestSuiteAction(config.action, resources)
     report = action.run()
-    if report.successful:
+    if report.successful():
         print("Final result: SUCCESS")
     else:
         print("Final result: FAILURE")

--- a/monitoring/uss_qualifier/reports/report.py
+++ b/monitoring/uss_qualifier/reports/report.py
@@ -208,9 +208,7 @@ class TestSuiteActionReport(ImplicitDict):
     action_generator: Optional[ActionGeneratorReport]
     """If this action was an action generator, this field will hold its report"""
 
-    def _get_applicable_report(
-        self,
-    ) -> Tuple["TestSuiteReport", "TestScenarioReport", "ActionGeneratorReport"]:
+    def _get_applicable_report(self) -> Tuple[bool, bool, bool]:
         test_suite = "test_suite" in self and self.test_suite is not None
         test_scenario = "test_scenario" in self and self.test_scenario is not None
         action_generator = (


### PR DESCRIPTION
As part of #925, mock_uss needs to be restructured a bit to prepare for adding functionality to act as a backend implementation client for atproxy.  Toward that end, this PR:

1. Explicitly prefixes all Flask-route-decorated functions to avoid function name conflicts between different capabilities (the function names of Flask route handlers must be globally unique within a Flask application)
2. Separates SCD handlers into a small route handler that parses inputs and returns responses, and a function that actually performs the logic -- only this latter function will be used by the backend implementation client capability of mock_uss to be added in a future PR
3. Improves error messages in two places
4. Fixes a bug where uss_qualifier would always print to screen/log that tests were successful even when they failed (because `success` is a method rather than a property and methods implicitly evaluate to true)
5. Fixes an incorrect type annotation