### PR TITLE
[terraform-aws] Unset default disk_size to use default value and allow backward compatibility

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/cluster.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/cluster.tf
@@ -30,7 +30,6 @@ resource "aws_eks_node_group" "eks_node_group" {
   cluster_name           = aws_eks_cluster.kubernetes_cluster.name
   subnet_ids             = [data.aws_subnet.main_subnet.id] # Limit nodes to one subnet
   node_role_arn          = aws_iam_role.dss-cluster-node-group.arn
-  disk_size              = 10
   node_group_name_prefix = aws_eks_cluster.kubernetes_cluster.name
   instance_types = [
     var.aws_instance_type


### PR DESCRIPTION
The new default base image used by AWS is`AL2023_x86_64_STANDARD` and it requires at least 20GB of disk.
This disk is distinct from Persistent Volumes claimed by Kubernetes workloads.

This PR removes the explicit disk_size setting to fallback to the [default value of 20 if not specified](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group#disk_size-1)
and ensure backward compatibility with already running deployments. This is part of preparing the migration to Kubernetes 1.32. (#1155)

Since it is not possible to spin up a node with 10GB disk size, I tested manually changing the previous disk size to 25GB and exercised this PR change to validate the default is not applied and no change was made to the Kubernetes node pool.
No change has been detected by terraform.
