### PR TITLE
[tanka] Add checksum on yugabyte deployments

### DIFF
--- a/deploy/services/tanka/yugabyte.libsonnet
+++ b/deploy/services/tanka/yugabyte.libsonnet
@@ -53,6 +53,9 @@ local volumes = import 'volumes.libsonnet';
             labels+: {
               yugabytedUi: "true",
             },
+            annotations+: {
+              "checksum/config": std.native('sha256')(std.manifestJson(metadata.yugabyte)),
+            },
           },
           spec+: {
             affinity: {
@@ -376,6 +379,9 @@ local volumes = import 'volumes.libsonnet';
           metadata+: {
             labels+: {
               yugabytedUi: "true",
+            },
+            annotations+: {
+              "checksum/config": std.native('sha256')(std.manifestJson(metadata.yugabyte)),
             },
           },
           spec+: {


### PR DESCRIPTION
In tanka, changing config didn't redeploy services if changes are only in gflags.

This adds an annotation linked to the whole config, so a change trigger a redeployment (similar to the solution used in helm).

Fix #1344 