### PR TITLE
Lock potentially used subscriptions

### DIFF
--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -99,9 +99,16 @@ func (a *Server) DeleteOperationalIntentReference(ctx context.Context, req *rest
 				"Current version is %s but client specified version %s", old.OVN, ovn)
 		}
 
-		// Early lock on the subscriptions covering the cells relevant to the OIR
+		// Lock subscriptions based on the cell and subscriptions we're going to use
+		// to reduce the number of retries under concurrent load.
 		// See issue #1002 for details.
-		err = r.LockSubscriptionsOnCells(ctx, old.Cells)
+		var subscriptionIds = make([]dssmodels.ID, 0)
+
+		if old.SubscriptionID != nil {
+			subscriptionIds = append(subscriptionIds, *old.SubscriptionID)
+		}
+
+		err = r.LockSubscriptionsOnCells(ctx, old.Cells, subscriptionIds)
 		if err != nil {
 			return stacktrace.Propagate(err, "Unable to acquire lock")
 		}
@@ -826,18 +833,31 @@ func (a *Server) upsertOperationalIntentReference(ctx context.Context, now time.
 	var responseOK *restapi.ChangeOperationalIntentReferenceResponse
 	var responseConflict *restapi.AirspaceConflictResponse
 	action := func(ctx context.Context, r repos.Repository) (err error) {
-		// Lock subscriptions based on the cell to reduce the number of retries under concurrent load.
-		// See issue #1002 for details.
-		err = r.LockSubscriptionsOnCells(ctx, validParams.cells)
-		if err != nil {
-			return stacktrace.Propagate(err, "Unable to acquire lock")
-		}
 
 		// Get existing OperationalIntent, if any
 		old, err := r.GetOperationalIntent(ctx, validParams.id)
 		if err != nil {
 			return stacktrace.Propagate(err, "Could not get OperationalIntent from repo")
 		}
+
+		// Lock subscriptions based on the cell and subscriptions we're going to use
+		// to reduce the number of retries under concurrent load.
+		// See issue #1002 for details.
+		var subscriptionIds = make([]dssmodels.ID, 0)
+
+		if old != nil && old.SubscriptionID != nil {
+			subscriptionIds = append(subscriptionIds, *old.SubscriptionID)
+		}
+
+		if !validParams.subscriptionID.Empty() {
+			subscriptionIds = append(subscriptionIds, validParams.subscriptionID)
+		}
+
+		err = r.LockSubscriptionsOnCells(ctx, validParams.cells, subscriptionIds)
+		if err != nil {
+			return stacktrace.Propagate(err, "Unable to acquire lock")
+		}
+
 		// Validate the request against the previous OIR
 		if err := validateUpsertRequestAgainstPreviousOIR(manager, validParams.ovn, old); err != nil {
 			return stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "Request validation failed")

--- a/pkg/scd/repos/repos.go
+++ b/pkg/scd/repos/repos.go
@@ -58,8 +58,8 @@ type Subscription interface {
 	// notification indices.
 	IncrementNotificationIndices(ctx context.Context, subscriptionIds []dssmodels.ID) ([]int, error)
 
-	// LockSubscriptionsOnCells locks the subscriptions of interest on specific cells.
-	LockSubscriptionsOnCells(ctx context.Context, cells s2.CellUnion) error
+	// LockSubscriptionsOnCells locks the subscriptions of interest on specific cells and, optionnaly, specific subscriptions via their IDs
+	LockSubscriptionsOnCells(ctx context.Context, cells s2.CellUnion, subscriptionIds []dssmodels.ID) error
 
 	// ListExpiredSubscriptions lists all subscriptions older than the threshold.
 	// Their age is determined by their end time, or by their update time if they do not have an end time.


### PR DESCRIPTION
Based on report from #1311, it's possible that fix from #1002 was not sufficient:

During deletion, if the subscription is not covered by intent's cells, or during update of an operational intent, if the old subscription or the id passed in parameters it not covered by intent's cells, we may have some deadlock situations, with cross-transations locks.

This fix that issue by also locking those subscriptions explicitly via their ID, however it mean that `GetOperationalIntent` will be called before getting the lock in case of updates.