### PR TITLE
[dss][scd] DSS0210,A2-7-2,4d: Consider expired subscriptions as deleted

### DIFF
--- a/pkg/scd/subscriptions_handler.go
+++ b/pkg/scd/subscriptions_handler.go
@@ -422,7 +422,7 @@ func (a *Server) QuerySubscriptions(ctx context.Context, req *restapi.QuerySubsc
 		}
 		for _, sub := range subs {
 			// Do not return subscriptions which are expired.
-			// TODO: Add reference to TSC investigation outcome.
+			// This implementation decision is described and motivated in https://github.com/interuss/tsc/pull/12.
 			isExpired := sub.EndTime.Before(nowMarker)
 			if !isExpired && sub.Manager == dssmodels.Manager(*req.Auth.ClientID) {
 				// Get dependent Operations


### PR DESCRIPTION
DSS0210,A2-7-2,4d requires that expired subscriptions should be automatically deleted. This PR adapts the querySubscription according to [tsc investigation (option 2)](https://github.com/interuss/tsc/pull/12) to filter out expired records. 
Note that following the model of RID, a future PR will need to add a garbage collection job. (Option 1)
