### PR TITLE
[terraform] Remove usage of `latest` image

### DIFF
--- a/deploy/infrastructure/modules/terraform-aws-dss/terraform.dev.example.tfvars
+++ b/deploy/infrastructure/modules/terraform-aws-dss/terraform.dev.example.tfvars
@@ -19,7 +19,7 @@ aws_instance_type            = "t3.medium"
 aws_kubernetes_storage_class = "gp2"
 
 # DSS configuration
-image = "latest"
+image = "docker.io/interuss/dss:latest"
 authorization = {
   public_key_pem_path = "/test-certs/auth2.pem"
 }

--- a/deploy/operations/ci/aws-1/terraform.tfvars
+++ b/deploy/operations/ci/aws-1/terraform.tfvars
@@ -18,7 +18,7 @@ aws_instance_type            = "t3.medium"
 aws_kubernetes_storage_class = "gp2"
 
 # DSS configuration
-image = "latest"
+image = "docker.io/interuss/dss:latest"
 authorization = {
   public_key_pem_path = "/test-certs/auth2.pem"
 }


### PR DESCRIPTION
Following #1028, this PR updates references to the latest variable.