### PR TITLE
[tanka] Add crdb_cluster_name

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-commons-dss/tanka.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/tanka.tf
@@ -17,6 +17,7 @@ resource "local_file" "tanka_config_main" {
     VAR_STORAGE_CLASS                        = var.kubernetes_storage_class
     VAR_DOCKER_IMAGE_NAME                    = var.image
     VAR_CRDB_DOCKER_IMAGE_NAME               = "cockroachdb/cockroach:${var.crdb_image_tag}"
+    VAR_CRDB_CLUSTER_NAME                    = var.crdb_cluster_name
     VAR_YUGABYTE_CLOUD                       = var.yugabyte_cloud
     VAR_YUGABYTE_REGION                      = var.yugabyte_region
     VAR_YUGABYTE_ZONE                        = var.yugabyte_zone

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
@@ -20,6 +20,7 @@ local metadata = metadataBase {
     shouldInit: ${VAR_SHOULD_INIT},
     JoinExisting: [${VAR_CRDB_EXTERNAL_NODES}],
     storageClass: '${VAR_STORAGE_CLASS}',
+    clusterName: '${VAR_CRDB_CLUSTER_NAME}',
   },
   yugabyte+: {
     image: '${VAR_YUGABYTE_DOCKER_IMAGE_NAME}',

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/variables.gen.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/variables.gen.tf
@@ -230,8 +230,6 @@ variable "crdb_cluster_name" {
   The CRDB cluster name must be 6-20 characters in length, and can include lowercase letters, numbers,
   and dashes (but no leading or trailing dashes). A cluster's name cannot be edited after it is created.
 
-  At the moment, this variable is only used for helm charts deployments.
-
   Example: interuss-us-production
   EOT
 }

--- a/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
@@ -246,7 +246,6 @@ nodes join the intended cluster when you are running multiple clusters.
 The CRDB cluster is automatically given a randomly-generated name if an empty string is provided.
 The CRDB cluster name must be 6-20 characters in length, and can include lowercase letters, numbers,
 and dashes (but no leading or trailing dashes). A cluster's name cannot be edited after it is created.</p>
-<p>At the moment, this variable is only used for helm charts deployments.</p>
 <p>Example: interuss-us-production</p>
 </td>
             </tr><tr>

--- a/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
@@ -338,8 +338,6 @@ variable "crdb_cluster_name" {
   The CRDB cluster name must be 6-20 characters in length, and can include lowercase letters, numbers,
   and dashes (but no leading or trailing dashes). A cluster's name cannot be edited after it is created.
 
-  At the moment, this variable is only used for helm charts deployments.
-
   Example: interuss-us-production
   EOT
 }

--- a/deploy/infrastructure/modules/terraform-google-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-google-dss/TFVARS.gen.md
@@ -242,7 +242,6 @@ nodes join the intended cluster when you are running multiple clusters.
 The CRDB cluster is automatically given a randomly-generated name if an empty string is provided.
 The CRDB cluster name must be 6-20 characters in length, and can include lowercase letters, numbers,
 and dashes (but no leading or trailing dashes). A cluster's name cannot be edited after it is created.</p>
-<p>At the moment, this variable is only used for helm charts deployments.</p>
 <p>Example: interuss-us-production</p>
 </td>
             </tr><tr>

--- a/deploy/infrastructure/modules/terraform-google-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-google-dss/variables.gen.tf
@@ -327,8 +327,6 @@ variable "crdb_cluster_name" {
   The CRDB cluster name must be 6-20 characters in length, and can include lowercase letters, numbers,
   and dashes (but no leading or trailing dashes). A cluster's name cannot be edited after it is created.
 
-  At the moment, this variable is only used for helm charts deployments.
-
   Example: interuss-us-production
   EOT
 }

--- a/deploy/infrastructure/utils/definitions/crdb_cluster_name.tf
+++ b/deploy/infrastructure/utils/definitions/crdb_cluster_name.tf
@@ -7,8 +7,6 @@ variable "crdb_cluster_name" {
   The CRDB cluster name must be 6-20 characters in length, and can include lowercase letters, numbers,
   and dashes (but no leading or trailing dashes). A cluster's name cannot be edited after it is created.
 
-  At the moment, this variable is only used for helm charts deployments.
-
   Example: interuss-us-production
   EOT
 }

--- a/deploy/operations/ci/aws-1/variables.gen.tf
+++ b/deploy/operations/ci/aws-1/variables.gen.tf
@@ -338,8 +338,6 @@ variable "crdb_cluster_name" {
   The CRDB cluster name must be 6-20 characters in length, and can include lowercase letters, numbers,
   and dashes (but no leading or trailing dashes). A cluster's name cannot be edited after it is created.
 
-  At the moment, this variable is only used for helm charts deployments.
-
   Example: interuss-us-production
   EOT
 }

--- a/deploy/services/tanka/cockroachdb.libsonnet
+++ b/deploy/services/tanka/cockroachdb.libsonnet
@@ -92,7 +92,9 @@ local volumes = import 'volumes.libsonnet';
               'http-addr': '0.0.0.0',
               cache: '25%',
               'max-sql-memory': '25%',
-            },
+            } + if metadata.cockroach.clusterName != "" then {
+                'cluster-name': metadata.cockroach.clusterName,
+            } else {},
           },
           terminationGracePeriodSeconds: 300,
         },

--- a/deploy/services/tanka/metadata_base.libsonnet
+++ b/deploy/services/tanka/metadata_base.libsonnet
@@ -20,6 +20,7 @@
     nodeIPs: error 'must supply the per-node ip addresses as an array', // For AWS, this array should contain the allocation id of the elastic ips.
     JoinExisting: [],
     storageClass: 'standard',
+    clusterName: '',
   },
   yugabyte: {
     image: error 'must specify yugabyte db image',


### PR DESCRIPTION
Add crdb_cluster_name to tanka.

Without that, it's not possible to have a tanka cluster jointing an exisiting helm cluster, crdb show the following error: "cluster name check failed on ping response: peer node expects cluster name ‹"interuss-example"›, use --cluster-name to configure"