### PR TITLE
[terraform-aws] Update policy following API change

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/AWSLoadBalancerControllerPolicy.json
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/AWSLoadBalancerControllerPolicy.json
@@ -199,6 +199,28 @@
     {
       "Effect": "Allow",
       "Action": [
+        "elasticloadbalancing:AddTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "elasticloadbalancing:CreateAction": [
+            "CreateTargetGroup",
+            "CreateLoadBalancer"
+          ]
+        },
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:DeregisterTargets"
       ],


### PR DESCRIPTION
This PR fixes #966. The solution was proposed in [aws-load-balancer-controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller): https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2692#issuecomment-1602615427

Updating the policy to match AWS API change solves the issue. 