### PR TITLE
[tests] update monitoring image to latest release 0.16.0

### DIFF
--- a/build/dev/dss_probing_qualifier_config.yaml
+++ b/build/dev/dss_probing_qualifier_config.yaml
@@ -67,7 +67,7 @@ v1:
                     specification: {}
                 kentland_planning_area:
                     dependencies: {}
-                    resource_type: resources.astm.f3548.v21.PlanningAreaResource
+                    resource_type: resources.PlanningAreaResource
                     specification:
                         base_url: https://uss_qualifier.test.utm/dummy_base_url
                         volume:
@@ -150,6 +150,7 @@ v1:
                             - base_url: http://core-service:8082
                               has_private_address: true
                               participant_id: uss1
+                              supports_ovn_request: true
                               user_participant_ids:
                                   - mock_uss
                 second_utm_auth:

--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -40,7 +40,7 @@ if ! docker run --link "$OAUTH_CONTAINER":oauth \
 	--network dss_sandbox-default \
 	-v "${RESULTFILE}:/app/test_result" \
 	-w /app/monitoring/prober \
-	interuss/monitoring:v0.11.1 \
+	interuss/monitoring:v0.16.0 \
 	pytest \
 	"${1:-.}" \
 	-rsx \

--- a/build/dev/qualify_locally.sh
+++ b/build/dev/qualify_locally.sh
@@ -37,7 +37,7 @@ if ! docker run --link "$OAUTH_CONTAINER":oauth \
 	-w /app/monitoring/uss_qualifier \
 	-e AUTH_SPEC='DummyOAuth(http://oauth:8085/token,uss_qualifier)' \
 	-e AUTH_SPEC_2='DummyOAuth(http://oauth:8085/token,uss_qualifier_2)' \
-	interuss/monitoring:v0.11.1 \
+	interuss/monitoring:v0.16.0 \
     python main.py --config dss_probing_qualifier_config; then
 
     if [ "$CI" == "true" ]; then

--- a/deploy/operations/ci/aws-1/test-resources.yaml
+++ b/deploy/operations/ci/aws-1/test-resources.yaml
@@ -219,7 +219,7 @@ spec:
           image: alpine:3.17.3
           command: [ 'sh', '-c', "until wget -nv https://dss.ci.aws-interuss.uspace.dev/healthy; do echo waiting for dss to be available from the public internet; sleep 2; done" ]
       containers:
-        - image: interuss/monitoring:v0.11.1
+        - image: interuss/monitoring:v0.16.0
           name: uss-qualifier
           workingDir: /app/monitoring/uss_qualifier
           volumeMounts:

--- a/test/migrations/rid_db_post_migration_e2e.sh
+++ b/test/migrations/rid_db_post_migration_e2e.sh
@@ -82,7 +82,7 @@ docker run --link dummy-oauth-for-testing:oauth \
 	--link core-service-for-testing:core-service \
 	-v "${RESULTFILE}:/app/test_result" \
 	-w /app/monitoring/prober \
-	interuss/monitoring:v0.11.1 \
+	interuss/monitoring:v0.16.0 \
 	pytest \
 	"${1:-.}" \
 	-rsx \


### PR DESCRIPTION
This includes a slight adaptation of the test configuration, which is based on the uss_qualifier's [configurations.dev.dss_probing.yaml](https://github.com/interuss/monitoring/blob/41668970347e90087b43253e25d983cfca0001fc/monitoring/uss_qualifier/configurations/dev/dss_probing.yaml).

On a sidenote, this slightly increases the coverage:

```diff
 Summary coverage rate:
   source files: 66
-  lines.......: 70.1% (6427 of 9163 lines)
+  lines.......: 70.3% (6441 of 9163 lines)
   functions...: no data found
 Message summary:
   no messages were reported
```