### PR TITLE
[infrastructure] Add variable to set kubernetes cluster version. Default to 1.24

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/cluster.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/cluster.tf
@@ -23,7 +23,7 @@ resource "aws_eks_cluster" "kubernetes_cluster" {
     aws_eip.ip_crdb
   ]
 
-  version = "1.24"
+  version = var.kubernetes_version
 }
 
 resource "aws_eks_node_group" "eks_node_group" {

--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/variables.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/variables.tf
@@ -87,3 +87,19 @@ variable "node_count" {
   }
 }
 
+variable "kubernetes_version" {
+  type        = string
+  description = <<-EOT
+    Desired version of the Kubernetes cluster control plane and nodes.
+
+    Supported versions:
+      - 1.24
+  EOT
+
+  validation {
+    condition     = var.kubernetes_version == "1.24"
+    error_message = "Only 1.24 is supported."
+  }
+}
+
+

--- a/deploy/infrastructure/dependencies/terraform-google-kubernetes/cluster.tf
+++ b/deploy/infrastructure/dependencies/terraform-google-kubernetes/cluster.tf
@@ -11,6 +11,8 @@ resource "google_container_cluster" "kubernetes_cluster" {
   ip_allocation_policy {
     # Intentionally left empty.
   }
+
+  min_master_version = var.kubernetes_version
 }
 
 resource "google_container_node_pool" "dss_pool" {

--- a/deploy/infrastructure/dependencies/terraform-google-kubernetes/variables.tf
+++ b/deploy/infrastructure/dependencies/terraform-google-kubernetes/variables.tf
@@ -78,3 +78,19 @@ variable "node_count" {
   }
 }
 
+variable "kubernetes_version" {
+  type        = string
+  description = <<-EOT
+    Desired version of the Kubernetes cluster control plane and nodes.
+
+    Supported versions:
+      - 1.24
+  EOT
+
+  validation {
+    condition     = var.kubernetes_version == "1.24"
+    error_message = "Only 1.24 is supported."
+  }
+}
+
+

--- a/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.md
+++ b/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.md
@@ -88,6 +88,16 @@ Number of Kubernetes nodes which should correspond to the desired CockroachDB no
 Example: `3`
 
 
+### kubernetes_version
+
+*Type: `string`*
+
+Desired version of the Kubernetes cluster control plane and nodes.
+
+Supported versions:
+- 1.24
+
+
 ### aws_kubernetes_storage_class
 
 *Type: `string`*

--- a/deploy/infrastructure/modules/terraform-aws-dss/main.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/main.tf
@@ -8,6 +8,7 @@ module "terraform-aws-kubernetes" {
   aws_route53_zone_id          = var.aws_route53_zone_id
   aws_iam_permissions_boundary = var.aws_iam_permissions_boundary
   node_count                   = var.node_count
+  kubernetes_version           = var.kubernetes_version
 
   source = "../../dependencies/terraform-aws-kubernetes"
 }

--- a/deploy/infrastructure/modules/terraform-aws-dss/variables.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/variables.tf
@@ -87,6 +87,22 @@ variable "node_count" {
   }
 }
 
+variable "kubernetes_version" {
+  type        = string
+  description = <<-EOT
+    Desired version of the Kubernetes cluster control plane and nodes.
+
+    Supported versions:
+      - 1.24
+  EOT
+
+  validation {
+    condition     = var.kubernetes_version == "1.24"
+    error_message = "Only 1.24 is supported."
+  }
+}
+
+
 variable "aws_kubernetes_storage_class" {
   type        = string
   description = <<-EOT

--- a/deploy/infrastructure/modules/terraform-google-dss/README.md
+++ b/deploy/infrastructure/modules/terraform-google-dss/README.md
@@ -20,8 +20,9 @@ Download & install the following tools to your workstation:
 2. Check that the DSS project is correctly selected: gcloud config list project
     1. Set another one if needed using: `gcloud config set project $GOOGLE_PROJECT_NAME`
 3. Enable the following API using [Google Cloud CLI](https://cloud.google.com/endpoints/docs/openapi/enable-api#gcloud):
-    1. `container.googleapis.com`
-    2. If you want to manage DNS entries with terraform: `dns.googleapis.com`
+    1. `compute.googleapis.com`
+    2. `container.googleapis.com`
+    3. If you want to manage DNS entries with terraform: `dns.googleapis.com`
 4. Install the auth plugin to connect to kubernetes: `gcloud components install gke-gcloud-auth-plugin`
 5. Run `gcloud auth application-default login` to generate credentials to call Google Cloud Platform APIs.
     1. If the result of performing the authorization indicates 404 in the browser, check whether a local dummy-oauth instance is running (using port 8085).  Stop the dummy-oauth instance if it is running.

--- a/deploy/infrastructure/modules/terraform-google-dss/TFVARS.md
+++ b/deploy/infrastructure/modules/terraform-google-dss/TFVARS.md
@@ -82,6 +82,16 @@ Number of Kubernetes nodes which should correspond to the desired CockroachDB no
 Example: `3`
 
 
+### kubernetes_version
+
+*Type: `string`*
+
+Desired version of the Kubernetes cluster control plane and nodes.
+
+Supported versions:
+- 1.24
+
+
 ### google_kubernetes_storage_class
 
 *Type: `string`*

--- a/deploy/infrastructure/modules/terraform-google-dss/main.tf
+++ b/deploy/infrastructure/modules/terraform-google-dss/main.tf
@@ -8,6 +8,7 @@ module "terraform-google-kubernetes" {
   google_dns_managed_zone_name = var.google_dns_managed_zone_name
   google_machine_type          = var.google_machine_type
   node_count                   = var.node_count
+  kubernetes_version           = var.kubernetes_version
 
   source = "../../dependencies/terraform-google-kubernetes"
 }

--- a/deploy/infrastructure/modules/terraform-google-dss/variables.tf
+++ b/deploy/infrastructure/modules/terraform-google-dss/variables.tf
@@ -78,6 +78,22 @@ variable "node_count" {
   }
 }
 
+variable "kubernetes_version" {
+  type        = string
+  description = <<-EOT
+    Desired version of the Kubernetes cluster control plane and nodes.
+
+    Supported versions:
+      - 1.24
+  EOT
+
+  validation {
+    condition     = var.kubernetes_version == "1.24"
+    error_message = "Only 1.24 is supported."
+  }
+}
+
+
 variable "google_kubernetes_storage_class" {
   type        = string
   description = <<-EOT

--- a/deploy/infrastructure/utils/README.md
+++ b/deploy/infrastructure/utils/README.md
@@ -2,6 +2,8 @@
 
 This directory contains the following tools to simplify the management of the terraform modules:
 
-1. `generate_terraform_variables.sh`: Terraform variables can't be shared between modules without repeating their definition at every level of encapsulation.
-   To prevent repeating ourselves and to maintain a consistent level of quality for every module and dependencies, this script takes variables 
-   in the `definitions` directory and creates a `variables.tf` file in each modules with the appropriate content.
+## `generate_terraform_variables.sh`
+Terraform variables can't be shared between modules without repeating their definition at every level of encapsulation.
+To prevent repeating ourselves and to maintain a consistent level of quality for every module and dependencies, this script takes variables 
+in the `definitions` directory and creates a `variables.tf` file in each modules with the appropriate content.
+Assignment of `definitions` files to modules is made in `variables.py`.

--- a/deploy/infrastructure/utils/definitions/kubernetes_version.tf
+++ b/deploy/infrastructure/utils/definitions/kubernetes_version.tf
@@ -1,0 +1,14 @@
+variable "kubernetes_version" {
+  type        = string
+  description = <<-EOT
+    Desired version of the Kubernetes cluster control plane and nodes.
+
+    Supported versions:
+      - 1.24
+  EOT
+
+  validation {
+    condition     = var.kubernetes_version == "1.24"
+    error_message = "Only 1.24 is supported."
+  }
+}

--- a/deploy/infrastructure/utils/variables.py
+++ b/deploy/infrastructure/utils/variables.py
@@ -36,13 +36,14 @@ COMMONS_DSS_VARIABLES = GLOBAL_VARIABLES + [
     "desired_scd_db_version",
     "crdb_locality",
     "crdb_external_nodes",
-    "kubernetes_namespace",
+    "kubernetes_namespace"
 ]
 
 # dependencies/terraform-*-kubernetes
 COMMON_KUBERNETES_VARIABLES = GLOBAL_VARIABLES + [
     "cluster_name",
     "node_count",
+    "kubernetes_version"
 ]
 
 # dependencies/terraform-google-kubernetes

--- a/deploy/operations/ci/aws-1/main.tf
+++ b/deploy/operations/ci/aws-1/main.tf
@@ -20,6 +20,7 @@ module "terraform-aws-dss" {
   crdb_hostname_suffix         = var.crdb_hostname_suffix
   crdb_locality                = var.crdb_locality
   image                        = var.image
+  kubernetes_version           = var.kubernetes_version
   node_count                   = 3
   should_init                  = true
   enable_scd                   = true

--- a/deploy/operations/ci/aws-1/terraform.tfvars
+++ b/deploy/operations/ci/aws-1/terraform.tfvars
@@ -11,6 +11,7 @@ app_hostname = "dss.ci.aws-interuss.uspace.dev"
 crdb_hostname_suffix = "db.ci.aws-interuss.uspace.dev"
 
 # Kubernetes configuration
+kubernetes_version           = 1.24
 cluster_name                 = "dss-ci-aws-ue1"
 node_count                   = 3
 aws_instance_type            = "t3.medium"

--- a/deploy/operations/ci/aws-1/variables.tf
+++ b/deploy/operations/ci/aws-1/variables.tf
@@ -87,6 +87,22 @@ variable "node_count" {
   }
 }
 
+variable "kubernetes_version" {
+  type        = string
+  description = <<-EOT
+    Desired version of the Kubernetes cluster control plane and nodes.
+
+    Supported versions:
+      - 1.24
+  EOT
+
+  validation {
+    condition     = var.kubernetes_version == "1.24"
+    error_message = "Only 1.24 is supported."
+  }
+}
+
+
 variable "aws_kubernetes_storage_class" {
   type        = string
   description = <<-EOT


### PR DESCRIPTION
This PR adds a variable to set the Kubernetes cluster version in preparation to migrate to version 1.27 (#968).
This will allow current users to control the migration process.

Note that TFVARS.md and variables.tf are automatically generated.

Tested on Google cloud manually and automatically for AWS [here](https://github.com/Orbitalize/dss/actions/runs/7644196668/job/20830095705).