### PR TITLE
[helm] Switch yugabyte chart to interuss fork

### DIFF
--- a/deploy/services/helm-charts/dss/Chart.yaml
+++ b/deploy/services/helm-charts/dss/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
     version: 10.0.7
     condition: cockroachdb.enabled
   - name: yugabyte
-    repository: https://charts.yugabyte.com/
-    version: 2.25.1
+    repository: https://interuss.github.io/yugabyte-charts/
+    version: 2025.1.0
     condition: yugabyte.enabled


### PR DESCRIPTION
Change helm chat for yugabyte to interuss fork.

https://github.com/interuss/yugabyte-charts/pull/3 need to be merged first, to create an initial release.

(Others PR with fixes are also needed).