### PR TITLE
Fix core-service healthcheck port and add health verification

### DIFF
--- a/build/dev/docker-compose_dss.yaml
+++ b/build/dev/docker-compose_dss.yaml
@@ -138,7 +138,7 @@ services:
     networks:
       - dss_sandbox_default_network
     healthcheck:
-      test: wget -O - 'http://localhost/healthy' || exit 1
+      test: wget -O - 'http://localhost:8082/healthy' || exit 1
       interval: 3m
       start_period: 30s
       start_interval: 5s

--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -30,6 +30,25 @@ for container_name in "${localhost_containers[@]}"; do
 	fi
 done
 
+# Wait for containers with healthchecks to become healthy
+for container_name in "${localhost_containers[@]}"; do
+	if docker container inspect -f '{{.State.Health.Status}}' "$container_name" >/dev/null 2>&1; then
+		echo "Waiting for $container_name to be healthy..."
+		for i in $(seq 1 60); do
+			health="$( docker container inspect -f '{{.State.Health.Status}}' "$container_name" )"
+			if [ "$health" == "healthy" ]; then
+				echo "$container_name is healthy!"
+				break
+			fi
+			if [ "$i" -eq 60 ]; then
+				echo "Error: $container_name did not become healthy within 60 seconds (status: $health)"
+				exit 1
+			fi
+			sleep 1
+		done
+	fi
+done
+
 echo "Re/Create e2e_test_result file"
 RESULTFILE="$(pwd)/e2e_test_result"
 touch "${RESULTFILE}"

--- a/build/dev/qualify_locally.sh
+++ b/build/dev/qualify_locally.sh
@@ -30,6 +30,25 @@ for container_name in "${localhost_containers[@]}"; do
 	fi
 done
 
+# Wait for containers with healthchecks to become healthy
+for container_name in "${localhost_containers[@]}"; do
+	if docker container inspect -f '{{.State.Health.Status}}' "$container_name" >/dev/null 2>&1; then
+		echo "Waiting for $container_name to be healthy..."
+		for i in $(seq 1 60); do
+			health="$( docker container inspect -f '{{.State.Health.Status}}' "$container_name" )"
+			if [ "$health" == "healthy" ]; then
+				echo "$container_name is healthy!"
+				break
+			fi
+			if [ "$i" -eq 60 ]; then
+				echo "Error: $container_name did not become healthy within 60 seconds (status: $health)"
+				exit 1
+			fi
+			sleep 1
+		done
+	fi
+done
+
 if ! docker run --link "$OAUTH_CONTAINER":oauth \
 	--link "$CORE_SERVICE_CONTAINER":core-service \
 	--network dss_sandbox-default \


### PR DESCRIPTION
## Summary
- The docker-compose healthcheck for `local-dss-core-service` hits `http://localhost/healthy` (port 80) but the core service listens on port 8082, so the healthcheck never passes. This was not previously visible because nothing in the test pipeline checks container health status.
- `probe_locally.sh` and `qualify_locally.sh` verified that containers were in the `running` state but did not check whether Docker's healthcheck had passed, so the broken healthcheck was not caught by CI
- Both scripts now wait up to 60 seconds for containers with healthchecks to report `healthy` before proceeding, ensuring healthcheck misconfigurations are caught going forward

## Test plan
- [x] Verified the old healthcheck URL (`http://localhost/healthy`) fails inside the container (port 80 not listening)
- [x] Verified the fixed URL (`http://localhost:8082/healthy`) succeeds inside the container
- [x] Started the local DSS instance and confirmed all containers report as `(healthy)`
- [x] Verified the new health wait loop passes with healthy containers
- [ ] CI passes `make probe-locally` and `make qualify-locally`

🤖 Generated with [Claude Code](https://claude.com/claude-code)