### PR TITLE
[core-service] Rename enable_http to allow_http_base_urls

### DIFF
--- a/build/dev/haproxy_local_setup.sh
+++ b/build/dev/haproxy_local_setup.sh
@@ -163,7 +163,7 @@ docker run -d --name core-service-for-testing -p 8082:8082 \
 	-dump_requests \
 	-accepted_jwt_audiences core-service,localhost \
 	-enable_scd	\
-	-enable_http
+	-allow_http_base_urls
 
 echo " -------------- DUMMY OAUTH -------------- "
 echo "Building dummy-oauth server container"

--- a/build/dev/startup/core_service.sh
+++ b/build/dev/startup/core_service.sh
@@ -18,7 +18,7 @@ if [ "$DEBUG_ON" = "1" ]; then
   -addr :8082 \
   -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox-local-dss-core-service-1,core-service \
   -enable_scd \
-  -enable_http
+  -allow_http_base_urls
 else
   echo "Debug Mode: off"
 
@@ -30,6 +30,5 @@ else
   -addr :8082 \
   -accepted_jwt_audiences localhost,host.docker.internal,local-dss-core-service,dss_sandbox-local-dss-core-service-1,core-service \
   -enable_scd \
-  -enable_http
+  -allow_http_base_urls
 fi
-

--- a/cmds/core-service/README.md
+++ b/cmds/core-service/README.md
@@ -22,7 +22,7 @@ go run ./cmds/core-service \
   -dump_requests \
   -accepted_jwt_audiences localhost \
   -enable_scd \
-  -enable_http
+  -allow_http_base_urls
 ```
 
 ### Prerequisites

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -41,11 +41,11 @@ import (
 )
 
 var (
-	address    = flag.String("addr", ":8080", "Local address that the service binds to and listens on for incoming connections")
-	enableSCD  = flag.Bool("enable_scd", false, "Enables the Strategic Conflict Detection API")
-	enableHTTP = flag.Bool("enable_http", false, "Enables http scheme for Strategic Conflict Detection API")
-	timeout    = flag.Duration("server timeout", 10*time.Second, "Default timeout for server calls")
-	locality   = flag.String("locality", "", "self-identification string used as CRDB table writer column")
+	address           = flag.String("addr", ":8080", "Local address that the service binds to and listens on for incoming connections")
+	enableSCD         = flag.Bool("enable_scd", false, "Enables the Strategic Conflict Detection API")
+	allowHTTPBaseUrls = flag.Bool("allow_http_base_urls", false, "Enables http scheme for Strategic Conflict Detection API")
+	timeout           = flag.Duration("server timeout", 10*time.Second, "Default timeout for server calls")
+	locality          = flag.String("locality", "", "self-identification string used as CRDB table writer column")
 
 	logFormat            = flag.String("log_format", logging.DefaultFormat, "The log format in {json, console}")
 	logLevel             = flag.String("log_level", logging.DefaultLevel.String(), "The log level")
@@ -158,17 +158,17 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 
 	app := application.NewFromTransactor(ridStore, logger)
 	return &rid_v1.Server{
-			App:        app,
-			Timeout:    *timeout,
-			Locality:   locality,
-			EnableHTTP: *enableHTTP,
-			Cron:       ridCron,
+			App:               app,
+			Timeout:           *timeout,
+			Locality:          locality,
+			AllowHTTPBaseUrls: *allowHTTPBaseUrls,
+			Cron:              ridCron,
 		}, &rid_v2.Server{
-			App:        app,
-			Timeout:    *timeout,
-			Locality:   locality,
-			EnableHTTP: *enableHTTP,
-			Cron:       ridCron,
+			App:               app,
+			Timeout:           *timeout,
+			Locality:          locality,
+			AllowHTTPBaseUrls: *allowHTTPBaseUrls,
+			Cron:              ridCron,
 		}, nil
 }
 
@@ -200,10 +200,10 @@ func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, erro
 	scdCron.Start()
 
 	return &scd.Server{
-		Store:            scdStore,
-		DSSReportHandler: &scd.JSONLoggingReceivedReportHandler{ReportLogger: logger},
-		Timeout:          *timeout,
-		EnableHTTP:       *enableHTTP,
+		Store:             scdStore,
+		DSSReportHandler:  &scd.JSONLoggingReceivedReportHandler{ReportLogger: logger},
+		Timeout:           *timeout,
+		AllowHTTPBaseUrls: *allowHTTPBaseUrls,
 	}, nil
 }
 

--- a/pkg/rid/server/v1/isa_handler.go
+++ b/pkg/rid/server/v1/isa_handler.go
@@ -88,7 +88,7 @@ func (s *Server) CreateIdentificationServiceArea(ctx context.Context, req *resta
 			Message: dsserr.Handle(ctx, stacktrace.NewErrorWithCode(dsserr.BadRequest, "Invalid ID format"))}}
 	}
 
-	if !s.EnableHTTP {
+	if !s.AllowHTTPBaseUrls {
 		err = ridmodels.ValidateURL(string(req.Body.FlightsUrl))
 		if err != nil {
 			return restapi.CreateIdentificationServiceAreaResponseSet{Response400: &restapi.ErrorResponse{

--- a/pkg/rid/server/v1/server.go
+++ b/pkg/rid/server/v1/server.go
@@ -15,11 +15,11 @@ import (
 
 // Server implements ridv1.Implementation.
 type Server struct {
-	App        application.App
-	Timeout    time.Duration
-	Locality   string
-	EnableHTTP bool
-	Cron       *cron.Cron
+	App               application.App
+	Timeout           time.Duration
+	Locality          string
+	AllowHTTPBaseUrls bool
+	Cron              *cron.Cron
 }
 
 func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {

--- a/pkg/rid/server/v1/subscription_handler.go
+++ b/pkg/rid/server/v1/subscription_handler.go
@@ -187,7 +187,7 @@ func (s *Server) CreateSubscription(ctx context.Context, req *restapi.CreateSubs
 			Message: dsserr.Handle(ctx, stacktrace.NewErrorWithCode(dsserr.BadRequest, "Invalid ID format"))}}
 	}
 
-	if !s.EnableHTTP {
+	if !s.AllowHTTPBaseUrls {
 		err = ridmodels.ValidateURL(string(*req.Body.Callbacks.IdentificationServiceAreaUrl))
 		if err != nil {
 			return restapi.CreateSubscriptionResponseSet{Response400: &restapi.ErrorResponse{

--- a/pkg/rid/server/v2/isa_handler.go
+++ b/pkg/rid/server/v2/isa_handler.go
@@ -82,7 +82,7 @@ func (s *Server) CreateIdentificationServiceArea(ctx context.Context, req *resta
 			Message: dsserr.Handle(ctx, stacktrace.NewErrorWithCode(dsserr.BadRequest, "Invalid ID format"))}}
 	}
 
-	if !s.EnableHTTP {
+	if !s.AllowHTTPBaseUrls {
 		err = ridmodels.ValidateURL(string(req.Body.UssBaseUrl))
 		if err != nil {
 			return restapi.CreateIdentificationServiceAreaResponseSet{Response400: &restapi.ErrorResponse{

--- a/pkg/rid/server/v2/server.go
+++ b/pkg/rid/server/v2/server.go
@@ -15,11 +15,11 @@ import (
 
 // Server implements ridv2.Implementation.
 type Server struct {
-	App        application.App
-	Timeout    time.Duration
-	Locality   string
-	EnableHTTP bool
-	Cron       *cron.Cron
+	App               application.App
+	Timeout           time.Duration
+	Locality          string
+	AllowHTTPBaseUrls bool
+	Cron              *cron.Cron
 }
 
 func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {

--- a/pkg/rid/server/v2/subscription_handler.go
+++ b/pkg/rid/server/v2/subscription_handler.go
@@ -179,7 +179,7 @@ func (s *Server) CreateSubscription(ctx context.Context, req *restapi.CreateSubs
 			Message: dsserr.Handle(ctx, stacktrace.NewErrorWithCode(dsserr.BadRequest, "Invalid ID format"))}}
 	}
 
-	if !s.EnableHTTP {
+	if !s.AllowHTTPBaseUrls {
 		err = ridmodels.ValidateURL(string(req.Body.UssBaseUrl))
 		if err != nil {
 			return restapi.CreateSubscriptionResponseSet{Response400: &restapi.ErrorResponse{

--- a/pkg/scd/constraints_handler.go
+++ b/pkg/scd/constraints_handler.go
@@ -260,7 +260,7 @@ func (a *Server) PutConstraintReference(ctx context.Context, manager string, ent
 		return nil, stacktrace.NewErrorWithCode(dsserr.BadRequest, "Missing required UssBaseUrl")
 	}
 
-	if !a.EnableHTTP {
+	if !a.AllowHTTPBaseUrls {
 		err = scdmodels.ValidateUSSBaseURL(string(params.UssBaseUrl))
 		if err != nil {
 			return nil, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Failed to validate base URL")

--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -371,7 +371,7 @@ func (a *Server) upsertOperationalIntentReference(ctx context.Context, authorize
 		return nil, nil, stacktrace.NewErrorWithCode(dsserr.BadRequest, "Missing required UssBaseUrl")
 	}
 
-	if !a.EnableHTTP {
+	if !a.AllowHTTPBaseUrls {
 		err = scdmodels.ValidateUSSBaseURL(string(params.UssBaseUrl))
 		if err != nil {
 			return nil, nil, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Failed to validate base URL")
@@ -483,7 +483,7 @@ func (a *Server) upsertOperationalIntentReference(ctx context.Context, authorize
 			// an error will have been returned earlier.
 			// If they are not set at this point, continue without creating an implicit subscription.
 			if params.NewSubscription != nil && params.NewSubscription.UssBaseUrl != "" {
-				if !a.EnableHTTP {
+				if !a.AllowHTTPBaseUrls {
 					err := scdmodels.ValidateUSSBaseURL(string(params.NewSubscription.UssBaseUrl))
 					if err != nil {
 						return stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Failed to validate USS base URL")

--- a/pkg/scd/server.go
+++ b/pkg/scd/server.go
@@ -35,10 +35,10 @@ func makeSubscribersToNotify(subscriptions []*scdmodels.Subscription) []restapi.
 
 // Server implements scdv1.Implementation.
 type Server struct {
-	Store            scdstore.Store
-	DSSReportHandler ReceivedReportHandler
-	Timeout          time.Duration
-	EnableHTTP       bool
+	Store             scdstore.Store
+	DSSReportHandler  ReceivedReportHandler
+	Timeout           time.Duration
+	AllowHTTPBaseUrls bool
 }
 
 func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {

--- a/pkg/scd/subscriptions_handler.go
+++ b/pkg/scd/subscriptions_handler.go
@@ -104,7 +104,7 @@ func (a *Server) PutSubscription(ctx context.Context, manager string, subscripti
 		return nil, stacktrace.NewErrorWithCode(dsserr.BadRequest, "Invalid ID format: `%s`", subscriptionid)
 	}
 
-	if !a.EnableHTTP {
+	if !a.AllowHTTPBaseUrls {
 		err = scdmodels.ValidateUSSBaseURL(string(params.UssBaseUrl))
 		if err != nil {
 			return nil, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Failed to validate base URL")

--- a/test/migrations/rid_db_post_migration_e2e.sh
+++ b/test/migrations/rid_db_post_migration_e2e.sh
@@ -60,7 +60,7 @@ docker run -d --name core-service-for-testing \
 	-dump_requests \
 	-accepted_jwt_audiences core-service \
 	-enable_scd	\
-	-enable_http
+	-allow_http_base_urls
 
 echo " -------------- DUMMY OAUTH -------------- "
 echo "Building dummy-oauth server container"


### PR DESCRIPTION
### Breaking Change
Clients of `core-service` will need to update the command-line parameter, `enable_http` to `allow_http_base_urls`, namely [Monitoring – core_service.sh L21/33](https://github.com/interuss/monitoring/blob/ad6483fbd8394eb20d2d4aa9c318e6a3701479cc/build/dev/startup/core_service.sh#L21-L33).