### PR TITLE
[terraform-aws] Adjust recommended instance type

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/variables.gen.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/variables.gen.tf
@@ -18,7 +18,7 @@ variable "aws_instance_type" {
   description = <<-EOT
   AWS EC2 instance type used for the Kubernetes node pool.
 
-  Example: `m6g.xlarge` for production and `t3.medium` for development
+  Example: `m6a.xlarge` for production and `t3.medium` for development
   EOT
 }
 

--- a/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
@@ -30,7 +30,7 @@ Currently, the terraform module uses the two first availability zones of the reg
                 <td><code>string</code></td>
                 <td></td>
                 <td><p>AWS EC2 instance type used for the Kubernetes node pool.</p>
-<p>Example: <code>m6g.xlarge</code> for production and <code>t3.medium</code> for development</p>
+<p>Example: <code>m6a.xlarge</code> for production and <code>t3.medium</code> for development</p>
 </td>
             </tr><tr>
                 <td>aws_route53_zone_id</td>

--- a/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
@@ -18,7 +18,7 @@ variable "aws_instance_type" {
   description = <<-EOT
   AWS EC2 instance type used for the Kubernetes node pool.
 
-  Example: `m6g.xlarge` for production and `t3.medium` for development
+  Example: `m6a.xlarge` for production and `t3.medium` for development
   EOT
 }
 

--- a/deploy/infrastructure/utils/definitions/aws_instance_type.tf
+++ b/deploy/infrastructure/utils/definitions/aws_instance_type.tf
@@ -3,6 +3,6 @@ variable "aws_instance_type" {
   description = <<-EOT
   AWS EC2 instance type used for the Kubernetes node pool.
 
-  Example: `m6g.xlarge` for production and `t3.medium` for development
+  Example: `m6a.xlarge` for production and `t3.medium` for development
   EOT
 }

--- a/deploy/operations/ci/aws-1/variables.gen.tf
+++ b/deploy/operations/ci/aws-1/variables.gen.tf
@@ -18,7 +18,7 @@ variable "aws_instance_type" {
   description = <<-EOT
   AWS EC2 instance type used for the Kubernetes node pool.
 
-  Example: `m6g.xlarge` for production and `t3.medium` for development
+  Example: `m6a.xlarge` for production and `t3.medium` for development
   EOT
 }
 


### PR DESCRIPTION
m6g instances are arm based instances which is currently not properly supported by InterUSS.
m6a instances are the most cost effective non-burstable instances.