### PR TITLE
Helm charts: add gitignore

### DIFF
--- a/deploy/services/helm-charts/dss/.gitignore
+++ b/deploy/services/helm-charts/dss/.gitignore
@@ -1,0 +1,3 @@
+Chart.lock
+charts
+values.dev.yaml


### PR DESCRIPTION
This PR add a gitignore file for the helm charts, to ignore local config and various helm internal files.