### PR TITLE
[dev] Remove version in docker compose

### DIFF
--- a/build/dev/docker-compose_dss.yaml
+++ b/build/dev/docker-compose_dss.yaml
@@ -3,8 +3,6 @@
 
 # To bring up this system, see standalone_instance.md.
 
-version: '3.8'
-
 services:
 
   local-dss-crdb:


### PR DESCRIPTION
Remove the following warning when using the start-locally docker compose file: 

> the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 