### PR TITLE
 Yugabyte: helm charts 

### DIFF
--- a/deploy/infrastructure/README.md
+++ b/deploy/infrastructure/README.md
@@ -9,13 +9,20 @@ The [modules](modules) directory contains the terraform public modules required 
 - [terraform-aws-dss](./modules/terraform-aws-dss/README.md): Amazon Web Services deployment
 - [terraform-google-dss](./modules/terraform-google-dss/README.md): Google Cloud Engine deployment
 
+
 ## Dependencies
-The [dependencies](dependencies) directory contains submodules used by the public modules described above. They are not expected to be 
+The [dependencies](dependencies) directory contains submodules used by the public modules described above. They are not expected to be
 used directly by users. Those submodules are the combination of the cloud specific dependencies `terraform-*-kubernetes`
-and `terraform-common-dss`. `terraform-common-dss` module aggregates and outputs the infrastructure configuration 
+and `terraform-common-dss`. `terraform-common-dss` module aggregates and outputs the infrastructure configuration
 which can be used as input to the `Services` deployment as shown in the diagram below.
 
 ![Infrastructure Modules](../../assets/generated/deploy_infrastructure_modules.png)
+
+## Local
+
+The [local](local) directory contains various documentation that can be used to spawn a cluster locally.
+
+- [minikuke](./local/minikube/README.md): Minikube local deployment
 
 ## Utils
 This [utils folder](utils) contains scripts to help manage the terraform modules and dependencies. See the README in that folder for details.

--- a/deploy/infrastructure/local/minikube/README.md
+++ b/deploy/infrastructure/local/minikube/README.md
@@ -1,0 +1,51 @@
+# minikube
+
+This module provide instructions to prepare a local minikube cluster.
+
+Minikube is going to take care of most of the work by spawning a local kubernetes cluster.
+
+## Getting started
+
+### Prerequisites
+
+Download & install the following tools to your workstation:
+
+1. Install [minikube](https://minikube.sigs.k8s.io/docs/start/) (First step only).
+2. Install tools from [Prerequisites](../../../../build/README.md)
+
+### Create a new minikube cluster
+
+1. Run `minikube start -p dss-local-cluster` to create a new cluster.
+2. Run `minikube tunnel -p dss-local-cluster` and keep it running to expose LoadBalancer services.
+
+If needed, you can change the name of the cluster (`dss-local-cluster` in this documentation) as needed. You may also deploy multiple cluster at the same time, using different names.
+
+### Access to the cluster
+
+Minikube provide a UI, should you want to keep track of deployment and/or inspect the cluster. To start it, use the following command:
+
+1. `minikube dashboard -p dss-local-cluster`
+
+You can also use any other tool as needed. You can switch to the cluster's context by using the following command:
+
+1. `kubectl config use-context dss-local-cluster`
+
+### Upload or update local image
+
+Should you want to run the local docker image that you [built](../../../../build/README.md), run the following commands to upload / update your image
+
+1. `minikube image -p dss-local-cluster push interuss-local/dss`
+
+In the helm charts, use `docker.io/interuss-local/dss:latest` as image and be sure to set the `imagePullPolicy` to `Never`.
+
+## Deployment of the DSS services
+
+You can now deploy the DSS services using [helm charts](../../../services/helm-charts/dss/README.md).
+
+Use the `global.cloudProvider` setting with the value `minikube` and deploy the charts on the `dss-local-cluster` kubernetes context.
+
+To access the service, find the external IP using the `kubectl get services dss-dss-gateway` command. The port 80, without HTTPs is used.
+
+## Clean up
+
+To delete all resources, run `minikube delete -p dss-local-cluster`.  Note that this operation can't be reverted and all data will be lost.

--- a/deploy/services/helm-charts/dss/.gitignore
+++ b/deploy/services/helm-charts/dss/.gitignore
@@ -1,0 +1,3 @@
+Chart.lock
+charts
+values.dev.yaml

--- a/deploy/services/helm-charts/dss/Chart.yaml
+++ b/deploy/services/helm-charts/dss/Chart.yaml
@@ -8,3 +8,8 @@ dependencies:
   - name: cockroachdb
     repository: https://charts.cockroachdb.com/
     version: 10.0.7
+    condition: cockroachdb.enabled
+  - name: yugabyte
+    repository: https://charts.yugabyte.com/
+    version: 2.25.1
+    condition: yugabyte.enabled

--- a/deploy/services/helm-charts/dss/templates/_helpers.tpl
+++ b/deploy/services/helm-charts/dss/templates/_helpers.tpl
@@ -1,9 +1,34 @@
-{{- define "cockroachImage" -}}
+{{- define "databaseImage" -}}
+{{- if $.Values.cockroachdb.enabled -}}
 {{ (printf "%s:%s" $.Values.cockroachdb.image.repository $.Values.cockroachdb.image.tag) }}
+{{- else -}}
+{{ (printf "%s:%s" $.Values.yugabyte.Image.repository $.Values.yugabyte.Image.tag) }}
+{{- end -}}
 {{- end -}}
 
-{{- define "cockroachHost" -}}
+{{- define "databasePort" -}}
+{{- if $.Values.cockroachdb.enabled -}}
+26257
+{{- else -}}
+5433
+{{- end -}}
+{{- end -}}
+
+{{- define "databaseUser" -}}
+{{- if $.Values.cockroachdb.enabled -}}
+root
+{{- else -}}
+yugabyte
+{{- end -}}
+{{- end -}}
+
+
+{{- define "databaseHost" -}}
+{{- if $.Values.cockroachdb.enabled -}}
 {{- printf "%s-public.default" $.Values.cockroachdb.fullnameOverride -}}
+{{- else -}}
+{{- printf "yb-tservers.default" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "init-container-wait-for-http" -}}
@@ -13,14 +38,18 @@
 {{- end -}}
 
 {{- define "init-container-wait-for-schema" -}}
-{{/*For some reason, calling the template cockroachImage fails here.*/}}
+{{/*For some reason, calling the template databaseImage fails here.*/}}
 - name: wait-for-schema-{{.schemaName}}
-  image: {{.cockroachImage}}
+  image: {{.databaseImage}}
   volumeMounts:
     {{- include "ca-certs:volumeMount" . | nindent 4 }}
     {{- include "client-certs:volumeMount" . | nindent 4 }}
   command:
     - sh
     - -c
-    - "/cockroach/cockroach sql --certs-dir /cockroach/cockroach-certs/ --host {{.cockroachHost}} --port \"26257\" --format raw -e \"SELECT * FROM crdb_internal.databases where name = '{{.schemaName}}';\" | grep {{.schemaName}}"
+{{ if .cockroachdb }}
+    - "/cockroach/cockroach sql --certs-dir /cockroach/cockroach-certs/ --host {{.databaseHost}} --port \"{{.databasePort}}\" --format raw -e \"SELECT * FROM crdb_internal.databases where name = '{{.schemaName}}';\" | grep {{.schemaName}}"
+{{ else }}
+    - "ysqlsh  --host {{.databaseHost}} --port \"{{.databasePort}}\" -c \"SELECT datname FROM pg_database where datname = '{{.schemaName}}';\" | grep {{.schemaName}}"
+{{ end }}
 {{- end -}}

--- a/deploy/services/helm-charts/dss/templates/_networking-minikuke.tpl
+++ b/deploy/services/helm-charts/dss/templates/_networking-minikuke.tpl
@@ -1,0 +1,14 @@
+{{- define "minikube-lb-default-annotations" -}}
+{{- end -}}
+
+{{- define "minikube-lb-crdb-annotations" -}}
+{{- end -}}
+
+{{- define "minikube-lb-spec" -}}
+{{- end -}}
+
+{{- define "minikube-ingress-dss-gateway-annotations" -}}
+{{- end -}}
+
+{{- define "minikube-ingress-spec" -}}
+{{- end -}}

--- a/deploy/services/helm-charts/dss/templates/cockroachdb-loadbalancers.yaml
+++ b/deploy/services/helm-charts/dss/templates/cockroachdb-loadbalancers.yaml
@@ -1,5 +1,7 @@
 {{- $cloudProvider := $.Values.global.cloudProvider}}
 
+{{- if $.Values.cockroachdb.enabled }}
+
 # Node Gateways
 {{- range $i, $lb := .Values.loadBalancers.cockroachdbNodes }}
 ---
@@ -31,4 +33,5 @@ spec:
   selector:
     statefulset.kubernetes.io/pod-name: {{$.Release.Name}}-cockroachdb-{{$i}}
   type: LoadBalancer
+{{- end }}
 {{- end }}

--- a/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
@@ -58,7 +58,7 @@ spec:
           command:
             - core-service
           image: {{ $dss.image }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ $dss.imagePullPolicy | default "Always" }}
           name: core-service
           ports:
             - containerPort: 8080

--- a/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
@@ -1,9 +1,17 @@
 {{- $dss := .Values.dss -}}
-{{- $cockroachImage := (include "cockroachImage" .) -}}
-{{- $cockroachHost :=  (include "cockroachHost" .) -}}
-{{- $waitForCockroachDB := include "init-container-wait-for-http" (dict "serviceName" "cockroachdb" "url" (printf "http://%s:8080/health" $cockroachHost)) -}}
-{{- $waitForRIDSchema := include "init-container-wait-for-schema" (dict "schemaName" "rid" "cockroachImage" $cockroachImage "cockroachHost" $cockroachHost) -}}
-{{- $waitForSCDSchema := include "init-container-wait-for-schema" (dict "schemaName" "scd" "cockroachImage" $cockroachImage "cockroachHost" $cockroachHost) -}}
+
+{{- $databaseImage := (include "databaseImage" .) -}}
+{{- $databaseHost :=  (include "databaseHost" .) -}}
+{{- $databasePort :=  (include "databasePort" .) -}}
+{{- $databaseUser :=  (include "databaseUser" .) -}}
+
+{{- $waitForDatabase := include "init-container-wait-for-http" (dict "serviceName" "cockroachdb" "url" (printf "http://%s:8080/health" $databaseHost)) -}}
+{{- if .Values.yugabyte.enabled }}
+{{- $waitForDatabase = include "init-container-wait-for-http" (dict "serviceName" "yb-tserver" "url" (printf "http://%s:9000/status" $databaseHost)) -}}
+{{- end -}}
+
+{{- $waitForRIDSchema := include "init-container-wait-for-schema" (dict "schemaName" "rid" "databaseImage" $databaseImage "databasePort" $databasePort "databaseHost" $databaseHost "cockroachdb" .Values.cockroachdb.enabled ) -}}
+{{- $waitForSCDSchema := include "init-container-wait-for-schema" (dict "schemaName" "scd" "databaseImage" $databaseImage "databasePort" $databasePort "databaseHost" $databaseHost "cockroachdb" .Values.cockroachdb.enabled ) -}}
 
 ---
 apiVersion: apps/v1
@@ -29,18 +37,21 @@ spec:
         app: {{.Release.Name}}-core-service
     spec:
       initContainers:
-        {{- $waitForCockroachDB | nindent 8 }}
+        {{- $waitForDatabase | nindent 8 }}
         {{- $waitForRIDSchema | nindent 8 }}
         {{- $waitForSCDSchema | nindent 8 }}
       containers:
         - args:
             - --accepted_jwt_audiences={{$dss.conf.hostname}}
             - --addr=:8080
-            - --cockroach_host={{$cockroachHost}}
-            - --cockroach_port=26257
+            - --cockroach_host={{ $databaseHost }}
+            - --cockroach_port={{ $databasePort }}
+            - --cockroach_user={{ $databaseUser }}
+{{ if $.Values.cockroachdb.enabled }}
             - --cockroach_ssl_dir=/cockroach/cockroach-certs
             - --cockroach_ssl_mode=verify-full
-            - --cockroach_user=root
+            - --locality={{ .Values.cockroachdb.conf.locality }}
+{{ end }}
             - --dump_requests=true
             - --enable_scd={{$dss.enableScd | default true}}
             - --garbage_collector_spec=@every 30m
@@ -51,7 +62,6 @@ spec:
             {{- if $dss.conf.jwksKeyIds }}
             - --jwks_key_ids={{ $dss.conf.jwksKeyIds | join "," }}
             {{- end }}
-            - --locality={{ .Values.cockroachdb.conf.locality }}
             {{- if $dss.conf.pubKeys }}
             - --public_key_files={{ $dss.conf.pubKeys | join "," }}
             {{- end }}

--- a/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
@@ -52,7 +52,7 @@ spec:
             - --jwks_key_ids={{ $dss.conf.jwksKeyIds | join "," }}
             {{- end }}
             - --locality={{ .Values.cockroachdb.conf.locality }}
-            {{- if $dss.conf.pubKeys}}
+            {{- if $dss.conf.pubKeys }}
             - --public_key_files={{ $dss.conf.pubKeys | join "," }}
             {{- end }}
           command:

--- a/deploy/services/helm-charts/dss/templates/dss-ingress-minikube.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-ingress-minikube.yaml
@@ -1,0 +1,37 @@
+{{- $cloudProvider := $.Values.global.cloudProvider}}
+{{- if eq $cloudProvider "minikube" }}
+{{/*
+Minikube application load balancer Ingress do not support elastic ip assignment yet. Therefore, the
+ingress is replaced by a network load balancer (Kubernetes Service of type Load Balancer)
+*/}}
+{{- with $.Values.loadBalancers.dssGateway }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    {{- include (printf "%s-ingress-dss-gateway-annotations" $cloudProvider)
+      (merge .
+        (dict
+          "name" "dss-gateway-external"
+          "cloudProvider" $cloudProvider
+        )
+      ) | nindent 4
+    }}
+  labels:
+    app: {{$.Release.Name}}-core-service
+    name: {{$.Release.Name}}-dss-gateway
+  name: {{$.Release.Name}}-dss-gateway
+  namespace: default
+spec:
+  {{- include (printf "%s-ingress-spec" $cloudProvider) . | nindent 2 }}
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: {{$.Release.Name}}-core-service
+  type: LoadBalancer
+{{- end }}
+{{- end }}

--- a/deploy/services/helm-charts/dss/templates/schema-manager.yaml
+++ b/deploy/services/helm-charts/dss/templates/schema-manager.yaml
@@ -1,9 +1,18 @@
 {{- $image := .Values.dss.image }}
-{{- $cockroachHost :=  (include "cockroachHost" .) -}}
+{{- $databaseHost :=  (include "databaseHost" .) -}}
+{{- $databasePort :=  (include "databasePort" .) -}}
+{{- $databaseUser :=  (include "databaseUser" .) -}}
 {{- $jobVersion := .Release.Revision -}} {{/* Jobs template definition is immutable, using the revision in the name forces the job to be recreated at each helm upgrade. */}}
-{{- $waitForCockroachDB := include "init-container-wait-for-http" (dict "serviceName" "cockroachdb" "url" (printf "http://%s:8080/health" $cockroachHost)) -}}
 
-{{- range $service, $schemaVersion := dict "rid" "4.0.0" "scd" "3.2.0" }}
+{{- $waitForDatabase := include "init-container-wait-for-http" (dict "serviceName" "cockroachdb" "url" (printf "http://%s:8080/health" $databaseHost)) -}}
+{{- $schemas := dict "rid" "4.0.0" "scd" "3.2.0" }}
+
+{{- if .Values.yugabyte.enabled }}
+{{- $waitForDatabase = include "init-container-wait-for-http" (dict "serviceName" "yb-tserver" "url" (printf "http://%s:9000/status" $databaseHost)) -}}
+{{- $schemas = dict "rid" "1.0.1" "scd" "1.0.1" }}
+{{- end -}}
+
+{{- range $service, $schemaVersion := $schemas }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -24,17 +33,21 @@ spec:
         name: {{$service}}-schema-manager-{{$jobVersion}}
     spec:
       initContainers:
-        {{- $waitForCockroachDB | nindent 8 }}
+        {{- $waitForDatabase | nindent 8 }}
       containers:
         - args:
             - migrate
-            - --cockroach_host={{$cockroachHost}}
-            - --cockroach_port=26257
+            - --cockroach_host={{ $databaseHost }}
+            - --cockroach_port={{ $databasePort }}
+            - --cockroach_user={{ $databaseUser }}
+{{ if $.Values.cockroachdb.enabled }}
             - --cockroach_ssl_dir=/cockroach/cockroach-certs
             - --cockroach_ssl_mode=verify-full
-            - --cockroach_user=root
-            - --db_version={{$schemaVersion}}
             - --schemas_dir=/db-schemas/{{$service}}
+{{ else }}
+            - --schemas_dir=/db-schemas/yugabyte/{{$service}}
+{{ end }}
+            - --db_version={{$schemaVersion}}
           command:
             - db-manager
             - migrate

--- a/deploy/services/helm-charts/dss/values.example.yaml
+++ b/deploy/services/helm-charts/dss/values.example.yaml
@@ -2,6 +2,8 @@
 
 dss:
   image: docker.io/interuss/dss:v0.15.0 # See https://hub.docker.com/r/interuss/dss/tags for official image releases.
+  # When running local images in minikube, uncomment the following line
+  # imagePullPolicy: Never
   conf:
     pubKeys:
       - /test-certs/auth2.pem
@@ -23,7 +25,7 @@ cockroachdb:
 
   statefulset:
     replicas: 3 # Must match the number of .loadBalancers.cockroachdbNodes items.
-    args:
+    args:  # Remove this whole block for minikube
       - --locality-advertise-addr=zone=interuss-example-google-ew1@$(hostname -f)
       - --advertise-addr=${HOSTNAME##*-}.db.example.com
     updateStrategy:

--- a/deploy/services/helm-charts/dss/values.example.yaml
+++ b/deploy/services/helm-charts/dss/values.example.yaml
@@ -13,6 +13,7 @@ dss:
     enableScd: true
 
 cockroachdb:
+  enabled: false
   # See https://github.com/cockroachdb/helm-charts/blob/master/cockroachdb/values.yaml
   image:
     tag: v24.1.3
@@ -35,6 +36,13 @@ cockroachdb:
   storage:
     persistentVolume:
       storageClass: standard
+
+yugabyte:
+  enabled: true
+  # See https://github.com/yugabyte/charts/blob/master/stable/yugabyte/values.yaml
+  Image:
+    tag: 2.25.1.0-b381
+  nameOverride: dss-yugabyte
 
 loadBalancers:
   cockroachdbNodes:

--- a/deploy/services/helm-charts/dss/values.schema.json
+++ b/deploy/services/helm-charts/dss/values.schema.json
@@ -175,7 +175,7 @@
       "type": "object",
       "properties": {
         "cloudProvider": {
-          "description": "Cloud provider identifier. `aws` or `google`",
+          "description": "Cloud provider identifier. `aws`, `google` or `minikube`",
           "type": "string"
         }
       },

--- a/deploy/services/helm-charts/dss/values.schema.json
+++ b/deploy/services/helm-charts/dss/values.schema.json
@@ -5,6 +5,10 @@
       "description": "Cockroach DB related configuration",
       "type": "object",
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable CockroachDB. YugabyteDB xor CockroachDB should be enabled (only one at at time, at least one)."
+        },
         "image": {
           "type": "object",
           "properties": {
@@ -59,10 +63,7 @@
               },
               "additionalItems": true
             }
-          },
-          "required": [
-            "args"
-          ]
+          }
         },
         "storage": {
           "type": "object",
@@ -82,7 +83,21 @@
         "image",
         "fullnameOverride",
         "conf",
-        "statefulset"
+        "statefulset",
+        "enabled"
+      ]
+    },
+    "yugabyte": {
+      "description": "Yugabyte related configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable YugabyteDB. YugabyteDB xor CockroachDB should be enabled (only one at at time, at least one)."
+        }
+      },
+      "required": [
+        "enabled"
       ]
     },
     "loadBalancers": {
@@ -184,6 +199,7 @@
   },
   "required": [
     "cockroachdb",
+    "yugabyte",
     "loadBalancers",
     "dss",
     "global"

--- a/deploy/services/helm-charts/dss/values.yaml
+++ b/deploy/services/helm-charts/dss/values.yaml
@@ -1,5 +1,6 @@
 # Default configuration
 cockroachdb:
+  enabled: true
   # See https://github.com/cockroachdb/helm-charts/blob/master/cockroachdb/values.yaml
   image:
     repository: cockroachdb/cockroach
@@ -12,3 +13,10 @@ cockroachdb:
         enabled: false
   ingress:
     enabled: false
+
+yugabyte:
+  enabled: false
+  Image:
+    repository: yugabytedb/yugabyte
+
+  # See https://github.com/yugabyte/charts/blob/master/stable/yugabyte/values.yaml


### PR DESCRIPTION
This PR add basic yugabyte support on helm charts. It's missing certificate and locality. It has been tested in minikube only.

It does follow #1154 , #1156 and #1157 , you may want to review bf0f05b0528ef619898bd0d783f0018cefbec25e only.
