### PR TITLE
[terraform] crdb image tag definition

### DIFF
--- a/deploy/infrastructure/utils/definitions/crdb_image_tag.tf
+++ b/deploy/infrastructure/utils/definitions/crdb_image_tag.tf
@@ -1,0 +1,10 @@
+variable "crdb_image_tag" {
+  type        = string
+  description = <<-EOT
+    Version tag of the CockroachDB image.
+    Until v.16, the recommended CockroachDB version is v21.2.7.
+    From v.17, the recommended CockroachDB version is v24.1.3.
+
+    Example: v24.1.3
+  EOT
+}


### PR DESCRIPTION
This PR adds to the repository the `crdb_image_tag` variable definition. This file is only used to generate definitions of terraform modules and dependencies. This should have been committed with #1080. 
A CI check may be added to verify that the source definitions are inline with the repository generated content. Issue #1084 has been captured to track this.