### PR TITLE
[dss] Reduce contention on OI creation/mutation endpoint

### DIFF
--- a/pkg/scd/repos/repos.go
+++ b/pkg/scd/repos/repos.go
@@ -2,7 +2,7 @@ package repos
 
 import (
 	"context"
-
+	"github.com/golang/geo/s2"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 )
@@ -51,6 +51,9 @@ type Subscription interface {
 	// specified Subscription and returns the resulting corresponding
 	// notification indices.
 	IncrementNotificationIndices(ctx context.Context, subscriptionIds []dssmodels.ID) ([]int, error)
+
+	// LockSubscriptionsOnCells locks the subscriptions of interest on specific cells.
+	LockSubscriptionsOnCells(ctx context.Context, cells s2.CellUnion) error
 }
 
 type UssAvailability interface {


### PR DESCRIPTION
This PR adds a lock at the beginning of the transactions creating or mutating operational intents.
Contention is mainly due to the ability of the transaction to increment the subscription's notification index.
The lock will ensure transactions with contention on subscriptions on the same cells to wait before starting preventing multiple retries.


Compared to the result reported in the issue #1002, we can identify the following overall test durations (single run) and number of transaction retries:

| test step | v0.11.0-rc1 | #1004 | 
| --- | --- | --- |
| test_create_ops_concurrent | 4s | 1.4 s | 
| test_mutate_ops_concurrent | 5.2s | 1.5 s |
| overall retries | 150 | 17 |
| overall CI run | ~ 24s | ~ 19s |

The following diagram shows the result of `scd/test_operation_simple_heavy_traffic_concurrent.py`. Test was run on a GCP deployment (3 core-services, 3 cockroach db nodes):


![Screenshot 2024-02-23 at 18 26 20](https://github.com/interuss/dss/assets/2004149/2e959970-4269-4d1f-aa83-1290f737cd80)

This improvement should address #742.

Note that due to the sensitivity of the change, I tried to keep it as focused as possible. Some opportunities for refactoring will be addressed separately.
