### PR TITLE
[rid] Fix Garbage Collector to use the current repository version

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -175,11 +175,7 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 		}
 	}
 
-	repo, err := ridStore.Interact(ctx)
-	if err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Unable to interact with store")
-	}
-	gc := ridc.NewGarbageCollector(repo, locality)
+	gc := ridc.NewGarbageCollector(ridStore, locality)
 
 	// schedule period tasks for RID Server
 	ridCron := cron.New()

--- a/pkg/rid/store/cockroach/garbage_collector.go
+++ b/pkg/rid/store/cockroach/garbage_collector.go
@@ -8,24 +8,31 @@ import (
 )
 
 type GarbageCollector struct {
-	repos  repos.Repository
+	store  *Store
 	writer string
 }
 
-func NewGarbageCollector(repos repos.Repository, writer string) *GarbageCollector {
+func NewGarbageCollector(store *Store, writer string) *GarbageCollector {
 	return &GarbageCollector{
-		repos:  repos,
+		store:  store,
 		writer: writer,
 	}
 }
 
 func (gc *GarbageCollector) DeleteRIDExpiredRecords(ctx context.Context) error {
-	err := gc.DeleteExpiredISAs(ctx)
+	repos, err := gc.store.Interact(ctx)
+	if err != nil {
+		return stacktrace.Propagate(err,
+			"Unable to interact with store")
+	}
+
+	err = gc.DeleteExpiredISAs(ctx, repos)
 	if err != nil {
 		return stacktrace.Propagate(err,
 			"Failed to delete RID expired records")
 	}
-	err = gc.DeleteExpiredSubscriptions(ctx)
+
+	err = gc.DeleteExpiredSubscriptions(ctx, repos)
 	if err != nil {
 		return stacktrace.Propagate(err,
 			"Failed to delete RID expired records")
@@ -34,15 +41,15 @@ func (gc *GarbageCollector) DeleteRIDExpiredRecords(ctx context.Context) error {
 	return nil
 }
 
-func (gc *GarbageCollector) DeleteExpiredISAs(ctx context.Context) error {
-	expiredISAs, err := gc.repos.ListExpiredISAs(ctx, gc.writer)
+func (gc *GarbageCollector) DeleteExpiredISAs(ctx context.Context, repos repos.Repository) error {
+	expiredISAs, err := repos.ListExpiredISAs(ctx, gc.writer)
 	if err != nil {
 		return stacktrace.Propagate(err,
 			"Failed to list expired ISAs")
 	}
 
 	for _, isa := range expiredISAs {
-		isaOut, err := gc.repos.DeleteISA(ctx, isa)
+		isaOut, err := repos.DeleteISA(ctx, isa)
 		if isaOut != nil {
 			return stacktrace.Propagate(err,
 				"Deleted ISA")
@@ -56,15 +63,15 @@ func (gc *GarbageCollector) DeleteExpiredISAs(ctx context.Context) error {
 	return nil
 }
 
-func (gc *GarbageCollector) DeleteExpiredSubscriptions(ctx context.Context) error {
-	expiredSubscriptions, err := gc.repos.ListExpiredSubscriptions(ctx, gc.writer)
+func (gc *GarbageCollector) DeleteExpiredSubscriptions(ctx context.Context, repos repos.Repository) error {
+	expiredSubscriptions, err := repos.ListExpiredSubscriptions(ctx, gc.writer)
 	if err != nil {
 		return stacktrace.Propagate(err,
 			"Failed to list expired Subscriptions")
 	}
 
 	for _, sub := range expiredSubscriptions {
-		subOut, err := gc.repos.DeleteSubscription(ctx, sub)
+		subOut, err := repos.DeleteSubscription(ctx, sub)
 		if subOut != nil {
 			return stacktrace.Propagate(err,
 				"Deleted Subscription")

--- a/pkg/rid/store/cockroach/garbage_collector_test.go
+++ b/pkg/rid/store/cockroach/garbage_collector_test.go
@@ -46,7 +46,7 @@ func TestDeleteExpiredISAs(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ret)
 
-	gc := NewGarbageCollector(repo, writer)
+	gc := NewGarbageCollector(store, writer)
 	err = gc.DeleteRIDExpiredRecords(ctx)
 	require.NoError(t, err)
 
@@ -90,7 +90,7 @@ func TestDeleteExpiredSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ret)
 
-	gc := NewGarbageCollector(repo, writer)
+	gc := NewGarbageCollector(store, writer)
 	err = gc.DeleteRIDExpiredRecords(ctx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
- Fixes #1252
- Passes the Store instead of the Repository to the Garbage Collector creation
- Recreates the repository inside the Garbage Collector methods 
- Updates unit tests to reflect changes