### PR TITLE
[ci] Wait for helm before next steps

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/network_lb.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/network_lb.tf
@@ -7,6 +7,8 @@ resource "helm_release" "aws-load-balancer-controller" {
 
   namespace = "kube-system"
 
+  wait = true
+
   set {
     name  = "clusterName"
     value = var.cluster_name

--- a/deploy/operations/ci/aws-1/test.sh
+++ b/deploy/operations/ci/aws-1/test.sh
@@ -37,7 +37,8 @@ kubectl apply -f "aws_auth_config_map.yml"
 cd "$BASEDIR/../../../services/helm-charts/dss"
 RELEASE_NAME="dss"
 helm dep update --kube-context="$KUBE_CONTEXT"
-helm upgrade --install --kube-context="$KUBE_CONTEXT" -f "${WORKSPACE_LOCATION}/helm_values.yml" "$RELEASE_NAME" .
+helm upgrade --install --debug --kube-context="$KUBE_CONTEXT" -f "${WORKSPACE_LOCATION}/helm_values.yml" "$RELEASE_NAME" .
+kubectl wait --for=condition=complete --timeout=3m job/rid-schema-manager-1
 
 # TODO: Test the deployment of the DSS
 
@@ -48,11 +49,12 @@ fi
 
 # Cleanup
 # Delete workloads
-helm uninstall --kube-context="$KUBE_CONTEXT" "$RELEASE_NAME"
+helm uninstall --debug --kube-context="$KUBE_CONTEXT" --wait --timeout 5m "$RELEASE_NAME"
 
-# Delete PVC to delete persistant volumes
-kubectl delete pvc --all=true
-# TODO: Check completness
+# Delete PVC to delete persistent volumes
+kubectl delete pvc --wait --all=true
+kubectl delete pv --wait --all=true
+# TODO: Check completeness
 
 # Delete cluster
 cd "$BASEDIR"


### PR DESCRIPTION
The CI deployment workflow sometimes fails because the AWS VPC can't be deleted due to some resources still present. (namely, resources managed by the AWS elastic load balancer helm chart).
This PR changes the helm commands to wait for the resources to be properly set up and tear down before exiting.

The expectation is that it will give more time to the AWS elastic load balancer helm to deprovision the load balancers and related resources before the cluster is destroyed. 

In addition, some Persistent Volumes are not completely deleted by EKS. A first attempt at enforcing it is included in this PR.