### PR TITLE
[SCD] Do not require key for accepted op intents of down USSes

### DIFF
--- a/pkg/scd/models/operational_intents.go
+++ b/pkg/scd/models/operational_intents.go
@@ -137,3 +137,9 @@ func (o *OperationalIntent) SetCells(cids []int64) {
 	}
 	o.Cells = cells
 }
+
+// RequiresKey indicates whether this OperationalIntent requires its OVN to be included in the provided keys when
+// another intersecting OperationalIntent is being created or updated.
+func (o *OperationalIntent) RequiresKey() bool {
+	return !(o.UssAvailability == UssAvailabilityStateDown && o.State == OperationalIntentStateAccepted)
+}

--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -551,7 +551,8 @@ func (a *Server) PutOperationalIntentReference(ctx context.Context, manager stri
 				return stacktrace.Propagate(err, "Unable to SearchOperations")
 			}
 			for _, relevantOp := range relevantOps {
-				if _, ok := key[relevantOp.OVN]; !ok {
+				_, ok := key[relevantOp.OVN]
+				if !ok && relevantOp.RequiresKey() {
 					if relevantOp.Manager != dssmodels.Manager(manager) {
 						relevantOp.OVN = scdmodels.NoOvnPhrase
 					}


### PR DESCRIPTION
The current implementation of the SCD handlers that create or update operational intents do not exclude the OVNs of accepted operational intents of down USSes from the required OVNs as it is required to by the standard.
This PR fixes this.