### PR TITLE
[terraform] Pin python-hcl2 dependency

### DIFF
--- a/deploy/infrastructure/utils/Dockerfile
+++ b/deploy/infrastructure/utils/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.10
 
-RUN pip install python-hcl2
+RUN pip install 'python-hcl2==5.1.1'
 
 WORKDIR /app


### PR DESCRIPTION
This PR pins the version to prevent uncontrolled changes of formatting when generating templates and keep the output of the [generate_terraform_variables.sh](https://github.com/Orbitalize/dss/blob/925e7b3ab0c4504dd800aeacdb6f72be1e13564c/deploy/infrastructure/utils/generate_terraform_variables.sh) script stable.