### PR TITLE
[terraform-helm] Generate helm values from terraform

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-commons-dss/main.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/main.tf
@@ -66,3 +66,67 @@ resource "local_file" "get_credentials" {
   })
   filename = "${local.workspace_location}/get-credentials.sh"
 }
+
+resource "local_file" "helm_chart_values" {
+  filename = "${local.workspace_location}/helm_values.yml"
+  content = yamlencode({
+    cockroachdb = {
+      fullnameOverride = "dss-cockroachdb"
+
+      conf = {
+        join         = var.crdb_external_nodes
+        cluster-name = "dss-aws-1"
+        single-node  = false
+        locality     = "zone=${var.crdb_locality}"
+      }
+
+      statefulset = {
+        args = [
+          "--locality-advertise-addr=zone=${var.crdb_locality}@$(hostname -f)",
+          "--advertise-addr=$${HOSTNAME##*-}.${var.crdb_hostname_suffix}"
+        ]
+      }
+
+      storage = {
+        persistentVolume = {
+          storageClass = var.kubernetes_storage_class
+        }
+      }
+    }
+
+    loadBalancers = {
+      cockroachdbNodes = [
+      for ip in var.crdb_internal_nodes[*].ip :
+      {
+        ip     = ip
+        subnet = var.workload_subnet
+      }
+      ]
+
+      dssGateway = {
+        ip       = var.ip_gateway
+        subnet   = var.workload_subnet
+        certName = var.gateway_cert_name
+      }
+    }
+
+    dss = {
+      image = local.image
+
+      conf = {
+        pubKeys      = [
+          "/test-certs/auth2.pem"
+        ]
+        jwksEndpoint = var.authorization.jwks != null ? var.authorization.jwks.endpoint : ""
+        jwksKeyIds   = var.authorization.jwks != null ? [var.authorization.jwks.key_id] : []
+        hostname     = var.app_hostname
+        enableScd    = var.enable_scd
+      }
+    }
+
+    global = {
+      cloudProvider = var.kubernetes_cloud_provider_name
+    }
+  })
+}
+


### PR DESCRIPTION
Progressing on #874, this PR adds to the dss terraform module the ability to generate a new configuration file which is used by helm as input values.

This file has been used for the runs here: https://github.com/Orbitalize/dss/actions/workflows/dss-deploy.yml