### PR TITLE
Init DSS deployment documentation with mkdocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: docs
+on:
+  push:
+    branches:
+      - master
+    tags:
+      # To modify to trigger the job for fork's releases
+      # Note: GitHub's filter pattern capabilities are limited[1], so this
+      # pattern matches more often than it should.  A more correct regex would
+      # be the one found in scripts/tag.sh.
+      # [1] https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      - "interuss/dss/v[0-9]+.[0-9]+.[0-9]+-?*"
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.repository == 'interuss/dss'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: ~/.cache
+          restore-keys: |
+            mkdocs-material-
+      - run: |
+          pip install mkdocs-material
+          pip install mkdocs-git-revision-date-localized-plugin
+          pip install mike
+      - if: ${{ github.ref_type == 'branch' }}
+        run: mike deploy --push dev
+        name: Deploy 'dev' deployment documentation from 'master' branch
+      - if: ${{ github.ref_type == 'tag' }}
+        run: |
+          VERSION=$(echo ${{ github.ref_name }} | sed -e "s/^interuss\/dss\/v//")
+          mike deploy --push --update-aliases $VERSION latest
+          mike set-default --push latest
+        name: Deploy new version of deployment documentation from tag

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# DSS Deployment
+
+Coming soon: this documentation is currently a work in progress.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,91 @@
+# yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
+
+site_name: DSS Deployment Documentation
+site_url: https://interuss.github.io/dss/
+repo_url: https://github.com/interuss/dss
+repo_name: interuss/dss
+extra:
+  version:
+    provider: mike
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/interuss
+docs_dir: docs
+edit_uri: edit/master/docs/
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/
+    - navigation.instant # no page reload on navigation, behaves as a single page app
+    - navigation.instant.prefetch # prefetches hovered links
+    - navigation.instant.progress # displays loading progress bar if loading takes more than 400ms
+    - navigation.tracking # tracks currently displayed page anchor in URL address
+    - navigation.tabs # displays top-level sections in menu below header
+    - navigation.sections # renders top-level sections as groups
+    - navigation.path # shows breadcrumb above title
+    - navigation.indexes # allows attaching page to section
+    - toc.follow # TOC in sidebar scrolls with page
+    - navigation.top # shows a back-to-top button
+
+    # https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/
+    - search.suggest # provides search completions
+
+
+    # https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/
+    - header.autohide # hides header on scroll down
+
+    # https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/
+    - navigation.footer # provides links to the previous and next page of the current page
+
+    # https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/
+    - content.action.edit # provides link to edit page on github
+    - content.action.view # provides link to view page on github
+
+plugins:
+  - search
+  - git-revision-date-localized: # displays last update date
+      fallback_to_build_date: true
+
+markdown_extensions:
+  # https://squidfunk.github.io/mkdocs-material/reference/admonitions/
+  - admonition # enable use of call-outs
+  - pymdownx.details # make call-outs collapsible
+  - pymdownx.superfences:
+      # https://squidfunk.github.io/mkdocs-material/reference/diagrams
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+  # https://squidfunk.github.io/mkdocs-material/reference/lists
+  - def_list # enables 'dl' description lists
+  - pymdownx.tasklist: # enables '- [x]'/'- [ ]' task lists
+      custom_checkbox: true
+
+  # https://squidfunk.github.io/mkdocs-material/reference/footnotes/
+  - footnotes # enables '[^1]' footnotes
+
+  # https://squidfunk.github.io/mkdocs-material/reference/data-tables/
+  - tables # enables tables
+
+  # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions
+  - pymdownx.betterem # improves markup detection
+  - pymdownx.highlight: # enables code syntax highlighting
+      anchor_linenums: true
+      pygments_lang_class: true
+      linenums: true # displays line numbers
+  - pymdownx.inlinehilite # enables inline code syntax highlighting
+  - pymdownx.smartsymbols # converts some symbols to their corresponding unicode equivalents
+  - pymdownx.snippets # enables inclusion of markdown snippets
+  - pymdownx.tabbed: # enables tabbed content
+      alternate_style: true
+
+  # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown
+  - toc:
+      permalink: true # displays a permalink next to headings
+
+nav:
+  - Home:
+    - 'index.md'


### PR DESCRIPTION
This should handle versioning by:
- always having a version 'dev' that has the latest documentation from master
- pushing on releases a new version of the documentation 

The result should already be visible on https://interuss.github.io/dss as I pushed the branch manually already.
I created a fake 0.1 version to showcase the versioning.

As discussed last week, the headings now do have a permalink associated.

The publishing for releases through the CI is half-tested, a bit manually and a bit through another repo. To actually test it I'd propose to merge this PR and then create a fake release.