### PR TITLE
Update Deprecated Terraform resources and set TF provider versions

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/main.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/main.tf
@@ -2,13 +2,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.0"
+      version = "~> 6.0"
     }
     tls = {
       source = "hashicorp/tls"
+      version = "~> 4.0"
     }
     helm = {
       source = "hashicorp/helm"
+      version = "~> 3.0"
     }
   }
 }
@@ -28,7 +30,7 @@ data "aws_eks_cluster_auth" "kubernetes_cluster" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = aws_eks_cluster.kubernetes_cluster.endpoint
     cluster_ca_certificate = base64decode(aws_eks_cluster.kubernetes_cluster.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.kubernetes_cluster.token

--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/network_lb.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/network_lb.tf
@@ -10,26 +10,24 @@ resource "helm_release" "aws-load-balancer-controller" {
 
   wait = true
 
-  set {
-    name  = "clusterName"
-    value = var.cluster_name
-  }
-
-  set {
-    name  = "region"
-    value = var.aws_region
-  }
-
-  set {
-    name  = "vpcId"
-    value = aws_subnet.dss[0].vpc_id
-  }
-
-  set {
-    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-    value = aws_iam_role.AWSLoadBalancerControllerRole.arn
-
-  }
+  set = [
+    {
+      name  = "clusterName"
+      value = var.cluster_name
+    },
+    {
+      name  = "region"
+      value = var.aws_region
+    },
+    {
+      name  = "vpcId"
+      value = aws_subnet.dss[0].vpc_id
+    },
+    {
+      name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+      value = aws_iam_role.AWSLoadBalancerControllerRole.arn
+    }
+  ]
 
   depends_on = [
     aws_eks_cluster.kubernetes_cluster,
@@ -61,7 +59,7 @@ output "app_hostname_cert_arn" {
 # Public Elastic IP for the gateway (1 per subnet)
 # At the moment, worker nodes will be deployed in the same subnet, so only one elastic ip is required.
 resource "aws_eip" "gateway" {
-  vpc   = true
+  domain = "vpc"
   count = 1
 
   tags = {
@@ -74,7 +72,7 @@ resource "aws_eip" "gateway" {
 # Public Elastic IPs for the crdb instances
 resource "aws_eip" "ip_crdb" {
   count = var.datastore_type == "cockroachdb" ? var.node_count : 0
-  vpc   = true
+  domain = "vpc"
 
   tags = {
     Name = format("%s-ip-crdb%v", var.cluster_name, count.index)
@@ -86,7 +84,7 @@ resource "aws_eip" "ip_crdb" {
 # Public Elastic IPs for the yubagybte master instances
 resource "aws_eip" "ip_yugabyte_masters" {
   count = var.datastore_type == "yugabyte" ? var.node_count : 0
-  vpc   = true
+  domain = "vpc"
 
   tags = {
     Name = format("%s-ip-yugabyte-master%v", var.cluster_name, count.index)
@@ -98,7 +96,7 @@ resource "aws_eip" "ip_yugabyte_masters" {
 # Public Elastic IPs for the yubagybte tserver instances
 resource "aws_eip" "ip_yugabyte_tservers" {
   count = var.datastore_type == "yugabyte" ? var.node_count : 0
-  vpc   = true
+  domain = "vpc"
 
   tags = {
     Name = format("%s-ip-yugabyte-tserver%v", var.cluster_name, count.index)


### PR DESCRIPTION
Attempting to standup a fresh instance of the DSS using the aws terraform script results in errors due to formatting changes in recent provider updates. 

Running terraform init for the first time pulls the latest version of the providers listed in [dss/deploy/infrastructure/dependencies/terraform-aws-kubernetes/main.tf ](https://github.com/interuss/dss/blob/master/deploy/infrastructure/dependencies/terraform-aws-kubernetes/main.tf) - because there are no versions attached.

## Solution 
Set major version and allow for minor / patch version updates while making updates to the deprecated formatting.

### Terraform Provider versions
[Documentation for Terraform version](https://developer.hashicorp.com/terraform/tutorials/configuration-language/versions#review-example-configuration) format for allowing minor and patch changes

```terraform
terraform {
  required_providers {
    aws = {
      version = "~> 5.52.0"
    }
    random = {
      version = "~> 3.6.2"
    }
  }

  required_version = "~> 1.1.9"
}
```

>This configuration sets required_version to ~> 1.1.9. The ~> symbol allows the patch version to be greater than 9 but requires the major and minor versions (1.1) to match the version that the configuration specifies. Terraform will error if you attempt to use this configuration with a more recent version than 1.1.x, because of this required_version setting.


### AWS VPC

According to the [aws provider docs](https://registry.terraform.io/providers/hashicorp/aws/6.0.0/docs/resources/eip), vpc on aws_eip must be set on a domain attribute. Setting the value as vpc = true was deprecated in the [previous version ](https://registry.terraform.io/providers/hashicorp/aws/5.100.0/docs/resources/eip#vpc-3)of the aws provider.
```terraform

resource "aws_eip" "lb" {
  instance = aws_instance.web.id
  domain   = "vpc"
}
```

### Helm Release 
According to the [Helm provider docs](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#example-usage---chart-repository)
Set must be formatted as a list containing the individual set attributes. Individual set values was valid in the [previous version of the provider](https://registry.terraform.io/providers/hashicorp/helm/2.17.0/docs/resources/release#example-usage---chart-repository).

```terraform
resource "helm_release" "example" {
  name       = "my-redis-release"
  repository = "https://charts.bitnami.com/bitnami"
  chart      = "redis"
  version    = "6.0.1"

  set = [
    {
      name  = "cluster.enabled"
      value = "true"
    },
    {
      name  = "metrics.enabled"
      value = "true"
    }
  ]
```
### Helm Provider Kubernetes Config

Kubernetes has moved from a [nested block](
https://registry.terraform.io/providers/hashicorp/helm/2.17.0/docs) to an [attribute](https://registry.terraform.io/providers/hashicorp/helm/3.0.2/docs) on the helm provider
```terraform
provider "helm" {
  kubernetes = {
    config_path = "~/.kube/config"
  }
}
```
