### PR TITLE
[security] Clarify dumpRequests and set default to false

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -50,7 +50,7 @@ var (
 
 	logFormat            = flag.String("log_format", logging.DefaultFormat, "The log format in {json, console}")
 	logLevel             = flag.String("log_level", logging.DefaultLevel.String(), "The log level")
-	dumpRequests         = flag.Bool("dump_requests", false, "Log HTTP request and response")
+	dumpRequests         = flag.Bool("dump_requests", false, "Log full HTTP request and response (note: will dump sensitive information to logs; intended only for debugging and/or development)")
 	profServiceName      = flag.String("gcp_prof_service_name", "", "Service name for the Go profiler")
 	garbageCollectorSpec = flag.String("garbage_collector_spec", "@every 30m", "Garbage collector schedule. The value must follow robfig/cron format. See https://godoc.org/github.com/robfig/cron#hdr-Usage for more detail.")
 

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
@@ -30,7 +30,7 @@ local metadata = metadataBase {
     jwksEndpoint: '${VAR_JWKS_ENDPOINT}',
     jwksKeyIds: ['${VAR_JWKS_KEY_ID}'],
     hostname: '${VAR_APP_HOSTNAME}',
-    dumpRequests: true,
+    dumpRequests: false,
     sslPolicy: '${VAR_SSL_POLICY}'
   },
   schema_manager+: {

--- a/deploy/services/tanka/examples/minimum/main.jsonnet
+++ b/deploy/services/tanka/examples/minimum/main.jsonnet
@@ -27,7 +27,7 @@ local metadata = metadataBase {
     jwksEndpoint: 'VAR_JWKS_ENDPOINT',
     jwksKeyIds: ['VAR_JWKS_KEY_ID'],
     hostname: 'VAR_APP_HOSTNAME',
-    dumpRequests: true,
+    dumpRequests: false,
     sslPolicy: 'VAR_SSL_POLICY'
   },
   schema_manager+: {


### PR DESCRIPTION
Previously, it was not necessarily obvious that the `dumpRequests` option would cause the DSS to place sensitive information (Bearer authorization tokens) into logs.  This PR clarifies that behavior, and also sets that option to `false` in the example deployment configurations (favoring production deployment usage over development usage by default) for increased safety.