### PR TITLE
 [tanka] Yugabyte: add options to prepare for terraform output 

### DIFF
--- a/deploy/services/tanka/metadata_base.libsonnet
+++ b/deploy/services/tanka/metadata_base.libsonnet
@@ -26,7 +26,17 @@
     storageClass: 'standard',
     masterNodeIPs: [],
     tserverNodeIPs: [],
-    masterAddresses: ["yb-master-0.yb-masters.default.svc.cluster.local:7100", "yb-master-1.yb-masters.default.svc.cluster.local:7100", "yb-master-2.yb-masters.default.svc.cluster.local:7100"],
+    masterAddresses: ["yb-master-0.yb-masters.${NAMESPACE}.svc.cluster.local:7100", "yb-master-1.yb-masters.${NAMESPACE}.svc.cluster.local:7100", "yb-master-2.yb-masters.${NAMESPACE}.svc.cluster.local:7100"],
+    master: {
+      rpc_bind_addresses: "${HOSTNAME}.yb-masters.${NAMESPACE}.svc.cluster.local",
+      server_broadcast_addresses: "${HOSTNAME}.yb-masters.${NAMESPACE}.svc.cluster.local:7100",
+    },
+    tserver: {
+      rpc_bind_addresses: "${HOSTNAME}.yb-tservers.${NAMESPACE}.svc.cluster.local",
+      server_broadcast_addresses: "${HOSTNAME}.yb-tservers.${NAMESPACE}.svc.cluster.local:9100",
+    },
+    fix_27367_issue: false,
+    light_resources: false,
     placement: {
       cloud: error 'must specify placement cloud',
       region: error 'must specify placement region',
@@ -46,6 +56,7 @@
     jwksEndpoint: '',
     jwksKeyIds: [],
     hostname: error 'must specify hostname',
+    publicEndpoint: '',
     dumpRequests: false,
     certName: if $.cloud_provider == "aws" then error 'must specify certName for AWS cloud provider', # Only used by AWS
     sslPolicy: '', # SSL Policy Name. Only used by Google Cloud.
@@ -77,6 +88,7 @@
     image: error 'must specify image',
     desired_rid_db_version: '4.0.0',
     desired_scd_db_version: '3.2.0',
+    desired_aux_db_version: '1.0.0',
   },
   image_pull_secret: '',
   subnet: if $.cloud_provider == "aws" then error 'must specify subnet for AWS cloud provider', // For AWS, subnet of the elastic ips

--- a/deploy/services/tanka/yugabyte-auxiliary.libsonnet
+++ b/deploy/services/tanka/yugabyte-auxiliary.libsonnet
@@ -34,7 +34,7 @@ local yugabyteLB(metadata, name, ip) =
           "server.conf.template": |||
             --fs_data_dirs=/mnt/disk0,/mnt/disk1
             --master_addresses=%s
-            --replication_factor=3
+            --replication_factor=%s
             --enable_ysql=true
             --certs_dir=/opt/certs/yugabyte
             --use_node_to_node_encryption=true
@@ -47,15 +47,19 @@ local yugabyteLB(metadata, name, ip) =
             --num_cpus=2
             --max_log_size=256
             --undefok=num_cpus,enable_ysql
-            --rpc_bind_addresses=${HOSTNAME}.yb-masters.${NAMESPACE}.svc.cluster.local
-            --server_broadcast_addresses=${HOSTNAME}.yb-masters.${NAMESPACE}.svc.cluster.local:7100
+            --rpc_bind_addresses=%s
+            --server_broadcast_addresses=%s
             --webserver_interface=0.0.0.0
             --default_memory_limit_to_ram_ratio=0.85
             --placement_cloud=%s
             --placement_region=%s
             --placement_zone=%s
+            --use_private_ip=zone
           ||| % [
             std.join(",", metadata.yugabyte.masterAddresses),
+            std.length(metadata.yugabyte.masterAddresses),
+            metadata.yugabyte.master.rpc_bind_addresses,
+            metadata.yugabyte.master.server_broadcast_addresses,
             metadata.yugabyte.placement.cloud,
             metadata.yugabyte.placement.region,
             metadata.yugabyte.placement.zone,
@@ -73,6 +77,7 @@ local yugabyteLB(metadata, name, ip) =
             --allow_insecure_connections=false
             --use_client_to_server_encryption=true
             --certs_for_client_dir=/opt/certs/yugabyte
+            --cert_node_filename=${HOSTNAME}.yb-tservers.${NAMESPACE}.svc.cluster.local
             --enable_ysql=true
             --pgsql_proxy_bind_address=0.0.0.0:5433
             --tserver_enable_metrics_snapshotter=true
@@ -86,14 +91,17 @@ local yugabyteLB(metadata, name, ip) =
             --undefok=num_cpus,enable_ysql
             --use_node_hostname_for_local_tserver=true
             --cql_proxy_bind_address=0.0.0.0:9042
-            --rpc_bind_addresses=${HOSTNAME}.yb-tservers.${NAMESPACE}.svc.cluster.local
-            --server_broadcast_addresses=${HOSTNAME}.yb-tservers.${NAMESPACE}.svc.cluster.local:9100
+            --rpc_bind_addresses=%s
+            --server_broadcast_addresses=%s
             --webserver_interface=0.0.0.0
             --placement_cloud=%s
             --placement_region=%s
             --placement_zone=%s
+            --use_private_ip=zone
           ||| % [
             std.join(",", metadata.yugabyte.masterAddresses),
+            metadata.yugabyte.tserver.rpc_bind_addresses,
+            metadata.yugabyte.tserver.server_broadcast_addresses,
             metadata.yugabyte.placement.cloud,
             metadata.yugabyte.placement.region,
             metadata.yugabyte.placement.zone,


### PR DESCRIPTION
This PR follow #1224.

It fix & prepare tanka yugabyte states to be multi-cluster compatible.

No update in documentation / base flles to keep that for the end.