### PR TITLE
[aux] Add CAs endpoint

### DIFF
--- a/deploy/operations/certificates-management/ca_pool.py
+++ b/deploy/operations/certificates-management/ca_pool.py
@@ -74,6 +74,7 @@ def regenerate_ca_files(cluster):
         f.write("\n\n".join(CAs))
 
     shutil.copy(cluster.ca_pool_ca, cluster.client_ca)
+    shutil.copy(cluster.ca_cert_file, cluster.client_instance_ca)
 
     for node_type in ["master", "tserver"]:
         shutil.copy(cluster.ca_pool_ca, getattr(cluster, f"{node_type}_ca"))

--- a/deploy/operations/certificates-management/cluster.py
+++ b/deploy/operations/certificates-management/cluster.py
@@ -52,6 +52,10 @@ class Cluster(object):
         return os.path.join(self.client_certs_dir, "root.crt")
 
     @property
+    def client_instance_ca(self):
+        return os.path.join(self.client_certs_dir, "ca-instance.crt")
+
+    @property
     def master_certs_dir(self):
         return os.path.join(self.directory, "masters")
 

--- a/deploy/services/helm-charts/dss/templates/_volumes.tpl
+++ b/deploy/services/helm-charts/dss/templates/_volumes.tpl
@@ -13,6 +13,9 @@
 - mountPath: /opt/yugabyte-certs/ca.crt
   name: ca-certs
   subPath: root.crt
+- mountPath: /opt/yugabyte-certs/ca-instance.crt
+  name: ca-certs
+  subPath: ca-instance.crt
 {{- end -}}
 {{- end -}}
 {{- define "client-certs:volume" -}}

--- a/interfaces/aux_/aux_.yaml
+++ b/interfaces/aux_/aux_.yaml
@@ -84,6 +84,15 @@ components:
       - timestamp
       - source
 
+    CAsResponse:
+      type: object
+      properties:
+        CAs:
+          description: A list of certificates, each in PEM format.
+          type: array
+          items:
+            type: string
+
 paths:
   /aux/v1/version:
     get:
@@ -201,6 +210,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '501':
+          description: >-
+            The server has not implemented this operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /aux/v1/configuration/accepted_ca_certs:
+    get:
+      summary: Current certificates of certificate authorities (CAs) that this DSS instance accepts as legitimate signers of node certificates for the pool of DSS instances constituting the DSS Airspace Representation.
+      operationId: getAcceptedCAs
+      tags: [ dss ]
+      responses:
+        '200':
+          description: The information is successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CAsResponse'
+        '501':
+          description: >-
+            The server has not implemented this operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /aux/v1/configuration/ca_certs:
+    get:
+      summary: Current certificates of certificate authorities (CAs) that signed the node certificates for this DSS instance. May return more that one certificate (e.g. for rotations).  Other DSS instances in the pool should accept node certificates signed by these CAs.
+      operationId: getInstanceCAs
+      tags: [ dss ]
+      responses:
+        '200':
+          description: The information is successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CAsResponse'
         '501':
           description: >-
             The server has not implemented this operation.

--- a/pkg/api/auxv1/interface.gen.go
+++ b/pkg/api/auxv1/interface.gen.go
@@ -7,9 +7,9 @@ import (
 )
 
 var (
+	InterussPoolStatusReadScope             = api.RequiredScope("interuss.pool_status.read")
 	DssWriteIdentificationServiceAreasScope = api.RequiredScope("dss.write.identification_service_areas")
 	DssReadIdentificationServiceAreasScope  = api.RequiredScope("dss.read.identification_service_areas")
-	InterussPoolStatusReadScope             = api.RequiredScope("interuss.pool_status.read")
 	GetVersionSecurity                      = []api.AuthorizationOption{}
 	ValidateOauthSecurity                   = []api.AuthorizationOption{
 		{
@@ -29,6 +29,8 @@ var (
 			"Auth": {InterussPoolStatusReadScope},
 		},
 	}
+	GetAcceptedCAsSecurity = []api.AuthorizationOption{}
+	GetInstanceCAsSecurity = []api.AuthorizationOption{}
 )
 
 type GetVersionRequest struct {
@@ -106,6 +108,36 @@ type GetDSSInstancesResponseSet struct {
 	Response500 *api.InternalServerErrorBody
 }
 
+type GetAcceptedCAsRequest struct {
+	// The result of attempting to authorize this request
+	Auth api.AuthorizationResult
+}
+type GetAcceptedCAsResponseSet struct {
+	// The information is successfully returned.
+	Response200 *CAsResponse
+
+	// The server has not implemented this operation.
+	Response501 *ErrorResponse
+
+	// Auto-generated internal server error response
+	Response500 *api.InternalServerErrorBody
+}
+
+type GetInstanceCAsRequest struct {
+	// The result of attempting to authorize this request
+	Auth api.AuthorizationResult
+}
+type GetInstanceCAsResponseSet struct {
+	// The information is successfully returned.
+	Response200 *CAsResponse
+
+	// The server has not implemented this operation.
+	Response501 *ErrorResponse
+
+	// Auto-generated internal server error response
+	Response500 *api.InternalServerErrorBody
+}
+
 type Implementation interface {
 	// Queries the version of the DSS.
 	GetVersion(ctx context.Context, req *GetVersionRequest) GetVersionResponseSet
@@ -118,4 +150,10 @@ type Implementation interface {
 
 	// Queries the current information for DSS instances participating in the pool.
 	GetDSSInstances(ctx context.Context, req *GetDSSInstancesRequest) GetDSSInstancesResponseSet
+
+	// Current certificates of certificate authorities (CAs) that this DSS instance accepts as legitimate signers of node certificates for the pool of DSS instances constituting the DSS Airspace Representation.
+	GetAcceptedCAs(ctx context.Context, req *GetAcceptedCAsRequest) GetAcceptedCAsResponseSet
+
+	// Current certificates of certificate authorities (CAs) that signed the node certificates for this DSS instance. May return more that one certificate (e.g. for rotations).  Other DSS instances in the pool should accept node certificates signed by these CAs.
+	GetInstanceCAs(ctx context.Context, req *GetInstanceCAsRequest) GetInstanceCAsResponseSet
 }

--- a/pkg/api/auxv1/types.gen.go
+++ b/pkg/api/auxv1/types.gen.go
@@ -44,3 +44,8 @@ type Heartbeat struct {
 	// The time by which a new heartbeat should be registered for this DSS instance if the DSS instance operator's system is behaving correctly.
 	NextHeartbeatExpectedBefore *string `json:"next_heartbeat_expected_before,omitempty"`
 }
+
+type CAsResponse struct {
+	// A list of certificates, each in PEM format.
+	Cas *[]string `json:"CAs,omitempty"`
+}

--- a/pkg/api/ridv1/interface.gen.go
+++ b/pkg/api/ridv1/interface.gen.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	DssWriteIdentificationServiceAreasScope  = api.RequiredScope("dss.write.identification_service_areas")
 	DssReadIdentificationServiceAreasScope   = api.RequiredScope("dss.read.identification_service_areas")
+	DssWriteIdentificationServiceAreasScope  = api.RequiredScope("dss.write.identification_service_areas")
 	SearchIdentificationServiceAreasSecurity = []api.AuthorizationOption{
 		{
 			"AuthFromAuthorizationAuthority": {DssReadIdentificationServiceAreasScope},

--- a/pkg/api/scdv1/interface.gen.go
+++ b/pkg/api/scdv1/interface.gen.go
@@ -8,10 +8,10 @@ import (
 
 var (
 	UtmAvailabilityArbitrationScope          = api.RequiredScope("utm.availability_arbitration")
-	UtmStrategicCoordinationScope            = api.RequiredScope("utm.strategic_coordination")
-	UtmConstraintManagementScope             = api.RequiredScope("utm.constraint_management")
-	UtmConformanceMonitoringSaScope          = api.RequiredScope("utm.conformance_monitoring_sa")
 	UtmConstraintProcessingScope             = api.RequiredScope("utm.constraint_processing")
+	UtmConstraintManagementScope             = api.RequiredScope("utm.constraint_management")
+	UtmStrategicCoordinationScope            = api.RequiredScope("utm.strategic_coordination")
+	UtmConformanceMonitoringSaScope          = api.RequiredScope("utm.conformance_monitoring_sa")
 	QueryOperationalIntentReferencesSecurity = []api.AuthorizationOption{
 		{
 			"Authority": {UtmStrategicCoordinationScope},

--- a/pkg/aux_/accepted_ca_certs.go
+++ b/pkg/aux_/accepted_ca_certs.go
@@ -1,0 +1,43 @@
+package aux
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	restapi "github.com/interuss/dss/pkg/api/auxv1"
+	"github.com/interuss/dss/pkg/datastore/flags"
+)
+
+func (a *Server) GetAcceptedCAs(ctx context.Context, req *restapi.GetAcceptedCAsRequest) restapi.GetAcceptedCAsResponseSet {
+
+	connectParameters := flags.ConnectParameters()
+
+	CAFile := connectParameters.GetCAFile()
+
+	if CAFile == "" {
+		return restapi.GetAcceptedCAsResponseSet{Response200: &restapi.CAsResponse{}}
+	}
+
+	data, err := os.ReadFile(CAFile)
+
+	if err != nil {
+		msg := fmt.Sprintf("Unable to read CA certificate file for accepted CAs, did try to read '%s', got: %s", CAFile, err)
+		return restapi.GetAcceptedCAsResponseSet{Response501: &restapi.ErrorResponse{Message: &msg}}
+	}
+
+	var CAs []string
+
+	for _, CA := range strings.Split(string(data), START_OF_CERTIFICATE) {
+		CA = strings.Trim(CA, "\r\n")
+
+		if CA != "" {
+			// Re-add the start mark that was removed by Split()
+			CA = START_OF_CERTIFICATE + "\n" + CA
+			CAs = append(CAs, CA)
+		}
+	}
+
+	return restapi.GetAcceptedCAsResponseSet{Response200: &restapi.CAsResponse{Cas: &CAs}}
+}

--- a/pkg/aux_/instance_ca_certs.go
+++ b/pkg/aux_/instance_ca_certs.go
@@ -1,0 +1,43 @@
+package aux
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	restapi "github.com/interuss/dss/pkg/api/auxv1"
+	"github.com/interuss/dss/pkg/datastore/flags"
+)
+
+func (a *Server) GetInstanceCAs(ctx context.Context, req *restapi.GetInstanceCAsRequest) restapi.GetInstanceCAsResponseSet {
+
+	connectParameters := flags.ConnectParameters()
+
+	CAFile := connectParameters.GetInstanceCAFile()
+
+	if CAFile == "" {
+		return restapi.GetInstanceCAsResponseSet{Response200: &restapi.CAsResponse{}}
+	}
+
+	data, err := os.ReadFile(CAFile)
+
+	if err != nil {
+		msg := fmt.Sprintf("Unable to read CA certificate file for this DSS instance, did try to read '%s', got: %s", CAFile, err)
+		return restapi.GetInstanceCAsResponseSet{Response501: &restapi.ErrorResponse{Message: &msg}}
+	}
+
+	var CAs []string
+
+	for _, CA := range strings.Split(string(data), START_OF_CERTIFICATE) {
+		CA = strings.Trim(CA, "\r\n")
+
+		if CA != "" {
+			// Re-add the start mark that was removed by Split()
+			CA = START_OF_CERTIFICATE + "\n" + CA
+			CAs = append(CAs, CA)
+		}
+	}
+
+	return restapi.GetInstanceCAsResponseSet{Response200: &restapi.CAsResponse{Cas: &CAs}}
+}

--- a/pkg/aux_/utils.go
+++ b/pkg/aux_/utils.go
@@ -1,0 +1,3 @@
+package aux
+
+const START_OF_CERTIFICATE = "-----BEGIN CERTIFICATE-----"

--- a/pkg/datastore/connectParameters.go
+++ b/pkg/datastore/connectParameters.go
@@ -2,10 +2,11 @@ package datastore
 
 import (
 	"fmt"
-	"github.com/interuss/stacktrace"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/interuss/stacktrace"
 )
 
 type (
@@ -104,9 +105,29 @@ func (cp ConnectParameters) BuildDSN() (string, error) {
 	if dir == "" {
 		return "", stacktrace.NewError("Missing datastore ssl_dir")
 	}
-	dsnMap["sslrootcert"] = fmt.Sprintf("%s/ca.crt", dir)
+	dsnMap["sslrootcert"] = cp.GetCAFile()
 	dsnMap["sslcert"] = fmt.Sprintf("%s/client.%s.crt", dir, u)
 	dsnMap["sslkey"] = fmt.Sprintf("%s/client.%s.key", dir, u)
 
 	return formatDSN(dsnMap), nil
+}
+
+// Return the CA file to use
+func (cp ConnectParameters) GetCAFile() string {
+
+	if cp.SSL.Mode == "disable" || cp.SSL.Dir == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/ca.crt", cp.SSL.Dir)
+}
+
+// Return the instance CA file to use
+func (cp ConnectParameters) GetInstanceCAFile() string {
+
+	if cp.SSL.Mode == "disable" || cp.SSL.Dir == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/ca-instance.crt", cp.SSL.Dir)
 }


### PR DESCRIPTION
Contributing to #1140, this PR add an endpoint listing current CAs in the pool, and the CA(s) of the instance.

Idea would be to use that list of certificates to join a pool.

It doesn't include security, assuming thoses are public.
I only updated the yugabyte script to expose the CA of the instance, it won't works for cockroachdb.
