### PR TITLE
[terraform-aws] Pin aws-load-balancer-controller to v2.9 (helm chart: 1.9)

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/AWSLoadBalancerControllerPolicy.json
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/AWSLoadBalancerControllerPolicy.json
@@ -38,7 +38,9 @@
         "elasticloadbalancing:DescribeTargetGroups",
         "elasticloadbalancing:DescribeTargetGroupAttributes",
         "elasticloadbalancing:DescribeTargetHealth",
-        "elasticloadbalancing:DescribeTags"
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:DescribeTrustStores",
+        "elasticloadbalancing:DescribeListenerAttributes"
       ],
       "Resource": "*"
     },
@@ -187,7 +189,8 @@
         "elasticloadbalancing:DeleteLoadBalancer",
         "elasticloadbalancing:ModifyTargetGroup",
         "elasticloadbalancing:ModifyTargetGroupAttributes",
-        "elasticloadbalancing:DeleteTargetGroup"
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:ModifyListenerAttributes"
       ],
       "Resource": "*",
       "Condition": {

--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/network_lb.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/network_lb.tf
@@ -4,6 +4,7 @@ resource "helm_release" "aws-load-balancer-controller" {
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
   name       = "aws-load-balancer-controller"
+  version    = "1.9.0"
 
   namespace = "kube-system"
 


### PR DESCRIPTION
This PR fixes #1127 by pinning the aws-load-balancer-controller to version 2.9. As shown in the [helm chart definition](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/release-2.9/helm/aws-load-balancer-controller/Chart.yaml#L4), the version of the chart is 1.9. In addition, the [policy file](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/release-2.9/docs/install/iam_policy.json) is updated accordingly.