### PR TITLE
[dss] Ensure clean workspace for releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 build/workspace
+!build/workspace/.gitkeep
 **/.terraform

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 build/workspace
+**/.terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,9 @@ WORKDIR /app
 # Get dependencies - will also be cached if we won't change mod/sum
 RUN go mod download
 
-COPY .git /app/.git
-COPY cmds /app/cmds
-RUN mkdir -p cmds/db-manager
-
-COPY pkg /app/pkg
-COPY cmds/db-manager cmds/db-manager
-
-RUN go install ./...
-
-COPY scripts /app/scripts
-COPY Makefile /app
+# In order to reliably compute the version of the build, all files must be present.
+# This is required to detect a dirty workspace using `scripts/git/version.sh`.
+COPY . /app
 RUN make interuss
 
 

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -32,6 +32,7 @@ import (
 	ridc "github.com/interuss/dss/pkg/rid/store/cockroach"
 	"github.com/interuss/dss/pkg/scd"
 	scdc "github.com/interuss/dss/pkg/scd/store/cockroach"
+	"github.com/interuss/dss/pkg/version"
 	"github.com/interuss/stacktrace"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
@@ -207,6 +208,7 @@ func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, erro
 // RunHTTPServer starts the DSS HTTP server.
 func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality string) error {
 	logger := logging.WithValuesFromContext(ctx, logging.Logger).With(zap.String("address", address))
+	logger.Info("version", zap.Any("version", version.Current()))
 	logger.Info("build", zap.Any("description", build.Describe()))
 	logger.Info("config", zap.Bool("scd", *enableSCD))
 


### PR DESCRIPTION
As reported by #1048 , `build/build.sh`  always classifies built/released images and binaries as dirty. This PR fixes this issue by copying all files to the intermediary `build` layer.

A redundant `go install` step is removed in the Dockerfile since it is already run in the Makefile and there is no clear benefit in caching non-executable packages there.

`**/.terrafom` are ignored since terraform providers binaries are cached there and the size may quickly be few 100s of megabytes, make the context slow to load when building the docker image.

The result is correctly reflected by the CI. No `-dirty` suffix is observed on the commit and version injected in the binary build: https://github.com/interuss/dss/actions/runs/9846450148/job/27184246127?pr=1053#step:7:281