### PR TITLE
[auth] Remove token signatures in logs

### DIFF
--- a/pkg/logging/http.go
+++ b/pkg/logging/http.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/interuss/dss/pkg/auth/claims"
@@ -48,8 +49,10 @@ func redactHeaders(headers http.Header) http.Header {
 	newHeaders := headers.Clone()
 
 	for key, values := range newHeaders {
-		for i, val := range values {
-			newHeaders[key][i] = tokenRegex.ReplaceAllString(val, "$1[REDACTED]")
+		if strings.ToLower(key) == "authorization" {
+			for i, val := range values {
+				newHeaders[key][i] = tokenRegex.ReplaceAllString(val, "$1[REDACTED]")
+			}
 		}
 	}
 


### PR DESCRIPTION
I noticed that the DSS logs are recording full tokens, which is a security concern.

This PR redacts the signature of JWT tokens, making them unusable while still logging the core payload to be debuggable.