### PR TITLE
[tf-aws] Add missing image_pull_secret variable

### DIFF
--- a/deploy/infrastructure/modules/terraform-aws-dss/main.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/main.tf
@@ -14,6 +14,7 @@ module "terraform-aws-kubernetes" {
 module "terraform-commons-dss" {
   # See variables.tf for variables description.
   image                          = var.image
+  image_pull_secret              = var.image_pull_secret
   kubernetes_namespace           = var.kubernetes_namespace
   kubernetes_storage_class       = var.aws_kubernetes_storage_class
   app_hostname                   = var.app_hostname


### PR DESCRIPTION
This PR adds a missing variable flag to `terraform-aws-dss`.
The variable flag should have been added as part of #944 