### PR TITLE
[deployment] Update removed/deprecated resources and fields for Kubernetes v1.25

### DIFF
--- a/build/deploy/base.libsonnet
+++ b/build/deploy/base.libsonnet
@@ -7,7 +7,6 @@ local util = import 'util.libsonnet';
     metadata: {
       name: name,
       namespace: metadata.namespace,
-      clusterName: metadata.clusterName,
       labels: {
         name: std.join('-', std.split(name, ':')),
       },
@@ -54,7 +53,7 @@ local util = import 'util.libsonnet';
 
   },
 
-  PodDisruptionBudget(metadata, name): $._Object('policy/v1beta1', 'PodDisruptionBudget', metadata, name) {
+  PodDisruptionBudget(metadata, name): $._Object('policy/v1', 'PodDisruptionBudget', metadata, name) {
     local pdb = self,
     app:: error "must specify app",
     metadata+: {
@@ -72,7 +71,7 @@ local util = import 'util.libsonnet';
     },
   },
 
-  ManagedCert(metadata, name): $._Object('networking.gke.io/v1beta1', 'ManagedCertificate', metadata, name) {
+  ManagedCert(metadata, name): $._Object('networking.gke.io/v1', 'ManagedCertificate', metadata, name) {
 
   },
 


### PR DESCRIPTION
To support Kubernetes v1.25, the following changes are necessary:
- `metadata.clusterName` has been [removed](https://github.com/kubernetes/kubernetes/pull/109602)
- `PodDisruptionBudget` version `v1beta1` is [no longer served](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125).
- `ManagedCert` version `v1beta1` has been deprecated.