### PR TITLE
 [certificates] Fix CA copies for yugabyte 

### DIFF
--- a/deploy/operations/certificates-management/cluster.py
+++ b/deploy/operations/certificates-management/cluster.py
@@ -58,7 +58,7 @@ class Cluster(object):
 
     @property
     def client_ca(self):
-        return os.path.join(self.client_certs_dir, "root.crt")
+        return os.path.join(self.client_certs_dir, "ca.crt")
 
     @property
     def client_instance_ca(self):

--- a/deploy/operations/certificates-management/nodes.py
+++ b/deploy/operations/certificates-management/nodes.py
@@ -148,6 +148,8 @@ def generate_node(cluster, node_type, node_id):
     generate_node_csr(cluster, node_type, node_id)
     generate_node_cert(cluster, node_type, node_id)
 
+    shutil.copy(cluster.ca_pool_ca, getattr(cluster, f"{node_type}_ca"))
+
 
 l = logging.getLogger(__name__)
 


### PR DESCRIPTION
Follow #1354 

Fix two issues in CA copies for yugabyte certificate manager:

- CA for client was wrongly copied to 'root.crt'
- CA where not copied on generation of a node, affecting the presence of ca.crt when a new node is added
  - (Issue is not present on creation of a new certificate pool, just on existing ones) 