### PR TITLE
[apis] models.IDFromString strictly check for RFC 4122 variant of the V4  UUID format

### DIFF
--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -1,0 +1,84 @@
+package models
+
+import "testing"
+
+func TestIDFromString(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    ID
+		wantErr bool
+	}{
+		{
+			name: "compliant 1",
+			args: args{
+				s: "00000179-e36d-40be-838b-eca6ca350000",
+			},
+			want:    ID("00000179-e36d-40be-838b-eca6ca350000"),
+			wantErr: false,
+		},
+		{
+			name: "compliant 2",
+			args: args{
+				s: "03e5572a-f733-49af-bc14-8a18bd53ee39",
+			},
+			want:    ID("03e5572a-f733-49af-bc14-8a18bd53ee39"),
+			wantErr: false,
+		},
+		{
+			name: "wrong version",
+			args: args{
+				s: "00000179-e36d-50be-838b-eca6ca350000",
+			},
+			want:    ID(""),
+			wantErr: true,
+		},
+		{
+			name: "wrong variant",
+			args: args{
+				s: "00000179-e36d-d0be-d38b-eca6ca350000",
+			},
+			want:    ID(""),
+			wantErr: true,
+		},
+		{
+			name: "random",
+			args: args{
+				s: "sdh2o4mxc912asdvt34123dsfg2123dcsasefvaqyb4bp963r3",
+			},
+			want:    ID(""),
+			wantErr: true,
+		},
+		{
+			name: "missing leading char",
+			args: args{
+				s: "0000179-e36d-40be-838b-eca6ca350000",
+			},
+			want:    ID(""),
+			wantErr: true,
+		},
+		{
+			name: "missing last char",
+			args: args{
+				s: "00000179-e36d-40be-838b-eca6ca35000",
+			},
+			want:    ID(""),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IDFromString(tt.args.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IDFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IDFromString() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The OpenAPI specification for the [SCD endpoints](https://github.com/astm-utm/Protocol/blob/v1.0.0/utm.yaml#L120) specifies that we should use a UUID V4 of the RFC4122 variant. It provides a regexp(*) for validating the UUIDs in an unambiguous way.

However, In the context of SCD, the current implementation allows the use of IDs that don't conform to the V4-RFC4122 variant, such as `00000179-e36d-40be-d38b-eca6ca350000`

### Problem

This might be problematic if other implementations chose to enforce this more strictly:
 - a client may successfully create an entity on this DSS implementation
 - a client will then expect other DSS's for the relevant area to reply to requests, which said DSS's might reject because the requested IDs are not valid
 
More generally, a request for creating an entity should either be valid for all DSSes or invalid for all DSSes (at least, that seems like a reasonable requirement)

### Approach

A simple solution is to add two additional checks for UUIDs: one for the version, and the other for the variant.

This is a simple fix, which is provided as a first version of this PR: this does not seem to break any existing test, incl. the `prober`.

**However:**

The OpenAPI specs for the [RID v2_1 requirement](https://github.com/uastech/standards/blob/ab6037442d97e868183ed60d35dab4954d9f15d0/remoteid/canonical.yaml#L1038) side of the DSS requires a UUID V4 without specifying a variant. Note that the given example happens to be a RFC4122 variant, but there is no mention of RFC4122 in that file.

## **Chose solution**

 - amend the RID specification to more explicitly mandate a UUID V4 of the RFC4122 variant and apply that requirement to all UUID's in the DSS.
 - ~~separate the validation logic for UUIDs depending on if they are used in the RID or SCD contexts~~
 
As indicated by @nasajoey, the requirement for a v4 UUID implicitly means that it needs to respect RFC4122, as no other RFC mentions such an UUID. It is thus acceptable to expect _all_ endpoints (both RID v1/v2 and SCD) to only accept such identifiers. 
 


(*): `^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$`

