### PR TITLE
[ci] Reduce infrastructure information exposure

### DIFF
--- a/.github/workflows/dss-deploy.yml
+++ b/.github/workflows/dss-deploy.yml
@@ -3,8 +3,9 @@ on:
   workflow_dispatch: {}
 jobs:
   deploy:
-    name: Deploy DSS to AWS
+    name: Deploy DSS to AWS (manual)
     runs-on: ubuntu-latest
+    environment: ci-deploy-aws-1
     if: github.repository == 'interuss/dss' || github.repository == 'Orbitalize/dss'
     concurrency:
       group: dss-deploy-aws
@@ -20,30 +21,32 @@ jobs:
           echo "Host: ${{ runner.os }}"
           echo "Repository: ${{ github.repository }}"
           echo "Branch: ${{ github.ref }}"
-          docker images
 
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Configure AWS Credentials
+      - name: Connect to AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::301042233698:role/InterUSSGithubCI
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
           mask-aws-account-id: true
           role-duration-seconds: 5400
 
-      - name: Caller Id
-        run: |
-          aws sts get-caller-identity
-
-      - name: Test Deployment Scenario AWS-1
+      - name: "Test Deployment Scenario: AWS-1"
         shell: bash
         working-directory: ./deploy/operations/
         env:
           COMPOSE_PROFILES: aws-1
           AWS_REGION: us-east-1
+          TF_VAR_app_hostname: ${{ secrets.APP_HOSTNAME }}
+          TF_VAR_aws_iam_administrator_role: ${{ secrets.AWS_IAM_ADMINISTRATOR_ROLE }}
+          TF_VAR_aws_iam_ci_role: ${{ secrets.AWS_IAM_CI_ROLE }}
+          TF_VAR_aws_iam_permissions_boundary: ${{ secrets.AWS_IAM_PERMISSIONS_BOUNDARY }}
+          TF_VAR_aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          TF_VAR_aws_route53_zone_id: ${{ secrets.AWS_ROUTE53_ZONE_ID }}
+          TF_VAR_db_hostname_suffix: ${{ secrets.DB_HOSTNAME_SUFFIX }}
         run: |
           docker compose up --exit-code-from ci-aws-1

--- a/deploy/operations/ci/aws-1/terraform.tfvars
+++ b/deploy/operations/ci/aws-1/terraform.tfvars
@@ -3,13 +3,6 @@
 # AWS account
 aws_region = "us-east-1"
 
-# DNS Management
-aws_route53_zone_id = "Z03377073HUSGB4L9FKEK"
-
-# Hostnames
-app_hostname       = "dss.ci.aws-interuss.uspace.dev"
-db_hostname_suffix = "db.ci.aws-interuss.uspace.dev"
-
 # Kubernetes configuration
 kubernetes_version           = 1.32
 cluster_name                 = "dss-ci-aws-ue1"
@@ -19,15 +12,26 @@ aws_kubernetes_storage_class = "gp2"
 
 # DSS configuration
 image = "docker.io/interuss/dss:latest"
-authorization = {
-  public_key_pem_path = "/test-certs/auth2.pem"
-}
 should_init         = true
 crdb_image_tag      = "v24.1.3"
 crdb_cluster_name   = "interuss-ci"
 locality            = "interuss_dss-ci-aws-ue1"
 crdb_external_nodes = []
 
-aws_iam_permissions_boundary = "arn:aws:iam::301042233698:policy/GithubCIPermissionBoundaries20231130225039606500000001"
-aws_iam_administrator_role   = "arn:aws:iam::301042233698:role/AWSReservedSSO_AdministratorAccess_9b637c80b830ea2c"
-aws_iam_ci_role              = "arn:aws:iam::301042233698:role/InterUSSGithubCI"
+# The following variables are injected using the TF_VAR_name method.
+# Reference: https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_var_name
+
+# DNS
+# aws_route53_zone_id
+
+# Hostnames
+# app_hostname
+# db_hostname_suffix
+
+# DSS configuration
+# authorization # Value to be provided as json
+
+# AWS
+# aws_iam_permissions_boundary
+# aws_iam_administrator_role
+# aws_iam_ci_role


### PR DESCRIPTION
In order to reduce the information exposure of the infrastructure used by the CI job `Deploy DSS`, terraform variables containing references to actual AWS resources or domain names have been moved to environment secrets.