### PR TITLE
[scd] Validate Volume4D when parsing

### DIFF
--- a/pkg/models/scd_conversions.go
+++ b/pkg/models/scd_conversions.go
@@ -7,38 +7,63 @@ import (
 	"github.com/interuss/stacktrace"
 )
 
+type Volume4DOpts struct {
+	RequireAltitudeBounds bool
+	RequireTimeBounds     bool
+}
+
+func (opts *Volume4DOpts) to3DOpts() Volume3DOpts {
+	return Volume3DOpts{
+		RequireAltitudeBounds: opts.RequireAltitudeBounds,
+	}
+}
+
 // Volume4DFromSCDRest converts vol4 SCD v1 REST model to a Volume4D
-func Volume4DFromSCDRest(vol4 *restapi.Volume4D) (*Volume4D, error) {
-	vol3, err := Volume3DFromSCDRest(&vol4.Volume)
+func Volume4DFromSCDRest(vol4 *restapi.Volume4D, opts Volume4DOpts) (*Volume4D, error) {
+	vol3, err := Volume3DFromSCDRest(&vol4.Volume, opts.to3DOpts())
 	if err != nil {
 		return nil, err // No need to Propagate this error as this stack layer does not add useful information
 	}
 
-	result := &Volume4D{
-		SpatialVolume: vol3,
-	}
-
+	var startTime *time.Time
 	if vol4.TimeStart != nil {
 		ts, err := time.Parse(time.RFC3339Nano, vol4.TimeStart.Value)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "Error converting start time")
 		}
-		result.StartTime = &ts
+		startTime = &ts
+	} else if opts.RequireTimeBounds {
+		return nil, stacktrace.NewError("Missing start time")
 	}
 
+	var endTime *time.Time
 	if vol4.TimeEnd != nil {
 		ts, err := time.Parse(time.RFC3339Nano, vol4.TimeEnd.Value)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "Error converting end time")
 		}
-		result.EndTime = &ts
+		endTime = &ts
+	} else if opts.RequireTimeBounds {
+		return nil, stacktrace.NewError("Missing end time")
 	}
 
-	return result, nil
+	if startTime != nil && endTime != nil && startTime.After(*endTime) {
+		return nil, stacktrace.NewError("Start time cannot be after end time")
+	}
+
+	return &Volume4D{
+		SpatialVolume: vol3,
+		StartTime:     startTime,
+		EndTime:       endTime,
+	}, nil
+}
+
+type Volume3DOpts struct {
+	RequireAltitudeBounds bool
 }
 
 // Volume3DFromSCDRest converts a vol3 SCD v1 REST model to a Volume3D
-func Volume3DFromSCDRest(vol3 *restapi.Volume3D) (*Volume3D, error) {
+func Volume3DFromSCDRest(vol3 *restapi.Volume3D, opts Volume3DOpts) (*Volume3D, error) {
 	if vol3 == nil {
 		return nil, nil
 	}
@@ -52,6 +77,8 @@ func Volume3DFromSCDRest(vol3 *restapi.Volume3D) (*Volume3D, error) {
 			return nil, stacktrace.NewError("Invalid lower altitude reference")
 		}
 		altLo = float32p(float32(vol3.AltitudeLower.Value))
+	} else if opts.RequireAltitudeBounds {
+		return nil, stacktrace.NewError("Missing lower altitude")
 	}
 
 	var altHi *float32
@@ -63,6 +90,12 @@ func Volume3DFromSCDRest(vol3 *restapi.Volume3D) (*Volume3D, error) {
 			return nil, stacktrace.NewError("Invalid upper altitude reference")
 		}
 		altHi = float32p(float32(vol3.AltitudeUpper.Value))
+	} else if opts.RequireAltitudeBounds {
+		return nil, stacktrace.NewError("Missing upper altitude")
+	}
+
+	if altLo != nil && altHi != nil && *altLo > *altHi {
+		return nil, stacktrace.NewError("Lower altitude cannot be greater than upper altitude")
 	}
 
 	switch {

--- a/pkg/models/scd_conversions.go
+++ b/pkg/models/scd_conversions.go
@@ -23,10 +23,6 @@ func WithRequireTimeBounds() Volume4DValidator {
 
 func WithRequireAltitudeBounds() Volume4DValidator {
 	return func(v *Volume4D) error {
-		if v.SpatialVolume == nil {
-			return nil
-		}
-
 		if v.SpatialVolume.AltitudeLo == nil {
 			return stacktrace.NewError("Missing lower altitude")
 		}

--- a/pkg/models/scd_conversions.go
+++ b/pkg/models/scd_conversions.go
@@ -7,20 +7,39 @@ import (
 	"github.com/interuss/stacktrace"
 )
 
-type Volume4DOpts struct {
-	RequireAltitudeBounds bool
-	RequireTimeBounds     bool
+type Volume4DValidator func(*Volume4D) error
+
+func WithRequireTimeBounds() Volume4DValidator {
+	return func(v *Volume4D) error {
+		if v.StartTime == nil {
+			return stacktrace.NewError("Missing start time")
+		}
+		if v.EndTime == nil {
+			return stacktrace.NewError("Missing end time")
+		}
+		return nil
+	}
 }
 
-func (opts *Volume4DOpts) to3DOpts() Volume3DOpts {
-	return Volume3DOpts{
-		RequireAltitudeBounds: opts.RequireAltitudeBounds,
+func WithRequireAltitudeBounds() Volume4DValidator {
+	return func(v *Volume4D) error {
+		if v.SpatialVolume == nil {
+			return nil
+		}
+
+		if v.SpatialVolume.AltitudeLo == nil {
+			return stacktrace.NewError("Missing lower altitude")
+		}
+		if v.SpatialVolume.AltitudeHi == nil {
+			return stacktrace.NewError("Missing upper altitude")
+		}
+		return nil
 	}
 }
 
 // Volume4DFromSCDRest converts vol4 SCD v1 REST model to a Volume4D
-func Volume4DFromSCDRest(vol4 *restapi.Volume4D, opts Volume4DOpts) (*Volume4D, error) {
-	vol3, err := Volume3DFromSCDRest(&vol4.Volume, opts.to3DOpts())
+func Volume4DFromSCDRest(vol4 *restapi.Volume4D, validators ...Volume4DValidator) (*Volume4D, error) {
+	vol3, err := Volume3DFromSCDRest(&vol4.Volume)
 	if err != nil {
 		return nil, err // No need to Propagate this error as this stack layer does not add useful information
 	}
@@ -32,8 +51,6 @@ func Volume4DFromSCDRest(vol4 *restapi.Volume4D, opts Volume4DOpts) (*Volume4D, 
 			return nil, stacktrace.Propagate(err, "Error converting start time")
 		}
 		startTime = &ts
-	} else if opts.RequireTimeBounds {
-		return nil, stacktrace.NewError("Missing start time")
 	}
 
 	var endTime *time.Time
@@ -43,27 +60,29 @@ func Volume4DFromSCDRest(vol4 *restapi.Volume4D, opts Volume4DOpts) (*Volume4D, 
 			return nil, stacktrace.Propagate(err, "Error converting end time")
 		}
 		endTime = &ts
-	} else if opts.RequireTimeBounds {
-		return nil, stacktrace.NewError("Missing end time")
 	}
 
 	if startTime != nil && endTime != nil && startTime.After(*endTime) {
 		return nil, stacktrace.NewError("Start time cannot be after end time")
 	}
 
-	return &Volume4D{
+	volume := &Volume4D{
 		SpatialVolume: vol3,
 		StartTime:     startTime,
 		EndTime:       endTime,
-	}, nil
-}
+	}
 
-type Volume3DOpts struct {
-	RequireAltitudeBounds bool
+	for _, validator := range validators {
+		if err := validator(volume); err != nil {
+			return nil, err
+		}
+	}
+
+	return volume, nil
 }
 
 // Volume3DFromSCDRest converts a vol3 SCD v1 REST model to a Volume3D
-func Volume3DFromSCDRest(vol3 *restapi.Volume3D, opts Volume3DOpts) (*Volume3D, error) {
+func Volume3DFromSCDRest(vol3 *restapi.Volume3D) (*Volume3D, error) {
 	if vol3 == nil {
 		return nil, nil
 	}
@@ -77,8 +96,6 @@ func Volume3DFromSCDRest(vol3 *restapi.Volume3D, opts Volume3DOpts) (*Volume3D, 
 			return nil, stacktrace.NewError("Invalid lower altitude reference")
 		}
 		altLo = float32p(float32(vol3.AltitudeLower.Value))
-	} else if opts.RequireAltitudeBounds {
-		return nil, stacktrace.NewError("Missing lower altitude")
 	}
 
 	var altHi *float32
@@ -90,8 +107,6 @@ func Volume3DFromSCDRest(vol3 *restapi.Volume3D, opts Volume3DOpts) (*Volume3D, 
 			return nil, stacktrace.NewError("Invalid upper altitude reference")
 		}
 		altHi = float32p(float32(vol3.AltitudeUpper.Value))
-	} else if opts.RequireAltitudeBounds {
-		return nil, stacktrace.NewError("Missing upper altitude")
 	}
 
 	if altLo != nil && altHi != nil && *altLo > *altHi {

--- a/pkg/models/scd_conversions_test.go
+++ b/pkg/models/scd_conversions_test.go
@@ -1,0 +1,179 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	restapi "github.com/interuss/dss/pkg/api/scdv1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVolume4DFromSCDRest(t *testing.T) {
+	start := time.Date(2024, time.December, 15, 15, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	timeStart := restapi.Time{Value: start.Format(time.RFC3339), Format: TimeFormatRFC3339}
+	timeEnd := restapi.Time{Value: end.Format(time.RFC3339), Format: TimeFormatRFC3339}
+	invalid := restapi.Time{Value: start.Format(time.ANSIC)}
+	testCases := []struct {
+		name    string
+		opts    Volume4DOpts
+		rest    *restapi.Volume4D
+		want    *Volume4D
+		wantErr bool
+	}{
+		{
+			name: "Empty",
+			rest: &restapi.Volume4D{},
+			want: &Volume4D{SpatialVolume: &Volume3D{}},
+		},
+		{
+			name: "Times",
+			opts: Volume4DOpts{RequireTimeBounds: true},
+			rest: &restapi.Volume4D{TimeStart: &timeStart, TimeEnd: &timeEnd},
+			want: &Volume4D{
+				SpatialVolume: &Volume3D{},
+				StartTime:     &start,
+				EndTime:       &end,
+			},
+		},
+		{
+			name:    "InvalidTimeStart",
+			rest:    &restapi.Volume4D{TimeStart: &invalid},
+			wantErr: true,
+		},
+		{
+			name:    "InvalidTimeEnd",
+			rest:    &restapi.Volume4D{TimeEnd: &invalid},
+			wantErr: true,
+		},
+		{
+			name:    "TimeStartAfterTimeEnd",
+			rest:    &restapi.Volume4D{TimeStart: &timeEnd, TimeEnd: &timeStart},
+			wantErr: true,
+		},
+		{
+			name:    "MissingTimeStart",
+			opts:    Volume4DOpts{RequireTimeBounds: true},
+			rest:    &restapi.Volume4D{TimeEnd: &timeEnd},
+			wantErr: true,
+		},
+		{
+			name:    "MissingTimeEnd",
+			opts:    Volume4DOpts{RequireTimeBounds: true},
+			rest:    &restapi.Volume4D{TimeStart: &timeStart},
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, err := Volume4DFromSCDRest(testCase.rest, testCase.opts)
+			if testCase.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, testCase.want, actual)
+			}
+		})
+	}
+}
+
+func TestVolume3DFromSCDRest(t *testing.T) {
+	lower := restapi.Altitude{
+		Value:     100.0,
+		Reference: ReferenceW84,
+		Units:     UnitsM,
+	}
+	lo := float32(100.0)
+	upper := restapi.Altitude{
+		Value:     200.0,
+		Reference: ReferenceW84,
+		Units:     UnitsM,
+	}
+	hi := float32(200.0)
+	invalid := restapi.Altitude{Value: 0}
+
+	testCases := []struct {
+		name    string
+		opts    Volume3DOpts
+		rest    *restapi.Volume3D
+		want    *Volume3D
+		wantErr bool
+	}{
+		{
+			name: "Empty",
+			rest: &restapi.Volume3D{},
+			want: &Volume3D{},
+		},
+		{
+			name: "Polygon",
+			rest: &restapi.Volume3D{
+				OutlinePolygon: &restapi.Polygon{},
+			},
+			want: &Volume3D{
+				Footprint: &GeoPolygon{},
+			},
+		},
+		{
+			name: "Circle",
+			rest: &restapi.Volume3D{
+				OutlineCircle: &restapi.Circle{
+					Center: &restapi.LatLngPoint{},
+					Radius: &restapi.Radius{},
+				},
+			},
+			want: &Volume3D{
+				Footprint: &GeoCircle{},
+			},
+		},
+		{
+			name: "Altitudes",
+			rest: &restapi.Volume3D{AltitudeLower: &lower, AltitudeUpper: &upper},
+			opts: Volume3DOpts{RequireAltitudeBounds: true},
+			want: &Volume3D{AltitudeLo: &lo, AltitudeHi: &hi},
+		},
+		{
+			name:    "InvalidLowerAltitude",
+			rest:    &restapi.Volume3D{AltitudeLower: &invalid},
+			wantErr: true,
+		},
+		{
+			name:    "InvalidUpperAltitude",
+			rest:    &restapi.Volume3D{AltitudeUpper: &invalid},
+			wantErr: true,
+		},
+		{
+			name:    "LowerAltitudeGreaterThanUpperAltitude",
+			rest:    &restapi.Volume3D{AltitudeLower: &upper, AltitudeUpper: &lower},
+			wantErr: true,
+		},
+		{
+			name:    "MissingLowerAltitude",
+			opts:    Volume3DOpts{RequireAltitudeBounds: true},
+			rest:    &restapi.Volume3D{AltitudeUpper: &upper},
+			wantErr: true,
+		},
+		{
+			name:    "MissingUpperAltitude",
+			opts:    Volume3DOpts{RequireAltitudeBounds: true},
+			rest:    &restapi.Volume3D{AltitudeLower: &lower},
+			wantErr: true,
+		},
+		{
+			name:    "MuiltiGeom",
+			rest:    &restapi.Volume3D{OutlineCircle: &restapi.Circle{}, OutlinePolygon: &restapi.Polygon{}},
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, err := Volume3DFromSCDRest(testCase.rest, testCase.opts)
+			if testCase.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, testCase.want, actual)
+			}
+		})
+	}
+}

--- a/pkg/models/scd_conversions_test.go
+++ b/pkg/models/scd_conversions_test.go
@@ -14,13 +14,17 @@ func TestVolume4DFromSCDRest(t *testing.T) {
 
 	timeStart := restapi.Time{Value: start.Format(time.RFC3339), Format: TimeFormatRFC3339}
 	timeEnd := restapi.Time{Value: end.Format(time.RFC3339), Format: TimeFormatRFC3339}
-	invalid := restapi.Time{Value: start.Format(time.ANSIC)}
+	timeInvalid := restapi.Time{Value: start.Format(time.ANSIC)}
+	altLower := restapi.Altitude{Value: 100.0, Reference: ReferenceW84, Units: UnitsM}
+	altLo := float32(100.0)
+	altUpper := restapi.Altitude{Value: 200.0, Reference: ReferenceW84, Units: UnitsM}
+	altHi := float32(200.0)
 	testCases := []struct {
-		name    string
-		opts    Volume4DOpts
-		rest    *restapi.Volume4D
-		want    *Volume4D
-		wantErr bool
+		name       string
+		validators []Volume4DValidator
+		rest       *restapi.Volume4D
+		want       *Volume4D
+		wantErr    bool
 	}{
 		{
 			name: "Empty",
@@ -28,9 +32,9 @@ func TestVolume4DFromSCDRest(t *testing.T) {
 			want: &Volume4D{SpatialVolume: &Volume3D{}},
 		},
 		{
-			name: "Times",
-			opts: Volume4DOpts{RequireTimeBounds: true},
-			rest: &restapi.Volume4D{TimeStart: &timeStart, TimeEnd: &timeEnd},
+			name:       "Times",
+			validators: []Volume4DValidator{WithRequireTimeBounds()},
+			rest:       &restapi.Volume4D{TimeStart: &timeStart, TimeEnd: &timeEnd},
 			want: &Volume4D{
 				SpatialVolume: &Volume3D{},
 				StartTime:     &start,
@@ -39,12 +43,12 @@ func TestVolume4DFromSCDRest(t *testing.T) {
 		},
 		{
 			name:    "InvalidTimeStart",
-			rest:    &restapi.Volume4D{TimeStart: &invalid},
+			rest:    &restapi.Volume4D{TimeStart: &timeInvalid},
 			wantErr: true,
 		},
 		{
 			name:    "InvalidTimeEnd",
-			rest:    &restapi.Volume4D{TimeEnd: &invalid},
+			rest:    &restapi.Volume4D{TimeEnd: &timeInvalid},
 			wantErr: true,
 		},
 		{
@@ -53,22 +57,40 @@ func TestVolume4DFromSCDRest(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "MissingTimeStart",
-			opts:    Volume4DOpts{RequireTimeBounds: true},
-			rest:    &restapi.Volume4D{TimeEnd: &timeEnd},
-			wantErr: true,
+			name:       "MissingTimeStart",
+			validators: []Volume4DValidator{WithRequireTimeBounds()},
+			rest:       &restapi.Volume4D{TimeEnd: &timeEnd},
+			wantErr:    true,
 		},
 		{
-			name:    "MissingTimeEnd",
-			opts:    Volume4DOpts{RequireTimeBounds: true},
-			rest:    &restapi.Volume4D{TimeStart: &timeStart},
-			wantErr: true,
+			name:       "MissingTimeEnd",
+			validators: []Volume4DValidator{WithRequireTimeBounds()},
+			rest:       &restapi.Volume4D{TimeStart: &timeStart},
+			wantErr:    true,
+		},
+		{
+			name:       "Altitude",
+			validators: []Volume4DValidator{WithRequireAltitudeBounds()},
+			rest:       &restapi.Volume4D{Volume: restapi.Volume3D{AltitudeLower: &altLower, AltitudeUpper: &altUpper}},
+			want:       &Volume4D{SpatialVolume: &Volume3D{AltitudeLo: &altLo, AltitudeHi: &altHi}},
+		},
+		{
+			name:       "MissingLowerAltitude",
+			validators: []Volume4DValidator{WithRequireAltitudeBounds()},
+			rest:       &restapi.Volume4D{Volume: restapi.Volume3D{AltitudeUpper: &altUpper}},
+			wantErr:    true,
+		},
+		{
+			name:       "MissingUpperAltitude",
+			validators: []Volume4DValidator{WithRequireAltitudeBounds()},
+			rest:       &restapi.Volume4D{Volume: restapi.Volume3D{AltitudeLower: &altLower}},
+			wantErr:    true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual, err := Volume4DFromSCDRest(testCase.rest, testCase.opts)
+			actual, err := Volume4DFromSCDRest(testCase.rest, testCase.validators...)
 			if testCase.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -79,23 +101,14 @@ func TestVolume4DFromSCDRest(t *testing.T) {
 }
 
 func TestVolume3DFromSCDRest(t *testing.T) {
-	lower := restapi.Altitude{
-		Value:     100.0,
-		Reference: ReferenceW84,
-		Units:     UnitsM,
-	}
+	lower := restapi.Altitude{Value: 100.0, Reference: ReferenceW84, Units: UnitsM}
 	lo := float32(100.0)
-	upper := restapi.Altitude{
-		Value:     200.0,
-		Reference: ReferenceW84,
-		Units:     UnitsM,
-	}
+	upper := restapi.Altitude{Value: 200.0, Reference: ReferenceW84, Units: UnitsM}
 	hi := float32(200.0)
 	invalid := restapi.Altitude{Value: 0}
 
 	testCases := []struct {
 		name    string
-		opts    Volume3DOpts
 		rest    *restapi.Volume3D
 		want    *Volume3D
 		wantErr bool
@@ -129,7 +142,6 @@ func TestVolume3DFromSCDRest(t *testing.T) {
 		{
 			name: "Altitudes",
 			rest: &restapi.Volume3D{AltitudeLower: &lower, AltitudeUpper: &upper},
-			opts: Volume3DOpts{RequireAltitudeBounds: true},
 			want: &Volume3D{AltitudeLo: &lo, AltitudeHi: &hi},
 		},
 		{
@@ -148,18 +160,6 @@ func TestVolume3DFromSCDRest(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "MissingLowerAltitude",
-			opts:    Volume3DOpts{RequireAltitudeBounds: true},
-			rest:    &restapi.Volume3D{AltitudeUpper: &upper},
-			wantErr: true,
-		},
-		{
-			name:    "MissingUpperAltitude",
-			opts:    Volume3DOpts{RequireAltitudeBounds: true},
-			rest:    &restapi.Volume3D{AltitudeLower: &lower},
-			wantErr: true,
-		},
-		{
 			name:    "MuiltiGeom",
 			rest:    &restapi.Volume3D{OutlineCircle: &restapi.Circle{}, OutlinePolygon: &restapi.Polygon{}},
 			wantErr: true,
@@ -168,7 +168,7 @@ func TestVolume3DFromSCDRest(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual, err := Volume3DFromSCDRest(testCase.rest, testCase.opts)
+			actual, err := Volume3DFromSCDRest(testCase.rest)
 			if testCase.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/scd/constraints_handler.go
+++ b/pkg/scd/constraints_handler.go
@@ -418,8 +418,7 @@ func validateAndReturnConstraintUpsertParams(
 	valid.extents = make([]*dssmodels.Volume4D, len(params.Extents))
 	for idx, extent := range params.Extents {
 		// Start and end times are required for each volume
-		opts := dssmodels.Volume4DOpts{RequireTimeBounds: true}
-		cExtent, err := dssmodels.Volume4DFromSCDRest(&extent, opts)
+		cExtent, err := dssmodels.Volume4DFromSCDRest(&extent, dssmodels.WithRequireTimeBounds())
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "Failed to parse extent %d", idx)
 		}
@@ -465,7 +464,7 @@ func (a *Server) QueryConstraintReferences(ctx context.Context, req *restapi.Que
 	}
 
 	// Parse area of interest to common Volume4D
-	vol4, err := dssmodels.Volume4DFromSCDRest(aoi, dssmodels.Volume4DOpts{})
+	vol4, err := dssmodels.Volume4DFromSCDRest(aoi)
 	if err != nil {
 		return restapi.QueryConstraintReferencesResponseSet{Response400: &restapi.ErrorResponse{
 			Message: dsserr.Handle(ctx, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Failed to convert to internal geometry model"))}}

--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -267,7 +267,7 @@ func (a *Server) QueryOperationalIntentReferences(ctx context.Context, req *rest
 	}
 
 	// Parse area of interest to common Volume4D
-	vol4, err := dssmodels.Volume4DFromSCDRest(aoi, dssmodels.Volume4DOpts{})
+	vol4, err := dssmodels.Volume4DFromSCDRest(aoi)
 	if err != nil {
 		return restapi.QueryOperationalIntentReferencesResponseSet{Response400: &restapi.ErrorResponse{
 			Message: dsserr.Handle(ctx, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Error parsing geometry"))}}
@@ -506,8 +506,7 @@ func validateAndReturnOIRUpsertParams(
 	valid.extents = make([]*dssmodels.Volume4D, len(params.Extents))
 	for idx, extent := range params.Extents {
 		// Start and end times, as well as lower and upper altitudes, are required for each volume
-		opts := dssmodels.Volume4DOpts{RequireAltitudeBounds: true, RequireTimeBounds: true}
-		cExtent, err := dssmodels.Volume4DFromSCDRest(&extent, opts)
+		cExtent, err := dssmodels.Volume4DFromSCDRest(&extent, dssmodels.WithRequireTimeBounds(), dssmodels.WithRequireAltitudeBounds())
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "Failed to parse extent %d", idx)
 		}

--- a/pkg/scd/subscriptions_handler.go
+++ b/pkg/scd/subscriptions_handler.go
@@ -112,7 +112,9 @@ func (a *Server) PutSubscription(ctx context.Context, manager string, subscripti
 	}
 
 	// Parse extents
-	extents, err := dssmodels.Volume4DFromSCDRest(&params.Extents)
+	// If end time is not specified, the value will be chosen automatically by the DSS.
+	// If start time is not specified, it will default to the time the request is processed.
+	extents, err := dssmodels.Volume4DFromSCDRest(&params.Extents, dssmodels.Volume4DOpts{})
 	if err != nil {
 		return nil, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Unable to parse extents")
 	}
@@ -396,7 +398,7 @@ func (a *Server) QuerySubscriptions(ctx context.Context, req *restapi.QuerySubsc
 	}
 
 	// Parse area of interest to common Volume4D
-	vol4, err := dssmodels.Volume4DFromSCDRest(aoi)
+	vol4, err := dssmodels.Volume4DFromSCDRest(aoi, dssmodels.Volume4DOpts{})
 	if err != nil {
 		return restapi.QuerySubscriptionsResponseSet{Response400: &restapi.ErrorResponse{
 			Message: dsserr.Handle(ctx, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Failed to convert to internal geometry model"))}}

--- a/pkg/scd/subscriptions_handler.go
+++ b/pkg/scd/subscriptions_handler.go
@@ -114,7 +114,7 @@ func (a *Server) PutSubscription(ctx context.Context, manager string, subscripti
 	// Parse extents
 	// If end time is not specified, the value will be chosen automatically by the DSS.
 	// If start time is not specified, it will default to the time the request is processed.
-	extents, err := dssmodels.Volume4DFromSCDRest(&params.Extents, dssmodels.Volume4DOpts{})
+	extents, err := dssmodels.Volume4DFromSCDRest(&params.Extents)
 	if err != nil {
 		return nil, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Unable to parse extents")
 	}
@@ -398,7 +398,7 @@ func (a *Server) QuerySubscriptions(ctx context.Context, req *restapi.QuerySubsc
 	}
 
 	// Parse area of interest to common Volume4D
-	vol4, err := dssmodels.Volume4DFromSCDRest(aoi, dssmodels.Volume4DOpts{})
+	vol4, err := dssmodels.Volume4DFromSCDRest(aoi)
 	if err != nil {
 		return restapi.QuerySubscriptionsResponseSet{Response400: &restapi.ErrorResponse{
 			Message: dsserr.Handle(ctx, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Failed to convert to internal geometry model"))}}


### PR DESCRIPTION
Factorize validation for `Volume3D` and `Volume4D` during parsing:
- Ensure `startTime` < `endTime` when defined
- Ensure `altLo` < `altHi` when defined

Introduce parsing options to tune validation:
- Ensure `altLo` and `altHi` set when `RequireAltitudeBounds` enabled
- Ensure `startTime` ans `endTime` set when `RequireTimeBounds` enabled

Configuration options for SCD entities mutation:
- op-intent:  `RequireTimeBounds: true, RequireAltitudeBounds: true`
- constraints: `RequireTimeBounds: true, RequireAltitudeBounds: false`
- subscriptions: `RequireTimeBounds: false, RequireAltitudeBounds: false`

For SCD queries: `RequireTimeBounds: false, RequireAltitudeBounds: false`
