### PR TITLE
[terraform-aws] Improve terraform aws teardown dependencies

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/cluster.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/cluster.tf
@@ -1,7 +1,7 @@
 resource "aws_eks_cluster" "kubernetes_cluster" {
   name     = var.cluster_name
   role_arn = aws_iam_role.dss-cluster.arn
-  
+
   vpc_config {
     subnet_ids             = aws_subnet.dss[*].id
     endpoint_public_access = true
@@ -13,8 +13,14 @@ resource "aws_eks_cluster" "kubernetes_cluster" {
   # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
   # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
   depends_on = [
+    aws_iam_role.dss-cluster-node-group,
     aws_iam_role_policy_attachment.dss-cluster-service,
-    aws_internet_gateway.dss
+    aws_iam_role_policy_attachment.AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.AWSLoadBalancerControllerPolicy,
+    aws_internet_gateway.dss,
+    aws_eip.gateway,
+    aws_eip.ip_crdb
   ]
 
   version = "1.24"
@@ -39,4 +45,9 @@ resource "aws_eks_node_group" "eks_node_group" {
   lifecycle {
     create_before_destroy = true
   }
+
+  depends_on = [
+    aws_eip.gateway,
+    aws_eip.ip_crdb
+  ]
 }

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/output.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/output.tf
@@ -3,3 +3,7 @@ output "generated_files_location" {
   Workspace location with generated files: ${local.workspace_location}
   EOT
 }
+
+output "workspace_location" {
+  value = local.workspace_location
+}

--- a/deploy/infrastructure/modules/terraform-aws-dss/main.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/main.tf
@@ -6,7 +6,6 @@ module "terraform-aws-kubernetes" {
   crdb_hostname_suffix         = var.crdb_hostname_suffix
   aws_instance_type            = var.aws_instance_type
   aws_route53_zone_id          = var.aws_route53_zone_id
-  aws_iam_path                 = var.aws_iam_path
   aws_iam_permissions_boundary = var.aws_iam_permissions_boundary
   node_count                   = var.node_count
 

--- a/deploy/infrastructure/modules/terraform-aws-dss/output.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/output.tf
@@ -6,10 +6,19 @@ output "gateway_address" {
   value = module.terraform-aws-kubernetes.gateway_address
 }
 
+output "iam_role_node_group_arn" {
+  value = module.terraform-aws-kubernetes.iam_role_node_group_arn
+}
+
 output "generated_files_location" {
   value = module.terraform-commons-dss.generated_files_location
+}
+
+output "workspace_location" {
+  value = module.terraform-commons-dss.workspace_location
 }
 
 output "cluster_context" {
   value = module.terraform-aws-kubernetes.kubernetes_context_name
 }
+


### PR DESCRIPTION
Progressing on #874, this PR improves the current terraform scripts to better handle tear down on AWS in preparation to running as part of the CI.

Those changes have been exercised multiple times here: https://github.com/Orbitalize/dss/actions/workflows/dss-deploy.yml