### PR TITLE
Helm charts: add configurable imagePullPolicy

### DIFF
--- a/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
@@ -58,7 +58,7 @@ spec:
           command:
             - core-service
           image: {{ $dss.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ $dss.imagePullPolicy | default "Always" }}
           name: core-service
           ports:
             - containerPort: 8080


### PR DESCRIPTION
This PR make the `imagePullPolicy` configurable, with backward compatiliby using the old value as default.

It's needed for minikube/local cluster deployment (See #1154)