### PR TITLE
[doc] mention the USS qualifier in the documentation

### DIFF
--- a/build/pooling.md
+++ b/build/pooling.md
@@ -27,7 +27,7 @@ Kubernetes manages a set of services in a "cluster".  This is an entirely
 different thing from the CRDB data store, and this type of cluster is what the
 deployment instructions refer to.  A Kubernetes cluster contains one or more
 node pools: collections of machines available to run jobs.  This node pool is an
-entirely different thing from a DSS pool. 
+entirely different thing from a DSS pool.
 
 ## Objective
 
@@ -57,7 +57,7 @@ characteristic will not pass because the certificate is issued by
 "Cockroach CA" which is not a generally-trusted root CA, but we
 explicitly enable trust by manually exchanging the trusted CA public keys
 in ca.crt (see "Each CockroachDB node accepts the certificates of every other
-node" below).  However, all other checks should generally pass. 
+node" below).  However, all other checks should generally pass.
 
 ### "Each CockroachDB node is discoverable"
 
@@ -149,9 +149,11 @@ DSS instances to allow the new instance to join the existing pool:
 The USS owning the first DSS instance should follow
 [the deployment instructions](README.md).  They are not joining any existing
 cluster, and specifically `VAR_SHOULD_INIT` should be set `true` to initialize
-the CRDB cluster.  Upon deployment completion, the
-[prober test](https://github.com/interuss/monitoring/blob/main/monitoring/prober/README.md)
-should be run against the DSS instance to verify functionality.
+the CRDB cluster.  Upon deployment completion, the following should be run against the DSS instance to verify functionality:
+
+ - The [prober test](https://github.com/interuss/monitoring/blob/main/monitoring/prober/README.md)
+ - The [USS qualifier](https://github.com/interuss/monitoring/tree/main/monitoring/uss_qualifier), using the [DSS Probing](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml) configuration
+
 
 ### Joining an existing pool with new instance
 A USS wishing to join an existing pool (of perhaps just one instance following
@@ -175,7 +177,7 @@ by running the prober test on each DSS instance, and the
 [interoperability test scenario](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/scenarios/astm/netrid/v19/dss_interoperability.md)
 on the full pool (including the newly-added instance).
 
-Finally, the joining USS should provide its node addresses to all other 
+Finally, the joining USS should provide its node addresses to all other
 participants in the pool, and each other participant should add those addresses
 to the list of CRDB nodes their CRDB nodes will attempt to contact upon restart.
 
@@ -196,9 +198,9 @@ to scale down the Statefulset and that removes the last node first (ex:
 
 1. Check if all nodes are healthy and there are no
    under-replicated/unavailable ranges:
-   
+
    `kubectl exec -it cockroachdb-0 -- cockroach node status --ranges --certs-dir=cockroach-certs/`
-    
+
     1. If there are under-replicated ranges changes are it is because of a node
        failure. If all nodes are healthy then it should auto recover.
 
@@ -209,7 +211,7 @@ to scale down the Statefulset and that removes the last node first (ex:
    then decommission them. The following command assumes that `cockroachdb-0` is
    not targeted for decommission otherwise select a different instance to
    connect to:
-   
+
    `kubectl exec -it cockroachdb-0 -- cockroach node decommission <node id 1> [<node id 2> ...] --certs-dir=cockroach-certs/`
 
 1. If the command executes successfully all targeted nodes should not host any
@@ -217,7 +219,7 @@ to scale down the Statefulset and that removes the last node first (ex:
 
     a. In the event of a hung decommission please recommission the nodes and
     repeat the above step with smaller number of nodes to decommission:
-    
+
     `kubectl exec -it cockroachdb-0 -- cockroach node recommission <node id 1> [<node id 2> ...] --certs-dir=cockroach-certs/`
 
 1. Power down the pods or delete the Statefulset, whichever is applicable
@@ -226,7 +228,7 @@ to scale down the Statefulset and that removes the last node first (ex:
        restart it immediately you will need to scale down understanding that it
        will remove node `cockroachdb-n` first; where `n` is the
        `size of statefulset - 1`.
-       
+
        To proceed: `kubectl scale statefulset cockroachdb --replicas=<X>`
 
     b. To remove the entire Statefulset:

--- a/introduction_to_repository.md
+++ b/introduction_to_repository.md
@@ -14,3 +14,8 @@ The [`monitoring` repository](https://github.com/interuss/monitoring) contains a
 #### Prober
 
 - The first and largest monitoring tool is the "prober" which is a full integration test of the DSS.  This tool is used during [continuous integration](.github/workflows/CI.md) for the DSS.
+
+#### USS Qualifier
+
+The Prober is slowly being superseded by the [USS qualifier](https://github.com/interuss/monitoring/tree/main/monitoring/uss_qualifier):
+it provides extensive test coverage for the features of a DSS deployment via the [DSS Probing](https://github.com/interuss/monitoring/blob/main/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml) configuration.

--- a/test/README.md
+++ b/test/README.md
@@ -30,6 +30,16 @@ repeatedly with `make probe-locally` without needing to rerun
 bring down the local DSS instance at the conclusion of testing, run
 `make stop-locally` or `make down-locally`.
 
+When developing or troubleshooting features with the help of the [USS qualifier](https://github.com/interuss/monitoring/tree/main/monitoring/uss_qualifier)
+where it might be useful to quickly iterate on changes both in the DSS and in a qualifier scenario,
+an option is to:
+
+1. build the DSS image locally via `make build-dss`
+2. use the locally built version (`interuss-local/dss:latest`) in the [docker-compose file](https://github.com/interuss/monitoring/blob/843e69a166e6fb76459ebcda171dcd77a26ea5dc/build/dev/docker-compose.yaml#L46) that defines the qualifier's local test environment
+3. start or restart the local USS qualifier deployment via `make restart-all` (in the [monitoring repository](https://github.com/interuss/monitoring/blob/843e69a166e6fb76459ebcda171dcd77a26ea5dc/Makefile#L116))
+4. run the USS qualifier with a pre-packaged configuration such as `f3548_self_contained` or `dss_probing` in the monitoring repo. Eg, `./run_locally.sh configurations.dev.f3548_self_contained` from within the [monitoring/uss_qualifier](https://github.com/interuss/monitoring/tree/main/monitoring/uss_qualifier) directory of the qualifier repository.
+
+
 ### Running a subset of tests
 To run a specific test in the [prober](../monitoring/prober) test suite,
 simply add its name as the first argument to the script to run prober locally


### PR DESCRIPTION
Given that the qualifier starts taking over some of the prober's responsibilities in terms of testing the DSS's features, we need to mention it as a way to test a DSS deployment.