### PR TITLE
 [monitoring] Add telemetry in router 

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -317,11 +317,8 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 	handler = authorizer.TokenMiddleware(handler)
 
 	if *enableOpenTelemetry {
-		httpSpanName := func(operation string, req *http.Request) string {
-			return fmt.Sprintf("%s %s", req.Method, req.URL.Path)
-		}
-
-		handler = otelhttp.NewHandler(handler, "http", otelhttp.WithSpanNameFormatter(httpSpanName))
+		// We use the default settings; the APIRouter handler will override the span value accordingly, as it has more information.
+		handler = otelhttp.NewHandler(handler, "http")
 	}
 
 	httpServer := &http.Server{

--- a/interfaces/openapi-to-go-server/example/api/common.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/common.gen.go
@@ -62,6 +62,8 @@ type Route struct {
 	Method  string
 	Pattern *regexp.Regexp
 	Handler Handler
+	Name    string
+	Path    string
 }
 
 type PartialRouter interface {

--- a/interfaces/openapi-to-go-server/example/api/rid/server.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/rid/server.gen.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"example/api"
+	"fmt"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"regexp"
 )
@@ -15,10 +18,24 @@ type APIRouter struct {
 	Authorizer     api.Authorizer
 }
 
+var tracer = otel.Tracer("rid.api")
+
 // *rid.APIRouter (type defined above) implements the api.PartialRouter interface
 func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	for _, route := range s.Routes {
 		if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
+
+			span := trace.SpanFromContext(r.Context())
+
+			if span.IsRecording() {
+				// Current span is the one from the otelhttp handler
+				span.SetName(fmt.Sprintf("%s %s", r.Method, route.Path))
+			}
+
+			ctx, span := tracer.Start(r.Context(), route.Name)
+			defer span.End()
+			r = r.WithContext(ctx)
+
 			route.Handler(route.Pattern, w, r)
 			return true
 		}
@@ -522,34 +539,34 @@ func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {
 	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 10)}
 
 	pattern := regexp.MustCompile("^/rid/v1/dss/identification_service_areas$")
-	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchIdentificationServiceAreas}
+	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchIdentificationServiceAreas, Name: "rid.SearchIdentificationServiceAreas", Path: "/rid/v1/dss/identification_service_areas"}
 
 	pattern = regexp.MustCompile("^/rid/v1/dss/identification_service_areas/(?P<id>[^/]*)$")
-	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetIdentificationServiceArea}
+	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetIdentificationServiceArea, Name: "rid.GetIdentificationServiceArea", Path: "/rid/v1/dss/identification_service_areas/{id}"}
 
 	pattern = regexp.MustCompile("^/rid/v1/dss/identification_service_areas/(?P<id>[^/]*)$")
-	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateIdentificationServiceArea}
+	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateIdentificationServiceArea, Name: "rid.CreateIdentificationServiceArea", Path: "/rid/v1/dss/identification_service_areas/{id}"}
 
 	pattern = regexp.MustCompile("^/rid/v1/dss/identification_service_areas/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateIdentificationServiceArea}
+	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateIdentificationServiceArea, Name: "rid.UpdateIdentificationServiceArea", Path: "/rid/v1/dss/identification_service_areas/{id}/{version}"}
 
 	pattern = regexp.MustCompile("^/rid/v1/dss/identification_service_areas/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteIdentificationServiceArea}
+	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteIdentificationServiceArea, Name: "rid.DeleteIdentificationServiceArea", Path: "/rid/v1/dss/identification_service_areas/{id}/{version}"}
 
 	pattern = regexp.MustCompile("^/rid/v1/dss/subscriptions$")
-	router.Routes[5] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchSubscriptions}
+	router.Routes[5] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchSubscriptions, Name: "rid.SearchSubscriptions", Path: "/rid/v1/dss/subscriptions"}
 
 	pattern = regexp.MustCompile("^/rid/v1/dss/subscriptions/(?P<id>[^/]*)$")
-	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription}
+	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription, Name: "rid.GetSubscription", Path: "/rid/v1/dss/subscriptions/{id}"}
 
 	pattern = regexp.MustCompile("^/rid/v1/dss/subscriptions/(?P<id>[^/]*)$")
-	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription}
+	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription, Name: "rid.CreateSubscription", Path: "/rid/v1/dss/subscriptions/{id}"}
 
 	pattern = regexp.MustCompile("^/rid/v1/dss/subscriptions/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription}
+	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription, Name: "rid.UpdateSubscription", Path: "/rid/v1/dss/subscriptions/{id}/{version}"}
 
 	pattern = regexp.MustCompile("^/rid/v1/dss/subscriptions/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription}
+	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription, Name: "rid.DeleteSubscription", Path: "/rid/v1/dss/subscriptions/{id}/{version}"}
 
 	return router
 }

--- a/interfaces/openapi-to-go-server/example/api/scd/server.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/scd/server.gen.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"example/api"
+	"fmt"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"regexp"
 )
@@ -15,10 +18,24 @@ type APIRouter struct {
 	Authorizer     api.Authorizer
 }
 
+var tracer = otel.Tracer("scd.api")
+
 // *scd.APIRouter (type defined above) implements the api.PartialRouter interface
 func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	for _, route := range s.Routes {
 		if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
+
+			span := trace.SpanFromContext(r.Context())
+
+			if span.IsRecording() {
+				// Current span is the one from the otelhttp handler
+				span.SetName(fmt.Sprintf("%s %s", r.Method, route.Path))
+			}
+
+			ctx, span := tracer.Start(r.Context(), route.Name)
+			defer span.End()
+			r = r.WithContext(ctx)
+
 			route.Handler(route.Pattern, w, r)
 			return true
 		}
@@ -953,58 +970,58 @@ func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {
 	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 18)}
 
 	pattern := regexp.MustCompile("^/scd/dss/v1/operational_intent_references/query$")
-	router.Routes[0] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QueryOperationalIntentReferences}
+	router.Routes[0] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QueryOperationalIntentReferences, Name: "scd.QueryOperationalIntentReferences", Path: "/scd/dss/v1/operational_intent_references/query"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/operational_intent_references/(?P<entityid>[^/]*)$")
-	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetOperationalIntentReference}
+	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetOperationalIntentReference, Name: "scd.GetOperationalIntentReference", Path: "/scd/dss/v1/operational_intent_references/{entityid}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/operational_intent_references/(?P<entityid>[^/]*)$")
-	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateOperationalIntentReference}
+	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateOperationalIntentReference, Name: "scd.CreateOperationalIntentReference", Path: "/scd/dss/v1/operational_intent_references/{entityid}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/operational_intent_references/(?P<entityid>[^/]*)/(?P<ovn>[^/]*)$")
-	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateOperationalIntentReference}
+	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateOperationalIntentReference, Name: "scd.UpdateOperationalIntentReference", Path: "/scd/dss/v1/operational_intent_references/{entityid}/{ovn}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/operational_intent_references/(?P<entityid>[^/]*)/(?P<ovn>[^/]*)$")
-	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteOperationalIntentReference}
+	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteOperationalIntentReference, Name: "scd.DeleteOperationalIntentReference", Path: "/scd/dss/v1/operational_intent_references/{entityid}/{ovn}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/constraint_references/query$")
-	router.Routes[5] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QueryConstraintReferences}
+	router.Routes[5] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QueryConstraintReferences, Name: "scd.QueryConstraintReferences", Path: "/scd/dss/v1/constraint_references/query"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/constraint_references/(?P<entityid>[^/]*)$")
-	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetConstraintReference}
+	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetConstraintReference, Name: "scd.GetConstraintReference", Path: "/scd/dss/v1/constraint_references/{entityid}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/constraint_references/(?P<entityid>[^/]*)$")
-	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateConstraintReference}
+	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateConstraintReference, Name: "scd.CreateConstraintReference", Path: "/scd/dss/v1/constraint_references/{entityid}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/constraint_references/(?P<entityid>[^/]*)/(?P<ovn>[^/]*)$")
-	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateConstraintReference}
+	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateConstraintReference, Name: "scd.UpdateConstraintReference", Path: "/scd/dss/v1/constraint_references/{entityid}/{ovn}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/constraint_references/(?P<entityid>[^/]*)/(?P<ovn>[^/]*)$")
-	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteConstraintReference}
+	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteConstraintReference, Name: "scd.DeleteConstraintReference", Path: "/scd/dss/v1/constraint_references/{entityid}/{ovn}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/subscriptions/query$")
-	router.Routes[10] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QuerySubscriptions}
+	router.Routes[10] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QuerySubscriptions, Name: "scd.QuerySubscriptions", Path: "/scd/dss/v1/subscriptions/query"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/subscriptions/(?P<subscriptionid>[^/]*)$")
-	router.Routes[11] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription}
+	router.Routes[11] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription, Name: "scd.GetSubscription", Path: "/scd/dss/v1/subscriptions/{subscriptionid}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/subscriptions/(?P<subscriptionid>[^/]*)$")
-	router.Routes[12] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription}
+	router.Routes[12] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription, Name: "scd.CreateSubscription", Path: "/scd/dss/v1/subscriptions/{subscriptionid}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/subscriptions/(?P<subscriptionid>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[13] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription}
+	router.Routes[13] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription, Name: "scd.UpdateSubscription", Path: "/scd/dss/v1/subscriptions/{subscriptionid}/{version}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/subscriptions/(?P<subscriptionid>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[14] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription}
+	router.Routes[14] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription, Name: "scd.DeleteSubscription", Path: "/scd/dss/v1/subscriptions/{subscriptionid}/{version}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/reports$")
-	router.Routes[15] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.MakeDssReport}
+	router.Routes[15] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.MakeDssReport, Name: "scd.MakeDssReport", Path: "/scd/dss/v1/reports"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/uss_availability/(?P<uss_id>[^/]*)$")
-	router.Routes[16] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetUssAvailability}
+	router.Routes[16] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetUssAvailability, Name: "scd.GetUssAvailability", Path: "/scd/dss/v1/uss_availability/{uss_id}"}
 
 	pattern = regexp.MustCompile("^/scd/dss/v1/uss_availability/(?P<uss_id>[^/]*)$")
-	router.Routes[17] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.SetUssAvailability}
+	router.Routes[17] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.SetUssAvailability, Name: "scd.SetUssAvailability", Path: "/scd/dss/v1/uss_availability/{uss_id}"}
 
 	return router
 }

--- a/interfaces/openapi-to-go-server/example/run_example.sh
+++ b/interfaces/openapi-to-go-server/example/run_example.sh
@@ -13,4 +13,4 @@ cd "${BASEDIR}" || exit
 docker image build -t openapi-to-go-server-demo . || exit
 
 echo "Running server..."
-docker container run -it -p 8080:8080 openapi-to-go-server-demo
+docker container run -it -p 8180:8080 openapi-to-go-server-demo

--- a/interfaces/openapi-to-go-server/generate.py
+++ b/interfaces/openapi-to-go-server/generate.py
@@ -103,7 +103,15 @@ def _generate_apis(
         routes, new_imports = rendering.routes(api, api_package, ensure_500)
         server_template_vars = {
             "<PACKAGE>": api.package,
-            "<IMPORTS>": rendering.imports(list(new_imports) + [api_import]),
+            "<IMPORTS>": rendering.imports(
+                list(new_imports)
+                + [
+                    api_import,
+                    "fmt",
+                    "go.opentelemetry.io/otel",
+                    "go.opentelemetry.io/otel/trace",
+                ]
+            ),
             "<API_PACKAGE>": api_package,
             "<ROUTES>": "\n".join(routes),
             "<ROUTING>": "\n".join(rendering.routing(api, api_package)),

--- a/interfaces/openapi-to-go-server/rendering.py
+++ b/interfaces/openapi-to-go-server/rendering.py
@@ -458,8 +458,17 @@ def routing(api: apis.API, api_package: str) -> List[str]:
             )
         )
         lines.append(
-            "router.Routes[%d] = &%s.Route{Method: %s, Pattern: pattern, Handler: router.%s}"
-            % (i, api_package, operation.verb_const_name, operation.interface_name)
+            'router.Routes[%d] = &%s.Route{Method: %s, Pattern: pattern, Handler: router.%s, Name: "%s.%s", Path: "%s%s"}'
+            % (
+                i,
+                api_package,
+                operation.verb_const_name,
+                operation.interface_name,
+                api.package,
+                operation.interface_name,
+                prefix,
+                operation.path,
+            )
         )
         lines.append("")
         first_assignment = False

--- a/interfaces/openapi-to-go-server/templates/common.go.template
+++ b/interfaces/openapi-to-go-server/templates/common.go.template
@@ -59,6 +59,8 @@ type Route struct {
     Method  string
     Pattern *regexp.Regexp
     Handler Handler
+    Name    string
+    Path    string
 }
 
 type PartialRouter interface {

--- a/interfaces/openapi-to-go-server/templates/server.go.template
+++ b/interfaces/openapi-to-go-server/templates/server.go.template
@@ -8,10 +8,24 @@ type APIRouter struct {
     Authorizer <API_PACKAGE>.Authorizer
 }
 
+var tracer = otel.Tracer("<PACKAGE>.<API_PACKAGE>")
+
 // *<PACKAGE>.APIRouter (type defined above) implements the <API_PACKAGE>.PartialRouter interface
 func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
     for _, route := range s.Routes {
         if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
+
+            // We retrieve the current span from the otelhttp handler to set its name property.
+            span := trace.SpanFromContext(r.Context())
+
+            if span.IsRecording() {  // If the span is not recording, the name cannot be changed. This also likely means the otelhttp handler is not present (tracing disabled).
+                span.SetName(fmt.Sprintf("%s %s", r.Method, route.Path))
+            }
+
+            ctx, span := tracer.Start(r.Context(), route.Name)
+            defer span.End()
+            r = r.WithContext(ctx)
+
             route.Handler(route.Pattern, w, r)
             return true
         }

--- a/pkg/api/auxv1/server.gen.go
+++ b/pkg/api/auxv1/server.gen.go
@@ -3,7 +3,10 @@ package auxv1
 
 import (
 	"context"
+	"fmt"
 	"github.com/interuss/dss/pkg/api"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"regexp"
 )
@@ -14,10 +17,24 @@ type APIRouter struct {
 	Authorizer     api.Authorizer
 }
 
+var tracer = otel.Tracer("auxv1.api")
+
 // *auxv1.APIRouter (type defined above) implements the api.PartialRouter interface
 func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	for _, route := range s.Routes {
 		if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
+
+			// We retrieve the current span from the otelhttp handler to set its name property.
+			span := trace.SpanFromContext(r.Context())
+
+			if span.IsRecording() { // If the span is not recording, the name cannot be changed. This also likely means the otelhttp handler is not present (tracing disabled).
+				span.SetName(fmt.Sprintf("%s %s", r.Method, route.Path))
+			}
+
+			ctx, span := tracer.Start(r.Context(), route.Name)
+			defer span.End()
+			r = r.WithContext(ctx)
+
 			route.Handler(route.Pattern, w, r)
 			return true
 		}
@@ -295,28 +312,28 @@ func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {
 	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 8)}
 
 	pattern := regexp.MustCompile("^/aux/v1/version$")
-	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetVersion}
+	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetVersion, Name: "auxv1.GetVersion", Path: "/aux/v1/version"}
 
 	pattern = regexp.MustCompile("^/aux/v1/validate_oauth$")
-	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.ValidateOauth}
+	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.ValidateOauth, Name: "auxv1.ValidateOauth", Path: "/aux/v1/validate_oauth"}
 
 	pattern = regexp.MustCompile("^/aux/v1/pool$")
-	router.Routes[2] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetPool}
+	router.Routes[2] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetPool, Name: "auxv1.GetPool", Path: "/aux/v1/pool"}
 
 	pattern = regexp.MustCompile("^/aux/v1/pool/dss_instances$")
-	router.Routes[3] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetDSSInstances}
+	router.Routes[3] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetDSSInstances, Name: "auxv1.GetDSSInstances", Path: "/aux/v1/pool/dss_instances"}
 
 	pattern = regexp.MustCompile("^/aux/v1/pool/dss_instances/heartbeat$")
-	router.Routes[4] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.PutDSSInstancesHeartbeat}
+	router.Routes[4] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.PutDSSInstancesHeartbeat, Name: "auxv1.PutDSSInstancesHeartbeat", Path: "/aux/v1/pool/dss_instances/heartbeat"}
 
 	pattern = regexp.MustCompile("^/aux/v1/configuration/accepted_ca_certs$")
-	router.Routes[5] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetAcceptedCAs}
+	router.Routes[5] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetAcceptedCAs, Name: "auxv1.GetAcceptedCAs", Path: "/aux/v1/configuration/accepted_ca_certs"}
 
 	pattern = regexp.MustCompile("^/aux/v1/configuration/ca_certs$")
-	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetInstanceCAs}
+	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetInstanceCAs, Name: "auxv1.GetInstanceCAs", Path: "/aux/v1/configuration/ca_certs"}
 
 	pattern = regexp.MustCompile("^/aux/v1/configuration/scd_lock_mode$")
-	router.Routes[7] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetScdLockMode}
+	router.Routes[7] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetScdLockMode, Name: "auxv1.GetScdLockMode", Path: "/aux/v1/configuration/scd_lock_mode"}
 
 	return router
 }

--- a/pkg/api/common.gen.go
+++ b/pkg/api/common.gen.go
@@ -62,6 +62,8 @@ type Route struct {
 	Method  string
 	Pattern *regexp.Regexp
 	Handler Handler
+	Name    string
+	Path    string
 }
 
 type PartialRouter interface {

--- a/pkg/api/ridv1/server.gen.go
+++ b/pkg/api/ridv1/server.gen.go
@@ -4,7 +4,10 @@ package ridv1
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/interuss/dss/pkg/api"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"regexp"
 )
@@ -15,10 +18,24 @@ type APIRouter struct {
 	Authorizer     api.Authorizer
 }
 
+var tracer = otel.Tracer("ridv1.api")
+
 // *ridv1.APIRouter (type defined above) implements the api.PartialRouter interface
 func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	for _, route := range s.Routes {
 		if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
+
+			// We retrieve the current span from the otelhttp handler to set its name property.
+			span := trace.SpanFromContext(r.Context())
+
+			if span.IsRecording() { // If the span is not recording, the name cannot be changed. This also likely means the otelhttp handler is not present (tracing disabled).
+				span.SetName(fmt.Sprintf("%s %s", r.Method, route.Path))
+			}
+
+			ctx, span := tracer.Start(r.Context(), route.Name)
+			defer span.End()
+			r = r.WithContext(ctx)
+
 			route.Handler(route.Pattern, w, r)
 			return true
 		}
@@ -522,34 +539,34 @@ func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {
 	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 10)}
 
 	pattern := regexp.MustCompile("^/v1/dss/identification_service_areas$")
-	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchIdentificationServiceAreas}
+	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchIdentificationServiceAreas, Name: "ridv1.SearchIdentificationServiceAreas", Path: "/v1/dss/identification_service_areas"}
 
 	pattern = regexp.MustCompile("^/v1/dss/identification_service_areas/(?P<id>[^/]*)$")
-	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetIdentificationServiceArea}
+	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetIdentificationServiceArea, Name: "ridv1.GetIdentificationServiceArea", Path: "/v1/dss/identification_service_areas/{id}"}
 
 	pattern = regexp.MustCompile("^/v1/dss/identification_service_areas/(?P<id>[^/]*)$")
-	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateIdentificationServiceArea}
+	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateIdentificationServiceArea, Name: "ridv1.CreateIdentificationServiceArea", Path: "/v1/dss/identification_service_areas/{id}"}
 
 	pattern = regexp.MustCompile("^/v1/dss/identification_service_areas/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateIdentificationServiceArea}
+	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateIdentificationServiceArea, Name: "ridv1.UpdateIdentificationServiceArea", Path: "/v1/dss/identification_service_areas/{id}/{version}"}
 
 	pattern = regexp.MustCompile("^/v1/dss/identification_service_areas/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteIdentificationServiceArea}
+	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteIdentificationServiceArea, Name: "ridv1.DeleteIdentificationServiceArea", Path: "/v1/dss/identification_service_areas/{id}/{version}"}
 
 	pattern = regexp.MustCompile("^/v1/dss/subscriptions$")
-	router.Routes[5] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchSubscriptions}
+	router.Routes[5] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchSubscriptions, Name: "ridv1.SearchSubscriptions", Path: "/v1/dss/subscriptions"}
 
 	pattern = regexp.MustCompile("^/v1/dss/subscriptions/(?P<id>[^/]*)$")
-	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription}
+	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription, Name: "ridv1.GetSubscription", Path: "/v1/dss/subscriptions/{id}"}
 
 	pattern = regexp.MustCompile("^/v1/dss/subscriptions/(?P<id>[^/]*)$")
-	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription}
+	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription, Name: "ridv1.CreateSubscription", Path: "/v1/dss/subscriptions/{id}"}
 
 	pattern = regexp.MustCompile("^/v1/dss/subscriptions/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription}
+	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription, Name: "ridv1.UpdateSubscription", Path: "/v1/dss/subscriptions/{id}/{version}"}
 
 	pattern = regexp.MustCompile("^/v1/dss/subscriptions/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription}
+	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription, Name: "ridv1.DeleteSubscription", Path: "/v1/dss/subscriptions/{id}/{version}"}
 
 	return router
 }

--- a/pkg/api/ridv2/server.gen.go
+++ b/pkg/api/ridv2/server.gen.go
@@ -4,7 +4,10 @@ package ridv2
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/interuss/dss/pkg/api"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"regexp"
 )
@@ -15,10 +18,24 @@ type APIRouter struct {
 	Authorizer     api.Authorizer
 }
 
+var tracer = otel.Tracer("ridv2.api")
+
 // *ridv2.APIRouter (type defined above) implements the api.PartialRouter interface
 func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	for _, route := range s.Routes {
 		if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
+
+			// We retrieve the current span from the otelhttp handler to set its name property.
+			span := trace.SpanFromContext(r.Context())
+
+			if span.IsRecording() { // If the span is not recording, the name cannot be changed. This also likely means the otelhttp handler is not present (tracing disabled).
+				span.SetName(fmt.Sprintf("%s %s", r.Method, route.Path))
+			}
+
+			ctx, span := tracer.Start(r.Context(), route.Name)
+			defer span.End()
+			r = r.WithContext(ctx)
+
 			route.Handler(route.Pattern, w, r)
 			return true
 		}
@@ -522,34 +539,34 @@ func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {
 	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 10)}
 
 	pattern := regexp.MustCompile("^/rid/v2/dss/identification_service_areas$")
-	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchIdentificationServiceAreas}
+	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchIdentificationServiceAreas, Name: "ridv2.SearchIdentificationServiceAreas", Path: "/rid/v2/dss/identification_service_areas"}
 
 	pattern = regexp.MustCompile("^/rid/v2/dss/identification_service_areas/(?P<id>[^/]*)$")
-	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetIdentificationServiceArea}
+	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetIdentificationServiceArea, Name: "ridv2.GetIdentificationServiceArea", Path: "/rid/v2/dss/identification_service_areas/{id}"}
 
 	pattern = regexp.MustCompile("^/rid/v2/dss/identification_service_areas/(?P<id>[^/]*)$")
-	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateIdentificationServiceArea}
+	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateIdentificationServiceArea, Name: "ridv2.CreateIdentificationServiceArea", Path: "/rid/v2/dss/identification_service_areas/{id}"}
 
 	pattern = regexp.MustCompile("^/rid/v2/dss/identification_service_areas/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateIdentificationServiceArea}
+	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateIdentificationServiceArea, Name: "ridv2.UpdateIdentificationServiceArea", Path: "/rid/v2/dss/identification_service_areas/{id}/{version}"}
 
 	pattern = regexp.MustCompile("^/rid/v2/dss/identification_service_areas/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteIdentificationServiceArea}
+	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteIdentificationServiceArea, Name: "ridv2.DeleteIdentificationServiceArea", Path: "/rid/v2/dss/identification_service_areas/{id}/{version}"}
 
 	pattern = regexp.MustCompile("^/rid/v2/dss/subscriptions$")
-	router.Routes[5] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchSubscriptions}
+	router.Routes[5] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.SearchSubscriptions, Name: "ridv2.SearchSubscriptions", Path: "/rid/v2/dss/subscriptions"}
 
 	pattern = regexp.MustCompile("^/rid/v2/dss/subscriptions/(?P<id>[^/]*)$")
-	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription}
+	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription, Name: "ridv2.GetSubscription", Path: "/rid/v2/dss/subscriptions/{id}"}
 
 	pattern = regexp.MustCompile("^/rid/v2/dss/subscriptions/(?P<id>[^/]*)$")
-	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription}
+	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription, Name: "ridv2.CreateSubscription", Path: "/rid/v2/dss/subscriptions/{id}"}
 
 	pattern = regexp.MustCompile("^/rid/v2/dss/subscriptions/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription}
+	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription, Name: "ridv2.UpdateSubscription", Path: "/rid/v2/dss/subscriptions/{id}/{version}"}
 
 	pattern = regexp.MustCompile("^/rid/v2/dss/subscriptions/(?P<id>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription}
+	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription, Name: "ridv2.DeleteSubscription", Path: "/rid/v2/dss/subscriptions/{id}/{version}"}
 
 	return router
 }

--- a/pkg/api/scdv1/server.gen.go
+++ b/pkg/api/scdv1/server.gen.go
@@ -4,7 +4,10 @@ package scdv1
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/interuss/dss/pkg/api"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"regexp"
 )
@@ -15,10 +18,24 @@ type APIRouter struct {
 	Authorizer     api.Authorizer
 }
 
+var tracer = otel.Tracer("scdv1.api")
+
 // *scdv1.APIRouter (type defined above) implements the api.PartialRouter interface
 func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	for _, route := range s.Routes {
 		if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
+
+			// We retrieve the current span from the otelhttp handler to set its name property.
+			span := trace.SpanFromContext(r.Context())
+
+			if span.IsRecording() { // If the span is not recording, the name cannot be changed. This also likely means the otelhttp handler is not present (tracing disabled).
+				span.SetName(fmt.Sprintf("%s %s", r.Method, route.Path))
+			}
+
+			ctx, span := tracer.Start(r.Context(), route.Name)
+			defer span.End()
+			r = r.WithContext(ctx)
+
 			route.Handler(route.Pattern, w, r)
 			return true
 		}
@@ -953,58 +970,58 @@ func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {
 	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 18)}
 
 	pattern := regexp.MustCompile("^/dss/v1/operational_intent_references/query$")
-	router.Routes[0] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QueryOperationalIntentReferences}
+	router.Routes[0] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QueryOperationalIntentReferences, Name: "scdv1.QueryOperationalIntentReferences", Path: "/dss/v1/operational_intent_references/query"}
 
 	pattern = regexp.MustCompile("^/dss/v1/operational_intent_references/(?P<entityid>[^/]*)$")
-	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetOperationalIntentReference}
+	router.Routes[1] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetOperationalIntentReference, Name: "scdv1.GetOperationalIntentReference", Path: "/dss/v1/operational_intent_references/{entityid}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/operational_intent_references/(?P<entityid>[^/]*)$")
-	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateOperationalIntentReference}
+	router.Routes[2] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateOperationalIntentReference, Name: "scdv1.CreateOperationalIntentReference", Path: "/dss/v1/operational_intent_references/{entityid}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/operational_intent_references/(?P<entityid>[^/]*)/(?P<ovn>[^/]*)$")
-	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateOperationalIntentReference}
+	router.Routes[3] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateOperationalIntentReference, Name: "scdv1.UpdateOperationalIntentReference", Path: "/dss/v1/operational_intent_references/{entityid}/{ovn}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/operational_intent_references/(?P<entityid>[^/]*)/(?P<ovn>[^/]*)$")
-	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteOperationalIntentReference}
+	router.Routes[4] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteOperationalIntentReference, Name: "scdv1.DeleteOperationalIntentReference", Path: "/dss/v1/operational_intent_references/{entityid}/{ovn}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/constraint_references/query$")
-	router.Routes[5] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QueryConstraintReferences}
+	router.Routes[5] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QueryConstraintReferences, Name: "scdv1.QueryConstraintReferences", Path: "/dss/v1/constraint_references/query"}
 
 	pattern = regexp.MustCompile("^/dss/v1/constraint_references/(?P<entityid>[^/]*)$")
-	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetConstraintReference}
+	router.Routes[6] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetConstraintReference, Name: "scdv1.GetConstraintReference", Path: "/dss/v1/constraint_references/{entityid}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/constraint_references/(?P<entityid>[^/]*)$")
-	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateConstraintReference}
+	router.Routes[7] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateConstraintReference, Name: "scdv1.CreateConstraintReference", Path: "/dss/v1/constraint_references/{entityid}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/constraint_references/(?P<entityid>[^/]*)/(?P<ovn>[^/]*)$")
-	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateConstraintReference}
+	router.Routes[8] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateConstraintReference, Name: "scdv1.UpdateConstraintReference", Path: "/dss/v1/constraint_references/{entityid}/{ovn}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/constraint_references/(?P<entityid>[^/]*)/(?P<ovn>[^/]*)$")
-	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteConstraintReference}
+	router.Routes[9] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteConstraintReference, Name: "scdv1.DeleteConstraintReference", Path: "/dss/v1/constraint_references/{entityid}/{ovn}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/subscriptions/query$")
-	router.Routes[10] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QuerySubscriptions}
+	router.Routes[10] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.QuerySubscriptions, Name: "scdv1.QuerySubscriptions", Path: "/dss/v1/subscriptions/query"}
 
 	pattern = regexp.MustCompile("^/dss/v1/subscriptions/(?P<subscriptionid>[^/]*)$")
-	router.Routes[11] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription}
+	router.Routes[11] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetSubscription, Name: "scdv1.GetSubscription", Path: "/dss/v1/subscriptions/{subscriptionid}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/subscriptions/(?P<subscriptionid>[^/]*)$")
-	router.Routes[12] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription}
+	router.Routes[12] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.CreateSubscription, Name: "scdv1.CreateSubscription", Path: "/dss/v1/subscriptions/{subscriptionid}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/subscriptions/(?P<subscriptionid>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[13] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription}
+	router.Routes[13] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.UpdateSubscription, Name: "scdv1.UpdateSubscription", Path: "/dss/v1/subscriptions/{subscriptionid}/{version}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/subscriptions/(?P<subscriptionid>[^/]*)/(?P<version>[^/]*)$")
-	router.Routes[14] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription}
+	router.Routes[14] = &api.Route{Method: http.MethodDelete, Pattern: pattern, Handler: router.DeleteSubscription, Name: "scdv1.DeleteSubscription", Path: "/dss/v1/subscriptions/{subscriptionid}/{version}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/reports$")
-	router.Routes[15] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.MakeDssReport}
+	router.Routes[15] = &api.Route{Method: http.MethodPost, Pattern: pattern, Handler: router.MakeDssReport, Name: "scdv1.MakeDssReport", Path: "/dss/v1/reports"}
 
 	pattern = regexp.MustCompile("^/dss/v1/uss_availability/(?P<uss_id>[^/]*)$")
-	router.Routes[16] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetUssAvailability}
+	router.Routes[16] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetUssAvailability, Name: "scdv1.GetUssAvailability", Path: "/dss/v1/uss_availability/{uss_id}"}
 
 	pattern = regexp.MustCompile("^/dss/v1/uss_availability/(?P<uss_id>[^/]*)$")
-	router.Routes[17] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.SetUssAvailability}
+	router.Routes[17] = &api.Route{Method: http.MethodPut, Pattern: pattern, Handler: router.SetUssAvailability, Name: "scdv1.SetUssAvailability", Path: "/dss/v1/uss_availability/{uss_id}"}
 
 	return router
 }


### PR DESCRIPTION
Add telemetry directly in router, providing clean tracenames.

Follow #1390 and #1365 

Example server tested with `./run_example.sh` and still working as expected.

Name has been removed from default handler, meaning unknown route or `/healthy` will just be named 'http', but that probably ok.

<img width="2223" height="1162" alt="image_2026-03-11_10-40-38" src="https://github.com/user-attachments/assets/7d618f62-1c47-4cbb-975d-235ef8adeee2" />

Router set parent trace name to the path + start a span for actual processing.
Example traces:

<img width="2077" height="485" alt="image_2026-03-11_10-37-40" src="https://github.com/user-attachments/assets/042fdb82-d815-418d-a933-9509faa28c71" />
<img width="2100" height="731" alt="image_2026-03-11_10-38-11" src="https://github.com/user-attachments/assets/1cc69cb4-955e-48f0-ab07-e2139e466da1" />


