### PR TITLE
[scd] check subscription version is present and correct when deleting

### DIFF
--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -40,7 +40,7 @@ if ! docker run --link "$OAUTH_CONTAINER":oauth \
 	--network dss_sandbox-default \
 	-v "${RESULTFILE}:/app/test_result" \
 	-w /app/monitoring/prober \
-	interuss/monitoring:v0.2.0 \
+	interuss/monitoring:v0.3.0 \
 	pytest \
 	"${1:-.}" \
 	-rsx \

--- a/test/migrations/rid_db_post_migration_e2e.sh
+++ b/test/migrations/rid_db_post_migration_e2e.sh
@@ -82,7 +82,7 @@ docker run --link dummy-oauth-for-testing:oauth \
 	--link core-service-for-testing:core-service \
 	-v "${RESULTFILE}:/app/test_result" \
 	-w /app/monitoring/prober \
-	interuss/monitoring:v0.2.0 \
+	interuss/monitoring:v0.3.0 \
 	pytest \
 	"${1:-.}" \
 	-rsx \


### PR DESCRIPTION
Discovered that the `version` of a subscription was plainly ignored when writing some tests for the deletion endpoint.

With the present fix we obtain the expected failure when:
 - the version is missing
 - the version is wrong
 
 While the deletion functionality still works when the provided version is correct.