### PR TITLE
[ci] run the uss-qualifier as part of the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,7 @@ jobs:
       run: make start-locally
     - name: Probe local DSS instance
       run: make probe-locally
+    - name: Run Qualifier against local DSS instance
+      run: make qualify-locally
     - name: Bring down local DSS instance
       run: make down-locally

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,10 @@ start-locally:
 probe-locally:
 	build/dev/probe_locally.sh
 
+.PHONY: qualify-locally
+qualify-locally:
+	build/dev/qualify_locally.sh
+
 .PHONY: collect-local-logs
 collect-local-logs:
 	docker logs dss_sandbox-local-dss-core-service-1 2> core-service-for-testing.log

--- a/build/dev/dss_probing_qualifier_config.yaml
+++ b/build/dev/dss_probing_qualifier_config.yaml
@@ -1,0 +1,217 @@
+v1:
+    artifacts:
+        raw_report:
+            indent: null
+            redact_access_tokens: true
+        report_html: null
+        sequence_view:
+            redact_access_tokens: true
+            render_kml: true
+        templated_reports: null
+        tested_requirements:
+            - participant_requirements:
+                  uss1: all_astm_dss_requirements
+              report_name: requirements
+              requirement_collections:
+                  all_astm_dss_requirements:
+                      requirement_collections:
+                          - requirement_sets:
+                                - astm.f3411.v22a.dss_provider
+                                - astm.f3411.v19.dss_provider
+                                - astm.f3548.v21.dss_provider
+    test_run:
+        action:
+            on_failure: Continue
+            test_suite:
+                resources:
+                    f3411v19_dss_instances: netrid_dss_instances_v19
+                    f3411v22a_dss_instances: netrid_dss_instances_v22a
+                    f3548v21_dss_instances: scd_dss_instances
+                    flight_intents: che_non_conflicting_flights
+                    id_generator: id_generator
+                    planning_area: kentland_planning_area
+                    problematically_big_area: kentland_problematically_big_area
+                    second_utm_auth: second_utm_auth
+                    service_area: kentland_service_area
+                    test_exclusions: test_exclusions
+                    utm_client_identity: utm_client_identity
+                suite_type: suites.interuss.dss.all_tests
+        execution:
+            include_action_when: null
+            skip_action_when: null
+            stop_fast: true
+            stop_when_resource_not_created: false
+        non_baseline_inputs:
+            - v1.test_run.resources.resource_declarations.utm_auth
+            - v1.test_run.resources.resource_declarations.second_utm_auth
+            - v1.test_run.resources.resource_declarations.scd_dss_instances
+            - v1.test_run.resources.resource_declarations.netrid_dss_instances_v22a
+            - v1.test_run.resources.resource_declarations.netrid_dss_instances_v19
+        resources:
+            resource_declarations:
+                che_non_conflicting_flights:
+                    dependencies: {}
+                    resource_type: resources.flight_planning.FlightIntentsResource
+                    specification:
+                        file:
+                            path: test_data.flight_intents.standard.non_conflicting
+                        transformations:
+                            - relative_translation:
+                                  degrees_east: 7.4774
+                                  degrees_north: 46.9748
+                                  meters_up: 605
+                id_generator:
+                    dependencies:
+                        client_identity: utm_client_identity
+                    resource_type: resources.interuss.IDGeneratorResource
+                    specification: {}
+                kentland_planning_area:
+                    dependencies: {}
+                    resource_type: resources.astm.f3548.v21.PlanningAreaResource
+                    specification:
+                        base_url: https://uss_qualifier.test.utm/dummy_base_url
+                        volume:
+                            altitude_lower:
+                                reference: W84
+                                units: M
+                                value: 0
+                            altitude_upper:
+                                reference: W84
+                                units: M
+                                value: 3048
+                            outline_polygon:
+                                vertices:
+                                    - lat: 37.1853
+                                      lng: -80.614
+                                    - lat: 37.2148
+                                      lng: -80.614
+                                    - lat: 37.2148
+                                      lng: -80.544
+                                    - lat: 37.1853
+                                      lng: -80.544
+                kentland_problematically_big_area:
+                    dependencies: {}
+                    resource_type: resources.VerticesResource
+                    specification:
+                        vertices:
+                            - lat: 38
+                              lng: -81
+                            - lat: 37
+                              lng: -81
+                            - lat: 37
+                              lng: -80
+                            - lat: 38
+                              lng: -80
+                kentland_service_area:
+                    dependencies: {}
+                    resource_type: resources.netrid.ServiceAreaResource
+                    specification:
+                        altitude_max: 3048
+                        altitude_min: 0
+                        base_url: https://uss_qualifier.test.utm/dummy_base_url
+                        footprint:
+                            - lat: 37.1853
+                              lng: -80.614
+                            - lat: 37.2148
+                              lng: -80.614
+                            - lat: 37.2148
+                              lng: -80.544
+                            - lat: 37.1853
+                              lng: -80.544
+                        reference_time: '2023-01-10T00:00:00.123456+00:00'
+                        time_end: '2023-01-10T01:00:01.123456+00:00'
+                        time_start: '2023-01-10T00:00:01.123456+00:00'
+                netrid_dss_instances_v19:
+                    dependencies:
+                        auth_adapter: utm_auth
+                    resource_type: resources.astm.f3411.DSSInstancesResource
+                    specification:
+                        dss_instances:
+                            - base_url: http://core-service:8082
+                              has_private_address: true
+                              participant_id: uss1
+                              rid_version: F3411-19
+                netrid_dss_instances_v22a:
+                    dependencies:
+                        auth_adapter: utm_auth
+                    resource_type: resources.astm.f3411.DSSInstancesResource
+                    specification:
+                        dss_instances:
+                            - base_url: http://core-service:8082/rid/v2
+                              has_private_address: true
+                              participant_id: uss1
+                              rid_version: F3411-22a
+                scd_dss_instances:
+                    dependencies:
+                        auth_adapter: utm_auth
+                    resource_type: resources.astm.f3548.v21.DSSInstancesResource
+                    specification:
+                        dss_instances:
+                            - base_url: http://core-service:8082
+                              has_private_address: true
+                              participant_id: uss1
+                              user_participant_ids:
+                                  - mock_uss
+                second_utm_auth:
+                    dependencies: {}
+                    resource_type: resources.communications.AuthAdapterResource
+                    specification:
+                        environment_variable_containing_auth_spec: AUTH_SPEC_2
+                        scopes_authorized:
+                            - utm.strategic_coordination
+                test_exclusions:
+                    dependencies: {}
+                    resource_type: resources.dev.TestExclusionsResource
+                    specification:
+                        allow_cleartext_queries: true
+                        allow_private_addresses: true
+                utm_auth:
+                    dependencies: {}
+                    resource_type: resources.communications.AuthAdapterResource
+                    specification:
+                        environment_variable_containing_auth_spec: AUTH_SPEC
+                        scopes_authorized:
+                            - rid.inject_test_data
+                            - dss.read.identification_service_areas
+                            - rid.service_provider
+                            - rid.display_provider
+                            - dss.write.identification_service_areas
+                            - dss.read.identification_service_areas
+                            - interuss.flight_planning.direct_automated_test
+                            - interuss.flight_planning.plan
+                            - utm.inject_test_data
+                            - utm.strategic_coordination
+                            - utm.conformance_monitoring_sa
+                            - utm.availability_arbitration
+                            - utm.constraint_management
+                            - interuss.versioning.read_system_versions
+                            - interuss.geospatial_map.query
+                            - ''
+                utm_client_identity:
+                    dependencies:
+                        auth_adapter: utm_auth
+                    resource_type: resources.communications.ClientIdentityResource
+                    specification:
+                        whoami_audience: localhost
+                        whoami_scope: rid.display_provider
+    validation:
+        criteria:
+            - applicability:
+                  test_scenarios: {}
+              pass_condition:
+                  each_element:
+                      has_execution_error: false
+            - applicability:
+                  failed_checks:
+                      has_severity:
+                          higher_than: Low
+              pass_condition:
+                  elements:
+                      count:
+                          equal_to: 0.0
+            - applicability:
+                  skipped_actions: {}
+              pass_condition:
+                  elements:
+                      count:
+                          equal_to: 3.0

--- a/build/dev/qualify_locally.sh
+++ b/build/dev/qualify_locally.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -x
+
+# Find and change to repo root directory
+OS=$(uname)
+if [[ "$OS" == "Darwin" ]]; then
+	# OSX uses BSD readlink
+	BASEDIR="$(dirname "$0")"
+else
+	BASEDIR=$(readlink -e "$(dirname "$0")")
+fi
+cd "${BASEDIR}/../.." || exit 1
+
+CORE_SERVICE_CONTAINER="dss_sandbox-local-dss-core-service-1"
+OAUTH_CONTAINER="dss_sandbox-local-dss-dummy-oauth-1"
+declare -a localhost_containers=("$CORE_SERVICE_CONTAINER" "$OAUTH_CONTAINER")
+
+for container_name in "${localhost_containers[@]}"; do
+	if [ "$( docker container inspect -f '{{.State.Status}}' "$container_name" )" == "running" ]; then
+		echo "$container_name available!"
+	else
+    echo '#########################################################################'
+    echo '## Prerequisite to run this command is:                                ##'
+    echo '## Local DSS instance + Dummy OAuth server (/build/dev/run_locally.sh) ##'
+    echo '#########################################################################'
+		echo "Error: $container_name not running. Execute 'build/dev/run_locally.sh up' before running build/dev/probe_locally.sh";
+		exit 1;
+	fi
+done
+
+if ! docker run --link "$OAUTH_CONTAINER":oauth \
+	--link "$CORE_SERVICE_CONTAINER":core-service \
+	--network dss_sandbox-default \
+	-v "$(pwd)/build/dev/dss_probing_qualifier_config.yaml:/app/monitoring/uss_qualifier/dss_probing_qualifier_config.yaml" \
+	-w /app/monitoring/uss_qualifier \
+	-e AUTH_SPEC='DummyOAuth(http://oauth:8085/token,uss_qualifier)' \
+	-e AUTH_SPEC_2='DummyOAuth(http://oauth:8085/token,uss_qualifier_2)' \
+	interuss/monitoring:v0.8.0 \
+    python main.py --config dss_probing_qualifier_config; then
+
+    if [ "$CI" == "true" ]; then
+        echo "=== END OF TEST RESULTS ==="
+        echo "Dumping core-service logs"
+        docker logs "$CORE_SERVICE_CONTAINER"
+    fi
+    echo "Qualifier did not succeed."
+    exit 1
+else
+    echo "Qualifier succeeded."
+fi


### PR DESCRIPTION
To increase test coverage, we add a step to the CI that will run the qualifier against the DSS version built from the current PR.

Notes:
 - this currently only runs "single instance tests", as, to the best of my understanding, only a single DSS instance is started in CI (therefore, only a single DSS is configured)
 - this does not run any CRDB-specific checks (they are skipped) 
 - the configuration was obtained by running the qualifier with the `--config-output` option, with the following modifications:
   - removal of the second DSS
   - add `has_private_address: true` to dss resource specifications (otherwise the qualifier fails on resource initialisation)
   - set `uss1: all_astm_dss_requirements` in the `participant_requirements` artifacts section
  
 
Test plan:
 This worked both locally when running the qualifier from a docker image built from a recent release of the `interuss/monitoring` image, and passes on the CI when running with the monitoring release `v0.8.0`
 
 See [this successful test run](https://github.com/interuss/dss/pull/1045/checks#step:11:205) for example
