### PR TITLE
[tanka] Upgrade prometheus to latest version

### DIFF
--- a/NEXT_RELEASE_NOTES.md
+++ b/NEXT_RELEASE_NOTES.md
@@ -87,6 +87,7 @@ The release notes should contain at least the following sections:
     * The initial run may take longer than expected when deleting entries that may have been accumulating.
 * Published images are now signed with [sigstore](https://www.sigstore.dev/), see [how to verify it](https://interuss.github.io/dss/latest/build/#verify-signature-of-prebuilt-interuss-docker-images).
 * Deployment documentation has been moved to a new [website](https://interuss.github.io/dss/latest/) instead of various README in the repository tree.
+* Prometheus (deployed if using tanka) has been upgraded to version 3. If you customized / used Prometheus outside of provided configuration, please follow [upgrade guide](https://prometheus.io/docs/prometheus/latest/migration/).
 
 ## Minimal database schema version
 

--- a/deploy/services/tanka/metadata_base.libsonnet
+++ b/deploy/services/tanka/metadata_base.libsonnet
@@ -71,7 +71,7 @@
     },
   },
   prometheus: {
-    image: 'prom/prometheus:v2.35.0',
+    image: 'prom/prometheus:v3.8.1',
     expose_external: false,
     IP: '',  // This is the static external ip address for promethus ingress, leaving blank means your cloud provider will assign an ephemeral IP
     whitelist_ip_ranges: error 'must specify whitelisted CIDR IP Blocks, or empty list for fully public access',


### PR DESCRIPTION
Upgrade prometheus to latest version

Tested in a tanka deployment, seems to continue to works.

<img width="4686" height="1281" alt="image" src="https://github.com/user-attachments/assets/8dfeff7a-a5fb-40d0-856c-c30b37c0c9c6" />
