### PR TITLE
[helm] Example of CRDB statefulset update partition

### DIFF
--- a/deploy/services/helm-charts/dss/values.example.yaml
+++ b/deploy/services/helm-charts/dss/values.example.yaml
@@ -26,6 +26,9 @@ cockroachdb:
     args:
       - --locality-advertise-addr=zone=interuss-example-google-ew1@$(hostname -f)
       - --advertise-addr=${HOSTNAME##*-}.db.example.com
+    updateStrategy:
+      rollingUpdate:
+        partition: 0 # Used for migrations. See /deploy/MIGRATIONS.md#helm-deployment-notes
 
   storage:
     persistentVolume:


### PR DESCRIPTION
To support the documentation of CRDB Upgrades (See #1075), this PR adds a placeholder in the helm values example file to set the update [partition](https://kubernetes.io/fr/docs/concepts/workloads/controllers/statefulset/#partitions) of the CRDB statefulset.