### PR TITLE
[helm] Switch grafana deployment strategy to Recreate

### DIFF
--- a/deploy/services/helm-charts/dss/values.yaml
+++ b/deploy/services/helm-charts/dss/values.yaml
@@ -278,3 +278,6 @@ grafana:
   persistence:
     type: pvc
     enabled: true
+
+  deploymentStrategy:
+    type: Recreate


### PR DESCRIPTION
Using the volume did prevent release, as volume is locked by existing grafana pod.

Fix #1346 