### PR TITLE
[interfaces/astm-utm-protocol] Target interuss/astm-utm-protocol repo as submodule and regen apis files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "interfaces/astm-utm/Protocol"]
 	path = interfaces/astm-utm/Protocol
-	url = https://github.com/astm-utm/Protocol
+	url = https://github.com/interuss/astm-utm-protocol
 [submodule "interfaces/rid/v1"]
 	path = interfaces/rid/v1
 	url = https://github.com/uastech/standards

--- a/interfaces/openapi-to-go-server/example/api/scd/interface.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/scd/interface.gen.go
@@ -7,11 +7,11 @@ import (
 )
 
 var (
-	UtmAvailabilityArbitrationScope          = api.RequiredScope("utm.availability_arbitration")
 	UtmConformanceMonitoringSaScope          = api.RequiredScope("utm.conformance_monitoring_sa")
 	UtmConstraintManagementScope             = api.RequiredScope("utm.constraint_management")
-	UtmStrategicCoordinationScope            = api.RequiredScope("utm.strategic_coordination")
 	UtmConstraintProcessingScope             = api.RequiredScope("utm.constraint_processing")
+	UtmAvailabilityArbitrationScope          = api.RequiredScope("utm.availability_arbitration")
+	UtmStrategicCoordinationScope            = api.RequiredScope("utm.strategic_coordination")
 	QueryOperationalIntentReferencesSecurity = []api.AuthorizationOption{
 		{
 			"Authority": {UtmStrategicCoordinationScope},

--- a/interfaces/openapi-to-go-server/example/api/scd/types.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/scd/types.gen.go
@@ -4,11 +4,17 @@ package scd
 // String whose format matches a version-4 UUID according to RFC 4122.
 type UUIDv4Format string
 
+// String whose format matches a version-7 UUID according to RFC 9562.
+type UUIDv7Format string
+
 // Identifier for an Entity communicated through the DSS.  Formatted as a UUIDv4.
 type EntityID UUIDv4Format
 
 // A token associated with a particular UTM Entity+version created by the DSS upon creation or modification of an Entity reference and provided to the client creating or modifying the Entity reference.  The EntityOVN is stored privately by the DSS and then compared against entries in a Key provided to mutate the airspace.  The EntityOVN is also provided by the client whenever that client transmits the full information of the Entity (either via GET, or via a subscription notification).
 type EntityOVN string
+
+// Numeric version of this entity which increments upon each change in the entity, regardless of whether any field of the entity changes.  A USS with the details of this entity when it was at a particular version does not need to retrieve the details again until the version changes.
+type EntityVersion int32
 
 // Identifier for a subscription communicated through the DSS.  Formatted as a UUIDv4.
 type SubscriptionID UUIDv4Format
@@ -228,8 +234,7 @@ type OperationalIntentReference struct {
 
 	UssAvailability UssAvailabilityState `json:"uss_availability"`
 
-	// Numeric version of this operational intent which increments upon each change in the operational intent, regardless of whether any field of the operational intent reference changes.  A USS with the details of this operational intent when it was at a particular version does not need to retrieve the details again until the version changes.
-	Version int32 `json:"version"`
+	Version EntityVersion `json:"version"`
 
 	State OperationalIntentState `json:"state"`
 
@@ -269,6 +274,10 @@ type PutOperationalIntentReferenceParameters struct {
 
 	// If an existing subscription is not specified in `subscription_id`, and the operational intent is in the Activated, Nonconforming, or Contingent state, then this field must be populated.  When this field is populated, an implicit subscription will be created and associated with this operational intent, and will generally be deleted automatically upon the deletion of this operational intent.
 	NewSubscription *ImplicitSubscriptionParameters `json:"new_subscription,omitempty"`
+
+	// This optional field not part of the original F3548 standard API allows a USS to request a specific OVN when creating or updating an operational intent. When creating an operational intent, this enables a USS to immediately publish the operational intent details with the expected OVN. When updating an operational intent, this enables a USS to immediately make available this new version of the operational intent details if specifically requested by the remote USS. The USS must still wait for the DSS receipt to actually publish the new operational intent details. This allows USSs to obtain correct operational intent details even if the DSS takes a long time to respond and/or the USS processing  it.
+	// The requested suffix must be a UUIDv7 string containing a timestamp of the current time. If the suffix is invalid, and notably if the time is too far in the past or the future, the request will be rejected. If the suffix is valid, the DSS will set the OVN of the operational intent to be `{entityid}_{requested_ovn_suffix}`. If no suffix is set, the DSS will proceed as specified by the standard.
+	RequestedOvnSuffix *UUIDv7Format `json:"requested_ovn_suffix,omitempty"`
 }
 
 // Information necessary to create a subscription to serve a single operational intent's notification needs.
@@ -313,8 +322,7 @@ type ConstraintReference struct {
 
 	UssAvailability UssAvailabilityState `json:"uss_availability"`
 
-	// Numeric version of this constraint which increments upon each change in the constraint, regardless of whether any field of the constraint reference changes.  A USS with the details of this constraint when it was at a particular version does not need to retrieve the details again until the version changes.
-	Version int32 `json:"version"`
+	Version EntityVersion `json:"version"`
 
 	// Opaque version number of this constraint.  Populated only when the ConstraintReference is managed by the USS retrieving or providing it.  Not populated when the ConstraintReference is not managed by the USS retrieving or providing it (instead, the USS must obtain the OVN from the details retrieved from the managing USS).
 	Ovn *EntityOVN `json:"ovn,omitempty"`

--- a/pkg/api/auxv1/interface.gen.go
+++ b/pkg/api/auxv1/interface.gen.go
@@ -7,13 +7,15 @@ import (
 )
 
 var (
-	GetVersionSecurity    = []api.AuthorizationOption{}
-	ValidateOauthSecurity = []api.AuthorizationOption{
+	DssWriteIdentificationServiceAreasScope = api.RequiredScope("dss.write.identification_service_areas")
+	DssReadIdentificationServiceAreasScope  = api.RequiredScope("dss.read.identification_service_areas")
+	GetVersionSecurity                      = []api.AuthorizationOption{}
+	ValidateOauthSecurity                   = []api.AuthorizationOption{
 		{
-			"Auth": {"dss.read.identification_service_areas"},
+			"Auth": {DssReadIdentificationServiceAreasScope},
 		},
 		{
-			"Auth": {"dss.write.identification_service_areas"},
+			"Auth": {DssWriteIdentificationServiceAreasScope},
 		},
 	}
 )

--- a/pkg/api/scdv1/interface.gen.go
+++ b/pkg/api/scdv1/interface.gen.go
@@ -7,11 +7,11 @@ import (
 )
 
 var (
+	UtmAvailabilityArbitrationScope          = api.RequiredScope("utm.availability_arbitration")
+	UtmStrategicCoordinationScope            = api.RequiredScope("utm.strategic_coordination")
 	UtmConstraintManagementScope             = api.RequiredScope("utm.constraint_management")
 	UtmConformanceMonitoringSaScope          = api.RequiredScope("utm.conformance_monitoring_sa")
-	UtmStrategicCoordinationScope            = api.RequiredScope("utm.strategic_coordination")
 	UtmConstraintProcessingScope             = api.RequiredScope("utm.constraint_processing")
-	UtmAvailabilityArbitrationScope          = api.RequiredScope("utm.availability_arbitration")
 	QueryOperationalIntentReferencesSecurity = []api.AuthorizationOption{
 		{
 			"Authority": {UtmStrategicCoordinationScope},

--- a/pkg/scd/models/constraints.go
+++ b/pkg/scd/models/constraints.go
@@ -32,7 +32,7 @@ func (c *Constraint) ToRest() *restapi.ConstraintReference {
 		Id:              restapi.EntityID(c.ID.String()),
 		Ovn:             &ovn,
 		Manager:         c.Manager.String(),
-		Version:         int32(c.Version),
+		Version:         restapi.EntityVersion(c.Version),
 		UssBaseUrl:      restapi.ConstraintUssBaseURL(c.USSBaseURL),
 		UssAvailability: UssAvailabilityStateUnknown.ToRest(),
 	}

--- a/pkg/scd/models/operational_intents.go
+++ b/pkg/scd/models/operational_intents.go
@@ -103,7 +103,7 @@ func (o *OperationalIntent) ToRest() *restapi.OperationalIntentReference {
 		Id:              restapi.EntityID(o.ID.String()),
 		Ovn:             &ovn,
 		Manager:         o.Manager.String(),
-		Version:         int32(o.Version),
+		Version:         restapi.EntityVersion(o.Version),
 		UssBaseUrl:      restapi.OperationalIntentUssBaseURL(o.USSBaseURL),
 		SubscriptionId:  subID,
 		State:           o.State.ToRest(),


### PR DESCRIPTION
Step towards addressing #1078.
`make apis` was ran to regenerate the `.gen.go` files.