### PR TITLE
[yugabyte] Limit exposed ports

### DIFF
--- a/deploy/services/helm-charts/dss/templates/yugabyte-loadbalancers.yaml
+++ b/deploy/services/helm-charts/dss/templates/yugabyte-loadbalancers.yaml
@@ -28,27 +28,9 @@ spec:
     - name: yugabyte-master-db-ext-{{$i}}
       port: 7100
       targetPort: 7100
-    - name: yugabyte-master-ui-ext-{{$i}}
-      port: 7000
-      targetPort: 7000
     - name: yugabyte-tserver-db-ext-{{$i}}
       port: 9100
       targetPort: 9100
-    - name: yugabyte-tserver-ui-ext-{{$i}}
-      port: 9000
-      targetPort: 9000
-    - name: yugabyte-tserver-ycql-ext-{{$i}}
-      port: 9042
-      targetPort: 9042
-    - name: yugabyte-tserver-ysql-ext-{{$i}}
-      port: 5433
-      targetPort: 5433
-    - name: yugabyte-tserver-metrics-ext-{{$i}}
-      port: 13000
-      targetPort: 13000
-    - name: yugabyte-tserver-metrics-2-ext-{{$i}}
-      port: 12000
-      targetPort: 12000
   publishNotReadyAddresses: true
   selector:
      yugabytedUi: "true"

--- a/deploy/services/tanka/yugabyte-auxiliary.libsonnet
+++ b/deploy/services/tanka/yugabyte-auxiliary.libsonnet
@@ -131,6 +131,7 @@ local yugabyteLB(metadata, name, ip) =
       masters: base.Service(metadata, 'yb-masters') {
         app:: 'yb-master',
         spec+: {
+          clusterIP: "None",
           ports: [
             {
               port: 7000,
@@ -150,6 +151,7 @@ local yugabyteLB(metadata, name, ip) =
       tServers: base.Service(metadata, 'yb-tservers') {
         app:: 'yb-tserver',
         spec+: {
+          clusterIP: "None",
           ports: [
             {
               port: 9000,
@@ -205,36 +207,12 @@ local yugabyteLB(metadata, name, ip) =
             publishNotReadyAddresses: true,
             ports: [
               {
-                port: 7000,
-                name: 'http-ui',
-              },
-              {
                 port: 7100,
                 name: 'tcp-rpc-port',
               },
               {
-                port: 9000,
-                name: 'http-ui-2',
-              },
-              {
-                port: 12000,
-                name: 'http-ycql-met',
-              },
-              {
-                port: 13000,
-                name: 'http-ysql-met',
-              },
-              {
                 port: 9100,
                 name: 'tcp-rpc2-port',
-              },
-              {
-                port: 9042,
-                name: 'tcp-yql-port',
-              },
-              {
-                port: 5433,
-                name: 'tcp-ysql-port',
               },
             ],
           },


### PR DESCRIPTION
Limit exposed port for yugabyte services to secure services only.

This will limits the debugging capabilities, but management tools for the cluster are still working (tested (in original PR) by having new nodes joining a cluster).

Extracted from #1310 , contrib to #1214

