### PR TITLE
[tanka] Expose crdb statefulset update partition

### DIFF
--- a/build/deploy/base.libsonnet
+++ b/build/deploy/base.libsonnet
@@ -155,7 +155,7 @@ local util = import 'util.libsonnet';
       updateStrategy: {
         type: 'RollingUpdate',
         rollingUpdate: {
-          partition: 0,
+          partition: metadata.cockroach.partition,
         },
       },
 

--- a/build/deploy/metadata_base.libsonnet
+++ b/build/deploy/metadata_base.libsonnet
@@ -18,6 +18,7 @@
     nodeIPs: error 'must supply the per-node ip addresses as an array', // For AWS, this array should contain the allocation id of the elastic ips.
     JoinExisting: [],
     storageClass: 'standard',
+    partition: 0, // Only used for CRDB upgrades. This manages the partition of the statefulset rolling update. See /deploy/MIGRATIONS.md#tanka-deployment-notes
   },
   PSP: {
     roleRef: '',


### PR DESCRIPTION
To facilitate support of CRDB upgrades, this PR exposes the CRDB statefulset partition as a metadata.
