### PR TITLE
[terraform] Fix CRDB version for automated deployment

### DIFF
--- a/deploy/operations/ci/aws-1/terraform.tfvars
+++ b/deploy/operations/ci/aws-1/terraform.tfvars
@@ -23,7 +23,7 @@ authorization = {
   public_key_pem_path = "/test-certs/auth2.pem"
 }
 should_init         = true
-crdb_image_tag      = "v24.3.1"
+crdb_image_tag      = "v24.1.3"
 crdb_cluster_name   = "interuss-ci"
 crdb_locality       = "interuss_dss-ci-aws-ue1"
 crdb_external_nodes = []

--- a/deploy/services/helm-charts/dss/values.example.yaml
+++ b/deploy/services/helm-charts/dss/values.example.yaml
@@ -13,7 +13,7 @@ dss:
 cockroachdb:
   # See https://github.com/cockroachdb/helm-charts/blob/master/cockroachdb/values.yaml
   image:
-    tag: v24.3.1
+    tag: v24.1.3
   fullnameOverride: dss-cockroachdb
   conf:
     join: []


### PR DESCRIPTION
This PR fixes the CRDB version and helm example. The error was introduced by #1075.