### PR TITLE
[yugabyte] Enable node_to_node_encryption_use_client_certificates

### DIFF
--- a/deploy/services/helm-charts/dss/values.yaml
+++ b/deploy/services/helm-charts/dss/values.yaml
@@ -52,3 +52,9 @@ yugabyte:
     clientToServer: true
     insecure: false
     provided: true
+
+  gflags:
+    master:
+      node_to_node_encryption_use_client_certificates: "true"
+    tserver:
+      node_to_node_encryption_use_client_certificates: "true"

--- a/deploy/services/tanka/yugabyte-auxiliary.libsonnet
+++ b/deploy/services/tanka/yugabyte-auxiliary.libsonnet
@@ -55,6 +55,7 @@ local yugabyteLB(metadata, name, ip) =
             --placement_region=%s
             --placement_zone=%s
             --use_private_ip=zone
+            --node_to_node_encryption_use_client_certificates=true
           ||| % [
             std.join(",", metadata.yugabyte.masterAddresses),
             std.length(metadata.yugabyte.masterAddresses),
@@ -98,6 +99,7 @@ local yugabyteLB(metadata, name, ip) =
             --placement_region=%s
             --placement_zone=%s
             --use_private_ip=zone
+            --node_to_node_encryption_use_client_certificates=true
           ||| % [
             std.join(",", metadata.yugabyte.masterAddresses),
             metadata.yugabyte.tserver.rpc_bind_addresses,


### PR DESCRIPTION
Enable node_to_node_encryption_use_client_certificates in yugaybte (helm/tanka).

Require yugabyte with https://github.com/yugabyte/yugabyte-db/pull/29521 applied.