### PR TITLE
Set default termination grace period for cockroachdb pod to 5 minutes

### DIFF
--- a/deploy/services/tanka/cockroachdb.libsonnet
+++ b/deploy/services/tanka/cockroachdb.libsonnet
@@ -94,7 +94,7 @@ local volumes = import 'volumes.libsonnet';
               'max-sql-memory': '25%',
             },
           },
-          terminationGracePeriodSeconds: 60,
+          terminationGracePeriodSeconds: 300,
         },
       },
       podManagementPolicy: 'Parallel',


### PR DESCRIPTION
CockroachDB [recommends](https://www.cockroachlabs.com/docs/stable/node-shutdown#termination-grace-period-on-kubernetes) a 5 minute grace period for node draining. Updating the default tanka config to match that 