### PR TITLE
[ci] update cluster name format

### DIFF
--- a/deploy/operations/ci/aws-1/terraform.tfvars
+++ b/deploy/operations/ci/aws-1/terraform.tfvars
@@ -23,7 +23,7 @@ authorization = {
   public_key_pem_path = "/test-certs/auth2.pem"
 }
 should_init         = true
-crdb_cluster_name   = "interuss_ci"
+crdb_cluster_name   = "interuss-ci"
 crdb_locality       = "interuss_dss-ci-aws-ue1"
 crdb_external_nodes = []
 


### PR DESCRIPTION
This PR fixes the cluster name format used by the CI to deploy the DSS automatically