### PR TITLE
[terraform-aws-kubernetes] Reduce the size of the default node disks

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/cluster.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/cluster.tf
@@ -30,7 +30,7 @@ resource "aws_eks_node_group" "eks_node_group" {
   cluster_name           = aws_eks_cluster.kubernetes_cluster.name
   subnet_ids             = [data.aws_subnet.main_subnet.id] # Limit nodes to one subnet
   node_role_arn          = aws_iam_role.dss-cluster-node-group.arn
-  disk_size              = 100
+  disk_size              = 10
   node_group_name_prefix = aws_eks_cluster.kubernetes_cluster.name
   instance_types = [
     var.aws_instance_type


### PR DESCRIPTION
The size of disks used by the EC2 node is not actually used by the workloads deployed in Kubernetes. Volumes created by Kubernetes are attached to that node and therefore provisioning 100G for the host do not make sense.
This PR reduces it at 10G.

Note that this change may require a recreation of the nodes, therefore, it is probably soon the right time to start versioning the terraform, tanka and helm manifests in a package manager, cf [C.4] of https://github.com/interuss/dss/issues/874.