### PR TITLE
[yugabyte] Fix migrations

### DIFF
--- a/build/db_schemas/yugabyte/scd/downfrom-v1.1.0-remove_locks.sql
+++ b/build/db_schemas/yugabyte/scd/downfrom-v1.1.0-remove_locks.sql
@@ -1,3 +1,3 @@
 DROP TABLE IF EXISTS scd_locks;
 
-UPDATE schema_versions set schema_version = 'v1.0.0' WHERE onerow_enforcer = TRUE;
+UPDATE schema_versions set schema_version = 'v1.0.1' WHERE onerow_enforcer = TRUE;


### PR DESCRIPTION
#1363 had a mistake in the yugabyte down migration, that has been merged in parallel from #1376 that introduced database tests.

This PR fix the issue with the down migration to make master's CI check green again.