### PR TITLE
Update default version to more recent version

### DIFF
--- a/deploy/services/helm-charts/dss/values.yaml
+++ b/deploy/services/helm-charts/dss/values.yaml
@@ -15,4 +15,4 @@ cockroachdb:
     enabled: false
 
 dss:
-  image: docker.io/interuss/dss:v0.7.0
+  image: docker.io/interuss/dss:v0.15.0


### PR DESCRIPTION
There's been a handful of bugfixes across versions since the current default 0.7.0, especially notable is the USS_Availability fixes from 0.9.0.

New users should be on a much newer version by default and shouldn't have to worry about selecting a version.