### PR TITLE
[rid] Fix garbage collector by deleting multiples entries at a time

### DIFF
--- a/pkg/rid/store/cockroach/garbage_collector.go
+++ b/pkg/rid/store/cockroach/garbage_collector.go
@@ -42,11 +42,7 @@ func (gc *GarbageCollector) DeleteExpiredISAs(ctx context.Context) error {
 	}
 
 	for _, isa := range expiredISAs {
-		isaOut, err := gc.repos.DeleteISA(ctx, isa)
-		if isaOut != nil {
-			return stacktrace.Propagate(err,
-				"Deleted ISA")
-		}
+		_, err := gc.repos.DeleteISA(ctx, isa)
 		if err != nil {
 			return stacktrace.Propagate(err,
 				"Failed to delete ISAs")
@@ -64,11 +60,7 @@ func (gc *GarbageCollector) DeleteExpiredSubscriptions(ctx context.Context) erro
 	}
 
 	for _, sub := range expiredSubscriptions {
-		subOut, err := gc.repos.DeleteSubscription(ctx, sub)
-		if subOut != nil {
-			return stacktrace.Propagate(err,
-				"Deleted Subscription")
-		}
+		_, err := gc.repos.DeleteSubscription(ctx, sub)
 		if err != nil {
 			return stacktrace.Propagate(err,
 				"Failed to delete Subscription")


### PR DESCRIPTION
Fix  #1249 

Don't return an error when an ISA/subscription has been deleted (looking at the code It doesn't seems to make sense) + add tests to validate that more than one subscription/ISA is removed. (And without the fix, the test indeed doesn't pass).