### PR TITLE
[core-service] Close indicator file

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -309,11 +309,11 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 	if err != nil {
 		return stacktrace.Propagate(err, "Error touching file to indicate service ready")
 	}
-	
+
 	err = readyFile.Close()
 	if err != nil {
-        return stacktrace.Propagate(err, "Error closing touched file to indicate service ready")
-    }
+		return stacktrace.Propagate(err, "Error closing touched file to indicate service ready")
+	}
 
 	logger.Info("Starting DSS HTTP server")
 	return httpServer.ListenAndServe()

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -309,7 +309,10 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 	if err != nil {
 		return stacktrace.Propagate(err, "Error touching file to indicate service ready")
 	}
-	readyFile.Close()
+	err = readyFile.Close()
+	if err != nil {
+        return stacktrace.Propagate(err, "Error closing touched file to indicate service ready")
+    }
 
 	logger.Info("Starting DSS HTTP server")
 	return httpServer.ListenAndServe()

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -309,6 +309,7 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 	if err != nil {
 		return stacktrace.Propagate(err, "Error touching file to indicate service ready")
 	}
+	
 	err = readyFile.Close()
 	if err != nil {
         return stacktrace.Propagate(err, "Error closing touched file to indicate service ready")


### PR DESCRIPTION
core-service uses an indicator file to communicate service readiness, but previously didn't detect an extreme edge case where closing that file generated an error.  This PR fixes that extreme edge case.