### PR TITLE
[ci] prober/qualifer: update monitoring image to 0.9.1

### DIFF
--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -40,7 +40,7 @@ if ! docker run --link "$OAUTH_CONTAINER":oauth \
 	--network dss_sandbox-default \
 	-v "${RESULTFILE}:/app/test_result" \
 	-w /app/monitoring/prober \
-	interuss/monitoring:v0.9.0 \
+	interuss/monitoring:v0.9.1 \
 	pytest \
 	"${1:-.}" \
 	-rsx \

--- a/build/dev/qualify_locally.sh
+++ b/build/dev/qualify_locally.sh
@@ -37,7 +37,7 @@ if ! docker run --link "$OAUTH_CONTAINER":oauth \
 	-w /app/monitoring/uss_qualifier \
 	-e AUTH_SPEC='DummyOAuth(http://oauth:8085/token,uss_qualifier)' \
 	-e AUTH_SPEC_2='DummyOAuth(http://oauth:8085/token,uss_qualifier_2)' \
-	interuss/monitoring:v0.9.0 \
+	interuss/monitoring:v0.9.1 \
     python main.py --config dss_probing_qualifier_config; then
 
     if [ "$CI" == "true" ]; then


### PR DESCRIPTION
Updates the image used for running the prober and qualifier to the latest released monitoring image.

Test plan: passes locally, check how the CI handles it.