### PR TITLE
Fix documentation link typo in error log for CheckCurrentMajorSchemaVersion error 

### DIFF
--- a/pkg/scd/store/cockroach/store.go
+++ b/pkg/scd/store/cockroach/store.go
@@ -66,11 +66,11 @@ func (s *Store) CheckCurrentMajorSchemaVersion(ctx context.Context) error {
 		return stacktrace.Propagate(err, "Failed to get database schema version for strategic conflict detection")
 	}
 	if vs == cockroach.UnknownVersion {
-		return stacktrace.NewError("Strategic conflict detection database has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas")
+		return stacktrace.NewError("Strategic conflict detection database has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
 	}
 
 	if currentMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for strategic conflict detection! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", vs, currentMajorSchemaVersion)
+		return stacktrace.NewError("Unsupported schema version for strategic conflict detection! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas", vs, currentMajorSchemaVersion)
 	}
 
 	return nil


### PR DESCRIPTION
Documentation link in error log for migration is not going to correct section of dss/build readme file (Upgrading Database Schemas) because of a typo in upgrading word.