### PR TITLE
[yugabyte] Add prometheus monitoring and grafana dashboard

### DIFF
--- a/deploy/services/helm-charts/dss/templates/yugabyte-services.yaml
+++ b/deploy/services/helm-charts/dss/templates/yugabyte-services.yaml
@@ -1,0 +1,77 @@
+{{- if $.Values.yugabyte.enabled }}
+
+{{- range $i, $lb := .Values.loadBalancers.yugabyteMasterNodes }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/path: prometheus-metrics
+    prometheus.io/port: '7000'
+    prometheus.io/scrape: 'true'
+  labels:
+    app: yb-master-{{$i}}
+    name: yb-master-{{$i}}
+  name: yb-master-{{$i}}
+spec:
+  ports:
+    - name: http-ui
+      port: 7000
+      targetPort: 7000
+  publishNotReadyAddresses: true
+  selector:
+    app: yb-master
+    apps.kubernetes.io/pod-index: '{{$i}}'
+  type: ClusterIP
+  clusterIP: None
+{{- end }}
+
+{{- range $i, $lb := .Values.loadBalancers.yugabyteTserverNodes }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/path: prometheus-metrics
+    prometheus.io/port: '9000'
+    prometheus.io/scrape: 'true'
+  labels:
+    app: yb-tserver-{{$i}}
+    name: yb-tserver-{{$i}}
+  name: yb-tserver-{{$i}}
+spec:
+  ports:
+    - name: http-ui
+      port: 9000
+      targetPort: 9000
+  publishNotReadyAddresses: true
+  selector:
+    app: yb-tserver
+    apps.kubernetes.io/pod-index: '{{$i}}'
+  type: ClusterIP
+  clusterIP: None
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/path: prometheus-metrics
+    prometheus.io/port: '13000'
+    prometheus.io/scrape: 'true'
+  labels:
+    app: yb-ysql-{{$i}}
+    name: yb-ysql-{{$i}}
+  name: yb-ysql-{{$i}}
+spec:
+  ports:
+    - name: http-ysql-met
+      port: 13000
+      targetPort: 13000
+  publishNotReadyAddresses: true
+  selector:
+    app: yb-tserver
+    apps.kubernetes.io/pod-index: '{{$i}}'
+  type: ClusterIP
+  clusterIP: None
+{{- end }}
+{{- end }}

--- a/deploy/services/helm-charts/dss/values.yaml
+++ b/deploy/services/helm-charts/dss/values.yaml
@@ -151,6 +151,55 @@ prometheus:
             target_label: pod_name
             replacement: $1
             action: replace
+          - regex: (yb-.*)
+            replacement: dss
+            source_labels: [__meta_kubernetes_endpoints_label_app]
+            target_label: node_prefix
+          - regex: (yb-master.*)
+            replacement: master_export
+            source_labels: [__meta_kubernetes_endpoints_label_app]
+            target_label: export_type
+          - regex: (yb-master.*)
+            replacement: yb-master
+            source_labels: [__meta_kubernetes_endpoints_label_app]
+            target_label: group
+          - regex: (yb-tserver.*)
+            replacement: tserver_export
+            source_labels: [__meta_kubernetes_endpoints_label_app]
+            target_label: export_type
+          - regex: (yb-tserver.*)
+            replacement: yb-tserver
+            source_labels: [__meta_kubernetes_endpoints_label_app]
+            target_label: group
+          - regex: (yb-ysql.*)
+            replacement: ysql_export
+            source_labels: [__meta_kubernetes_endpoints_label_app]
+            target_label: export_type
+          - regex: (yb-ysql.*)
+            replacement: ysql
+            source_labels: [__meta_kubernetes_endpoints_label_app]
+            target_label: group
+          metric_relabel_configs:
+          - regex: (.*)
+            replacement: $1
+            source_labels: [__name__]
+            target_label: saved_name
+          - regex: handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(.*)
+            replacement: $1
+            source_labels: [__name__]
+            target_label: server_type
+          - regex: handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(.*)
+            replacement: $2
+            source_labels: [__name__]
+            target_label: service_type
+          - regex: handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(_sum|_count)?
+            replacement: $3
+            source_labels: [__name__]
+            target_label: service_method
+          - regex: handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(_sum|_count)?
+            replacement: rpc_latency$4
+            source_labels: [__name__]
+            target_label: __name__
           kubernetes_sd_configs:
           - role: endpoints
 

--- a/deploy/services/tanka/grafana_dashboards/yugabyte.json
+++ b/deploy/services/tanka/grafana_dashboards/yugabyte.json
@@ -1,0 +1,12833 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.0.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Monitor YugabyteDB",
+  "editable": true,
+  "gnetId": 12620,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1600177212495,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Master Node Status",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "$datasource",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 102,
+      "interval": null,
+      "links": [],
+      "mappingType": 2,
+      "mappingTypes": [
+        {
+          "$$hashKey": "object:180",
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "$$hashKey": "object:181",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "$$hashKey": "object:183",
+          "from": "0.51",
+          "text": "Running",
+          "to": "1"
+        },
+        {
+          "$$hashKey": "object:184",
+          "from": "-1",
+          "text": "Not Running",
+          "to": "0.5"
+        }
+      ],
+      "repeat": "master_node",
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg(up{node_prefix=\"$dbcluster\",instance=~\"${master_node}\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0,1",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Master Status - $master_node",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "collapsed": false,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 103,
+      "panels": [],
+      "title": "TServer Node Status",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 0,
+        "y": 5
+      },
+      "id": 104,
+      "interval": null,
+      "links": [],
+      "mappingType": 2,
+      "mappingTypes": [
+        {
+          "$$hashKey": "object:243",
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "$$hashKey": "object:244",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "$$hashKey": "object:246",
+          "from": "0.51",
+          "text": "Running",
+          "to": "1"
+        },
+        {
+          "$$hashKey": "object:247",
+          "from": "-1",
+          "text": "Not Running",
+          "to": "0.5"
+        }
+      ],
+      "repeat": "tserver_node",
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg(up{node_prefix=\"$dbcluster\",instance=~\"${tserver_node}\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0,1",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "TServer Status - $tserver_node",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "collapsed": false,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 10,
+      "panels": [],
+      "title": "YSQL Ops & Latency",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_SelectStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Select",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_UpdateStmt_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Update",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_DeleteStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Delete",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_InsertStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Insert",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_OtherStmts_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Other",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_Transactions_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Transaction",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total YSQL Ops / Sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 18,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_SelectStmt_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_SelectStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Select",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_InsertStmt_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_InsertStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Insert",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_UpdateStmt_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_UpdateStmt_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Update",
+          "refId": "C"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_DeleteStmt_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_DeleteStmt_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Delete",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_OtherStmts_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_OtherStmts_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Other",
+          "refId": "E"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_Transactions_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_Transactions_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Transaction",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YSQL Op Latency (Avg)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 45,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_SelectStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Select - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 46,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance)(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_SelectStmt_sum\"}[5m])) / avg by (exported_instance)(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_SelectStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Select - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 43,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_InsertStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Insert - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 51,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_InsertStmt_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_InsertStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Insert - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "hiddenSeries": false,
+      "id": 41,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_UpdateStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Update - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "hiddenSeries": false,
+      "id": 50,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_UpdateStmt_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_UpdateStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Update - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 45
+      },
+      "hiddenSeries": false,
+      "id": 42,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_DeleteStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Delete - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 45
+      },
+      "hiddenSeries": false,
+      "id": 49,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_DeleteStmt_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_DeleteStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Delete - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
+      "hiddenSeries": false,
+      "id": 40,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_OtherStmts_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Others - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
+      "hiddenSeries": false,
+      "id": 48,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_OtherStmts_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_OtherStmts_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Others - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "hiddenSeries": false,
+      "id": 44,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_Transactions_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transactions - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 63
+      },
+      "hiddenSeries": false,
+      "id": 47,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_Transactions_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_ysqlserver_SQLProcessor_Transactions_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transactions - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 72
+      },
+      "id": 144,
+      "panels": [],
+      "title": "Master",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 73
+      },
+      "hiddenSeries": false,
+      "id": 152,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(threads_running{node_prefix=\"$dbcluster\",export_type=\"master_export\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Running",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(threads_started{node_prefix=\"$dbcluster\",export_type=\"master_export\"})",
+          "interval": "",
+          "legendFormat": "Started",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Threads",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 73
+      },
+      "hiddenSeries": false,
+      "id": 148,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Total Avg - Sync",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Total Avg - Commit",
+          "refId": "E"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Total Avg  - Append",
+          "refId": "F"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Sync",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Commit",
+          "refId": "B"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Append",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Master Log Ops / Sec / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "ops",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 82
+      },
+      "hiddenSeries": false,
+      "id": 151,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(log_sync_latency_sum{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])) / avg(irate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Sync",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(log_group_commit_latency_sum{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])) / avg(irate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Commit",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(irate(log_append_latency_sum{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])) / avg(irate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Append",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Master Log Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "µs",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 82
+      },
+      "hiddenSeries": false,
+      "id": 147,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total Avg - Log Bytes Read",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total Avg - Log Cache Size",
+          "refId": "E"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Log Bytes Read",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Log Cache Size",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Log Stats / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "deckbytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 91
+      },
+      "hiddenSeries": false,
+      "id": 150,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total Avg - Log Bytes Logged",
+          "refId": "B"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Log Bytes Logged",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Log Bytes Written / Sec / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "Bps",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 91
+      },
+      "hiddenSeries": false,
+      "id": 145,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(glog_info_messages{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Info",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(glog_warning_messages{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Warning",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(glog_error_messages{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Error",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Glog messages",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 100
+      },
+      "hiddenSeries": false,
+      "id": 149,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Total Avg - Log Bytes Read",
+          "refId": "B"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Log Bytes Read",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Log Bytes Read / Sec / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "Bps",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 100
+      },
+      "hiddenSeries": false,
+      "id": 68,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rpcs_in_queue_yb_master_MasterService{node_prefix=\"$dbcluster\"})",
+          "interval": "",
+          "legendFormat": "Master RPC",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "RPC queue sizes (Master)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 109
+      },
+      "hiddenSeries": false,
+      "id": 146,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"master_export\"}))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total Avg - Num Ops",
+          "refId": "D"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"master_export\"})) / 1024",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Num Ops",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Log Cache Num Ops / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "ops",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 109
+      },
+      "hiddenSeries": false,
+      "id": 153,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Write_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Write",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Read_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Read",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Ops / Sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 118
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",export_type=\"master_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Write_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Write_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Write",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",export_type=\"master_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Read_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Read_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Read",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Op / Sec / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 118
+      },
+      "hiddenSeries": false,
+      "id": 160,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",export_type=\"master_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Read_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Read_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Read",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",export_type=\"master_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Write_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"master_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Write_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Write",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 127
+      },
+      "hiddenSeries": false,
+      "id": 29,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_incoming_queue_time_sum{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])) / avg(irate(rpc_incoming_queue_time_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Incoming Queue",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(handler_latency_outbound_transfer_sum{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])) / avg(irate(handler_latency_outbound_transfer_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Outbound transfer time",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(irate(handler_latency_outbound_call_queue_time_sum{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m])) / avg(irate(handler_latency_outbound_call_queue_time_count{node_prefix=\"$dbcluster\",export_type=\"master_export\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Outbound queue time",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Reactor Delays",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 136
+      },
+      "id": 8,
+      "panels": [],
+      "title": "YCQL Ops & Latency",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 137
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_SelectStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Select",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_UpdateStmt_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Update",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_DeleteStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Delete",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_InsertStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Insert",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_OtherStmts_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Other",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_Transaction_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Transaction",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total YCQL Ops / Sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 137
+      },
+      "hiddenSeries": false,
+      "id": 74,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_SelectStmt_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_SelectStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Select",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_InsertStmt_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_InsertStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Insert",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_UpdateStmt_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_UpdateStmt_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Update",
+          "refId": "C"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_DeleteStmt_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_DeleteStmt_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Delete",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_OtherStmts_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_OtherStmts_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Other",
+          "refId": "E"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_Transaction_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_Transaction_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Transaction",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YCQL Op Latency (Avg)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 146
+      },
+      "hiddenSeries": false,
+      "id": 21,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p95\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_SelectStmt\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Select",
+          "refId": "A"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p95\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_InsertStmt\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Insert",
+          "refId": "B"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p95\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_UpdateStmt\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Update",
+          "refId": "C"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p95\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_DeleteStmt\"})",
+          "interval": "",
+          "legendFormat": "Delete",
+          "refId": "D"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p95\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_OtherStmts\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Other",
+          "refId": "E"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p95\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_Transaction\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Transaction",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YCQL Op Latency (P95)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 146
+      },
+      "hiddenSeries": false,
+      "id": 64,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p99\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_SelectStmt\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Select",
+          "refId": "A"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p99\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_InsertStmt\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Insert",
+          "refId": "B"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p99\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_UpdateStmt\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Update",
+          "refId": "C"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p99\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_DeleteStmt\"})",
+          "interval": "",
+          "legendFormat": "Delete",
+          "refId": "D"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p99\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_OtherStmts\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Other",
+          "refId": "E"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\", quantile=\"p99\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_Transaction\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Transaction",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YCQL Op Latency (P99)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 155
+      },
+      "hiddenSeries": false,
+      "id": 33,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_SelectStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Select - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 155
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_SelectStmt_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_SelectStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Select - Op Latency (Avg) /  Tserver",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 164
+      },
+      "hiddenSeries": false,
+      "id": 32,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_UpdateStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Update - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 164
+      },
+      "hiddenSeries": false,
+      "id": 37,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_UpdateStmt_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_UpdateStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Update - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 173
+      },
+      "hiddenSeries": false,
+      "id": 31,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_DeleteStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Delete - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 173
+      },
+      "hiddenSeries": false,
+      "id": 36,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_DeleteStmt_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_DeleteStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Delete - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 182
+      },
+      "hiddenSeries": false,
+      "id": 30,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_InsertStmt_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Insert - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 182
+      },
+      "hiddenSeries": false,
+      "id": 38,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_InsertStmt_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_InsertStmt_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Insert - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 191
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "tserver",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_OtherStmts_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Others - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 191
+      },
+      "hiddenSeries": false,
+      "id": 35,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_OtherStmts_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_OtherStmts_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_Transaction_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_Transaction_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Transaction",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Others - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 200
+      },
+      "hiddenSeries": false,
+      "id": 34,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_Transaction_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transaction - Op / Sec / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 200
+      },
+      "hiddenSeries": false,
+      "id": 39,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "v",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_Transaction_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_Transaction_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transaction - Op Latency (Avg) / TServer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 209
+      },
+      "hiddenSeries": false,
+      "id": 73,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_incoming_queue_time_sum{node_prefix=\"$dbcluster\",export_type=\"cql_export\"}[5m])) / avg(irate(rpc_incoming_queue_time_count{node_prefix=\"$dbcluster\",export_type=\"cql_export\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Incoming Queue",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(handler_latency_outbound_transfer_sum{node_prefix=\"$dbcluster\",export_type=\"cql_export\"}[5m])) / avg(irate(handler_latency_outbound_transfer_count{node_prefix=\"$dbcluster\",export_type=\"cql_export\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Outbound transfer time",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(irate(handler_latency_outbound_call_queue_time_sum{node_prefix=\"$dbcluster\",export_type=\"cql_export\"}[5m])) / avg(irate(handler_latency_outbound_call_queue_time_count{node_prefix=\"$dbcluster\",export_type=\"cql_export\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Outbound queue time",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Reactor Delays",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 209
+      },
+      "hiddenSeries": false,
+      "id": 77,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_connections_alive{node_prefix=\"$dbcluster\",metric_id=\"yb.cqlserver\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Connections Alive",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YCQL Inbound Connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 218
+      },
+      "hiddenSeries": false,
+      "id": 72,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_CQLServerService_ProcessRequest_sum\"}[5m])) / sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_CQLServerService_ProcessRequest_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_CQLServerService_ParseRequest_sum\"}[5m])) / sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_CQLServerService_ParseRequest_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Parse",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_CQLServerService_AnalyzeRequest_sum\"}[5m])) / sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_CQLServerService_AnalyzeRequest_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Analyze",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_CQLServerService_ExecuteRequest_sum\"}[5m])) / sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_CQLServerService_ExecuteRequest_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Execute",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YCQL Latency Breakdown",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 218
+      },
+      "hiddenSeries": false,
+      "id": 26,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_ResponseSize_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_cqlserver_SQLProcessor_ResponseSize_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Response Size",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Response Size (bytes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 227
+      },
+      "hiddenSeries": false,
+      "id": 71,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rpcs_in_queue_yb_cqlserver_CQLServerService{node_prefix=\"$dbcluster\"})",
+          "interval": "",
+          "legendFormat": "YCQL RPC - Max",
+          "refId": "A"
+        },
+        {
+          "expr": "rpcs_in_queue_yb_cqlserver_CQLServerService{node_prefix=\"$dbcluster\"}",
+          "interval": "",
+          "legendFormat": "YCQL RPC - {{exported_instance}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "RPC queue sizes (YCQL)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 236
+      },
+      "id": 24,
+      "panels": [],
+      "title": "Tablet Server",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 237
+      },
+      "hiddenSeries": false,
+      "id": 62,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",export_type=\"tserver_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Read_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Read_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Read",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",export_type=\"tserver_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Write_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Write_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Write",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 237
+      },
+      "hiddenSeries": false,
+      "id": 161,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_incoming_queue_time_sum{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])) / avg(irate(rpc_incoming_queue_time_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Incoming Queue",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(handler_latency_outbound_transfer_sum{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])) / avg(irate(handler_latency_outbound_transfer_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Outbound transfer time",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(irate(handler_latency_outbound_call_queue_time_sum{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])) / avg(irate(handler_latency_outbound_call_queue_time_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Outbound queue time",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Reactor Delays",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 246
+      },
+      "hiddenSeries": false,
+      "id": 60,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Write_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Write",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Read_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Read",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Ops / Sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 246
+      },
+      "hiddenSeries": false,
+      "id": 154,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",export_type=\"tserver_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Write_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Write_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Write",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (exported_instance) (irate(rpc_latency_sum{node_prefix=\"$dbcluster\",export_type=\"tserver_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Read_sum\"}[5m])) / avg by (exported_instance) (irate(rpc_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\",saved_name=\"handler_latency_yb_tserver_TabletServerService_Read_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Read",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Op / Sec / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 255
+      },
+      "hiddenSeries": false,
+      "id": 27,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_UpdateConsensus_sum\"}[5m])) / sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_UpdateConsensus_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "UpdateConsensus",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_RequestConsensusVote_sum\"}[5m])) / sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_RequestConsensusVote_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "RequestConsensusVote",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Consensus Ops / Sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 255
+      },
+      "hiddenSeries": false,
+      "id": 28,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rpc_latency{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_ChangeConfig\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "ChangeConfig",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rpc_latency{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_RunLeaderElection\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "RunLeaderElection",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rpc_latency{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_LeaderStepDown\"})",
+          "interval": "",
+          "legendFormat": "LeaderStepDown",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rpc_latency{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_LeaderElectionLost\"})",
+          "interval": "",
+          "legendFormat": "LeaderElectionLost",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Consensus Change Config",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 264
+      },
+      "hiddenSeries": false,
+      "id": 61,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rpc_latency{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_StartRemoteBootstrap\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "remote bootstraps",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Remote Bootstraps",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 264
+      },
+      "hiddenSeries": false,
+      "id": 127,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_UpdateConsensus_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_UpdateConsensus_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "UpdateConsensus",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_RequestConsensusVote_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_RequestConsensusVote_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "RequestConsensusVote",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Consensus RPC Latencies",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 273
+      },
+      "hiddenSeries": false,
+      "id": 63,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_ChangeConfig_sum\"}[5m])) / avg(irate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_consensus_ConsensusService_ChangeConfig_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "ChangeConfig",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Change Config Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 273
+      },
+      "hiddenSeries": false,
+      "id": 25,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(threads_running{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Running",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(threads_started{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})",
+          "interval": "",
+          "legendFormat": "Started",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Threads",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 282
+      },
+      "hiddenSeries": false,
+      "id": 128,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(involuntary_context_switches{node_prefix=\"$dbcluster\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Involuntary",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(voluntary_context_switches{node_prefix=\"$dbcluster\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Voluntary",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Context Switches",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 282
+      },
+      "hiddenSeries": false,
+      "id": 129,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(spinlock_contention_time{node_prefix=\"$dbcluster\"}[5m])) / 1000000",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SpinLock",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "SpinLock Time/Server",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 291
+      },
+      "hiddenSeries": false,
+      "id": 130,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(log_sync_latency_sum{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])) / avg(irate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Sync",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(log_group_commit_latency_sum{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])) / avg(irate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Commit",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(irate(log_append_latency_sum{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])) / avg(irate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Append",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "TServer Log Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "µs",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 291
+      },
+      "hiddenSeries": false,
+      "id": 131,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Total Avg - Log Bytes Logged",
+          "refId": "B"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_bytes_logged{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Log Bytes Logged",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Log Bytes Written / Sec / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "Bps",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 300
+      },
+      "hiddenSeries": false,
+      "id": 132,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Total Avg - Log Bytes Read",
+          "refId": "B"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Log Bytes Read",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Log Bytes Read / Sec / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "Bps",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 300
+      },
+      "hiddenSeries": false,
+      "id": 133,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Total Avg - Sync",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Total Avg - Commit",
+          "refId": "E"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Total Avg  - Append",
+          "refId": "F"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_sync_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Sync",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_group_commit_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Commit",
+          "refId": "B"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (rate(log_append_latency_count{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Append",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "TServer Log Ops / Sec / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "ops",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 309
+      },
+      "hiddenSeries": false,
+      "id": 134,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(generic_current_allocated_bytes{node_prefix=\"$dbcluster\"}) / 1048576",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "In Use",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(generic_heap_size{node_prefix=\"$dbcluster\"}) / 1048576",
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "TServer TCMalloc Stats",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "decmbytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 309
+      },
+      "hiddenSeries": false,
+      "id": 135,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total Avg - Log Bytes Read",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total Avg - Log Cache Size",
+          "refId": "E"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_reader_bytes_read{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Log Bytes Read",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_cache_size{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Log Cache Size",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Log Stats / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "deckbytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 318
+      },
+      "hiddenSeries": false,
+      "id": 136,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total Avg - Num Ops",
+          "refId": "D"
+        },
+        {
+          "expr": "avg by (exported_instance) (sum without (table_id, table_name) (log_cache_num_ops{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})) / 1024",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{exported_instance}} - Num Ops",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Log Cache Num Ops / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "ops",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 318
+      },
+      "hiddenSeries": false,
+      "id": 137,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(glog_info_messages{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Info",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(glog_warning_messages{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Warning",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(glog_error_messages{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Error",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Glog messages",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 327
+      },
+      "hiddenSeries": false,
+      "id": 69,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rpcs_in_queue_yb_consensus_ConsensusService{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "A"
+        },
+        {
+          "expr": "max(rpcs_in_queue_yb_server_GenericService{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})",
+          "interval": "",
+          "legendFormat": "Generic",
+          "refId": "B"
+        },
+        {
+          "expr": "max(rpcs_in_queue_yb_tserver_RemoteBootstrapService{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})",
+          "interval": "",
+          "legendFormat": "RemoteBootstrap",
+          "refId": "C"
+        },
+        {
+          "expr": "max(rpcs_in_queue_yb_tserver_TabletServerService{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})",
+          "interval": "",
+          "legendFormat": "TS RPC",
+          "refId": "D"
+        },
+        {
+          "expr": "max(rpcs_in_queue_yb_tserver_TabletServerBackupService{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})",
+          "interval": "",
+          "legendFormat": "Backups",
+          "refId": "E"
+        },
+        {
+          "expr": "max(rpcs_in_queue_yb_tserver_TabletServerAdminService{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})",
+          "interval": "",
+          "legendFormat": "Admin",
+          "refId": "F"
+        },
+        {
+          "expr": "max(rpcs_in_queue_yb_cdc_CDCService{node_prefix=\"$dbcluster\",export_type=\"tserver_export\"})",
+          "interval": "",
+          "legendFormat": "CDC",
+          "refId": "G"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "RPC queue sizes (Tserver)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 336
+      },
+      "id": 79,
+      "panels": [],
+      "title": "RocksDB",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 337
+      },
+      "hiddenSeries": false,
+      "id": 81,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_number_db_seek{node_prefix=\"$dbcluster\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Seek",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_number_db_next{node_prefix=\"$dbcluster\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Next",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "LSM-DB Seek/Next Num Ops",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 337
+      },
+      "hiddenSeries": false,
+      "id": 98,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_number_db_seek{node_prefix=\"$dbcluster\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Seek",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "LSM-DB Seeks / Sec / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 346
+      },
+      "hiddenSeries": false,
+      "id": 82,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rocksdb_current_version_sst_files_size{node_prefix=\"$dbcluster\"})) / 1073741824",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Size of SSTables",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "SSTable size / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "decgbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 346
+      },
+      "hiddenSeries": false,
+      "id": 83,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rocksdb_current_version_num_sst_files{node_prefix=\"$dbcluster\"}))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Average SSTables / Node",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average SSTables / Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 355
+      },
+      "hiddenSeries": false,
+      "id": 84,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_bloom_filter_checked{node_prefix=\"$dbcluster\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Blooms checked",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_bloom_filter_useful{node_prefix=\"$dbcluster\"}[5m]))) ",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Blooms useful",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "LSM-DB Blooms usefulness",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 355
+      },
+      "hiddenSeries": false,
+      "id": 55,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_db_get_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name) (rate(rocksdb_db_get_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Get",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "LSM-DB Get Latencies",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 364
+      },
+      "hiddenSeries": false,
+      "id": 86,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_db_write_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name) (rate(rocksdb_db_write_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Write",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "LSM-DB Write Latencies",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 364
+      },
+      "hiddenSeries": false,
+      "id": 87,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_db_seek_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name) (rate(rocksdb_db_seek_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Seek ",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "LSM-DB Seek Latencies",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 373
+      },
+      "hiddenSeries": false,
+      "id": 88,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_db_mutex_wait_micros{node_prefix=\"$dbcluster\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Mutex",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "LSM-DB Mutex Wait Latencies",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 373
+      },
+      "hiddenSeries": false,
+      "id": 89,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_block_cache_hit{node_prefix=\"$dbcluster\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Hit",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_block_cache_miss{node_prefix=\"$dbcluster\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Miss",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Cache Hit & Miss",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 382
+      },
+      "hiddenSeries": false,
+      "id": 90,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(block_cache_single_touch_usage{node_prefix=\"$dbcluster\"}) / 1073741824",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Single Touch",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(block_cache_multi_touch_usage{node_prefix=\"$dbcluster\"}) / 1073741824",
+          "interval": "",
+          "legendFormat": "Multi Touch",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Block cache usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "decgbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 382
+      },
+      "hiddenSeries": false,
+      "id": 91,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_block_cache_add{node_prefix=\"$dbcluster\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Add",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_block_cache_single_touch_add{node_prefix=\"$dbcluster\"}[5m])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Single Touch Add",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_block_cache_multi_touch_add{node_prefix=\"$dbcluster\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Multi Touch Add",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Cache Add",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "decgbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 391
+      },
+      "hiddenSeries": false,
+      "id": 92,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_stall_micros{node_prefix=\"$dbcluster\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Stalls",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Stalls",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 391
+      },
+      "hiddenSeries": false,
+      "id": 93,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(majority_sst_files_rejections{node_prefix=\"$dbcluster\"}[5m])))",
+          "interval": "",
+          "legendFormat": "Rejections",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Rejections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 400
+      },
+      "hiddenSeries": false,
+      "id": 94,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_flush_write_bytes{node_prefix=\"$dbcluster\"}[5m]))) / 1048576",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Flush",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Flush write",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "decmbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 400
+      },
+      "hiddenSeries": false,
+      "id": 95,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_compact_read_bytes{node_prefix=\"$dbcluster\"}[5m]))) / 1048576",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Bytes Read",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(sum without (table_id, table_name) (rate(rocksdb_compact_write_bytes{node_prefix=\"$dbcluster\"}[5m]))) / 1048576",
+          "interval": "",
+          "legendFormat": "Bytes Written",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Compaction",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "decmbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 409
+      },
+      "hiddenSeries": false,
+      "id": 96,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (irate(rocksdb_numfiles_in_singlecompaction_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name) (irate(rocksdb_numfiles_in_singlecompaction_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Avg",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Compaction num files",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 409
+      },
+      "hiddenSeries": false,
+      "id": 97,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(sum without (table_id, table_name) (irate(rocksdb_compaction_times_micros_sum{node_prefix=\"$dbcluster\"}[5m]))) / avg(sum without (table_id, table_name) (irate(rocksdb_compaction_times_micros_count{node_prefix=\"$dbcluster\"}[5m]))\r)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Avg",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Compaction time",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 418
+      },
+      "id": 99,
+      "panels": [],
+      "title": "YEDIS Ops & Latency",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 419
+      },
+      "hiddenSeries": false,
+      "id": 114,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_get_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Get",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mget_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MGet",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_exists_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Exists",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getrange_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetRange",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_set_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Set",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mset_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MSet",
+          "refId": "G"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getset_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetSet",
+          "refId": "H"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_append_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Append",
+          "refId": "I"
+        },
+        {
+          "expr": " sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_del_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Del",
+          "refId": "J"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_setrange_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SetRange",
+          "refId": "K"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_incr_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Incr",
+          "refId": "L"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsget_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "TsGet",
+          "refId": "M"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsadd_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "TsAdd",
+          "refId": "N"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrangebytime_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "TsRangeByTime",
+          "refId": "O"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrem_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "TsRem",
+          "refId": "P"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_smembers_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SMembers",
+          "refId": "Q"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sismember_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SIsMember",
+          "refId": "R"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_scard_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SCard",
+          "refId": "S"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "T"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sadd_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SAdd",
+          "refId": "U"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_srem_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SRem",
+          "refId": "V"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_echo_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Echo",
+          "refId": "W"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_auth_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Auth",
+          "refId": "X"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_config_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Config",
+          "refId": "Y"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_info_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Info",
+          "refId": "Z"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_role_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Role"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_ping_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Ping"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_quit_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Quit"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_flushdb_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "FlushDB"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_command_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Command"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hget_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HGet"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmget_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HMGet"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hgetall_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HGetAll"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hkeys_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HKeys"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hvals_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HVals"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hlen_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HLen"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hexists_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HExists"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hstrlen_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HStrLen"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hset_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HSet"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmset_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HMSet"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hdel_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HDel"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hincrby_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HIncrBy"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total YEDIS Ops / Sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 419
+      },
+      "hiddenSeries": false,
+      "id": 118,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_get_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_get_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Get",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mget_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mget_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MGet",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "C"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_exists_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_exists_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Exists",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getrange_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getrange_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetRange",
+          "refId": "E"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_set_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_set_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Set",
+          "refId": "F"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mset_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mset_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MSet",
+          "refId": "G"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getset_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getset_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetSet",
+          "refId": "H"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_append_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_append_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Append",
+          "refId": "I"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_del_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_del_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Del",
+          "refId": "J"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_setrange_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_setrange_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SetRange",
+          "refId": "K"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_incr_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_incr_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Incr",
+          "refId": "L"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsget_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsget_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "TsGet",
+          "refId": "M"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsadd_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsadd_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "TsAdd",
+          "refId": "N"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrangebytime_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrangebytime_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "TsRangeByTime",
+          "refId": "O"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrem_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrem_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "TsRem",
+          "refId": "P"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_smembers_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_smembers_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SMembers",
+          "refId": "Q"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sismember_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sismember_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SIsMember",
+          "refId": "R"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_scard_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_scard_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SCard",
+          "refId": "S"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "T"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sadd_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sadd_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SAdd",
+          "refId": "U"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_srem_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_srem_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SRem",
+          "refId": "V"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_echo_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_echo_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Echo",
+          "refId": "W"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_auth_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_auth_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Auth",
+          "refId": "X"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_config_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_config_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Config",
+          "refId": "Y"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_info_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_info_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Info",
+          "refId": "Z"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_role_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_role_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Role"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_ping_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_ping_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Ping"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_quit_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_quit_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Quit"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_flushdb_sum\"}[5m])) /avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_flushdb_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "FlushDB"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_command_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_command_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Command"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hget_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hget_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HGet"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmget_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmget_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HMGet"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hgetall_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hgetall_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HGetAll"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hkeys_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hkeys_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HKeys"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hvals_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hvals_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HVals"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hlen_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hlen_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HLen"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hexists_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hexists_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HExists"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hstrlen_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hstrlen_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HStrLen"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hset_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hset_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HSet"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmset_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmset_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HMSet"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hdel_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hdel_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HDel"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hincrby_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hincrby_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HIncrBy"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YEDIS Op Latency (Avg)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 428
+      },
+      "hiddenSeries": false,
+      "id": 126,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_get\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Get",
+          "refId": "A"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mget\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MGet",
+          "refId": "B"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "C"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_exists\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Exists",
+          "refId": "D"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getrange\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetRange",
+          "refId": "E"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_set\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Set",
+          "refId": "F"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mset\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MSet",
+          "refId": "G"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getset\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetSet",
+          "refId": "H"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_append\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Append",
+          "refId": "I"
+        },
+        {
+          "expr": " max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_del\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Del",
+          "refId": "J"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_setrange\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SetRange",
+          "refId": "K"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_incr\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Incr",
+          "refId": "L"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsget\"})",
+          "interval": "",
+          "legendFormat": "TsGet",
+          "refId": "M"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsadd\"})",
+          "interval": "",
+          "legendFormat": "TsAdd",
+          "refId": "N"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrangebytime\"})",
+          "interval": "",
+          "legendFormat": "TsRangeByTime",
+          "refId": "O"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrem\"})",
+          "interval": "",
+          "legendFormat": "TsRem",
+          "refId": "P"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_smembers\"})",
+          "interval": "",
+          "legendFormat": "SMembers",
+          "refId": "Q"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sismember\"})",
+          "interval": "",
+          "legendFormat": "SIsMember",
+          "refId": "R"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_scard\"})",
+          "interval": "",
+          "legendFormat": "SCard",
+          "refId": "S"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen\"})",
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "T"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sadd\"})",
+          "interval": "",
+          "legendFormat": "SAdd",
+          "refId": "U"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_srem\"})",
+          "interval": "",
+          "legendFormat": "SRem",
+          "refId": "V"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_echo\"})\r",
+          "interval": "",
+          "legendFormat": "Echo",
+          "refId": "W"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_auth\"})\r",
+          "interval": "",
+          "legendFormat": "Auth",
+          "refId": "X"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_config\"})\r",
+          "interval": "",
+          "legendFormat": "Config",
+          "refId": "Y"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_info\"})\r",
+          "interval": "",
+          "legendFormat": "Info",
+          "refId": "Z"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_role\"})\r",
+          "interval": "",
+          "legendFormat": "Role"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_ping\"})\r",
+          "interval": "",
+          "legendFormat": "Ping"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_quit\"})\r",
+          "interval": "",
+          "legendFormat": "Quit"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_flushdb\"})\r",
+          "interval": "",
+          "legendFormat": "FlushDB"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_command\"})\r",
+          "interval": "",
+          "legendFormat": "Command"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hget\"})\r",
+          "interval": "",
+          "legendFormat": "HGet"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmget\"})\r",
+          "interval": "",
+          "legendFormat": "HMGet"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hgetall\"})\r",
+          "interval": "",
+          "legendFormat": "HGetAll"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hkeys\"})\r",
+          "interval": "",
+          "legendFormat": "HKeys"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hvals\"})\r",
+          "interval": "",
+          "legendFormat": "HVals"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hlen\"})\r",
+          "interval": "",
+          "legendFormat": "HLen"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hexists\"})\r",
+          "interval": "",
+          "legendFormat": "HExists"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hstrlen\"})\r",
+          "interval": "",
+          "legendFormat": "HStrLen"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hset\"})\r",
+          "interval": "",
+          "legendFormat": "HSet"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmset\"})\r",
+          "interval": "",
+          "legendFormat": "HMSet"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hdel\"})\r",
+          "interval": "",
+          "legendFormat": "HDel"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p95\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hincrby\"})\r",
+          "interval": "",
+          "legendFormat": "HIncrBy"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YEDIS Op Latency (P95)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 428
+      },
+      "hiddenSeries": false,
+      "id": 125,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_get\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Get",
+          "refId": "A"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mget\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MGet",
+          "refId": "B"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "C"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_exists\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Exists",
+          "refId": "D"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getrange\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetRange",
+          "refId": "E"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_set\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Set",
+          "refId": "F"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mset\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MSet",
+          "refId": "G"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getset\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetSet",
+          "refId": "H"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_append\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Append",
+          "refId": "I"
+        },
+        {
+          "expr": " max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_del\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Del",
+          "refId": "J"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_setrange\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SetRange",
+          "refId": "K"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_incr\"})\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Incr",
+          "refId": "L"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsget\"})",
+          "interval": "",
+          "legendFormat": "TsGet",
+          "refId": "M"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsadd\"})",
+          "interval": "",
+          "legendFormat": "TsAdd",
+          "refId": "N"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrangebytime\"})",
+          "interval": "",
+          "legendFormat": "TsRangeByTime",
+          "refId": "O"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrem\"})",
+          "interval": "",
+          "legendFormat": "TsRem",
+          "refId": "P"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_smembers\"})",
+          "interval": "",
+          "legendFormat": "SMembers",
+          "refId": "Q"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sismember\"})",
+          "interval": "",
+          "legendFormat": "SIsMember",
+          "refId": "R"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_scard\"})",
+          "interval": "",
+          "legendFormat": "SCard",
+          "refId": "S"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen\"})",
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "T"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sadd\"})",
+          "interval": "",
+          "legendFormat": "SAdd",
+          "refId": "U"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_srem\"})",
+          "interval": "",
+          "legendFormat": "SRem",
+          "refId": "V"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_echo\"})\r",
+          "interval": "",
+          "legendFormat": "Echo",
+          "refId": "W"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_auth\"})\r",
+          "interval": "",
+          "legendFormat": "Auth",
+          "refId": "X"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_config\"})\r",
+          "interval": "",
+          "legendFormat": "Config",
+          "refId": "Y"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_info\"})\r",
+          "interval": "",
+          "legendFormat": "Info",
+          "refId": "Z"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_role\"})\r",
+          "interval": "",
+          "legendFormat": "Role"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_ping\"})\r",
+          "interval": "",
+          "legendFormat": "Ping"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_quit\"})\r",
+          "interval": "",
+          "legendFormat": "Quit"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_flushdb\"})\r",
+          "interval": "",
+          "legendFormat": "FlushDB"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_command\"})\r",
+          "interval": "",
+          "legendFormat": "Command"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hget\"})\r",
+          "interval": "",
+          "legendFormat": "HGet"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmget\"})\r",
+          "interval": "",
+          "legendFormat": "HMGet"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hgetall\"})\r",
+          "interval": "",
+          "legendFormat": "HGetAll"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hkeys\"})\r",
+          "interval": "",
+          "legendFormat": "HKeys"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hvals\"})\r",
+          "interval": "",
+          "legendFormat": "HVals"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hlen\"})\r",
+          "interval": "",
+          "legendFormat": "HLen"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hexists\"})\r",
+          "interval": "",
+          "legendFormat": "HExists"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hstrlen\"})\r",
+          "interval": "",
+          "legendFormat": "HStrLen"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hset\"})\r",
+          "interval": "",
+          "legendFormat": "HSet"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmset\"})\r",
+          "interval": "",
+          "legendFormat": "HMSet"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hdel\"})\r",
+          "interval": "",
+          "legendFormat": "HDel"
+        },
+        {
+          "expr": "max(rpc_latency{node_prefix=\"$dbcluster\",quantile=\"p99\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hincrby\"})\r",
+          "interval": "",
+          "legendFormat": "HIncrBy"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YEDIS Op Latency (P99)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 437
+      },
+      "hiddenSeries": false,
+      "id": 117,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hget_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HGet",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmget_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HMGet",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hgetall_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HGetAll",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hkeys_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HKeys",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hvals_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HVals",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hlen_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HLen",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hexists_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HExists",
+          "refId": "G"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hstrlen_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HStrLen",
+          "refId": "H"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hset_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HSet",
+          "refId": "I"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmset_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HMSet",
+          "refId": "J"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hdel_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HDel",
+          "refId": "K"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hincrby_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HIncrBy",
+          "refId": "L"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total YEDIS Ops / Sec -- Hash",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 437
+      },
+      "hiddenSeries": false,
+      "id": 124,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hget_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hget_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HGet",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmget_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmget_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HMGet",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hgetall_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hgetall_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HGetAll",
+          "refId": "C"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hkeys_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hkeys_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HKeys",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hvals_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hvals_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HVals",
+          "refId": "E"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hlen_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hlen_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HLen",
+          "refId": "F"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hexists_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hexists_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HExists",
+          "refId": "G"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hstrlen_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hstrlen_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HStrLen",
+          "refId": "H"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hset_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hset_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "HSet",
+          "refId": "I"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmset_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hmset_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HMSet",
+          "refId": "J"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hdel_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hdel_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HDel",
+          "refId": "K"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hincrby_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_hincrby_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "HIncrBy",
+          "refId": "L"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YEDIS Op Latency -- Hash",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 446
+      },
+      "hiddenSeries": false,
+      "id": 57,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsget_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "TsGet",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsadd_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "TsAdd",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrangebytime_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "TsRangeByTime",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrem_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "TsRem",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total YEDIS Ops / Sec -- TS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 446
+      },
+      "hiddenSeries": false,
+      "id": 85,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsget_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsget_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "TsGet",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsadd_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsadd_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "TsAdd",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrangebytime_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrangebytime_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "TsRangeByTime",
+          "refId": "C"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrem_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_tsrem_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "TsRem",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YEDIS Op Latency -- TS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 455
+      },
+      "hiddenSeries": false,
+      "id": 56,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_smembers_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SMembers",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sismember_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SIsMember",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_scard_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SCard",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sadd_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SAdd",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_srem_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "SRem",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total YEDIS Ops / Sec -- Set",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 455
+      },
+      "hiddenSeries": false,
+      "id": 59,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_smembers_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_smembers_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SMembers",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sismember_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sismember_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SIsMember",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_scard_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_scard_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "SCard",
+          "refId": "C"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sadd_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_sadd_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "SAdd",
+          "refId": "E"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_srem_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_srem_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "SRem",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YEDIS Op Latency -- Set",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 464
+      },
+      "hiddenSeries": false,
+      "id": 54,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zadd_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "ZAdd",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zrem_count\"}[5m]))",
+          "interval": "",
+          "legendFormat": "ZRem",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zcard_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "ZCard",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zrevrange_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "ZRangeByScore",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zrangebyscore_count\"}[5m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "ZRevRange",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total YEDIS Ops / Sec -- Sorted Set",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 464
+      },
+      "hiddenSeries": false,
+      "id": 58,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zadd_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zadd_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "ZAdd",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zrem_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zrem_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "ZRem",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zcard_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zcard_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "ZCard",
+          "refId": "C"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zrevrange_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zrevrange_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "ZRevRange",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zrangebyscore_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_zrangebyscore_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "ZRangeByScore",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YEDIS Op Latency -- Sorted Set",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 473
+      },
+      "hiddenSeries": false,
+      "id": 115,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_get_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Get",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mget_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MGet",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_exists_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Exists",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getrange_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetRange",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_set_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Set",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mset_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MSet",
+          "refId": "G"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getset_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "GetSet",
+          "refId": "H"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_append_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Append",
+          "refId": "I"
+        },
+        {
+          "expr": " sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_del_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Del",
+          "refId": "J"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_setrange_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "SetRange",
+          "refId": "K"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_incr_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Incr",
+          "refId": "L"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total YEDIS Ops / Sec -- Str",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 473
+      },
+      "hiddenSeries": false,
+      "id": 108,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_get_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_get_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Get",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mget_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mget_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "MGet",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_strlen_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "StrLen",
+          "refId": "C"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_exists_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_exists_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Exists",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getrange_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getrange_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "GetRange",
+          "refId": "E"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_set_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_set_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Set",
+          "refId": "F"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mset_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_mset_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "MSet",
+          "refId": "G"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getset_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_getset_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "GetSet",
+          "refId": "H"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_append_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_append_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Append",
+          "refId": "I"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_del_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_del_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Del",
+          "refId": "J"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_setrange_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_setrange_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "SetRange",
+          "refId": "K"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_incr_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_incr_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Incr",
+          "refId": "L"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YEDIS Op Latency -- Str",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 482
+      },
+      "hiddenSeries": false,
+      "id": 116,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_echo_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Echo",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_auth_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Auth",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_config_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Config",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_info_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Info",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_role_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Role",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_ping_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Ping",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_quit_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Quit",
+          "refId": "G"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_flushdb_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "FlushDB",
+          "refId": "H"
+        },
+        {
+          "expr": "sum(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_command_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Command",
+          "refId": "I"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total YEDIS Ops / Sec -- Others",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ops",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 482
+      },
+      "hiddenSeries": false,
+      "id": 76,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_echo_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_echo_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Echo",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_auth_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_auth_count\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Auth",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_config_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_config_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Config",
+          "refId": "C"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_info_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_info_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Info",
+          "refId": "D"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_role_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_role_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Role",
+          "refId": "E"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_ping_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_ping_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Ping",
+          "refId": "F"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_quit_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_quit_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Quit",
+          "refId": "G"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_flushdb_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_flushdb_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "FlushDB",
+          "refId": "H"
+        },
+        {
+          "expr": "avg(rate(rpc_latency_sum{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_command_sum\"}[5m])) / avg(rate(rpc_latency_count{node_prefix=\"$dbcluster\",saved_name=\"handler_latency_yb_redisserver_RedisServerService_command_count\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Command",
+          "refId": "I"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YEDIS Op Latency -- Others",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 491
+      },
+      "hiddenSeries": false,
+      "id": 70,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(rpcs_in_queue_yb_redisserver_RedisServerService{node_prefix=\"$dbcluster\"})",
+          "interval": "",
+          "legendFormat": "YEDIS RPC - Max",
+          "refId": "A"
+        },
+        {
+          "expr": "rpcs_in_queue_yb_redisserver_RedisServerService{node_prefix=\"$dbcluster\"}",
+          "interval": "",
+          "legendFormat": "YEDIS RPC - {{exported_instance}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "RPC queue sizes (YEDIS)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 491
+      },
+      "hiddenSeries": false,
+      "id": 75,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(rpc_incoming_queue_time_sum{node_prefix=\"$dbcluster\",export_type=\"redis_export\"}[5m])) / avg(irate(rpc_incoming_queue_time_count{node_prefix=\"$dbcluster\",export_type=\"redis_export\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Incoming Queue",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(irate(handler_latency_outbound_transfer_sum{node_prefix=\"$dbcluster\",export_type=\"redis_export\"}[5m])) / avg(irate(handler_latency_outbound_transfer_count{node_prefix=\"$dbcluster\",export_type=\"redis_export\"}[5m]))\r",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Outbound transfer time",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(irate(handler_latency_outbound_call_queue_time_sum{node_prefix=\"$dbcluster\",export_type=\"redis_export\"}[5m])) / avg(irate(handler_latency_outbound_call_queue_time_count{node_prefix=\"$dbcluster\",export_type=\"redis_export\"}[5m]))\r",
+          "interval": "",
+          "legendFormat": "Outbound queue time",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "YBClient Reactor Delays",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [
+    "YugabyteDB",
+    "yugabytedb",
+    "ysql",
+    "ycql",
+    "yedis"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(node_prefix)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "YugabyteDB Cluster",
+        "multi": false,
+        "name": "dbcluster",
+        "options": [],
+        "query": "label_values(node_prefix)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(up{node_prefix=\"$dbcluster\", export_type=\"master_export\"}, instance)",
+        "hide": 2,
+        "includeAll": true,
+        "label": "",
+        "multi": true,
+        "name": "master_node",
+        "options": [],
+        "query": "label_values(up{node_prefix=\"$dbcluster\", export_type=\"master_export\"}, instance)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(up{node_prefix=\"$dbcluster\", export_type=\"tserver_export\"}, instance)",
+        "hide": 2,
+        "includeAll": true,
+        "label": "",
+        "multi": true,
+        "name": "tserver_node",
+        "options": [],
+        "query": "label_values(up{node_prefix=\"$dbcluster\", export_type=\"tserver_export\"}, instance)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "YugabyteDB",
+  "uid": "1IGjQaiMk",
+  "version": 1
+}

--- a/deploy/services/tanka/prometheus_configs/k8s-endpoints.libsonnet
+++ b/deploy/services/tanka/prometheus_configs/k8s-endpoints.libsonnet
@@ -67,6 +67,104 @@
           target_label: 'pod_name',
           regex: '(cockroachdb-\\d+)',
         },
+        {
+          source_labels: [
+            '__meta_kubernetes_endpoints_label_app',
+          ],
+          regex: '(yb-.*)',
+          replacement: 'dss',
+          target_label: 'node_prefix',
+        },
+        {
+          source_labels: [
+            '__meta_kubernetes_endpoints_label_app',
+          ],
+          regex: '(yb-master.*)',
+          replacement: 'master_export',
+          target_label: 'export_type',
+        },
+        {
+          source_labels: [
+            '__meta_kubernetes_endpoints_label_app',
+          ],
+          regex: '(yb-master.*)',
+          replacement: 'yb-master',
+          target_label: 'group',
+        },
+        {
+          source_labels: [
+            '__meta_kubernetes_endpoints_label_app',
+          ],
+          regex: '(yb-tserver.*)',
+          replacement: 'tserver_export',
+          target_label: 'export_type',
+        },
+        {
+          source_labels: [
+            '__meta_kubernetes_endpoints_label_app',
+          ],
+          regex: '(yb-tserver.*)',
+          replacement: 'yb-tserver',
+          target_label: 'group',
+        },
+        {
+          source_labels: [
+            '__meta_kubernetes_endpoints_label_app',
+          ],
+          regex: '(yb-ysql.*)',
+          replacement: 'ysql_export',
+          target_label: 'export_type',
+        },
+        {
+          source_labels: [
+            '__meta_kubernetes_endpoints_label_app',
+          ],
+          regex: '(yb-ysql.*)',
+          replacement: 'ysql',
+          target_label: 'group',
+        },
+      ],
+      metric_relabel_configs: [
+        {
+          source_labels: [
+            '__name__',
+          ],
+          regex: "(.*)",
+          target_label: "saved_name",
+          replacement: "$1",
+        },
+        {
+          source_labels: [
+            '__name__',
+          ],
+          regex: "handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(.*)",
+          target_label: "server_type",
+          replacement: "$1",
+        },
+        {
+          source_labels: [
+            '__name__',
+          ],
+          regex: "handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(.*)",
+          target_label: "service_type",
+          replacement: "$2",
+        },
+        {
+          source_labels: [
+            '__name__',
+          ],
+          regex: "handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(_sum|_count)?",
+          target_label: "service_method",
+          replacement: "$3",
+        },
+        {
+          source_labels: [
+            '__name__',
+          ],
+          regex: "handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(_sum|_count)?",
+          target_label: "__name__",
+          replacement: "rpc_latency$4",
+        },
       ],
       tls_config: {
         insecure_skip_verify: true,

--- a/deploy/services/tanka/yugabyte-auxiliary.libsonnet
+++ b/deploy/services/tanka/yugabyte-auxiliary.libsonnet
@@ -193,6 +193,81 @@ local yugabyteLB(metadata, name, ip) =
           ],
         },
       },
+      individualMasters: {
+        ["master-" + i]: base.Service(metadata, 'yb-master-' + i) {
+          app:: 'yb-master-' + i,
+          metadata+: {
+            annotations+: {
+              'prometheus.io/scrape': 'true',
+              'prometheus.io/port': '7000',
+              'prometheus.io/path': 'prometheus-metrics',
+            },
+          },
+          spec+: {
+            selector: {
+              'app': "yb-master",
+              'apps.kubernetes.io/pod-index': std.toString(i),
+            },
+            clusterIP: "None",
+            ports: [
+              {
+                port: 7000,
+                name: 'http-ui',
+              },
+            ],
+          },
+        } for i in std.range(0, std.length(metadata.yugabyte.masterNodeIPs) - 1)
+      },
+      individualTServers: {
+        ["tserver-" + i]: base.Service(metadata, 'yb-tserver-' + i) {
+          app:: 'yb-tserver-' + i,
+          metadata+: {
+            annotations+: {
+              'prometheus.io/scrape': 'true',
+              'prometheus.io/port': '9000',
+              'prometheus.io/path': 'prometheus-metrics',
+            },
+          },
+          spec+: {
+            selector: {
+              'app': "yb-tserver",
+              'apps.kubernetes.io/pod-index': std.toString(i),
+            },
+            clusterIP: "None",
+            ports: [
+              {
+                port: 9000,
+                name: 'http-ui',
+              },
+            ],
+          },
+        } for i in std.range(0, std.length(metadata.yugabyte.masterNodeIPs) - 1)
+      },
+      individualTServersYsql: {
+        ["ysql-" + i]: base.Service(metadata, 'yb-ysql-' + i) {
+          app:: 'yb-ysql-' + i,
+          metadata+: {
+            annotations+: {
+              'prometheus.io/scrape': 'true',
+              'prometheus.io/port': '13000',
+              'prometheus.io/path': 'prometheus-metrics',
+            },
+          },
+          spec+: {
+            selector: {
+              'app': "yb-tserver",
+              'apps.kubernetes.io/pod-index': std.toString(i),
+            },
+            clusterIP: "None",
+            ports: [
+              {
+                port: 13000,
+                name: 'http-ysql-met',
+              },
+            ],
+          },
+        } for i in std.range(0, std.length(metadata.yugabyte.masterNodeIPs) - 1)
+      },
       NodeGateways: {
         ["gateway-" + i]: yugabyteLB(metadata, 'ybdb-ext-' + i, metadata.yugabyte.masterNodeIPs[i]) {
           metadata+: {


### PR DESCRIPTION
This PR add prometheus monitoring and grafana dashboard for yugabyte.

Grafana dashboard in the official one, coming from https://github.com/yugabyte/yugabyte-db/tree/master/cloud/grafana

New relabel configs are coming from Yugabyte doc.

New services have been added with relevant Prometheus annotations for automatic scapping from Prometheus.

Running a test suite against a deployed DSS seems to generate spikes in metrics as expected:

YSQL:
<img width="1160" height="559" alt="image" src="https://github.com/user-attachments/assets/96c4ce06-c953-4951-bfb1-f71cdd7b02c6" />

Tserver:
<img width="1155" height="534" alt="image" src="https://github.com/user-attachments/assets/56902389-00f2-4278-a36d-d79f0efcb164" />
