### PR TITLE
 [tanka] Yugabyte, preparation 

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -307,6 +307,8 @@ a PR to that effect would be greatly appreciated.
         detection functionality (currently an R&D project tracking an initial
         draft of the upcoming ASTM standard).
 
+    1.  `VAR_DATASTORE`: Datastore to use. Can be set to 'cockroachdb' or 'yugabyte'.
+
     1.  `VAR_CRDB_DOCKER_IMAGE_NAME`: Docker image of cockroach db pods. Until
         DSS v0.16, the recommended CockroachDB image name is `cockroachdb/cockroach:v21.2.7`.
         From DSS v0.17, the recommended CockroachDB version is `cockroachdb/cockroach:v24.1.3`.

--- a/deploy/services/tanka/base.libsonnet
+++ b/deploy/services/tanka/base.libsonnet
@@ -108,7 +108,7 @@ local util = import 'util.libsonnet';
 
       minReadySeconds: 30,
 
-      replicas: std.length(metadata.cockroach.nodeIPs),
+      replicas: std.length(if metadata.datastore == 'cockroachdb' then metadata.cockroach.nodeIPs else metadata.yugabyte.masterNodeIPs),
       assert self.replicas >= 1,
     },
   },
@@ -183,7 +183,7 @@ local util = import 'util.libsonnet';
         for kv in util.objectItems(self.volumeClaimTemplates_)
       ],
 
-      replicas: std.length(metadata.cockroach.nodeIPs),
+      replicas: std.length(if metadata.datastore == 'cockroachdb' then metadata.cockroach.nodeIPs else metadata.yugabyte.masterNodeIPs),
       assert self.replicas >= 1,
     },
   },

--- a/deploy/services/tanka/cockroachdb.libsonnet
+++ b/deploy/services/tanka/cockroachdb.libsonnet
@@ -3,7 +3,7 @@ local util = import 'util.libsonnet';
 local volumes = import 'volumes.libsonnet';
 
 {
-  StatefulSet(metadata): base.StatefulSet(metadata, 'cockroachdb') {
+  StatefulSet(metadata): if metadata.datastore == 'cockroachdb' then base.StatefulSet(metadata, 'cockroachdb') {
     metadata+: {
       namespace: metadata.namespace,
     },
@@ -87,8 +87,8 @@ local volumes = import 'volumes.libsonnet';
               join: std.join(',', ['cockroachdb-0.cockroachdb'] +
                 if metadata.single_cluster then [] else metadata.cockroach.JoinExisting),
               logtostderr: true,
-              locality: 'zone=' + metadata.cockroach.locality,
-              'locality-advertise-addr': 'zone=' + metadata.cockroach.locality + '@$(hostname -f)',
+              locality: 'zone=' + metadata.locality,
+              'locality-advertise-addr': 'zone=' + metadata.locality + '@$(hostname -f)',
               'http-addr': '0.0.0.0',
               cache: '25%',
               'max-sql-memory': '25%',
@@ -117,5 +117,5 @@ local volumes = import 'volumes.libsonnet';
         },
       ],
     },
-  },
+  } else {}
 }

--- a/deploy/services/tanka/core-service.libsonnet
+++ b/deploy/services/tanka/core-service.libsonnet
@@ -115,7 +115,7 @@ local awsLoadBalancer(metadata) = base.AWSLoadBalancerWithManagedCert(metadata, 
                 jwks_key_ids: std.join(",", metadata.backend.jwksKeyIds),
                 dump_requests: metadata.backend.dumpRequests,
                 accepted_jwt_audiences: metadata.backend.hostname,
-                locality: metadata.cockroach.locality,
+                locality: metadata.locality,
                 enable_scd: metadata.enableScd,
               } + if metadata.backend.publicEndpoint != '' then {
                 public_endpoint: metadata.backend.publicEndpoint,

--- a/deploy/services/tanka/dss.libsonnet
+++ b/deploy/services/tanka/dss.libsonnet
@@ -1,5 +1,7 @@
 local cockroachAuxiliary = import 'cockroachdb-auxiliary.libsonnet';
 local cockroachdb = import 'cockroachdb.libsonnet';
+local yugabyteAuxiliary = import 'yugabyte-auxiliary.libsonnet';
+local yugabyte = import 'yugabyte.libsonnet';
 local backend = import 'core-service.libsonnet';
 local base = import 'base.libsonnet';
 local prometheus = import 'prometheus.libsonnet';
@@ -35,8 +37,10 @@ local RoleBinding(metadata) = base.RoleBinding(metadata, 'default:privileged') {
     },
     pspRB: if metadata.PSP.roleBinding then RoleBinding(metadata),
 
-    sset: cockroachdb.StatefulSet(metadata),
-    auxiliary: cockroachAuxiliary.all(metadata),
+    crdb_sset: cockroachdb.StatefulSet(metadata),
+    crdb_auxiliary: cockroachAuxiliary.all(metadata),
+    yugabyte_sset: yugabyte.all(metadata),
+    yugabyte_auxiliary: yugabyteAuxiliary.all(metadata),
     backend: backend.all(metadata),
     prometheus: prometheus.all(metadata),
     grafana: grafana.all(metadata),

--- a/deploy/services/tanka/examples/minikube/main.jsonnet
+++ b/deploy/services/tanka/examples/minikube/main.jsonnet
@@ -9,10 +9,17 @@ local metadata = metadataBase {
   clusterName: 'dss-local-cluster',
   single_cluster: true,
   enableScd: true,
+  datastore: 'yugabyte',
+  locality: 'minikube',
   cockroach+: {
     image: 'cockroachdb/cockroach:v24.1.3',
-    locality: 'minikube',
     nodeIPs: ['', '', ''],
+    shouldInit: true,
+  },
+  yugabyte+: {
+    image: '',
+    masterNodeIPs: ['', '', ''],
+    tserverNodeIPs: ['', '', ''],
     shouldInit: true,
   },
   backend+: {

--- a/deploy/services/tanka/examples/minimum/main.jsonnet
+++ b/deploy/services/tanka/examples/minimum/main.jsonnet
@@ -11,13 +11,20 @@ local metadata = metadataBase {
   clusterName: 'VAR_CLUSTER_CONTEXT',
   single_cluster: false,
   enableScd: false, // <-- This boolean value is VAR_ENABLE_SCD
+  datastore: 'VAR_DATASTORE',
+  locality: 'VAR_LOCALITY',
   cockroach+: {
     image: 'VAR_CRDB_DOCKER_IMAGE_NAME',
     hostnameSuffix: 'VAR_DB_HOSTNAME_SUFFIX',
-    locality: 'VAR_LOCALITY',
     nodeIPs: ['VAR_CRDB_NODE_IP1', 'VAR_CRDB_NODE_IP2', 'VAR_CRDB_NODE_IP3'],
     shouldInit: false, // <-- This boolean value is VAR_SHOULD_INIT
     JoinExisting: ['VAR_CRDB_EXTERNAL_NODE1', 'VAR_CRDB_EXTERNAL_NODE1', 'VAR_CRDB_EXTERNAL_NODE1' ],
+    storageClass: 'VAR_STORAGE_CLASS',
+  },
+  yugabyte+: {  // TODO: This part is not documented yet
+    image: 'VAR_YUGABYTE_DOCKER_IMAGE_NAME',
+    masterNodeIPs: ['VAR_YUGABYTE_MASTER_IP1', 'VAR_YUGABYTE_MASTER_IP2', 'VAR_YUGABYTE_MASTER_IP3'],
+    tserverNodeIPs: ['VAR_YUGABYTE_TSERVER_IP1', 'VAR_YUGABYTE_TSERVER_IP2', 'VAR_YUGABYTE_TSERVER_IP3'],
     storageClass: 'VAR_STORAGE_CLASS',
   },
   backend+: {

--- a/deploy/services/tanka/metadata_base.libsonnet
+++ b/deploy/services/tanka/metadata_base.libsonnet
@@ -8,8 +8,10 @@
   // This disables inter cluster crdb<->crdb access when set to true.
   single_cluster: false,
   enableScd: false,
+  datastore: 'cockroachdb',
+  locality: error 'must supply locality',
   cockroach: {
-    locality: error 'must supply crdb locality',
+    locality: '',
     hostnameSuffix: error 'must supply a hostnameSuffix, or override in statefulset',
     shouldInit: false,  // Set this to true if you are starting a new cluster.
     grpc_port: 26257,
@@ -18,6 +20,12 @@
     nodeIPs: error 'must supply the per-node ip addresses as an array', // For AWS, this array should contain the allocation id of the elastic ips.
     JoinExisting: [],
     storageClass: 'standard',
+  },
+  yugabyte: {
+    image: error 'must specify yugabyte db image',
+    storageClass: 'standard',
+    masterNodeIPs: [],
+    tserverNodeIPs: [],
   },
   PSP: {
     roleRef: '',

--- a/deploy/services/tanka/yugabyte-auxiliary.libsonnet
+++ b/deploy/services/tanka/yugabyte-auxiliary.libsonnet
@@ -1,0 +1,32 @@
+# TODO: This file is not implemented yet
+local base = import 'base.libsonnet';
+local volumes = import 'volumes.libsonnet';
+
+
+local googleYugabyteLB(metadata, name, ip) = base.Service(metadata, name) {
+  port:: metadata.yugabyte.grpc_port,
+  app:: 'yugabyte',
+  spec+: {
+    type: 'LoadBalancer',
+    loadBalancerIP: ip,
+  },
+};
+
+local awsYugabyteLB(metadata, name, ip) = base.AWSLoadBalancer(metadata, name, [ip], metadata.subnet) {
+  port:: metadata.yugabyte.grpc_port,
+  app:: 'yugabyte',
+};
+
+local minikubeYugabyteLB(metadata, name, ip) = base.Service(metadata, name) {
+  port:: metadata.yugabyte.grpc_port,
+  app:: 'yugabyte',
+};
+
+local yugabyteLB(metadata, name, ip) =
+    if metadata.cloud_provider == "google" then googleYugabyteLB(metadata, name, ip)
+    else if metadata.cloud_provider == "aws" then awsYugabyteLB(metadata, name, ip)
+    else if metadata.cloud_provider == "minikube" then minikubeYugabyteLB(metadata, name, ip);
+{
+  all(metadata): if metadata.datastore == 'yugabyte' then {
+  } else {}
+}

--- a/deploy/services/tanka/yugabyte.libsonnet
+++ b/deploy/services/tanka/yugabyte.libsonnet
@@ -1,0 +1,9 @@
+# TODO: This file is not implemented yet
+local base = import 'base.libsonnet';
+local util = import 'util.libsonnet';
+local volumes = import 'volumes.libsonnet';
+
+{
+  all(metadata): if metadata.datastore == 'yugabyte' then {
+  } else {}
+}


### PR DESCRIPTION
Follow #1221 

Yugabyte implementation in tanka: base PR

This PR prepare things for yugabyte implementation, by adding parameters, moving variables in correct location (e.g. locality) and applying minor fixes to make yugabyte and cochroachdb collaborate in a single states.

On yugabyte side it's mostly a stub that will be implemented in future PRs, this one has been created to ease reviewing in smaller PRs.