### PR TITLE
[terraform] Update example files for yugabyte

### DIFF
--- a/deploy/infrastructure/modules/terraform-aws-dss/terraform.dev.example.tfvars
+++ b/deploy/infrastructure/modules/terraform-aws-dss/terraform.dev.example.tfvars
@@ -8,8 +8,8 @@ aws_region = "eu-west-1"
 aws_route53_zone_id = "Z01551234567890123456"
 
 # Hostnames
-app_hostname         = "dss.interuss.example.com"
-crdb_hostname_suffix = "db.interuss.example.com"
+app_hostname       = "dss.interuss.example.com"
+db_hostname_suffix = "db.interuss.example.com"
 
 # Kubernetes configuration
 cluster_name                 = "dss-dev-ew1"
@@ -23,10 +23,19 @@ image = "docker.io/interuss/dss:latest"
 authorization = {
   public_key_pem_path = "/test-certs/auth2.pem"
 }
-should_init = true
+
+# Datastore
+datastore_type = "cockroachdb"
 
 # CockroachDB
 crdb_image_tag      = "v24.1.3"
 crdb_cluster_name   = "interuss_example"
 crdb_locality       = "interuss_dss-aws-ew1"
 crdb_external_nodes = []
+should_init         = true
+
+# Yugabyte
+yugabyte_region          = "aws-uss-1"
+yugabyte_zone            = "aws-uss-1"
+yugabyte_light_resources = false
+yugabyte_external_nodes  = []

--- a/deploy/infrastructure/modules/terraform-google-dss/terraform.dev.example.tfvars
+++ b/deploy/infrastructure/modules/terraform-google-dss/terraform.dev.example.tfvars
@@ -9,7 +9,7 @@ google_zone         = "europe-west6-a"
 # DNS
 google_dns_managed_zone_name = "interuss-example-com"
 app_hostname                 = "dss.interuss.example.com"
-crdb_hostname_suffix         = "db.interuss.example.com"
+db_hostname_suffix           = "db.interuss.example.com"
 
 # Kubernetes configuration
 cluster_name                    = "dss-dev-w6a"
@@ -24,16 +24,19 @@ image_pull_secret = ""
 authorization = {
   public_key_pem_path = "/test-certs/auth2.pem"
 }
-should_init = true
 
 # Datastore
 datastore_type = "cockroachdb"
 
 # CockroachDB
 crdb_image_tag      = "v24.1.3"
-crdb_cluster_name   = "interuss-example"
+crdb_cluster_name   = "interuss_example"
 crdb_locality       = "interuss_dss-dev-w6a"
 crdb_external_nodes = []
+should_init         = true
 
 # Yugabyte
-yugabyte_region = "uss-1"
+yugabyte_region          = "gcp-uss-1"
+yugabyte_zone            = "gcp-uss-1"
+yugabyte_light_resources = false
+yugabyte_external_nodes  = []


### PR DESCRIPTION
This PR assume #1203 has been merged, but doesn't include it to avoid git conflits.

Change terraform example files to include:
- new yugabyte options 
- reorder should_init option 
- fix example `crdb_cluster_name`