### PR TITLE
[aux] Add access to DAR ID via aux API

### DIFF
--- a/build/dev/read_pool_info.sh
+++ b/build/dev/read_pool_info.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Retrieve token from dummy OAuth server
+ACCESS_TOKEN=$(curl --silent \
+    "http://localhost:8085/token?grant_type=client_credentials&scope=interuss.pool_status.read&intended_audience=localhost&issuer=localhost&sub=manual_tester" \
+| python extract_json_field.py 'access_token')
+
+curl --silent -X GET  \
+"http://localhost:8082/aux/v1/pool" \
+-H "Authorization: Bearer ${ACCESS_TOKEN}" -H "Content-Type: application/json"

--- a/interfaces/aux_/aux_.yaml
+++ b/interfaces/aux_/aux_.yaml
@@ -20,6 +20,16 @@ components:
           description: Human-readable message indicating what error occurred and/or why.
           type: string
 
+    PoolResponse:
+      type: object
+      properties:
+        dar_id:
+          description: >-
+            Identifier of the DSS Airspace Representation shared by the pool of DSS instances to which this DSS instance belongs.
+            Each DSS instance participating in the pool should indicate the same DAR ID as this ID describes the DAR shared by the pool.
+          type: string
+          default: ""
+
     DSSInstancesResponse:
       type: object
       properties:
@@ -122,6 +132,44 @@ paths:
         - Auth:
             - dss.write.identification_service_areas
 
+  /aux/v1/pool:
+    get:
+      summary: Queries the current information about the pool of DSS instances constituting the DSS Airspace Representation.
+      operationId: getPool
+      tags: [ dss ]
+      security:
+      - Auth:
+        - interuss.pool_status.read
+      responses:
+        '200':
+          description: The information is successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PoolResponse'
+        '401':
+          description: >-
+            Bearer access token was not provided in Authorization header, token
+            could not be decoded, or token was invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: >-
+            The access token was decoded successfully but did not include a
+            scope appropriate to this endpoint.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '501':
+          description: >-
+            The server has not implemented this operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /aux/v1/pool/dss_instances:
     get:
       summary: Queries the current information for DSS instances participating in the pool.

--- a/pkg/api/auxv1/interface.gen.go
+++ b/pkg/api/auxv1/interface.gen.go
@@ -19,6 +19,11 @@ var (
 			"Auth": {DssWriteIdentificationServiceAreasScope},
 		},
 	}
+	GetPoolSecurity = []api.AuthorizationOption{
+		{
+			"Auth": {InterussPoolStatusReadScope},
+		},
+	}
 	GetDSSInstancesSecurity = []api.AuthorizationOption{
 		{
 			"Auth": {InterussPoolStatusReadScope},
@@ -59,6 +64,27 @@ type ValidateOauthResponseSet struct {
 	Response500 *api.InternalServerErrorBody
 }
 
+type GetPoolRequest struct {
+	// The result of attempting to authorize this request
+	Auth api.AuthorizationResult
+}
+type GetPoolResponseSet struct {
+	// The information is successfully returned.
+	Response200 *PoolResponse
+
+	// Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+	Response401 *ErrorResponse
+
+	// The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+	Response403 *ErrorResponse
+
+	// The server has not implemented this operation.
+	Response501 *ErrorResponse
+
+	// Auto-generated internal server error response
+	Response500 *api.InternalServerErrorBody
+}
+
 type GetDSSInstancesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
@@ -86,6 +112,9 @@ type Implementation interface {
 
 	// Validate Oauth token against the DSS.
 	ValidateOauth(ctx context.Context, req *ValidateOauthRequest) ValidateOauthResponseSet
+
+	// Queries the current information about the pool of DSS instances constituting the DSS Airspace Representation.
+	GetPool(ctx context.Context, req *GetPoolRequest) GetPoolResponseSet
 
 	// Queries the current information for DSS instances participating in the pool.
 	GetDSSInstances(ctx context.Context, req *GetDSSInstancesRequest) GetDSSInstancesResponseSet

--- a/pkg/api/auxv1/types.gen.go
+++ b/pkg/api/auxv1/types.gen.go
@@ -11,6 +11,11 @@ type ErrorResponse struct {
 	Message *string `json:"message,omitempty"`
 }
 
+type PoolResponse struct {
+	// Identifier of the DSS Airspace Representation shared by the pool of DSS instances to which this DSS instance belongs. Each DSS instance participating in the pool should indicate the same DAR ID as this ID describes the DAR shared by the pool.
+	DarId *string `json:"dar_id,omitempty"`
+}
+
 type DSSInstancesResponse struct {
 	DssInstances *[]DSSInstance `json:"dss_instances,omitempty"`
 }

--- a/pkg/aux_/pool.go
+++ b/pkg/aux_/pool.go
@@ -1,0 +1,33 @@
+package aux
+
+import (
+	"context"
+
+	"github.com/interuss/dss/pkg/api"
+	restapi "github.com/interuss/dss/pkg/api/auxv1"
+	dsserr "github.com/interuss/dss/pkg/errors"
+
+	"github.com/interuss/stacktrace"
+)
+
+func (a *Server) GetPool(ctx context.Context, req *restapi.GetPoolRequest) restapi.GetPoolResponseSet {
+	resp := restapi.GetPoolResponseSet{}
+	if req.Auth.Error != nil {
+		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
+		return resp
+	}
+
+	darID, err := a.Datastore.GetDSSAirspaceRepresentationID(ctx)
+
+	if err == nil {
+		resp.Response200 = &restapi.PoolResponse{DarId: &darID}
+	} else {
+		switch stacktrace.GetCode(err) {
+		case dsserr.NotImplemented:
+			resp.Response501 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(err, "Operation not implemented"))}
+		default:
+			resp.Response500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(err, "Could not retrieve DAR information"))}
+		}
+	}
+	return resp
+}

--- a/pkg/aux_/server.go
+++ b/pkg/aux_/server.go
@@ -5,13 +5,17 @@ import (
 
 	"github.com/interuss/dss/pkg/api"
 	restapi "github.com/interuss/dss/pkg/api/auxv1"
+	"github.com/interuss/dss/pkg/datastore"
 	dsserr "github.com/interuss/dss/pkg/errors"
+
 	"github.com/interuss/dss/pkg/version"
 	"github.com/interuss/stacktrace"
 )
 
 // Server implements auxv1.Implementation.
-type Server struct{}
+type Server struct {
+	*datastore.Datastore
+}
 
 func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {
 	switch stacktrace.GetCode(authErr) {

--- a/pkg/datastore/connectParameters.go
+++ b/pkg/datastore/connectParameters.go
@@ -83,7 +83,10 @@ func (cp ConnectParameters) BuildDSN() (string, error) {
 	}
 	dsnMap["application_name"] = an
 
-	dsnMap["dbname"] = cp.DBName
+	dbn := cp.DBName
+	if dbn != "" {
+		dsnMap["dbname"] = dbn
+	}
 
 	sslMode := cp.SSL.Mode
 	if sslMode == "" {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -159,6 +159,6 @@ func (ds *Datastore) GetDSSAirspaceRepresentationID(ctx context.Context) (string
 		}
 		return darID, nil
 	} else {
-		return "", stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetDSSAirspaceRepresentationID is not yet supported in current Datastore type")
+		return "", stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetDSSAirspaceRepresentationID is not yet supported in current Datastore type '%s'", ds.Version.Type)
 	}
 }

--- a/pkg/datastore/flags/flags.go
+++ b/pkg/datastore/flags/flags.go
@@ -16,7 +16,7 @@ func ConnectParameters() datastore.ConnectParameters {
 
 func init() {
 	flag.StringVar(&connectParameters.ApplicationName, "cockroach_application_name", "dss", "application name for tagging the connection to cockroach")
-	flag.StringVar(&connectParameters.DBName, "cockroach_db_name", "dss", "application name for tagging the connection to cockroach")
+	flag.StringVar(&connectParameters.DBName, "cockroach_db_name", "", "application name for tagging the connection to cockroach")
 	flag.StringVar(&connectParameters.Host, "cockroach_host", "", "cockroach host to connect to")
 	flag.IntVar(&connectParameters.Port, "cockroach_port", 26257, "cockroach port to connect to")
 	flag.StringVar(&connectParameters.SSL.Mode, "cockroach_ssl_mode", "disable", "cockroach sslmode")

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -42,6 +42,9 @@ const (
 
 	// Unauthenticated is used when an OAuth token is invalid or not supplied.
 	Unauthenticated
+
+	// NotImplemented is used when a feature needed for the operation has not yet been implemented.
+	NotImplemented
 )
 
 func init() {


### PR DESCRIPTION
A key piece of information about the pool of DSS instances to which a particular DSS instance is connected is the identity of the DSS Airspace Representation data store.  The technical embodiment of this concept is easily accessible in CockroachDB as the Cockroach cluster ID -- if two DSS instances' CRDB nodes have the same cluster ID, then those DSS instances are nearly certain to be part of the same pool/cluster.  This concept is also present in Yugabyte, though somewhat harder to access.

Providing access to this information is likely to be very useful as an easy verification that two DSS instances are part of the same pool, and can partially address #1171.

This PR was tested with read_pool_info.sh using the standard local CRDB-based deployment, as well as the local Yugabyte-based deployment with `COMPOSE_PROFILES=with-yugabyte`.