### PR TITLE
[tanka/terraform] Update terraform state to support latest tanka files, including yugabyte

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-commons-dss/default_latest.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/default_latest.tf
@@ -1,4 +1,4 @@
 locals {
-  rid_db_schema = var.desired_rid_db_version == "latest" ? "4.0.0" : var.desired_rid_db_version
-  scd_db_schema = var.desired_scd_db_version == "latest" ? "3.2.0" : var.desired_scd_db_version
+  rid_db_schema = var.desired_rid_db_version == "latest" ? (var.datastore_type == "cockroachdb" ? "4.0.0" : "1.0.1") : var.desired_rid_db_version
+  scd_db_schema = var.desired_scd_db_version == "latest" ? (var.datastore_type == "cockroachdb" ? "3.2.0" : "1.0.1") : var.desired_scd_db_version
 }

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/tanka.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/tanka.tf
@@ -1,29 +1,39 @@
 resource "local_file" "tanka_config_main" {
   content = templatefile("${path.module}/templates/main.jsonnet.tmp", {
-    root_path                    = path.module
-    VAR_NAMESPACE                = var.kubernetes_namespace
-    VAR_CLUSTER_CONTEXT          = var.kubernetes_context_name
-    VAR_ENABLE_SCD               = var.enable_scd
-    VAR_DB_HOSTNAME_SUFFIX       = var.db_hostname_suffix
-    VAR_LOCALITY                 = var.locality
-    VAR_CRDB_NODE_IPS            = join(",", [for i in var.crdb_internal_nodes[*].ip : "'${i}'"])
-    VAR_INGRESS_NAME             = var.ip_gateway
-    VAR_CRDB_EXTERNAL_NODES      = join(",", [for a in var.crdb_external_nodes : "'${a}'"])
-    VAR_STORAGE_CLASS            = var.kubernetes_storage_class
-    VAR_DOCKER_IMAGE_NAME        = var.image
-    VAR_CRDB_DOCKER_IMAGE_NAME   = "cockroachdb/cockroach:${var.crdb_image_tag}"
-    VAR_APP_HOSTNAME             = var.app_hostname
-    VAR_PUBLIC_KEY_PEM_PATH      = var.authorization.public_key_pem_path != null ? var.authorization.public_key_pem_path : ""
-    VAR_JWKS_ENDPOINT            = var.authorization.jwks != null ? var.authorization.jwks.endpoint : ""
-    VAR_JWKS_KEY_ID              = var.authorization.jwks != null ? var.authorization.jwks.key_id : ""
-    VAR_DESIRED_RID_DB_VERSION   = local.rid_db_schema
-    VAR_DESIRED_SCD_DB_VERSION   = local.scd_db_schema
-    VAR_SHOULD_INIT              = var.should_init
-    VAR_DOCKER_IMAGE_PULL_SECRET = var.image_pull_secret != null ? var.image_pull_secret : ""
-    VAR_CLOUD_PROVIDER           = var.kubernetes_cloud_provider_name
-    VAR_CERT_NAME                = var.gateway_cert_name
-    VAR_SUBNET                   = var.workload_subnet
-    VAR_SSL_POLICY               = var.ssl_policy
+    root_path                         = path.module
+    VAR_NAMESPACE                     = var.kubernetes_namespace
+    VAR_CLUSTER_CONTEXT               = var.kubernetes_context_name
+    VAR_ENABLE_SCD                    = var.enable_scd
+    VAR_DB_HOSTNAME_SUFFIX            = var.db_hostname_suffix
+    VAR_LOCALITY                      = var.locality
+    VAR_DATASTORE                     = var.datastore_type
+    VAR_CRDB_NODE_IPS                 = join(",", [for i in var.crdb_internal_nodes[*].ip : "'${i}'"])
+    VAR_INGRESS_NAME                  = var.ip_gateway
+    VAR_CRDB_EXTERNAL_NODES           = join(",", [for a in var.crdb_external_nodes : "'${a}'"])
+    VAR_STORAGE_CLASS                 = var.kubernetes_storage_class
+    VAR_DOCKER_IMAGE_NAME             = var.image
+    VAR_CRDB_DOCKER_IMAGE_NAME        = "cockroachdb/cockroach:${var.crdb_image_tag}"
+    VAR_YUGABYTE_CLOUD                = var.yugabyte_cloud
+    VAR_YUGABYTE_REGION               = var.yugabyte_region
+    VAR_YUGABYTE_ZONE                 = var.yugabyte_zone
+    VAR_YUGABYTE_MASTER_NODE_IPS      = join(",", [for a in var.yugabyte_internal_masters_nodes[*].ip : "'${a}'"])
+    VAR_YUGABYTE_TSERVER_NODE_IPS     = join(",", [for a in var.yugabyte_internal_tservers_nodes[*].ip : "'${a}'"])
+    VAR_YUGABYTE_MASTER_ADDRESSES     = join(",", [for m in concat([for i in range(var.node_count) : format("%s.master.${var.db_hostname_suffix}", i)], var.yugabyte_external_nodes) : "'${m}'"])
+    VAR_YUGABYTE_MASTER_BIND_ADDRESS  = "$${HOSTNAMENO}.master.${var.db_hostname_suffix}"
+    VAR_YUGABYTE_TSERVER_BIND_ADDRESS = "$${HOSTNAMENO}.tserver.${var.db_hostname_suffix}"
+    VAR_YUGABYTE_DOCKER_IMAGE_NAME    = "yugabytedb/yugabyte:2.25.1.0-b381" // TODO: This should be an option
+    VAR_APP_HOSTNAME                  = var.app_hostname
+    VAR_PUBLIC_KEY_PEM_PATH           = var.authorization.public_key_pem_path != null ? var.authorization.public_key_pem_path : ""
+    VAR_JWKS_ENDPOINT                 = var.authorization.jwks != null ? var.authorization.jwks.endpoint : ""
+    VAR_JWKS_KEY_ID                   = var.authorization.jwks != null ? var.authorization.jwks.key_id : ""
+    VAR_DESIRED_RID_DB_VERSION        = local.rid_db_schema
+    VAR_DESIRED_SCD_DB_VERSION        = local.scd_db_schema
+    VAR_SHOULD_INIT                   = var.should_init
+    VAR_DOCKER_IMAGE_PULL_SECRET      = var.image_pull_secret != null ? var.image_pull_secret : ""
+    VAR_CLOUD_PROVIDER                = var.kubernetes_cloud_provider_name
+    VAR_CERT_NAME                     = var.gateway_cert_name
+    VAR_SUBNET                        = var.workload_subnet
+    VAR_SSL_POLICY                    = var.ssl_policy
   })
   filename = "${local.workspace_location}/main.jsonnet"
 }

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
@@ -11,14 +11,37 @@ local metadata = metadataBase {
   clusterName: '${VAR_CLUSTER_CONTEXT}',
   single_cluster: false,
   enableScd: ${VAR_ENABLE_SCD}, // <-- This boolean value is VAR_ENABLE_SCD
+  datastore: '${VAR_DATASTORE}',
+  locality: '${VAR_LOCALITY}',
   cockroach+: {
     image: '${VAR_CRDB_DOCKER_IMAGE_NAME}',
     hostnameSuffix: '${VAR_DB_HOSTNAME_SUFFIX}',
-    locality: '${VAR_LOCALITY}',
     nodeIPs: [${VAR_CRDB_NODE_IPS}],
     shouldInit: ${VAR_SHOULD_INIT},
     JoinExisting: [${VAR_CRDB_EXTERNAL_NODES}],
     storageClass: '${VAR_STORAGE_CLASS}',
+  },
+  yugabyte+: {
+    image: '${VAR_YUGABYTE_DOCKER_IMAGE_NAME}',
+    masterNodeIPs: [${VAR_YUGABYTE_MASTER_NODE_IPS}],
+    tserverNodeIPs: [${VAR_YUGABYTE_TSERVER_NODE_IPS}],
+    masterAddresses: [${VAR_YUGABYTE_MASTER_ADDRESSES}],
+    master: {
+      rpc_bind_addresses: '${VAR_YUGABYTE_MASTER_BIND_ADDRESS}',
+      server_broadcast_addresses: '${VAR_YUGABYTE_MASTER_BIND_ADDRESS}',
+    },
+    tserver: {
+      rpc_bind_addresses: '${VAR_YUGABYTE_TSERVER_BIND_ADDRESS}',
+      server_broadcast_addresses: '${VAR_YUGABYTE_TSERVER_BIND_ADDRESS}',
+    },
+    placement: {
+      cloud: '${VAR_YUGABYTE_CLOUD}',
+      region: '${VAR_YUGABYTE_REGION}',
+      zone: '${VAR_YUGABYTE_ZONE}',
+    },
+    storageClass: '${VAR_STORAGE_CLASS}',
+    fix_27367_issue: true,
+    light_resources: true, // TODO Need to be an option
   },
   backend+: {
     ipName: '${VAR_INGRESS_NAME}',
@@ -30,10 +53,12 @@ local metadata = metadataBase {
     jwksEndpoint: '${VAR_JWKS_ENDPOINT}',
     jwksKeyIds: ['${VAR_JWKS_KEY_ID}'],
     hostname: '${VAR_APP_HOSTNAME}',
+    publicEndpoint: 'https://${VAR_APP_HOSTNAME}',
     dumpRequests: false,
     sslPolicy: '${VAR_SSL_POLICY}'
   },
   schema_manager+: {
+    enable: true,
     image: '${VAR_DOCKER_IMAGE_NAME}',
     desired_rid_db_version: '${VAR_DESIRED_RID_DB_VERSION}',
     desired_scd_db_version: '${VAR_DESIRED_SCD_DB_VERSION}',

--- a/deploy/services/tanka/yugabyte.libsonnet
+++ b/deploy/services/tanka/yugabyte.libsonnet
@@ -4,6 +4,8 @@ local volumes = import 'volumes.libsonnet';
 
 {
   all(metadata): if metadata.datastore == 'yugabyte' then {
+
+    # Thoses pre commands are used in yugabyte deployments to make the local ip pointing to the public hostname we want to use, until https://github.com/yugabyte/yugabyte-db/issues/27367 is fixed
     local precommand_prefix = "sed -E \"/\\.svc\\.cluster\\.local/ s/^([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)([[:space:]]+)/\\1 $(echo \"",
     local precommand_suffix = "\" | sed 's/[\\/&]/\\\\&/g')\\2/\" /etc/hosts > /tmp/newhosts && /bin/cp /tmp/newhosts /etc/hosts && \\",
     local master_precommand = if metadata.yugabyte.fix_27367_issue then precommand_prefix + metadata.yugabyte.master.server_broadcast_addresses + precommand_suffix else "",
@@ -87,11 +89,11 @@ local volumes = import 'volumes.libsonnet';
                 resources: {
                   limits: {
                     cpu: if metadata.yugabyte.light_resources then 0.1 else 2,
-                    memory: if metadata.yugabyte.light_resources then "0.5G" else "2Gi",
+                    memory: if metadata.yugabyte.light_resources then "0.5Gi" else "2Gi",
                   },
                   requests: {
                     cpu: if metadata.yugabyte.light_resources then 0.1 else 2,
-                    memory: if metadata.yugabyte.light_resources then "0.5G" else "2Gi",
+                    memory: if metadata.yugabyte.light_resources then "0.5Gi" else "2Gi",
                   },
                 },
                 ports: [{
@@ -414,11 +416,11 @@ local volumes = import 'volumes.libsonnet';
                 resources: {
                   limits: {
                     cpu: if metadata.yugabyte.light_resources then 0.1 else 2,
-                    memory: if metadata.yugabyte.light_resources then "0.5G" else "4Gi",
+                    memory: if metadata.yugabyte.light_resources then "0.5Gi" else "4Gi",
                   },
                   requests: {
                     cpu: if metadata.yugabyte.light_resources then 0.1 else 2,
-                    memory: if metadata.yugabyte.light_resources then "0.5G" else "4Gi",
+                    memory: if metadata.yugabyte.light_resources then "0.5Gi" else "4Gi",
                   },
                 },
                 ports: [{


### PR DESCRIPTION
This PR follow #1227 

It update terraform to generate files for the new tanka version, to support yugabyte, new endpoint and new migrations.

It's missing `light_resources` as an option that has not been included to limit the PR to a minimum.