### PR TITLE
[scd] oir deletion now checks for OVN correctness

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -27,7 +27,7 @@ const (
 	// BadRequest is used when a user supplies bad request parameters.
 	BadRequest
 
-	// VersionMismatch is used when updating a resource with an old version.
+	// VersionMismatch is used when updating or deleting a resource with an old or incorrect version.
 	VersionMismatch
 
 	// NotFound is used when looking up a resource that doesn't exist.


### PR DESCRIPTION
Adds the missing OVN check to the OIR deletion logic.

This is a first step towards fixing #1081 (it covers OIRs)

Test plan: a DSS version built from this PR passes the new [qualifier scenario](https://github.com/interuss/monitoring/pull/761) designed to detect this kind of issue.