### PR TITLE
[yugabyte] Fix ca path

### DIFF
--- a/deploy/services/helm-charts/dss/templates/_volumes.tpl
+++ b/deploy/services/helm-charts/dss/templates/_volumes.tpl
@@ -12,7 +12,7 @@
 {{ else }}
 - mountPath: /opt/yugabyte-certs/ca.crt
   name: ca-certs
-  subPath: root.crt
+  subPath: ca.crt
 - mountPath: /opt/yugabyte-certs/ca-instance.crt
   name: ca-certs
   subPath: ca-instance.crt

--- a/deploy/services/tanka/volumes.libsonnet
+++ b/deploy/services/tanka/volumes.libsonnet
@@ -110,7 +110,7 @@ local util = import 'util.libsonnet';
         ca_certs: [{
           name: 'ca-certs',
           mountPath: '/opt/yugabyte-certs/ca.crt',
-          subPath: 'root.crt',
+          subPath: 'ca.crt',
         }, {
           name: 'ca-certs',
           mountPath: '/opt/yugabyte-certs/ca-instance.crt',

--- a/deploy/services/tanka/yugabyte.libsonnet
+++ b/deploy/services/tanka/yugabyte.libsonnet
@@ -490,7 +490,7 @@ local volumes = import 'volumes.libsonnet';
                   value: "/mnt/disk0/cores",
                 }, {
                   name: 'SSL_CERTFILE',
-                  value: "/root/.yugabytedb/root.crt",
+                  value: "/root/.yugabytedb/ca.crt",
                 }],
                 livenessProbe: {
                   exec: {


### PR DESCRIPTION
Old value was still used and gone unnoticed as working with old workspaces.

Tested in a helm-tanka cluster, with fresh certificate store.