### PR TITLE
[cmd] Add public endpoint flag

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -47,6 +47,7 @@ var (
 	enableHTTP        = flag.Bool("enable_http", false, "DEPRECATED (replaced by allow_http_base_urls): Enables http scheme for Strategic Conflict Detection API")
 	timeout           = flag.Duration("server timeout", 10*time.Second, "Default timeout for server calls")
 	locality          = flag.String("locality", "", "self-identification string of this DSS instance")
+	publicEndpoint    = flag.String("public_endpoint", "", "Public endpoint to access this DSS instance. Must be an absolute URI")
 
 	logFormat            = flag.String("log_format", logging.DefaultFormat, "The log format in {json, console}")
 	logLevel             = flag.String("log_level", logging.DefaultLevel.String(), "The log level")

--- a/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
@@ -44,6 +44,7 @@ spec:
         - args:
             - --accepted_jwt_audiences={{$dss.conf.hostname}}
             - --addr=:8080
+            - --public_endpoint=https://{{$dss.conf.hostname}}
             - --cockroach_host={{ $datastoreHost }}
             - --cockroach_port={{ $datastorePort }}
             - --cockroach_user={{ $datastoreUser }}


### PR DESCRIPTION
Add public endpoint flag, for future use with monitoring / automatic config.

Not a lot of change, since helm charts / terraform (and probably tanka) already have the notion of public endpoint, this just pass it to the core service.