### PR TITLE
Include JWT `sub` field in logs 

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -281,9 +281,9 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 		multiRouter.Routers = append(multiRouter.Routers, &scdV1Router)
 	}
 
-	handler := logging.HTTPMiddleware(logger, *dumpRequests, &multiRouter)
+	handler := logging.HTTPMiddleware(logger, *dumpRequests, healthyEndpointMiddleware(logger, &multiRouter))
 
-	handler = auth.DecoderMiddleware(authorizer, healthyEndpointMiddleware(logger, handler))
+	handler = auth.DecoderMiddleware(authorizer, handler)
 
 	httpServer := &http.Server{
 		Addr:              address,

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -281,10 +281,9 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 		multiRouter.Routers = append(multiRouter.Routers, &scdV1Router)
 	}
 
-	handler := logging.HTTPMiddleware(logger, *dumpRequests,
-		healthyEndpointMiddleware(logger,
-			&multiRouter,
-		))
+	handler := logging.HTTPMiddleware(logger, *dumpRequests, &multiRouter)
+
+	handler = auth.DecoderMiddleware(authorizer, healthyEndpointMiddleware(logger, handler))
 
 	httpServer := &http.Server{
 		Addr:              address,

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -197,8 +197,8 @@ func (a *Authorizer) Authorize(_ http.ResponseWriter, r *http.Request, authOptio
 	} else {
 		// Use previously decoded values
 		missing, ok = r.Context().Value("authTokenMissing").(bool)
-		if !ok || missing {
-			return api.AuthorizationResult{Error: stacktrace.NewErrorWithCode(dsserr.Unauthenticated, "Missing access token")}
+		if !ok {
+			missing = true
 		}
 
 		validated, ok = r.Context().Value("authValidated").(bool)
@@ -215,6 +215,10 @@ func (a *Authorizer) Authorize(_ http.ResponseWriter, r *http.Request, authOptio
 		if !ok {
 			keyClaims = claims{}
 		}
+	}
+
+	if missing {
+		return api.AuthorizationResult{Error: stacktrace.NewErrorWithCode(dsserr.Unauthenticated, "Missing access token")}
 	}
 
 	if !validated {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -193,10 +193,8 @@ func (a *Authorizer) Authorize(_ http.ResponseWriter, r *http.Request, authOptio
 
 	// if the decoding middleware wasn't triggered, attempt decoding
 	if _, ok = r.Context().Value("authDecoded").(bool); !ok {
-		a.logger.Info("Decoding middleware not triggered")
 		missing, validated, keyClaims, err = a.extractClaims(r)
 	} else {
-		a.logger.Info("Decoding middleware already triggered")
 		// Use previously decoded values
 		missing, ok = r.Context().Value("authTokenMissing").(bool)
 		if !ok || missing {

--- a/pkg/logging/http.go
+++ b/pkg/logging/http.go
@@ -67,6 +67,12 @@ func HTTPMiddleware(logger *zap.Logger, dump bool, handler http.Handler) http.Ha
 				// replace req.Body with a copy
 				r.Body = io.NopCloser(bytes.NewReader(reqData))
 			}
+
+			subject, ok := r.Context().Value("authSubject").(string)
+			if !ok {
+				subject = ""
+			}
+			logger = logger.With(zap.String("req_sub", subject))
 		}
 
 		handler.ServeHTTP(trw, r)


### PR DESCRIPTION
In reference to #1051 

- Separated the decoding and authorization phases of a JWT token
- Added a new middleware that performs the decoding and stores the claims as part of the request
- Use request context to query the JWT's Subject value and dump them in the JSON logs
- Added a flag in the context to indicate previous decoding (avoid breaking existing interface)