### PR TITLE
[auth] Change to jwt.RegisteredClaims, support multiple audiences

### DIFF
--- a/pkg/auth/claims/claims.go
+++ b/pkg/auth/claims/claims.go
@@ -91,7 +91,7 @@ func (s *ScopeSet) ToStringSlice() []string {
 }
 
 type Claims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	Scopes ScopeSet `json:"scope"`
 }
 
@@ -101,9 +101,9 @@ func (c *Claims) Valid() error {
 	}
 	now := Now()
 
-	c.VerifyExpiresAt(now.Unix(), true)
+	c.VerifyExpiresAt(now, true)
 
-	if c.ExpiresAt > now.Add(time.Hour).Unix() {
+	if c.ExpiresAt.After(now.Add(time.Hour)) {
 		return errTokenExpireTooFar
 	}
 
@@ -111,5 +111,5 @@ func (c *Claims) Valid() error {
 		return errMissingIssuer
 	}
 
-	return c.StandardClaims.Valid()
+	return c.RegisteredClaims.Valid()
 }


### PR DESCRIPTION
Fix #1335 by:

* Changing to `jwt.RegisteredClaims` (`jwt.StandardClaims` is deprecated)
* Add that at least one audience is valid.
* Fixes `.ExpiresAt` usage (type changed with new claims)
* Fixes base unit tests by adding an audience + test base cases (single audience, multiple audience, no audience)
* Add unit tests for all possible combinations of {0, 1, 2} audiences accepted and provided.

Notice that not configuring an accepted audience is going to make all queries rejected. Should it make any query, regardless of audiences accepted (with others validations still being done) ?

(Extra notice: no audience provided in the token is also going to make queries rejected)