### PR TITLE
Publish latest tag when making a release

### DIFF
--- a/.github/workflows/dss-publish.yml
+++ b/.github/workflows/dss-publish.yml
@@ -45,5 +45,6 @@ jobs:
       - name: Build and push image
         env:
           DOCKER_URL: ${{ secrets.DOCKER_URL }}
+          DOCKER_UPDATE_LATEST: true
         run: |
           build/build.sh

--- a/build/build.sh
+++ b/build/build.sh
@@ -4,6 +4,8 @@
 # directory.  If run without a DOCKER_URL environment variable, it will just
 # build images named interuss-local/*.  If DOCKER_URL is present, it will both
 # build the versioned dss image and push it to the DOCKER_URL remote.
+# If DOCKER_URL is set, DOCKER_UPDATE_LATEST can be optionally set to `true` in order
+# to publish the latest tag along the version.
 
 set -eo pipefail
 
@@ -17,6 +19,7 @@ fi
 cd "${BASEDIR}"
 
 VERSION=$(./scripts/git/version.sh dss)
+LATEST_TAG="latest"
 
 if [[ -z "${DOCKER_URL}" ]]; then
   echo "DOCKER_URL environment variable is not set; building image to interuss-local/dss..."
@@ -34,6 +37,19 @@ else
   docker image push "${DOCKER_URL}/dss:${VERSION}"
 
   echo "Built and pushed docker image ${DOCKER_URL}/dss:${VERSION}"
+
+  if [[ "${DOCKER_UPDATE_LATEST}" == "true" ]]; then
+
+    echo "Tagging docker image ${DOCKER_URL}/dss:${LATEST_TAG}..."
+    docker tag "${DOCKER_URL}/dss:${VERSION}" "${DOCKER_URL}/dss:${LATEST_TAG}"
+
+    echo "Pushing docker image ${DOCKER_URL}/dss:${LATEST_TAG}..."
+
+    docker image push "${DOCKER_URL}/dss:${LATEST_TAG}"
+
+    echo "Built and pushed docker image ${DOCKER_URL}/dss:${LATEST_TAG}"
+
+  fi
 
   echo "VAR_DOCKER_IMAGE_NAME: ${DOCKER_URL}/dss:${VERSION}"
 fi


### PR DESCRIPTION
This PR adapts the current release workflow to update the `latest` tag along the version.

Script was tested locally using [my personal account](https://hub.docker.com/repository/docker/michaelbarroco/dss/tags?page=1&ordering=last_updated): 
```sh
DOCKER_URL="michaelbarroco" DOCKER_UPDATE_LATEST=true build/build.sh
```