### PR TITLE
[versioning] add new versioning endpoint

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "interfaces/rid/v2"]
 	path = interfaces/rid/v2
 	url = https://github.com/uastech/standards
+[submodule "interfaces/automated_testing_interfaces"]
+	path = interfaces/automated_testing_interfaces
+	url = https://github.com/interuss/automated_testing_interfaces.git

--- a/build/dev/read_version.sh
+++ b/build/dev/read_version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Retrieve token from dummy OAuth server
+ACCESS_TOKEN=$(curl --silent \
+    "http://localhost:8085/token?grant_type=client_credentials&scope=interuss.versioning.read_system_versions&intended_audience=localhost&issuer=localhost&sub=check_scd" \
+| python extract_json_field.py 'access_token')
+
+curl --silent -X GET  \
+"http://localhost:8082/versions/local.test.identity" \
+-H "Authorization: Bearer ${ACCESS_TOKEN}" -H "Content-Type: application/json"
+

--- a/build/dev/startup/core_service.sh
+++ b/build/dev/startup/core_service.sh
@@ -18,7 +18,9 @@ if [ "$DEBUG_ON" = "1" ]; then
   -addr :8082 \
   -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox-local-dss-core-service-1,core-service \
   -enable_scd \
-  -enable_http
+  -enable_http \
+  -system_identity "local.test.identity" \
+  -system_version "test-version"
 else
   echo "Debug Mode: off"
 
@@ -30,6 +32,8 @@ else
   -addr :8082 \
   -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox-local-dss-core-service-1,core-service \
   -enable_scd \
-  -enable_http
+  -enable_http \
+  -system_identity "local.test.identity" \
+  -system_version "test-version"
 fi
 

--- a/build/dev/startup/core_service.sh
+++ b/build/dev/startup/core_service.sh
@@ -18,9 +18,7 @@ if [ "$DEBUG_ON" = "1" ]; then
   -addr :8082 \
   -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox-local-dss-core-service-1,core-service \
   -enable_scd \
-  -enable_http \
-  -system_identity "local.test.identity" \
-  -system_version "test-version"
+  -enable_http
 else
   echo "Debug Mode: off"
 
@@ -32,8 +30,6 @@ else
   -addr :8082 \
   -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox-local-dss-core-service-1,core-service \
   -enable_scd \
-  -enable_http \
-  -system_identity "local.test.identity" \
-  -system_version "test-version"
+  -enable_http
 fi
 

--- a/pkg/api/versioningv1/interface.gen.go
+++ b/pkg/api/versioningv1/interface.gen.go
@@ -1,0 +1,47 @@
+// This file is auto-generated; do not change as any changes will be overwritten
+package versioning
+
+import (
+	"context"
+	"github.com/interuss/dss/pkg/api"
+)
+
+var (
+	InterussVersioningReadSystemVersionsScope = api.RequiredScope("interuss.versioning.read_system_versions")
+	GetVersionSecurity                        = []api.AuthorizationOption{
+		{
+			"Authority": {InterussVersioningReadSystemVersionsScope},
+		},
+	}
+)
+
+type GetVersionRequest struct {
+	// The system identity/boundary for which a version should be provided, if known.
+	SystemIdentity SystemBoundaryIdentifier
+
+	// The result of attempting to authorize this request
+	Auth api.AuthorizationResult
+}
+type GetVersionResponseSet struct {
+	// This interface successfully provided the version of the system identity/boundary that was requested.
+	Response200 *GetVersionResponse
+
+	// Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+	Response401 *api.EmptyResponseBody
+
+	// The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+	Response403 *api.EmptyResponseBody
+
+	// The requested system identity/boundary is not known, or the versioning automated testing interface is not available.
+	Response404 *api.EmptyResponseBody
+
+	// Auto-generated internal server error response
+	Response500 *api.InternalServerErrorBody
+}
+
+type Implementation interface {
+	// System version
+	// ---
+	// Get the requested system version.
+	GetVersion(ctx context.Context, req *GetVersionRequest) GetVersionResponseSet
+}

--- a/pkg/api/versioningv1/server.gen.go
+++ b/pkg/api/versioningv1/server.gen.go
@@ -1,0 +1,74 @@
+// This file is auto-generated; do not change as any changes will be overwritten
+package versioning
+
+import (
+	"context"
+	"github.com/interuss/dss/pkg/api"
+	"net/http"
+	"regexp"
+)
+
+type APIRouter struct {
+	Routes         []*api.Route
+	Implementation Implementation
+	Authorizer     api.Authorizer
+}
+
+// *versioning.APIRouter (type defined above) implements the api.PartialRouter interface
+func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
+	for _, route := range s.Routes {
+		if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
+			route.Handler(route.Pattern, w, r)
+			return true
+		}
+	}
+	return false
+}
+
+func (s *APIRouter) GetVersion(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
+	var req GetVersionRequest
+
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetVersionSecurity)
+
+	// Parse path parameters
+	pathMatch := exp.FindStringSubmatch(r.URL.Path)
+	req.SystemIdentity = SystemBoundaryIdentifier(pathMatch[1])
+
+	// Call implementation
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+	response := s.Implementation.GetVersion(ctx, &req)
+
+	// Write response to client
+	if response.Response200 != nil {
+		api.WriteJSON(w, 200, response.Response200)
+		return
+	}
+	if response.Response401 != nil {
+		api.WriteJSON(w, 401, response.Response401)
+		return
+	}
+	if response.Response403 != nil {
+		api.WriteJSON(w, 403, response.Response403)
+		return
+	}
+	if response.Response404 != nil {
+		api.WriteJSON(w, 404, response.Response404)
+		return
+	}
+	if response.Response500 != nil {
+		api.WriteJSON(w, 500, response.Response500)
+		return
+	}
+	api.WriteJSON(w, 500, api.InternalServerErrorBody{ErrorMessage: "Handler implementation did not set a response"})
+}
+
+func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {
+	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 1)}
+
+	pattern := regexp.MustCompile("^/versions/(?P<system_identity>[^/]*)$")
+	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetVersion}
+
+	return router
+}

--- a/pkg/api/versioningv1/types.gen.go
+++ b/pkg/api/versioningv1/types.gen.go
@@ -1,0 +1,16 @@
+// This file is auto-generated; do not change as any changes will be overwritten
+package versioning
+
+// Identifier of a system boundary, known to both the client and the USS separate from this API, for which this interface can provide a version.  While the format is not prescribed by this API, any value must be URL-safe.  It is recommended to use an approach similar to reverse-order Internet domain names and Java packages where the global scope is described with increasingly-precise identifiers joined by periods.  For instance, the system boundary containing the mandatory Network Identification U-space service might be identified with `gov.eu.uspace.v1.netid` because the authority defining this system boundary is a governmental organization (specifically, the European Union) with requirements imposed on the system under test by the U-space regulation (first version) -- specifically, the Network Identification Service section.
+type SystemBoundaryIdentifier string
+
+// Identifier of a particular version of a system (defined by a known system boundary).  While the format is not prescribed by this API, a semantic version (https://semver.org/) prefixed with a `v` is recommended.
+type VersionIdentifier string
+
+type GetVersionResponse struct {
+	// The requested system identity/boundary.
+	SystemIdentity *SystemBoundaryIdentifier `json:"system_identity,omitempty"`
+
+	// The version of the system with the specified system identity/boundary.
+	SystemVersion *VersionIdentifier `json:"system_version,omitempty"`
+}

--- a/pkg/versioning/server.go
+++ b/pkg/versioning/server.go
@@ -1,0 +1,58 @@
+package versioning
+
+import (
+	"context"
+	"github.com/interuss/dss/pkg/api"
+	versioning "github.com/interuss/dss/pkg/api/versioningv1"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/stacktrace"
+)
+
+type Server struct {
+	systemIdentity    *versioning.SystemBoundaryIdentifier
+	versionIdentifier *versioning.VersionIdentifier
+}
+
+func NewServer(systemIdentity string, versionIdentifier string) *Server {
+	return &Server{
+		systemIdentity:    (*versioning.SystemBoundaryIdentifier)(&systemIdentity),
+		versionIdentifier: (*versioning.VersionIdentifier)(&versionIdentifier),
+	}
+}
+
+func (s *Server) GetVersion(ctx context.Context, req *versioning.GetVersionRequest) versioning.GetVersionResponseSet {
+	// This should take care of unauthenticated requests as well as
+	// any request without the proper scope.
+	if req.Auth.Error != nil {
+		resp := versioning.GetVersionResponseSet{}
+		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
+		return resp
+	}
+
+	// TODO initial assumption is that the DSS reports the version for itself _only_:
+	//  confirm this is the correct approach. Alternatively we could configure a map of identities to versions
+	//  and provide versions for multiple identities.
+	if *s.systemIdentity != req.SystemIdentity {
+		return versioning.GetVersionResponseSet{
+			Response404: &api.EmptyResponseBody{},
+		}
+	}
+
+	return versioning.GetVersionResponseSet{
+		Response200: &versioning.GetVersionResponse{
+			SystemIdentity: s.systemIdentity,
+			SystemVersion:  s.versionIdentifier,
+		},
+	}
+}
+
+func setAuthError(ctx context.Context, authErr error, resp401, resp403 **api.EmptyResponseBody, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &api.EmptyResponseBody{}
+	case dsserr.PermissionDenied:
+		*resp403 = &api.EmptyResponseBody{}
+	default:
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
+}

--- a/pkg/versioning/server_test.go
+++ b/pkg/versioning/server_test.go
@@ -1,0 +1,31 @@
+package versioning
+
+import (
+	"context"
+	versioning "github.com/interuss/dss/pkg/api/versioningv1"
+	"github.com/interuss/dss/pkg/version"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestServer_GetVersion(t *testing.T) {
+	s := &Server{}
+
+	got := s.GetVersion(context.Background(),
+		&versioning.GetVersionRequest{
+			SystemIdentity: "empty",
+		}).Response200
+
+	assert.Equal(
+		t,
+		version.Current().String(),
+		string(*got.SystemVersion),
+	)
+
+	assert.Equal(
+		t,
+		"empty",
+		string(*got.SystemIdentity),
+	)
+
+}


### PR DESCRIPTION
Adds the versioning API to the DSS, according to https://github.com/interuss/automated_testing_interfaces/tree/main/versioning.

This is done by:
 - adding a submodule that points to the versioning endpoint spec [repository](https://github.com/interuss/automated_testing_interfaces)
 - running the generator, moving the generated files to a relevant place and checking them into git
 - serving the new route and returning the current binary version for any requested identity.
 
The endpoint was tested locally via the `build/dev/read_version.sh` test script.

resolves #1047 