### PR TITLE
[certificates-management] Fix initialization order

### DIFF
--- a/deploy/operations/certificates-management/init.py
+++ b/deploy/operations/certificates-management/init.py
@@ -223,12 +223,13 @@ def do_init(cluster):
 
     make_directories(cluster)
     generate_ca(cluster)
-    generate_clients(cluster)
-
-    do_generate_nodes(cluster)
 
     with open(cluster.ca_cert_file, "r") as f:
         do_add_cas(cluster, f.read())
+
+    generate_clients(cluster)
+
+    do_generate_nodes(cluster)
 
     l.info(
         "The new cluster certificates are ready! Don't forget to 'apply' the configuration."


### PR DESCRIPTION
The certificate-management tool was broken when initializing a new cluster dues to a wrong order.

That not the first time that changes have side effect, I created #1371 to have better testing and avoid future issues.
