### PR TITLE
[tooling] Enforce openapi scopes generator order

### DIFF
--- a/interfaces/openapi-to-go-server/apis.py
+++ b/interfaces/openapi-to-go-server/apis.py
@@ -59,7 +59,7 @@ class API:
         self.data_types = [dt for dt in self.data_types
                            if dt.name in required_data_types]
 
-    def security_scopes(self) -> Set[Tuple[str, operations.Scope]]:
+    def security_scopes(self) -> List[Tuple[str, operations.Scope]]:
         """Returns a set of unique security scopes used by this API.
 
         :return: set of unique tuples containing the authorization scheme and scope
@@ -70,7 +70,7 @@ class API:
             for scheme, scopes in so.option.items():
                 for scope in scopes:
                     scopes_set.add((scheme, scope))
-        return scopes_set
+        return sorted(scopes_set, key=lambda s: s[1].name)
 
 
 def make_api(package: str, api_path: str, spec: Dict) -> API:

--- a/pkg/api/auxv1/interface.gen.go
+++ b/pkg/api/auxv1/interface.gen.go
@@ -7,10 +7,10 @@ import (
 )
 
 var (
+	DssReadIdentificationServiceAreasScope  = api.RequiredScope("dss.read.identification_service_areas")
+	DssWriteIdentificationServiceAreasScope = api.RequiredScope("dss.write.identification_service_areas")
 	InterussPoolStatusHeartbeatWriteScope   = api.RequiredScope("interuss.pool_status.heartbeat.write")
 	InterussPoolStatusReadScope             = api.RequiredScope("interuss.pool_status.read")
-	DssWriteIdentificationServiceAreasScope = api.RequiredScope("dss.write.identification_service_areas")
-	DssReadIdentificationServiceAreasScope  = api.RequiredScope("dss.read.identification_service_areas")
 	GetVersionSecurity                      = []api.AuthorizationOption{}
 	ValidateOauthSecurity                   = []api.AuthorizationOption{
 		{

--- a/pkg/api/ridv2/interface.gen.go
+++ b/pkg/api/ridv2/interface.gen.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	RidServiceProviderScope                  = api.RequiredScope("rid.service_provider")
 	RidDisplayProviderScope                  = api.RequiredScope("rid.display_provider")
+	RidServiceProviderScope                  = api.RequiredScope("rid.service_provider")
 	SearchIdentificationServiceAreasSecurity = []api.AuthorizationOption{
 		{
 			"Authority": {RidDisplayProviderScope},

--- a/pkg/api/scdv1/interface.gen.go
+++ b/pkg/api/scdv1/interface.gen.go
@@ -8,10 +8,10 @@ import (
 
 var (
 	UtmAvailabilityArbitrationScope          = api.RequiredScope("utm.availability_arbitration")
-	UtmConstraintManagementScope             = api.RequiredScope("utm.constraint_management")
 	UtmConformanceMonitoringSaScope          = api.RequiredScope("utm.conformance_monitoring_sa")
-	UtmStrategicCoordinationScope            = api.RequiredScope("utm.strategic_coordination")
+	UtmConstraintManagementScope             = api.RequiredScope("utm.constraint_management")
 	UtmConstraintProcessingScope             = api.RequiredScope("utm.constraint_processing")
+	UtmStrategicCoordinationScope            = api.RequiredScope("utm.strategic_coordination")
 	QueryOperationalIntentReferencesSecurity = []api.AuthorizationOption{
 		{
 			"Authority": {UtmStrategicCoordinationScope},


### PR DESCRIPTION
The `openapi-to-go-server` return a unordered set of scopes, meaning that we get random unrelated changes everytime we build the API.

(Example: https://github.com/interuss/dss/pull/1363/changes/de42be09c471319408a3dff39b5d78b50a52cab0#diff-bb21552cc2d287b0949b37cae5b6dcf993eae2b0ca31a1e0e63f0dca8fbcd606L10 )

This PR enforce sorting to ensure stable generation of interface files.