### PR TITLE
Remove potential nil error to stacktrace.Propagate

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -209,6 +209,9 @@ func (a *Authorizer) Authorize(_ http.ResponseWriter, r *http.Request, authOptio
 		}
 	}
 	if !validated {
+		if err == nil { // If we have no keys, errs may be nil
+			err = stacktrace.NewErrorWithCode(dsserr.Unauthenticated, "No keys to validate against")
+		}
 		return api.AuthorizationResult{Error: stacktrace.PropagateWithCode(err, dsserr.Unauthenticated, "Access token validation failed")}
 	}
 

--- a/pkg/aux_/server.go
+++ b/pkg/aux_/server.go
@@ -25,6 +25,11 @@ func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi
 	case dsserr.PermissionDenied:
 		*resp403 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
 	default:
+
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+
 		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
 	}
 }

--- a/pkg/rid/server/v1/server.go
+++ b/pkg/rid/server/v1/server.go
@@ -29,6 +29,9 @@ func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi
 	case dsserr.PermissionDenied:
 		*resp403 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
 	default:
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
 		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
 	}
 }

--- a/pkg/rid/server/v2/server.go
+++ b/pkg/rid/server/v2/server.go
@@ -29,6 +29,9 @@ func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi
 	case dsserr.PermissionDenied:
 		*resp403 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
 	default:
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
 		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
 	}
 }

--- a/pkg/scd/server.go
+++ b/pkg/scd/server.go
@@ -48,6 +48,9 @@ func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi
 	case dsserr.PermissionDenied:
 		*resp403 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
 	default:
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
 		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
 	}
 }

--- a/pkg/versioning/server.go
+++ b/pkg/versioning/server.go
@@ -2,6 +2,7 @@ package versioning
 
 import (
 	"context"
+
 	"github.com/interuss/dss/pkg/api"
 	versioning "github.com/interuss/dss/pkg/api/versioningv1"
 	dsserr "github.com/interuss/dss/pkg/errors"
@@ -39,6 +40,10 @@ func setAuthError(ctx context.Context, authErr error, resp401, resp403 **api.Emp
 	case dsserr.PermissionDenied:
 		*resp403 = &api.EmptyResponseBody{}
 	default:
+
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
 		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
 	}
 }


### PR DESCRIPTION
I tried automatically and fail, so I did a manual pass to remove potential `stacktrace.Propagate(nil, ...` calls

This should remove most of them, the main potential worrying one is in the authentication part.

Effort towards #1255 