### PR TITLE
[terraform][google] Explicitly disable legacy endpoints on node pool

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-google-kubernetes/cluster.tf
+++ b/deploy/infrastructure/dependencies/terraform-google-kubernetes/cluster.tf
@@ -29,6 +29,10 @@ resource "google_container_node_pool" "dss_pool" {
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform"
     ]
+
+    metadata = {
+      "disable-legacy-endpoints" = true
+    }
   }
 
   lifecycle {


### PR DESCRIPTION
In this PR, we explicitly set `disable-legacy-endpoints` metadata to prevent unexpected override. 
By default, this value is set to true. However, if some metadata would be provided in the future, this default value is not preserved.
Reference: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#metadata