### PR TITLE
Add an overrideable way to name the load balancers so that multiple DSS can be deployed in one VPC

### DIFF
--- a/deploy/services/helm-charts/dss/templates/cockroachdb-loadbalancers.yaml
+++ b/deploy/services/helm-charts/dss/templates/cockroachdb-loadbalancers.yaml
@@ -1,4 +1,5 @@
 {{- $cloudProvider := $.Values.global.cloudProvider}}
+{{- $cockroachDbExternalNodeSuffix := default "" $.Values.cockroachdb.conf.crdbNodeSuffix }}
 
 {{- if $.Values.cockroachdb.enabled }}
 
@@ -12,7 +13,7 @@ metadata:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     {{- include (printf "%s-lb-crdb-annotations" $cloudProvider)
       (dict
-        "name" (printf "%s-%s" "cockroach-db-external-node" ( $i | toString) )
+        "name" (printf "%s-%s%s" "cockroach-db-external-node" ( $i | toString) $cockroachDbExternalNodeSuffix | trunc 31)
         "ip" $lb.ip
         "subnet" $lb.subnet
         "cloudProvider" $cloudProvider

--- a/deploy/services/helm-charts/dss/templates/dss-ingress-aws.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-ingress-aws.yaml
@@ -1,4 +1,5 @@
 {{- $cloudProvider := $.Values.global.cloudProvider}}
+{{- $gatewayId := default "" $.Values.dss.gatewayId }}
 {{- if eq $cloudProvider "aws" }}
 {{/*
 AWS application load balancer Ingress do not support elastic ip assignment yet. Therefore, the
@@ -13,7 +14,7 @@ metadata:
     {{- include (printf "%s-ingress-dss-gateway-annotations" $cloudProvider)
       (merge .
         (dict
-          "name" "dss-gateway-external"
+          "name" (printf "%s%s" $gatewayId "dss-gateway-external" | trunc 63)
           "cloudProvider" $cloudProvider
         )
       ) | nindent 4

--- a/deploy/services/helm-charts/dss/values.example.yaml
+++ b/deploy/services/helm-charts/dss/values.example.yaml
@@ -4,6 +4,8 @@ dss:
   image: docker.io/interuss/dss:v0.15.0 # See https://hub.docker.com/r/interuss/dss/tags for official image releases.
   # When running local images in minikube, uncomment the following line
   # imagePullPolicy: Never
+  # Unique identifier for the AWS networking component
+#  gatewayId: 6f1e5814-
   conf:
     pubKeys:
       - /test-certs/auth2.pem
@@ -20,6 +22,8 @@ cockroachdb:
   fullnameOverride: dss-cockroachdb
   conf:
     join: []
+    # Used to generate a unique identifier for the AWS networking component
+    # crdbNodeSuffix: dallas
     cluster-name: interuss-example
     single-node: false
     locality: zone=interuss-example-google-ew1


### PR DESCRIPTION
I will raise an issue to discuss. This is my proposed solution to the issue I've run into.

While deploying the DSS into an AWS VPC, the networking components are named in such a way that there can only be one running instance. Subsequent deployments result in 400 errors on the Service objects in Kubernetes with a "duplicate name" error. 

This can be confusing for a developer, since the terraform is designed in such a way that two environments can be deployed.