### PR TITLE
[helm] Enforce manual selection of cockroachdb image

### DIFF
--- a/deploy/services/helm-charts/dss/values.example.yaml
+++ b/deploy/services/helm-charts/dss/values.example.yaml
@@ -12,6 +12,8 @@ dss:
 
 cockroachdb:
   # See https://github.com/cockroachdb/helm-charts/blob/master/cockroachdb/values.yaml
+  image:
+    tag: v21.2.7
   fullnameOverride: dss-cockroachdb
   conf:
     join: []

--- a/deploy/services/helm-charts/dss/values.schema.json
+++ b/deploy/services/helm-charts/dss/values.schema.json
@@ -12,9 +12,13 @@
               "type": "string"
             },
             "tag": {
-              "type": "string"
+              "type": "string",
+              "description": "Version tag of the CockroachDB image. Until DSS v0.16, the recommended CockroachDB version is `v21.2.7`. From DSS v0.17, the recommended CockroachDB version is `v24.1.3`."
             }
-          }
+          },
+          "required": [
+            "tag"
+          ]
         },
         "fullnameOverride": {
           "description": "Name of the internal statefulset",

--- a/deploy/services/helm-charts/dss/values.yaml
+++ b/deploy/services/helm-charts/dss/values.yaml
@@ -3,7 +3,6 @@ cockroachdb:
   # See https://github.com/cockroachdb/helm-charts/blob/master/cockroachdb/values.yaml
   image:
     repository: cockroachdb/cockroach
-    tag: v21.2.7
   tls:
     certs:
       provided: true


### PR DESCRIPTION
In order to facilitate the upgrades of cockroachdb, this PR removes the default cockroach db version from the helm configuration and requires users to set it in their configuration.

In anticipation of the CockroachDB upgrade to 24.1.3 (#1075) and the DSS v17 release, the description is already taking it into account.

Current users who have already a configuration will have to add the version to their configuration. A note will be provided in the release notes.