### PR TITLE
[tanka] Align replicas number with nodeips length

### DIFF
--- a/build/deploy/base.libsonnet
+++ b/build/deploy/base.libsonnet
@@ -108,7 +108,8 @@ local util = import 'util.libsonnet';
 
       minReadySeconds: 30,
 
-      replicas: 3,
+      replicas: std.length(metadata.cockroach.nodeIPs),
+      assert self.replicas >= 1,
     },
   },
 
@@ -182,7 +183,7 @@ local util = import 'util.libsonnet';
         for kv in util.objectItems(self.volumeClaimTemplates_)
       ],
 
-      replicas: 3,
+      replicas: std.length(metadata.cockroach.nodeIPs),
       assert self.replicas >= 1,
     },
   },


### PR DESCRIPTION
In order to allow single node deployments, this PR updates the tanka manifests to map the number of services replicas with the number of CRDB IP addresses provided in the configuration.