### PR TITLE
[SCD] Populate uss_availability field of operational intents

### DIFF
--- a/pkg/scd/models/operational_intents.go
+++ b/pkg/scd/models/operational_intents.go
@@ -53,18 +53,19 @@ func (s OperationalIntentState) IsValidInDSS() bool {
 // OperationalIntent models an operational intent.
 type OperationalIntent struct {
 	// Reference
-	ID             dssmodels.ID
-	Manager        dssmodels.Manager
-	Version        VersionNumber
-	State          OperationalIntentState
-	OVN            OVN
-	StartTime      *time.Time
-	EndTime        *time.Time
-	USSBaseURL     string
-	SubscriptionID dssmodels.ID
-	AltitudeLower  *float32
-	AltitudeUpper  *float32
-	Cells          s2.CellUnion
+	ID              dssmodels.ID
+	Manager         dssmodels.Manager
+	UssAvailability UssAvailabilityState
+	Version         VersionNumber
+	State           OperationalIntentState
+	OVN             OVN
+	StartTime       *time.Time
+	EndTime         *time.Time
+	USSBaseURL      string
+	SubscriptionID  dssmodels.ID
+	AltitudeLower   *float32
+	AltitudeUpper   *float32
+	Cells           s2.CellUnion
 }
 
 func (s OperationalIntentState) String() string {
@@ -86,7 +87,7 @@ func (o *OperationalIntent) ToRest() *restapi.OperationalIntentReference {
 		UssBaseUrl:      restapi.OperationalIntentUssBaseURL(o.USSBaseURL),
 		SubscriptionId:  restapi.SubscriptionID(o.SubscriptionID.String()),
 		State:           o.State.ToRest(),
-		UssAvailability: UssAvailabilityStateUnknown.ToRest(),
+		UssAvailability: o.UssAvailability.ToRest(),
 	}
 
 	if o.StartTime != nil {


### PR DESCRIPTION
The current implementation of the SCD handlers that return operational intents will always return an USS availability state "Unknown". 
This PR implements the retrieval of the availability state of the operational intent's managing USS and embed it in the operational intent representation.
Please let me know if the approach taken is not correct, I have no experience with the cockroach part of the codebase.

~Note: as this is failing tests, I'm putting the PR back to draft until fixed.~