### PR TITLE
[certificate-management] Use shot name for common name

### DIFF
--- a/deploy/operations/certificates-management/nodes.py
+++ b/deploy/operations/certificates-management/nodes.py
@@ -25,7 +25,7 @@ distinguished_name = my_distinguished_name
 
 [ my_distinguished_name ]
 organizationName = {cluster.organization}
-commonName = {full_name}
+commonName = {short_name}
 
 # Multiple subject alternative names (SANs) such as IP Address,
 # DNS Name, Email, URI, and so on, can be specified under this section


### PR DESCRIPTION
Certificate generation may fail depending on the length of the `full_name` for certificate.

This switch to use the `short_name` instead.

All names are stored in `alt_names`, so this have no practical change.

Tested in a two-organization yugabyte cluster, peering was successful.