### PR TITLE
[helm] Add default for yugabyte placements

### DIFF
--- a/deploy/services/helm-charts/dss/values.yaml
+++ b/deploy/services/helm-charts/dss/values.yaml
@@ -56,5 +56,11 @@ yugabyte:
   gflags:
     master:
       node_to_node_encryption_use_client_certificates: "true"
+      placement_cloud: "cloud-1"
+      placement_region: "uss-1"
+      placement_zone: "zone-1"
     tserver:
       node_to_node_encryption_use_client_certificates: "true"
+      placement_cloud: "cloud-1"
+      placement_region: "uss-1"
+      placement_zone: "zone-1"


### PR DESCRIPTION
Since we added gflags in helm values for yugabyte in #1309 , we must set placements as well.

Without the fix crdb cannot be deployed.