### PR TITLE
[docs] Fetch all repo in CI rather than last commit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,8 @@ jobs:
     if: github.repository == 'interuss/dss'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]


### PR DESCRIPTION
This should fix the failing CI on master: https://github.com/interuss/dss/actions/runs/17064251418/job/48377588649#step:8:39

```
Run mike deploy --push dev
WARNING:root:
                [git-revision-date-localized-plugin] Running on GitHub Actions might lead to wrong
                Git revision dates due to a shallow git fetch depth.

                Try setting `fetch-depth: 0` in your GitHub Action.
                See https://github.com/actions/checkout for more information.
                
WARNING:root:
                [git-revision-date-localized-plugin] Running on GitHub Actions might lead to wrong
                Git revision dates due to a shallow git fetch depth.

                Try setting `fetch-depth: 0` in your GitHub Action.
                See https://github.com/actions/checkout for more information.
                
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/runner/work/dss/dss/site
INFO    -  Documentation built in 0.39 seconds
error: failed to push branch gh-pages to origin:
  To https://github.com/interuss/dss
   ! [rejected]        gh-pages -> gh-pages (fetch first)
  error: failed to push some refs to 'https://github.com/interuss/dss'
  hint: Updates were rejected because the remote contains work that you do not
  hint: have locally. This is usually caused by another repository pushing to
  hint: the same ref. If you want to integrate the remote changes, use
  hint: 'git pull' before pushing again.
  hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```