### PR TITLE
[yugabyte] Add yugabyte to local dev docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ restart-all: build-dss down-locally start-locally
 
 .PHONY: start-locally
 start-locally:
+	@test ${COMPOSE_PROFILES} || echo "\033[0;96mTo start Yugabyte datastore, set the docker compose profile to with-yugabyte. Example using env variable: export COMPOSE_PROFILES=with-yugabyte\033[0m"
 	build/dev/run_locally.sh up -d
 
 .PHONY: probe-locally

--- a/build/dev/docker-compose_dss.yaml
+++ b/build/dev/docker-compose_dss.yaml
@@ -22,6 +22,20 @@ services:
       start_period: 30s
       start_interval: 5s
 
+  local-dss-ybdb:
+    image: yugabytedb/yugabyte:2024.1.2.0-b77
+    command: bin/yugabyted start --background=false
+    ports:
+      - "7000:7000"
+      - "9000:9000"
+      - "15433:15433"
+      - "5433:5433"
+      - "9042:9042"
+    restart: always
+    networks:
+      - dss_sandbox_default_network
+    profiles: ["with-yugabyte"]
+
   local-dss-rid-bootstrapper:
     build:
       context: ../..


### PR DESCRIPTION
This PR introduces the yugabyte container to the local development environment.
A Docker Compose Profile `with-yugabyte` has been set to selectively start it.
A message has been added to `start-locally` Makefile target to guide developers.