### PR TITLE
Use docker compose v2 instead of docker-compose v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ probe-locally:
 
 .PHONY: collect-local-logs
 collect-local-logs:
-	docker logs dss_sandbox_local-dss-core-service_1 2> core-service-for-testing.log
+	docker logs dss_sandbox-local-dss-core-service-1 2> core-service-for-testing.log
 
 .PHONY: stop-locally
 stop-locally:

--- a/build/dev/docker-compose_dss.yaml
+++ b/build/dev/docker-compose_dss.yaml
@@ -15,6 +15,8 @@ services:
     ports:
       - "8080:8080"
     restart: always
+    networks:
+      - dss_sandbox_default_network 
 
   local-dss-rid-bootstrapper:
     build:
@@ -27,6 +29,8 @@ services:
     entrypoint: /startup/rid_bootstrapper.sh
     depends_on:
       - local-dss-crdb
+    networks:
+      - dss_sandbox_default_network 
 
   local-dss-scd-bootstrapper:
     build:
@@ -39,6 +43,8 @@ services:
     entrypoint: /startup/scd_bootstrapper.sh
     depends_on:
       - local-dss-crdb
+    networks:
+      - dss_sandbox_default_network 
 
   local-dss-core-service:
     build:
@@ -56,6 +62,8 @@ services:
     depends_on:
       - local-dss-rid-bootstrapper
       - local-dss-scd-bootstrapper
+    networks:
+      - dss_sandbox_default_network 
 
   local-dss-dummy-oauth:
     build:
@@ -65,6 +73,12 @@ services:
     command: -private_key_file /var/test-certs/auth2.key
     ports:
       - "8085:8085"
+    networks:
+      - dss_sandbox_default_network 
+
+networks:
+  dss_sandbox_default_network:
+    name: dss_sandbox-default
 
 volumes:
   local-dss-data:

--- a/build/dev/haproxy_local_setup.sh
+++ b/build/dev/haproxy_local_setup.sh
@@ -7,7 +7,7 @@ echo "DSS/crdb cluster setup  using HAProxy"
 RESULTFILE="$(pwd)/haproxy_cluster_setup"
 touch "${RESULTFILE}"
 cat /dev/null > "${RESULTFILE}"
-FLAGS="--network dss_sandbox_default cockroachdb/cockroach:v21.2.3 start --insecure --join=roacha,roachb,roachc"
+FLAGS="--network dss_sandbox-default cockroachdb/cockroach:v21.2.3 start --insecure --join=roacha,roachb,roachc"
 
 OS=$(uname)
 if [[ "$OS" == "Darwin" ]]; then
@@ -43,7 +43,7 @@ function cleanup() {
 	docker rm -f core-service-for-testing &> /dev/null || true
 
 	echo "Removing DSS network"
-	docker network rm dss_sandbox_default
+	docker network rm dss_sandbox-default
 }
 
 if [[ "$DC_COMMAND" == "down" ]]; then
@@ -85,7 +85,7 @@ echo "Stopping haproxy container"
 docker rm -f dss-crdb-cluster-for-testing &> /dev/null || true
 
 echo "Create DSS network"
-docker network create dss_sandbox_default
+docker network create dss_sandbox-default
 
 echo "Starting roacha with admin port on :8080"
 docker run -d --rm --name roacha \
@@ -118,7 +118,7 @@ docker exec -it roacha cat haproxy.cfg > "$(pwd)/haproxy.cfg"
 
 echo "Start the HAProxy container by mounting the cfg file."
 docker run -d --name dss-crdb-cluster-for-testing	\
-	--network dss_sandbox_default	\
+	--network dss_sandbox-default	\
 	-p 26257:26257	\
 	-v "$(pwd)/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg":ro haproxy:1.7
 sleep 1
@@ -126,7 +126,7 @@ sleep 1
 echo "Bootstrapping RID Database tables"
 docker run --rm --name rid-db-manager \
 	--link dss-crdb-cluster-for-testing:crdb \
-	--network dss_sandbox_default	\
+	--network dss_sandbox-default	\
 	local-interuss-dss-image \
 	/usr/bin/db-manager \
 	--schemas_dir db-schemas/rid \
@@ -137,7 +137,7 @@ sleep 1
 echo "Bootstrapping SCD Database tables"
 docker run --rm --name scd-db-manager \
 	--link dss-crdb-cluster-for-testing:crdb \
-	--network dss_sandbox_default	\
+	--network dss_sandbox-default	\
 	local-interuss-dss-image \
 	/usr/bin/db-manager \
 	--schemas_dir db-schemas/scd \
@@ -152,7 +152,7 @@ docker rm -f core-service-for-testing &> /dev/null || echo "No core service to c
 echo "Starting core service on :8082"
 docker run -d --name core-service-for-testing -p 8082:8082 \
 	--link dss-crdb-cluster-for-testing:crdb \
-	--network dss_sandbox_default	\
+	--network dss_sandbox-default	\
 	-v "$(pwd)/build/test-certs/auth2.pem:/app/test.crt" \
 	local-interuss-dss-image \
 	core-service \
@@ -174,7 +174,7 @@ docker rm -f dummy-oauth-for-testing &> /dev/null || echo "No dummy oauth to cle
 
 echo "Starting mock oauth server on :8085"
 docker run -d --name dummy-oauth-for-testing -p 8085:8085 \
-	--network dss_sandbox_default	\
+	--network dss_sandbox-default	\
 	-v "$(pwd)/build/test-certs/auth2.key:/app/test.key" \
 	local-dummy-oauth \
 	-private_key_file /app/test.key

--- a/build/dev/migrate_local_db.sh
+++ b/build/dev/migrate_local_db.sh
@@ -40,7 +40,7 @@ docker image build . -t interuss-local/dss . || exit 1
 #                    ^ DBVERSION_FLAG should word-split
 docker container run \
     -v "$(pwd)"/build/dev/local-dss-data:/var/local-dss-data \
-    --network dss_sandbox_default \
+    --network dss_sandbox-default \
     interuss-local/dss \
          --schemas_dir /db-schemas/"${1}" \
          ${DBVERSION_FLAG} \

--- a/build/dev/mutli_node_local_dss.md
+++ b/build/dev/mutli_node_local_dss.md
@@ -41,7 +41,7 @@ Run following to bring up a new node in the cluster environment:
 
     ```docker container run -d --name roachc \
         --hostname roachc -p 8087:8087  \
-        --network dss_sandbox_default \
+        --network dss_sandbox-default \
         cockroachdb/cockroach:v21.2.3 start --insecure --join=roacha,roachb
     ```
 

--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -37,7 +37,7 @@ cat /dev/null > "${RESULTFILE}"
 
 if ! docker run --link "$OAUTH_CONTAINER":oauth \
 	--link "$CORE_SERVICE_CONTAINER":core-service \
-	--network dss_sandbox_default \
+	--network dss_sandbox-default \
 	-v "${RESULTFILE}:/app/test_result" \
 	-w /app/monitoring/prober \
 	interuss/monitoring:v0.2.0 \

--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -13,8 +13,8 @@ else
 fi
 cd "${BASEDIR}/../.." || exit 1
 
-CORE_SERVICE_CONTAINER="dss_sandbox_local-dss-core-service_1"
-OAUTH_CONTAINER="dss_sandbox_local-dss-dummy-oauth_1"
+CORE_SERVICE_CONTAINER="dss_sandbox-local-dss-core-service-1"
+OAUTH_CONTAINER="dss_sandbox-local-dss-dummy-oauth-1"
 declare -a localhost_containers=("$CORE_SERVICE_CONTAINER" "$OAUTH_CONTAINER")
 
 for container_name in "${localhost_containers[@]}"; do

--- a/build/dev/run_locally.sh
+++ b/build/dev/run_locally.sh
@@ -2,11 +2,11 @@
 
 set -eo pipefail
 
-# This script will deploy a standalone DSS instance with docker-compose.  See
+# This script will deploy a standalone DSS instance with docker compose.  See
 # standalone_instance.md for more information.
 
-if [[ -z $(command -v docker-compose) ]]; then
-  echo "docker-compose is required but not installed.  Visit https://docs.docker.com/compose/install/ to install."
+if [[ -z $(command -v docker) ]]; then
+  echo "docker is required but not installed.  Visit https://docs.docker.com/install/ to install."
   exit 1
 fi
 
@@ -33,4 +33,4 @@ elif [[ "$DC_COMMAND" == "debug" ]]; then
 fi
 
 # shellcheck disable=SC2086
-docker-compose -f docker-compose_dss.yaml -p dss_sandbox $DC_COMMAND $DC_OPTIONS
+docker compose -f docker-compose_dss.yaml -p dss_sandbox $DC_COMMAND $DC_OPTIONS

--- a/build/dev/standalone_instance.md
+++ b/build/dev/standalone_instance.md
@@ -25,7 +25,6 @@ sandbox environment consisting of:
 ## Prerequisites
 
 * Install [Docker](https://docs.docker.com/v17.12/install/)
-* Install [docker-compose](https://docs.docker.com/compose/install/)
 
 ## Run
 
@@ -93,11 +92,11 @@ to debug any request sent to the local DSS endpoints hosted at `localhost:8082`.
     ![Debug_result_2](../../assets/debug/debug_result_2.png)
 ## Advanced
 
-[`run_locally.sh`](run_locally.sh) is a thin wrapper around a `docker-compose`
-command and all the `docker-compose` verbs may be passed to `run_locally.sh`.
+[`run_locally.sh`](run_locally.sh) is a thin wrapper around a `docker compose`
+command and all the `docker compose` verbs may be passed to `run_locally.sh`.
 The default option is `up --build` which forces to re-build the local deployment images before starting the containers; however, containers can be started directly by `run_locally.sh up`.
 The system can be removed entirely with `run_locally.sh down`.
-See all `docker-compose` verbs
+See all `docker compose` verbs
 [here](https://docs.docker.com/compose/reference/overview/).
 
 ## Database migration and versioning

--- a/build/dev/standalone_instance.md
+++ b/build/dev/standalone_instance.md
@@ -120,7 +120,7 @@ command like the one below, using `defaultdb` instead of `rid` if wiping remote
 ID prior to schema version 4.0.0, and `scd` instead of `rid` if wiping SCD:
 
 ```bash
-docker container exec -i dss_sandbox_local-dss-crdb_1 cockroach sql --insecure <<< 'use postgres; drop database rid cascade;'
+docker container exec -i dss_sandbox-local-dss-crdb-1 cockroach sql --insecure <<< 'use postgres; drop database rid cascade;'
 ```
 
 To just determine the current version of a database schema, simply omit the

--- a/build/dev/startup/core_service.sh
+++ b/build/dev/startup/core_service.sh
@@ -16,7 +16,7 @@ if [ "$DEBUG_ON" = "1" ]; then
   -log_format console \
   -dump_requests \
   -addr :8082 \
-  -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox_local-dss-core-service_1,core-service \
+  -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox-local-dss-core-service-1,core-service \
   -enable_scd \
   -enable_http
 else
@@ -28,7 +28,7 @@ else
   -log_format console \
   -dump_requests \
   -addr :8082 \
-  -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox_local-dss-core-service_1,core-service \
+  -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox-local-dss-core-service-1,core-service \
   -enable_scd \
   -enable_http
 fi

--- a/build/dev/wait_for_local_dss.sh
+++ b/build/dev/wait_for_local_dss.sh
@@ -1,9 +1,26 @@
 #!/bin/bash
 
-OAUTH_CONTAINER="dss_sandbox_local-dss-dummy-oauth_1"
-CORE_SERVICE_CONTAINER="dss_sandbox_local-dss-core-service_1"
+OAUTH_CONTAINER="dss_sandbox-local-dss-dummy-oauth-1"
+CORE_SERVICE_CONTAINER="dss_sandbox-local-dss-core-service-1"
 declare -a localhost_containers=("$OAUTH_CONTAINER" "$CORE_SERVICE_CONTAINER")
 
+# 2 minute timer to prevent infinite looping if a docker issue is present.
+timeout_duration=120
+
+# check to see if 2 minutes has elapsed which indicates a problem with the container(s)
+check_timeout() {
+   local start_time="$1"
+   local error_message="$2"
+   current_time=$(date +%s)
+   elapsed_time=$((current_time-start_time))
+   if ((elapsed_time >= timeout_duration)); then
+     echo "$error_message"
+     exit 1
+   fi
+}
+
+# start the timer
+start_time=$(date +%s)
 for container_name in "${localhost_containers[@]}"; do
   last_message=""
   while true; do
@@ -17,6 +34,7 @@ for container_name in "${localhost_containers[@]}"; do
       printf '%s' "${new_message}"
       last_message="${new_message}"
     fi
+    check_timeout "$start_time" "Timeout reached. Container failed to start. Exiting."
     sleep 3
   done
   if [ -n "${last_message}" ]; then
@@ -24,6 +42,8 @@ for container_name in "${localhost_containers[@]}"; do
   fi
 done
 
+# reset the timer
+start_time=$(date +%s)
 last_message=""
 while true; do
   health_status="$( docker container inspect -f '{{.State.Health.Status}}' "${CORE_SERVICE_CONTAINER}" )"
@@ -37,6 +57,7 @@ while true; do
         printf '%s' "${new_message}"
         last_message="${new_message}"
       fi
+      check_timeout "$start_time" "Timeout reached. Container failed to become available. Exiting."
       sleep 3
     fi
 done

--- a/test/README.md
+++ b/test/README.md
@@ -41,7 +41,7 @@ simply add its name as the first argument to the script to run prober locally
 
 ### Examining Core Service logs
 After a `make probe-locally` run, the Core Service logs can be examined in the
-Core Service container (usually `dss_sandbox_local-dss-core-service_1`) or
+Core Service container (usually `dss_sandbox-local-dss-core-service-1`) or
 dumped to core-service-for-testing.log using `make collect-local-logs`.
 
 ## Continuous integration


### PR DESCRIPTION
These updates for the docker compose updates to the container naming convention changes in Docker V2.