### PR TITLE
 [openapi-to-go-server] Fix old TODO for go >1.17 

### DIFF
--- a/interfaces/openapi-to-go-server/example/api/rid/interface.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/rid/interface.gen.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	DssWriteIdentificationServiceAreasScope  = api.RequiredScope("dss.write.identification_service_areas")
 	DssReadIdentificationServiceAreasScope   = api.RequiredScope("dss.read.identification_service_areas")
+	DssWriteIdentificationServiceAreasScope  = api.RequiredScope("dss.write.identification_service_areas")
 	SearchIdentificationServiceAreasSecurity = []api.AuthorizationOption{
 		{
 			"AuthFromAuthorizationAuthority": {DssReadIdentificationServiceAreasScope},

--- a/interfaces/openapi-to-go-server/example/api/rid/server.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/rid/server.gen.go
@@ -34,16 +34,15 @@ func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.
 
 	// Copy query parameters
 	query := r.URL.Query()
-	// TODO: Change to query.Has after Go 1.17
-	if query.Get("area") != "" {
+	if query.Has("area") {
 		v := GeoPolygonString(query.Get("area"))
 		req.Area = &v
 	}
-	if query.Get("earliest_time") != "" {
+	if query.Has("earliest_time") {
 		v := query.Get("earliest_time")
 		req.EarliestTime = &v
 	}
-	if query.Get("latest_time") != "" {
+	if query.Has("latest_time") {
 		v := query.Get("latest_time")
 		req.LatestTime = &v
 	}
@@ -285,8 +284,7 @@ func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWrite
 
 	// Copy query parameters
 	query := r.URL.Query()
-	// TODO: Change to query.Has after Go 1.17
-	if query.Get("area") != "" {
+	if query.Has("area") {
 		v := GeoPolygonString(query.Get("area"))
 		req.Area = &v
 	}

--- a/interfaces/openapi-to-go-server/example/api/scd/interface.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/scd/interface.gen.go
@@ -7,11 +7,11 @@ import (
 )
 
 var (
-	UtmConstraintProcessingScope             = api.RequiredScope("utm.constraint_processing")
-	UtmConstraintManagementScope             = api.RequiredScope("utm.constraint_management")
-	UtmStrategicCoordinationScope            = api.RequiredScope("utm.strategic_coordination")
-	UtmConformanceMonitoringSaScope          = api.RequiredScope("utm.conformance_monitoring_sa")
 	UtmAvailabilityArbitrationScope          = api.RequiredScope("utm.availability_arbitration")
+	UtmConformanceMonitoringSaScope          = api.RequiredScope("utm.conformance_monitoring_sa")
+	UtmConstraintManagementScope             = api.RequiredScope("utm.constraint_management")
+	UtmConstraintProcessingScope             = api.RequiredScope("utm.constraint_processing")
+	UtmStrategicCoordinationScope            = api.RequiredScope("utm.strategic_coordination")
 	QueryOperationalIntentReferencesSecurity = []api.AuthorizationOption{
 		{
 			"Authority": {UtmStrategicCoordinationScope},

--- a/interfaces/openapi-to-go-server/rendering.py
+++ b/interfaces/openapi-to-go-server/rendering.py
@@ -322,9 +322,8 @@ def routes(
         if operation.query_parameters:
             body.extend(comment(["Copy query parameters"]))
             body.append("query := r.URL.Query()")
-            body.extend(comment(["TODO: Change to query.Has after Go 1.17"]))
             for q in operation.query_parameters:
-                body.append('if query.Get("%s") != "" {' % q.name)
+                body.append('if query.Has("%s") {' % q.name)
                 if_body: List[str] = []
                 if q.go_type == "string":
                     if_body.append('v := query.Get("{}")'.format(q.name))

--- a/pkg/api/auxv1/server.gen.go
+++ b/pkg/api/auxv1/server.gen.go
@@ -56,8 +56,7 @@ func (s *APIRouter) ValidateOauth(exp *regexp.Regexp, w http.ResponseWriter, r *
 
 	// Copy query parameters
 	query := r.URL.Query()
-	// TODO: Change to query.Has after Go 1.17
-	if query.Get("owner") != "" {
+	if query.Has("owner") {
 		v := query.Get("owner")
 		req.Owner = &v
 	}
@@ -165,16 +164,15 @@ func (s *APIRouter) PutDSSInstancesHeartbeat(exp *regexp.Regexp, w http.Response
 
 	// Copy query parameters
 	query := r.URL.Query()
-	// TODO: Change to query.Has after Go 1.17
-	if query.Get("source") != "" {
+	if query.Has("source") {
 		v := query.Get("source")
 		req.Source = &v
 	}
-	if query.Get("timestamp") != "" {
+	if query.Has("timestamp") {
 		v := query.Get("timestamp")
 		req.Timestamp = &v
 	}
-	if query.Get("next_heartbeat_expected_before") != "" {
+	if query.Has("next_heartbeat_expected_before") {
 		v := query.Get("next_heartbeat_expected_before")
 		req.NextHeartbeatExpectedBefore = &v
 	}

--- a/pkg/api/ridv1/server.gen.go
+++ b/pkg/api/ridv1/server.gen.go
@@ -34,16 +34,15 @@ func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.
 
 	// Copy query parameters
 	query := r.URL.Query()
-	// TODO: Change to query.Has after Go 1.17
-	if query.Get("area") != "" {
+	if query.Has("area") {
 		v := GeoPolygonString(query.Get("area"))
 		req.Area = &v
 	}
-	if query.Get("earliest_time") != "" {
+	if query.Has("earliest_time") {
 		v := query.Get("earliest_time")
 		req.EarliestTime = &v
 	}
-	if query.Get("latest_time") != "" {
+	if query.Has("latest_time") {
 		v := query.Get("latest_time")
 		req.LatestTime = &v
 	}
@@ -285,8 +284,7 @@ func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWrite
 
 	// Copy query parameters
 	query := r.URL.Query()
-	// TODO: Change to query.Has after Go 1.17
-	if query.Get("area") != "" {
+	if query.Has("area") {
 		v := GeoPolygonString(query.Get("area"))
 		req.Area = &v
 	}

--- a/pkg/api/ridv2/server.gen.go
+++ b/pkg/api/ridv2/server.gen.go
@@ -34,16 +34,15 @@ func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.
 
 	// Copy query parameters
 	query := r.URL.Query()
-	// TODO: Change to query.Has after Go 1.17
-	if query.Get("area") != "" {
+	if query.Has("area") {
 		v := GeoPolygonString(query.Get("area"))
 		req.Area = &v
 	}
-	if query.Get("earliest_time") != "" {
+	if query.Has("earliest_time") {
 		v := query.Get("earliest_time")
 		req.EarliestTime = &v
 	}
-	if query.Get("latest_time") != "" {
+	if query.Has("latest_time") {
 		v := query.Get("latest_time")
 		req.LatestTime = &v
 	}
@@ -285,8 +284,7 @@ func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWrite
 
 	// Copy query parameters
 	query := r.URL.Query()
-	// TODO: Change to query.Has after Go 1.17
-	if query.Get("area") != "" {
+	if query.Has("area") {
 		v := GeoPolygonString(query.Get("area"))
 		req.Area = &v
 	}


### PR DESCRIPTION
Fix old to-do found in the code.

Follow #1389 

Regenerated example code as well, so #1369 has been applied there as well.