### PR TITLE
[tanka] Fix cockroachdb init

### DIFF
--- a/deploy/services/tanka/cockroachdb-auxiliary.libsonnet
+++ b/deploy/services/tanka/cockroachdb-auxiliary.libsonnet
@@ -44,7 +44,9 @@ local cockroachLB(metadata, name, ip) =
               args_:: {
                 'certs-dir': '/cockroach/cockroach-certs',
                 host: 'cockroachdb-0.cockroachdb.' + metadata.namespace,
-              },
+              } + if metadata.cockroach.clusterName != "" then {
+                'cluster-name': metadata.cockroach.clusterName,
+              } else {},
               volumeMounts: volumes.all(metadata).mounts.caCert + volumes.all(metadata).mounts.clientCert,
             },
           },


### PR DESCRIPTION
Init job for CockroachDB was not having `cluster-name` argument set, making deploy fail for new cluster using tanka.

Tested when deploying a new CRDB cluster.