### PR TITLE
[infrastructure] Remove useless variables

### DIFF
--- a/deploy/infrastructure/utils/definitions/kubernetes_cloud_provider.tf
+++ b/deploy/infrastructure/utils/definitions/kubernetes_cloud_provider.tf
@@ -1,4 +1,0 @@
-variable "kubernetes_cloud_provider_name" {
-  type        = string
-  description = "Cloud provider name"
-}

--- a/deploy/infrastructure/utils/definitions/kubernetes_get_credentials_cmd.tf
+++ b/deploy/infrastructure/utils/definitions/kubernetes_get_credentials_cmd.tf
@@ -1,4 +1,0 @@
-variable "kubernetes_get_credentials_cmd" {
-  type        = string
-  description = "Command to get credentials to access the Kubernetes cluster"
-}


### PR DESCRIPTION
This PR removes two variables which should have been removed previously since they are not publicly exposed.

They are actually managed internally [here](https://github.com/interuss/dss/blob/master/deploy/infrastructure/dependencies/terraform-commons-dss/variables_internal.tf).