### PR TITLE
[terraform-google][tanka] Set SSL policy to enforce secure TLS connections

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -380,6 +380,12 @@ a PR to that effect would be greatly appreciated.
 
     -   If you are only turning up a single DSS instance for development, you
         may optionally change `single_cluster` to `true`.
+    
+    1.  `VAR_SSL_POLICY`: When deploying on Google Cloud, a [ssl policy](https://cloud.google.com/load-balancing/docs/ssl-policies-concepts) 
+        can be applied to the DSS Ingress. This can be used to secure the TLS connection.
+        Follow the [instructions](https://cloud.google.com/load-balancing/docs/use-ssl-policies) to create the Global SSL Policy and 
+        replace VAR_SSL_POLICY variable with its name. `RESTRICTED` profile is recommended.
+        Leave it empty if not applicable.
 
 1.  Edit workspace/$CLUSTER_CONTEXT/spec.json and replace all VAR_*
     instances with appropriate values:

--- a/build/deploy/base.libsonnet
+++ b/build/deploy/base.libsonnet
@@ -258,5 +258,14 @@ local util = import 'util.libsonnet';
           'service.beta.kubernetes.io/aws-load-balancer-ssl-cert': certARN,
       },
     },
+  },
+
+  GoogleFrontendConfig(metadata, name, sslPolicy): $._Object('networking.gke.io/v1beta1', 'FrontendConfig', metadata, name) {
+    metadata+: {
+      name: name
+    },
+    spec+: {
+      sslPolicy: sslPolicy
+    }
   }
 }

--- a/build/deploy/core-service.libsonnet
+++ b/build/deploy/core-service.libsonnet
@@ -19,6 +19,7 @@ local awsLoadBalancer(metadata) = base.AWSLoadBalancerWithManagedCert(metadata, 
       annotations: {
         'kubernetes.io/ingress.global-static-ip-name': metadata.backend.ipName,
         'kubernetes.io/ingress.allow-http': 'false',
+        [if metadata.backend.sslPolicy != '' then 'networking.gke.io/v1beta1.FrontendConfig']: 'ssl-frontend-config',
       },
     },
     spec: {
@@ -32,6 +33,8 @@ local awsLoadBalancer(metadata) = base.AWSLoadBalancerWithManagedCert(metadata, 
       },
     },
   },
+
+  GoogleSSLPolicyFrontendConfig(metadata): base.GoogleFrontendConfig(metadata, 'ssl-frontend-config', metadata.backend.sslPolicy),
 
   GoogleManagedCertIngress(metadata): {
     ingress: $.GoogleIngress(metadata) {
@@ -68,6 +71,7 @@ local awsLoadBalancer(metadata) = base.AWSLoadBalancerWithManagedCert(metadata, 
   CloudNetwork(metadata): {
     google: if metadata.cloud_provider == "google" then {
       ingress: $.GoogleManagedCertIngress(metadata),
+      [if metadata.backend.sslPolicy != '' then 'frontendConfig']: $.GoogleSSLPolicyFrontendConfig(metadata),
       service: $.GoogleService(metadata),
     },
     aws_loadbalancer: if metadata.cloud_provider == "aws" then awsLoadBalancer(metadata)

--- a/build/deploy/examples/minimum/main.jsonnet
+++ b/build/deploy/examples/minimum/main.jsonnet
@@ -25,6 +25,7 @@ local metadata = metadataBase {
     jwksKeyIds: ['VAR_JWKS_KEY_ID'],
     hostname: 'VAR_APP_HOSTNAME',
     dumpRequests: true,
+    sslPolicy: 'VAR_SSL_POLICY'
   },
   schema_manager+: {
     image: 'VAR_DOCKER_IMAGE_NAME',

--- a/build/deploy/metadata_base.libsonnet
+++ b/build/deploy/metadata_base.libsonnet
@@ -34,6 +34,7 @@
     hostname: error 'must specify hostname',
     dumpRequests: false,
     certName: if $.cloud_provider == "aws" then error 'must specify certName for AWS cloud provider', # Only used by AWS
+    sslPolicy: '', # SSL Policy Name. Only used by Google Cloud.
   },
   alert: {
     enable: false,

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/main.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/main.tf
@@ -28,6 +28,7 @@ resource "local_file" "tanka_config_main" {
     VAR_CLOUD_PROVIDER           = var.kubernetes_cloud_provider_name
     VAR_CERT_NAME                = var.gateway_cert_name
     VAR_SUBNET                   = var.workload_subnet
+    VAR_SSL_POLICY               = var.ssl_policy
   })
   filename = "${local.workspace_location}/main.jsonnet"
 }

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
@@ -31,6 +31,7 @@ local metadata = metadataBase {
     jwksKeyIds: ['${VAR_JWKS_KEY_ID}'],
     hostname: '${VAR_APP_HOSTNAME}',
     dumpRequests: true,
+    sslPolicy: '${VAR_SSL_POLICY}'
   },
   schema_manager+: {
     image: '${VAR_DOCKER_IMAGE_NAME}',


### PR DESCRIPTION
This PR adds to tanka deployment the ability to set a SSL policy to the DSS Gateway ingress. Creation of the SSL Policy with terraform is addressed in #997.

When VAR_SSL_POLICY is provided, the following expected lines are added to the deployment compared to the original one:

```
>     networking.gke.io/v1beta1.FrontendConfig: ssl-frontend-config
...
> ---
> apiVersion: networking.gke.io/v1beta1
> kind: FrontendConfig
> metadata:
>   labels:
>     name: ssl-frontend-config
>   name: ssl-frontend-config
>   namespace: default
> spec:
>   sslPolicy: dss-ci-google-ue4-secure-ssl-policy
```

Tested on google cloud: https://dss.ci.google-interuss.uspace.dev/
Load balancer is correctly set with the provided ssl policy.