### PR TITLE
[cmd] Enable db-manager CLI to support subcommands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test-go-units:
 test-go-units-crdb: cleanup-test-go-units-crdb
 	@docker run -d --name dss-crdb-for-testing -p 26257:26257 -p 8080:8080  cockroachdb/cockroach:v24.1.3 start-single-node --insecure > /dev/null
 	@until [ -n "`docker logs dss-crdb-for-testing | grep 'nodeID'`" ]; do echo "Waiting for CRDB to be ready"; sleep 3; done;
-	go run ./cmds/db-manager/main.go --schemas_dir ./build/db_schemas/rid --db_version latest --cockroach_host localhost
+	go run ./cmds/db-manager/main.go migrate --schemas_dir ./build/db_schemas/rid --db_version latest --cockroach_host localhost
 	go test -count=1 -v ./pkg/rid/store/cockroach --cockroach_host localhost --cockroach_port 26257 --cockroach_ssl_mode disable --cockroach_user root --cockroach_db_name rid
 	go test -count=1 -v ./pkg/rid/application --cockroach_host localhost --cockroach_port 26257 --cockroach_ssl_mode disable --cockroach_user root --cockroach_db_name rid
 	@docker stop dss-crdb-for-testing > /dev/null

--- a/build/deploy/schema-manager.libsonnet
+++ b/build/deploy/schema-manager.libsonnet
@@ -16,7 +16,7 @@ local schema_dir = '/db-schemas';
             },
             soloContainer:: base.Container('rid-schema-manager') {
               image: metadata.schema_manager.image,
-              command: ['db-manager'],
+              command: ['db-manager', 'migrate'],
               args_:: {
                 cockroach_host: 'cockroachdb-balanced.' + metadata.namespace,
                 cockroach_port: metadata.cockroach.grpc_port,
@@ -42,7 +42,7 @@ local schema_dir = '/db-schemas';
             },
             soloContainer:: base.Container('scd-schema-manager') {
               image: metadata.schema_manager.image,
-              command: ['db-manager'],
+              command: ['db-manager', 'migrate'],
               args_:: {
                 cockroach_host: 'cockroachdb-balanced.' + metadata.namespace,
                 cockroach_port: metadata.cockroach.grpc_port,

--- a/build/dev/haproxy_local_setup.sh
+++ b/build/dev/haproxy_local_setup.sh
@@ -128,7 +128,7 @@ docker run --rm --name rid-db-manager \
 	--link dss-crdb-cluster-for-testing:crdb \
 	--network dss_sandbox-default	\
 	local-interuss-dss-image \
-	/usr/bin/db-manager \
+	/usr/bin/db-manager migrate \
 	--schemas_dir db-schemas/rid \
 	--db_version "latest" \
 	--cockroach_host crdb
@@ -139,7 +139,7 @@ docker run --rm --name scd-db-manager \
 	--link dss-crdb-cluster-for-testing:crdb \
 	--network dss_sandbox-default	\
 	local-interuss-dss-image \
-	/usr/bin/db-manager \
+	/usr/bin/db-manager migrate \
 	--schemas_dir db-schemas/scd \
 	--db_version "latest" \
 	--cockroach_host crdb

--- a/build/dev/startup/rid_bootstrapper.sh
+++ b/build/dev/startup/rid_bootstrapper.sh
@@ -11,7 +11,7 @@ else
   sleep 3
 
   echo "Bootstrapping RID DB..."
-  /usr/bin/db-manager \
+  /usr/bin/db-manager migrate \
     --schemas_dir /db-schemas/rid \
     --db_version "latest" \
     --cockroach_host local-dss-crdb

--- a/build/dev/startup/scd_bootstrapper.sh
+++ b/build/dev/startup/scd_bootstrapper.sh
@@ -11,7 +11,7 @@ else
   sleep 3
 
   echo "Bootstrapping SCD DB..."
-  /usr/bin/db-manager \
+  /usr/bin/db-manager migrate \
     --schemas_dir /db-schemas/scd \
     --db_version "latest" \
     --cockroach_host local-dss-crdb

--- a/cmds/core-service/README.md
+++ b/cmds/core-service/README.md
@@ -40,11 +40,11 @@ docker container run -p 26257:26257 -p 8080:8080 --rm cockroachdb/cockroach:v24.
 Once an initialized CockroachDB cluster is available, the necessary databases within the CRDB cluster must be created/configured properly.  This can be accomplished with [migrate_local_db.sh](../../build/dev/migrate_local_db.sh), as documented in the [standalone instance documentation](../../build/dev/standalone_instance.md), when using the standard standalone development DSS instance, or it can be accomplished manually with commands similar to those below starting from the repo root folder:
 
 ```bash
-go run ./cmds/db-manager \
+go run ./cmds/db-manager migrate \
   --schemas_dir ./build/db_schemas/rid \
   --db_version latest \
   --cockroach_host localhost
-go run ./cmds/db-manager \
+go run ./cmds/db-manager migrate \
   --schemas_dir ./build/db_schemas/scd \
   --db_version latest \
   --cockroach_host localhost

--- a/cmds/db-manager/main.go
+++ b/cmds/db-manager/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/interuss/dss/cmds/db-manager/migration"
+	"github.com/spf13/cobra"
+)
+
+var (
+	DBManagerCmd = &cobra.Command{
+		Use:   "db-manager",
+		Short: "DSS database management utility",
+	}
+)
+
+func init() {
+	DBManagerCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine) // enable support for flags not yet migrated to using pflag (e.g. crdb flags)
+	DBManagerCmd.AddCommand(migration.MigrationCmd)
+}
+
+func main() {
+	if err := DBManagerCmd.Execute(); err != nil {
+		log.Printf("failed to execute db-manager: %v", err)
+		os.Exit(1)
+	}
+}

--- a/cmds/db-manager/migration/migrate.go
+++ b/cmds/db-manager/migration/migrate.go
@@ -1,6 +1,6 @@
 // Script for Database bootstrap deployment and migration
 
-package main
+package migration
 
 import (
 	"context"
@@ -34,7 +34,7 @@ var (
 	dbVersion = flag.String("db_version", "", "the db version to migrate to (ex: 1.0.0) or use \"latest\" to automatically upgrade to the latest version or leave blank to print the current version")
 )
 
-func main() {
+func Migration() {
 	// Read and validate schemas_dir input
 	flag.Parse()
 	if *path == "" {

--- a/deploy/services/helm-charts/dss/templates/schema-manager.yaml
+++ b/deploy/services/helm-charts/dss/templates/schema-manager.yaml
@@ -36,6 +36,7 @@ spec:
             - --schemas_dir=/db-schemas/{{$service}}
           command:
             - db-manager
+            - migrate
           image: {{$image}}
           imagePullPolicy: IfNotPresent
           name: {{$service}}-schema-manager-{{$jobVersion}}

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,11 @@ require (
 	github.com/jonboulle/clockwork v0.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/spf13/cobra v1.8.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/net v0.23.0
 )
 
 require (
@@ -31,6 +34,7 @@ require (
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
@@ -40,7 +44,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ github.com/cockroachdb/cockroach-go/v2 v2.3.8 h1:53yoUo4+EtrC1NrAEgnnad4AS3ntNvG
 github.com/cockroachdb/cockroach-go/v2 v2.3.8/go.mod h1:9uH5jK4yQ3ZQUT9IXe4I2fHzMIF5+JC/oOdzTRgJYJk=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -89,6 +90,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.2.4/go.mod h1:AwSRAtLfXpU5
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/interuss/stacktrace v1.0.0 h1:AzxZ27CK6YRbxyDE3j23O27i2VEPStrMJRBafoznP7U=
 github.com/interuss/stacktrace v1.0.0/go.mod h1:WwNxCSINli7iw/AvwTCnlvC664Db+oItGERbj3XNFTg=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -117,6 +120,11 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=


### PR DESCRIPTION
This PR refactors the `db-manager` command to support subcommands (notably for #1116).
- The existing `db-manager` logic is now defined as the `migration` subcommand. Various updates of scripts, deployment files, and documentations are made in that regard.
- Introduce use of spf13/cobra and spf13/pflag libraries to support this.
- Note that not all flags are migrated to using spf13/pflag, however the existing ones that use `flag` are still supported (notably for the cockroachdb flags).
- `go mod tidy` was ran.
- The diff is unfortunately not very readable, however here is a change overview that should help review:
  - `cmds/db-manager/main.go` is a new file
  - `cmds/db-manager/main.go` was moved to `cmds/db-manager/migration/migration.go` and adapted:
    - panics are replaced by returning errors
    - flags are defined with spf13/pflag
    - context is passed from parent
    - check for parameter `schemas_dir` is replaced by use of function `MarkFlagRequired`
