### PR TITLE
[aux] Add empty DSS instances endpoint

### DIFF
--- a/build/dev/read_dss_instances.sh
+++ b/build/dev/read_dss_instances.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Retrieve token from dummy OAuth server
+ACCESS_TOKEN=$(curl --silent \
+    "http://localhost:8085/token?grant_type=client_credentials&scope=interuss.pool_status.read&intended_audience=localhost&issuer=localhost&sub=manual_tester" \
+| python extract_json_field.py 'access_token')
+
+curl --silent -X GET  \
+"http://localhost:8082/aux/v1/pool/dss_instances" \
+-H "Authorization: Bearer ${ACCESS_TOKEN}" -H "Content-Type: application/json"

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -46,7 +46,7 @@ var (
 	allowHTTPBaseUrls = flag.Bool("allow_http_base_urls", false, "Enables http scheme for Strategic Conflict Detection API")
 	enableHTTP        = flag.Bool("enable_http", false, "DEPRECATED (replaced by allow_http_base_urls): Enables http scheme for Strategic Conflict Detection API")
 	timeout           = flag.Duration("server timeout", 10*time.Second, "Default timeout for server calls")
-	locality          = flag.String("locality", "", "self-identification string used as CRDB table writer column")
+	locality          = flag.String("locality", "", "self-identification string of this DSS instance")
 
 	logFormat            = flag.String("log_format", logging.DefaultFormat, "The log format in {json, console}")
 	logLevel             = flag.String("log_level", logging.DefaultLevel.String(), "The log level")

--- a/interfaces/aux_/aux_.yaml
+++ b/interfaces/aux_/aux_.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: DSS Auxiliary API
-  version: 1.0.0
+  version: 1.1.0
 
 components:
   schemas:
@@ -19,6 +19,59 @@ components:
         message:
           description: Human-readable message indicating what error occurred and/or why.
           type: string
+
+    DSSInstancesResponse:
+      type: object
+      properties:
+        dss_instances:
+          type: array
+          items:
+            $ref: '#/components/schemas/DSSInstance'
+          default: []
+    DSSInstance:
+      type: object
+      properties:
+        instance_id:
+          description: Identity of this DSS instance participating in the pool (locality).
+          type: string
+        most_recent_heartbeat:
+          description: Most recent heartbeat registered for this DSS instance.
+          anyOf:
+          - $ref: '#/components/schemas/Heartbeat'
+      required:
+      - instance_id
+    Heartbeat:
+      type: object
+      properties:
+        timestamp:
+          description: Time at which heartbeat was registered.
+          type: string
+          format: date-time
+          example: '1985-04-12T23:20:50.52Z'
+        reporter:
+          description: Identity (via access token `sub` claim) of client reporting the heartbeat, or omitted if no client reported the heartbeat.
+          type: string
+          example: 'uss1'
+          default: ''
+        source:
+          description: Source/trigger of this heartbeat.
+          type: string
+          example: Startup
+        index:
+          description: Index of this heartbeat within the set of all heartbeats for this pool participant.
+          type: integer
+          format: int64
+          minimum: 0
+          example: 1
+          default: 0
+        unique_value:
+          description: If specified, a sufficiently unique value to verify synchronization between DSS instances with additional certainty.  A UUIDv4 is recommended.
+          type: string
+          example: 9d531807-f3fa-435a-ad54-4bca01a5df43
+          default: ''
+      required:
+      - timestamp
+      - source
 
 paths:
   /aux/v1/version:
@@ -67,10 +120,43 @@ paths:
             - dss.read.identification_service_areas
         - Auth:
             - dss.write.identification_service_areas
+
+  /aux/v1/pool/dss_instances:
+    get:
+      summary: Queries the current information for DSS instances participating in the pool.
+      operationId: getDSSInstances
+      tags: [ dss ]
+      security:
+      - Auth:
+        - interuss.pool_status.read
+      responses:
+        '200':
+          description: The known DSS instances participating in the pool are successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DSSInstancesResponse'
+        '401':
+          description: >-
+            Bearer access token was not provided in Authorization header, token
+            could not be decoded, or token was invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: >-
+            The access token was decoded successfully but did not include a
+            scope appropriate to this endpoint.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 security:
   - Auth:
       - dss.read.identification_service_areas
       - dss.write.identification_service_areas
+      - interuss.pool_status.read
 tags:
   - name: dss
     description: Endpoints exposed by the DSS server.

--- a/interfaces/openapi-to-go-server/Dockerfile
+++ b/interfaces/openapi-to-go-server/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-alpine
 
-COPY --from=golang:1.14-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.22-alpine /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 ADD ./requirements.txt /app/requirements.txt

--- a/pkg/api/auxv1/interface.gen.go
+++ b/pkg/api/auxv1/interface.gen.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	DssWriteIdentificationServiceAreasScope = api.RequiredScope("dss.write.identification_service_areas")
+	InterussPoolStatusReadScope             = api.RequiredScope("interuss.pool_status.read")
 	DssReadIdentificationServiceAreasScope  = api.RequiredScope("dss.read.identification_service_areas")
+	DssWriteIdentificationServiceAreasScope = api.RequiredScope("dss.write.identification_service_areas")
 	GetVersionSecurity                      = []api.AuthorizationOption{}
 	ValidateOauthSecurity                   = []api.AuthorizationOption{
 		{
@@ -16,6 +17,11 @@ var (
 		},
 		{
 			"Auth": {DssWriteIdentificationServiceAreasScope},
+		},
+	}
+	GetDSSInstancesSecurity = []api.AuthorizationOption{
+		{
+			"Auth": {InterussPoolStatusReadScope},
 		},
 	}
 )
@@ -53,10 +59,31 @@ type ValidateOauthResponseSet struct {
 	Response500 *api.InternalServerErrorBody
 }
 
+type GetDSSInstancesRequest struct {
+	// The result of attempting to authorize this request
+	Auth api.AuthorizationResult
+}
+type GetDSSInstancesResponseSet struct {
+	// The known DSS instances participating in the pool are successfully returned.
+	Response200 *DSSInstancesResponse
+
+	// Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+	Response401 *ErrorResponse
+
+	// The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+	Response403 *ErrorResponse
+
+	// Auto-generated internal server error response
+	Response500 *api.InternalServerErrorBody
+}
+
 type Implementation interface {
 	// Queries the version of the DSS.
 	GetVersion(ctx context.Context, req *GetVersionRequest) GetVersionResponseSet
 
 	// Validate Oauth token against the DSS.
 	ValidateOauth(ctx context.Context, req *ValidateOauthRequest) ValidateOauthResponseSet
+
+	// Queries the current information for DSS instances participating in the pool.
+	GetDSSInstances(ctx context.Context, req *GetDSSInstancesRequest) GetDSSInstancesResponseSet
 }

--- a/pkg/api/auxv1/server.gen.go
+++ b/pkg/api/auxv1/server.gen.go
@@ -87,14 +87,48 @@ func (s *APIRouter) ValidateOauth(exp *regexp.Regexp, w http.ResponseWriter, r *
 	api.WriteJSON(w, 500, api.InternalServerErrorBody{ErrorMessage: "Handler implementation did not set a response"})
 }
 
+func (s *APIRouter) GetDSSInstances(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
+	var req GetDSSInstancesRequest
+
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetDSSInstancesSecurity)
+
+	// Call implementation
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+	response := s.Implementation.GetDSSInstances(ctx, &req)
+
+	// Write response to client
+	if response.Response200 != nil {
+		api.WriteJSON(w, 200, response.Response200)
+		return
+	}
+	if response.Response401 != nil {
+		api.WriteJSON(w, 401, response.Response401)
+		return
+	}
+	if response.Response403 != nil {
+		api.WriteJSON(w, 403, response.Response403)
+		return
+	}
+	if response.Response500 != nil {
+		api.WriteJSON(w, 500, response.Response500)
+		return
+	}
+	api.WriteJSON(w, 500, api.InternalServerErrorBody{ErrorMessage: "Handler implementation did not set a response"})
+}
+
 func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {
-	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 2)}
+	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 3)}
 
 	pattern := regexp.MustCompile("^/aux/v1/version$")
 	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetVersion}
 
 	pattern = regexp.MustCompile("^/aux/v1/validate_oauth$")
 	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.ValidateOauth}
+
+	pattern = regexp.MustCompile("^/aux/v1/pool/dss_instances$")
+	router.Routes[2] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetDSSInstances}
 
 	return router
 }

--- a/pkg/api/auxv1/types.gen.go
+++ b/pkg/api/auxv1/types.gen.go
@@ -10,3 +10,32 @@ type ErrorResponse struct {
 	// Human-readable message indicating what error occurred and/or why.
 	Message *string `json:"message,omitempty"`
 }
+
+type DSSInstancesResponse struct {
+	DssInstances *[]DSSInstance `json:"dss_instances,omitempty"`
+}
+
+type DSSInstance struct {
+	// Identity of this DSS instance participating in the pool (locality).
+	InstanceId string `json:"instance_id"`
+
+	// Most recent heartbeat registered for this DSS instance.
+	MostRecentHeartbeat *Heartbeat `json:"most_recent_heartbeat,omitempty"`
+}
+
+type Heartbeat struct {
+	// Time at which heartbeat was registered.
+	Timestamp string `json:"timestamp"`
+
+	// Identity (via access token `sub` claim) of client reporting the heartbeat, or omitted if no client reported the heartbeat.
+	Reporter *string `json:"reporter,omitempty"`
+
+	// Source/trigger of this heartbeat.
+	Source string `json:"source"`
+
+	// Index of this heartbeat within the set of all heartbeats for this pool participant.
+	Index *int64 `json:"index,omitempty"`
+
+	// If specified, a sufficiently unique value to verify synchronization between DSS instances with additional certainty.  A UUIDv4 is recommended.
+	UniqueValue *string `json:"unique_value,omitempty"`
+}

--- a/pkg/aux_/pool_participants.go
+++ b/pkg/aux_/pool_participants.go
@@ -1,0 +1,19 @@
+package aux
+
+import (
+	"context"
+
+	restapi "github.com/interuss/dss/pkg/api/auxv1"
+	"github.com/interuss/stacktrace"
+)
+
+func (a *Server) GetDSSInstances(ctx context.Context, req *restapi.GetDSSInstancesRequest) restapi.GetDSSInstancesResponseSet {
+	if req.Auth.Error != nil {
+		resp := restapi.GetDSSInstancesResponseSet{}
+		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
+		return resp
+	}
+
+	// Pool participant storage is not yet implemented.
+	return restapi.GetDSSInstancesResponseSet{Response200: &restapi.DSSInstancesResponse{DssInstances: &[]restapi.DSSInstance{}}}
+}

--- a/pkg/aux_/server.go
+++ b/pkg/aux_/server.go
@@ -13,6 +13,17 @@ import (
 // Server implements auxv1.Implementation.
 type Server struct{}
 
+func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
+}
+
 // GetVersion returns information about the version of the server.
 func (a *Server) GetVersion(context.Context, *restapi.GetVersionRequest) restapi.GetVersionResponseSet {
 	return restapi.GetVersionResponseSet{Response200: &restapi.VersionResponse{


### PR DESCRIPTION
This PR takes a first step toward addressing #1171 and #1140 (via database entries rather than just endpoints per instance) by defining an aux-API `pool/dss_instances` endpoint that can be read to (in the future) retrieve information about DSS instances in the pool -- especially heartbeat information to verify integrity of the pool on an ongoing basis.

Future PRs can build on this by:
1. Creating a place in the database to store this DSS instance information
2. Reading from the database to report DSS instance information
3. Upserting an entry for the current DSS instance on startup
4. Adding a PUT `pool/dss_instances/{instance_id}/heartbeat` endpoint to register a heartbeat via client (but this request would be refused if the DSS instance the request was addressed to was not {instance_id})

This PR was tested with the added `read_dss_instances.sh` script.