### PR TITLE
[tanka] Add anotations on grafana deployment to ensure redeployment on config changes

### DIFF
--- a/deploy/services/tanka/grafana.libsonnet
+++ b/deploy/services/tanka/grafana.libsonnet
@@ -78,6 +78,14 @@ local notifierConfig(metadata) = {
           },
         },
         template+: {
+          metadata+: {
+            annotations+: {
+              "checksum/datasource": std.native('sha256')(std.manifestJson(datasourcePrometheus(metadata))),
+              "checksum/dashboardConfig": std.native('sha256')(std.manifestJson(dashboardConfig)),
+              "checksum/dashboard": std.native('sha256')(std.manifestJson(dashboard.all(metadata).config)),
+              "checksum/notifierConfig": if metadata.alert.enable == true then std.native('sha256')(std.manifestJson(notifierConfig(metadata))) else "",
+            },
+          },
           spec: {
             containers: [
               {


### PR DESCRIPTION
Similar as #1350 , but for grafana.

Grafana helm chart already include checksum, the fix is for tanka only.