### PR TITLE
[docs] Add actual links to migrated doc pages ; Adapt CI to check links to docs website

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,3 +1,3 @@
 # Deploying a DSS instance
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/build).

--- a/build/deploy/README.md
+++ b/build/deploy/README.md
@@ -1,6 +1,7 @@
 # Kubernetes deployment via Tanka
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+The documentation and configuration have been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/services/tanka/).
+Architecture, Survivability and Sizing sections have been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/architecture/)
 
 ## Migrating configurations to new location
 

--- a/build/pooling.md
+++ b/build/pooling.md
@@ -1,3 +1,3 @@
 # DSS Pooling (moved)
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/operations/pooling).

--- a/deploy/MIGRATION.md
+++ b/deploy/MIGRATION.md
@@ -1,3 +1,3 @@
 # CockroachDB and Kubernetes version migration
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/migration).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,3 +1,3 @@
 # DSS Deployment
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/).

--- a/deploy/architecture.md
+++ b/deploy/architecture.md
@@ -1,3 +1,3 @@
 # Kubernetes deployment
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/architecture).

--- a/deploy/infrastructure/local/minikube/README.md
+++ b/deploy/infrastructure/local/minikube/README.md
@@ -1,3 +1,3 @@
 # minikube
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/infrastructure/local-minikube).

--- a/deploy/infrastructure/modules/terraform-aws-dss/DNS.md
+++ b/deploy/infrastructure/modules/terraform-aws-dss/DNS.md
@@ -1,3 +1,3 @@
 # Setup DNS
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/infrastructure/terraform-aws-dss/dns).

--- a/deploy/infrastructure/modules/terraform-aws-dss/README.md
+++ b/deploy/infrastructure/modules/terraform-aws-dss/README.md
@@ -1,3 +1,3 @@
 # terraform-aws-dss
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/infrastructure/terraform-aws-dss).

--- a/deploy/infrastructure/modules/terraform-google-dss/DNS.md
+++ b/deploy/infrastructure/modules/terraform-google-dss/DNS.md
@@ -1,3 +1,3 @@
 # Setup DNS
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/infrastructure/terraform-google-dss/dns).

--- a/deploy/infrastructure/modules/terraform-google-dss/README.md
+++ b/deploy/infrastructure/modules/terraform-google-dss/README.md
@@ -1,3 +1,3 @@
 # terraform-google-dss
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/infrastructure/terraform-google-dss).

--- a/deploy/operations/README.md
+++ b/deploy/operations/README.md
@@ -1,3 +1,3 @@
 # Operations
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/operations).

--- a/deploy/operations/certificates-management/README.md
+++ b/deploy/operations/certificates-management/README.md
@@ -1,3 +1,3 @@
 # Certificates management
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/operations/certificates-management).

--- a/deploy/operations/ci/aws-1/README.md
+++ b/deploy/operations/ci/aws-1/README.md
@@ -1,3 +1,3 @@
 # AWS-1 CI deployment
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/operations/ci/aws-1).

--- a/deploy/operations/monitoring.md
+++ b/deploy/operations/monitoring.md
@@ -1,3 +1,3 @@
 # Monitoring
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/operations/monitoring).

--- a/deploy/operations/pooling-crdb.md
+++ b/deploy/operations/pooling-crdb.md
@@ -1,3 +1,3 @@
 # DSS Pooling
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/operations/pooling-crdb).

--- a/deploy/operations/pooling.md
+++ b/deploy/operations/pooling.md
@@ -1,3 +1,3 @@
 # DSS Pooling
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/operations/pooling).

--- a/deploy/operations/troubleshooting.md
+++ b/deploy/operations/troubleshooting.md
@@ -1,3 +1,3 @@
 # Troubleshooting
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/operations/troubleshooting).

--- a/deploy/services/helm-charts/dss/README.md
+++ b/deploy/services/helm-charts/dss/README.md
@@ -1,3 +1,3 @@
 # DSS Helm Chart
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/services/helm-charts).

--- a/deploy/services/tanka/README.md
+++ b/deploy/services/tanka/README.md
@@ -1,3 +1,3 @@
 # Kubernetes deployment via Tanka
 
-This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss).
+This documentation has been moved to [interuss.github.io/dss](https://interuss.github.io/dss/dev/services/tanka).

--- a/test/repo_hygiene/Dockerfile
+++ b/test/repo_hygiene/Dockerfile
@@ -2,7 +2,7 @@
 #
 # `docker build` should be run from this folder
 
-FROM python:3.8
+FROM python:3.11
 ADD ./requirements.txt /app/requirements.txt
 RUN pip install -r /app/requirements.txt
 RUN rm -rf __pycache__

--- a/test/repo_hygiene/md_files/local_links.py
+++ b/test/repo_hygiene/md_files/local_links.py
@@ -4,27 +4,46 @@ import marko
 import marko.block
 import marko.inline
 
-
 REPO_CONTENT_BASE_URL = "https://github.com/interuss/dss/tree/master/"
+DOCS_BASE_URL = "https://interuss.github.io/dss/dev/"
+
+
+def _abs_path(repo_root: str, relative_path: str) -> str:
+    return os.path.realpath(os.path.join(repo_root, relative_path))
 
 
 def check_local_links(parent: marko.block.Element, doc_path: str, repo_root: str) -> None:
+    def check(rel_paths: str | list[str]) -> None:
+        """Raises an exception if all provided relative paths do not exist."""
+        if isinstance(rel_paths, str):
+            rel_paths = [rel_paths]
+
+        abs_paths = [_abs_path(repo_root, rel_path) for rel_path in rel_paths]
+        if all([not os.path.exists(abs_path) for abs_path in abs_paths]):
+            md_relative_path = os.path.relpath(doc_path, repo_root)
+            raise ValueError(f"Document {md_relative_path} has a link to {parent.dest} but none of {','.join(rel_paths)} exist in the repository ({','.join(abs_paths)} in the repo_hygiene container)")
+
     if isinstance(parent, marko.inline.Link):
-        if parent.dest.startswith(REPO_CONTENT_BASE_URL):
-            relative_path = parent.dest[len(REPO_CONTENT_BASE_URL):]
-        elif parent.dest.startswith("http://") or parent.dest.startswith("https://"):
+        relative_path = parent.dest
+        if "#" in relative_path:
+            relative_path = relative_path.split("#")[0]
+
+        if relative_path.startswith(REPO_CONTENT_BASE_URL):
+            check(relative_path[len(REPO_CONTENT_BASE_URL):])
+        elif relative_path.startswith(DOCS_BASE_URL):
+            # Check links to documentation hosted on interuss.github.io/dss
+            relative_path = relative_path[len(DOCS_BASE_URL):]
+            if relative_path.endswith("/"):
+                relative_path = relative_path[:-1]
+            if relative_path.endswith("/index.html"):
+                relative_path = relative_path[:-11]
+            check([f"docs/{relative_path}.md", f"docs/{relative_path}/index.md"])
+        elif relative_path.startswith("http://") or relative_path.startswith("https://"):
             # Don't check absolute paths to other locations
-            relative_path = None
+            return
         else:
             md_path = os.path.relpath(os.path.dirname(doc_path), repo_root)
-            relative_path = os.path.join(md_path, parent.dest)
-        if relative_path is not None:
-            if "#" in relative_path:
-                relative_path = relative_path.split("#")[0]
-            abs_path = os.path.realpath(os.path.join(repo_root, relative_path))
-            if not os.path.exists(abs_path):
-                md_relative_path = os.path.relpath(doc_path, repo_root)
-                raise ValueError(f"Document {md_relative_path} has a link to {parent.dest} but {relative_path} does not exist in the repository ({abs_path} in the repo_hygiene container)")
+            check(os.path.join(md_path, relative_path))
     else:
         if hasattr(parent, "children") and not isinstance(parent.children, str):
             for child in parent.children:


### PR DESCRIPTION
Includes a refactoring of `check_local_links` to enable checking links to documentation website (`dev` version which matches master).
- factor away `_abs_path` for clarity
- factor away `check` to validate relative paths and early return when no check is required
- upgrade Python of hygiene Docker image to 3.11 because 3.8 was not happy about one of the changes