### PR TITLE
[helm] Update schema-manager to use migrate subcommand in the helm chart

### DIFF
--- a/deploy/services/helm-charts/dss/templates/schema-manager.yaml
+++ b/deploy/services/helm-charts/dss/templates/schema-manager.yaml
@@ -27,6 +27,7 @@ spec:
         {{- $waitForCockroachDB | nindent 8 }}
       containers:
         - args:
+            - migrate
             - --cockroach_host={{$cockroachHost}}
             - --cockroach_port=26257
             - --cockroach_ssl_dir=/cockroach/cockroach-certs


### PR DESCRIPTION
#1122 moved the schema migration commands under the `migrate` subcommand. This PR updates the helm chart to use the subcommand.