### PR TITLE
[dss][scd] Removing OVN from missing entities when upserting OIR

### DIFF
--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -611,14 +611,24 @@ func (a *Server) upsertOperationalIntentReference(ctx context.Context, authorize
 				if len(missingOps) > 0 {
 					responseConflict.MissingOperationalIntents = new([]restapi.OperationalIntentReference)
 					for _, missingOp := range missingOps {
-						*responseConflict.MissingOperationalIntents = append(*responseConflict.MissingOperationalIntents, *missingOp.ToRest())
+						p := missingOp.ToRest()
+						if missingOp.Manager != manager {
+							noOvnPhrase := restapi.EntityOVN(scdmodels.NoOvnPhrase)
+							p.Ovn = &noOvnPhrase
+						}
+						*responseConflict.MissingOperationalIntents = append(*responseConflict.MissingOperationalIntents, *p)
 					}
 				}
 
 				if len(missingConstraints) > 0 {
 					responseConflict.MissingConstraints = new([]restapi.ConstraintReference)
 					for _, missingConstraint := range missingConstraints {
-						*responseConflict.MissingConstraints = append(*responseConflict.MissingConstraints, *missingConstraint.ToRest())
+						c := missingConstraint.ToRest()
+						if missingConstraint.Manager != manager {
+							noOvnPhrase := restapi.EntityOVN(scdmodels.NoOvnPhrase)
+							c.Ovn = &noOvnPhrase
+						}
+						*responseConflict.MissingConstraints = append(*responseConflict.MissingConstraints, *c)
 					}
 				}
 


### PR DESCRIPTION
When upserting an OIR with missing keys, DSS currently returns the full reference for the missing entity, including the OVN. Returning the OVN could be a problem because an USS may create a conflicted OIR without having the get the OIR details from other USS.

This PR hides the OVNs from the missing entities that are not owned from the requiring manager, matching the behavior of the GET and QUERY endpoints.

**Old upsert return:**
`
{
    "message": "Current OVNs not provided for one or more OperationalIntents or Constraints",
    "missing_operational_intents": [
        {
	    "id": "46d06891-38d7-46dd-be98-2f617810f15e",
	    ...
	    "ovn": "t6Or7spPB0cJ8AV0zN088GBtfHTw6m4qZG9jan3T870_",
	    ....
	}
    ]
}
`

**New upsert return:**
`
{
    "message": "Current OVNs not provided for one or more OperationalIntents or Constraints",
    "missing_operational_intents": [
        {
	    "id": "46d06891-38d7-46dd-be98-2f617810f15e",
	    ...
	    "ovn": "Available from USS",
	    ....
	}
    ]
}
`