### PR TITLE
[helm] Improve public endpoint setting with backward compatiblity

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-commons-dss/helm.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/helm.tf
@@ -63,10 +63,11 @@ resource "local_file" "helm_chart_values" {
         pubKeys = [
           "/test-certs/auth2.pem"
         ]
-        jwksEndpoint = var.authorization.jwks != null ? var.authorization.jwks.endpoint : ""
-        jwksKeyIds   = var.authorization.jwks != null ? [var.authorization.jwks.key_id] : []
-        hostname     = var.app_hostname
-        enableScd    = var.enable_scd
+        jwksEndpoint   = var.authorization.jwks != null ? var.authorization.jwks.endpoint : ""
+        jwksKeyIds     = var.authorization.jwks != null ? [var.authorization.jwks.key_id] : []
+        hostname       = var.app_hostname
+        publicEndpoint = "https://${var.app_hostname}"
+        enableScd      = var.enable_scd
       }
     }
 
@@ -201,10 +202,11 @@ resource "local_file" "helm_chart_values" {
         pubKeys = [
           "/test-certs/auth2.pem"
         ]
-        jwksEndpoint = var.authorization.jwks != null ? var.authorization.jwks.endpoint : ""
-        jwksKeyIds   = var.authorization.jwks != null ? [var.authorization.jwks.key_id] : []
-        hostname     = var.app_hostname
-        enableScd    = var.enable_scd
+        jwksEndpoint   = var.authorization.jwks != null ? var.authorization.jwks.endpoint : ""
+        jwksKeyIds     = var.authorization.jwks != null ? [var.authorization.jwks.key_id] : []
+        hostname       = var.app_hostname
+        publicEndpoint = "https://${var.app_hostname}"
+        enableScd      = var.enable_scd
       }
     }
 

--- a/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
@@ -44,7 +44,9 @@ spec:
         - args:
             - --accepted_jwt_audiences={{$dss.conf.hostname}}
             - --addr=:8080
-            - --public_endpoint=https://{{$dss.conf.hostname}}
+{{ if $dss.conf.publicEndpoint }}
+            - --public_endpoint={{$dss.conf.publicEndpoint}}
+{{ end }}
             - --cockroach_host={{ $datastoreHost }}
             - --cockroach_port={{ $datastorePort }}
             - --cockroach_user={{ $datastoreUser }}

--- a/deploy/services/helm-charts/dss/values.example.yaml
+++ b/deploy/services/helm-charts/dss/values.example.yaml
@@ -10,6 +10,7 @@ dss:
     jwksEndpoint: ''
     jwksKeyIds: []
     hostname: dss.example.com
+    publicEndpoint: https://dss.example.com
     enableScd: true
 
 cockroachdb:

--- a/deploy/services/helm-charts/dss/values.schema.json
+++ b/deploy/services/helm-charts/dss/values.schema.json
@@ -271,6 +271,10 @@
             "hostname": {
               "type": "string",
               "description": "Public hostname of the dss. Example: dss.example.com"
+            },
+            "publicEndpoint": {
+              "type": "string",
+              "description": "Public endpoint of the dss. Example: https://dss.example.com. Only for dss version >= 0.20.0, otherwise left this value empty."
             }
           },
           "required": ["hostname"]


### PR DESCRIPTION
Improve management of the new public_endpoint setting in helm chart by using an explicit setting, that can be set to "" to run older version.

This still enforce usage of the future latest image on the terraform states.