### PR TITLE
[scd] Fix missing transaction timeout in SCD datastore

### DIFF
--- a/pkg/scd/store/datastore/store.go
+++ b/pkg/scd/store/datastore/store.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
@@ -24,6 +25,11 @@ const (
 var (
 	// DefaultClock is what is used as the Store's clock, returned from Dial.
 	DefaultClock = clockwork.NewRealClock()
+
+	// DefaultTimeout is the timeout applied to the txn retrier.
+	// If a given deadline is already supplied on the context, the earlier
+	// deadline is used.
+	DefaultTimeout = 10 * time.Second
 
 	// DatabaseName is the name of database storing strategic conflict detection data.
 	DatabaseName = "scd"
@@ -92,6 +98,9 @@ func (s *Store) Interact(_ context.Context) (repos.Repository, error) {
 
 // Transact implements store.Transactor interface.
 func (s *Store) Transact(ctx context.Context, f func(context.Context, repos.Repository) error) error {
+	ctx, cancel := context.WithTimeout(ctx, DefaultTimeout)
+	defer cancel()
+
 	ctx = crdb.WithMaxRetries(ctx, flags.ConnectParameters().MaxRetries)
 	return crdbpgx.ExecuteTx(ctx, s.db.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
 		return f(ctx, &repo{


### PR DESCRIPTION
Fixes #1393

**Problem**
The SCD `Transact()` method passed the context to CockroachDB with no deadline, so database transactions had no timeout. When a proxy timed out and dropped the client connection, the DSS continued processing and committed state changes which is the behaviour observed with the PUT /dss/v1/operational_intent_references request that completed and transitioned state to "Activated" after the client already received a 503.

**Fix**
Apply `context.WithTimeout(ctx, DefaultTimeout)` in SCD's `Transact()` before executing the database transaction. This mirrors the existing pattern already used by both the RID and AUX datastores.

**Known Limitation**
`DefaultTimeout` is hardcoded to 10s in the store rather than being wired to the `--server timeout` flag. This matches current RID/AUX behaviour but is not ideal .the long-term fix is an HTTP middleware/interceptor that sets a context deadline based on the flag uniformly for all handlers, as noted in the existing TODO in `pkg/rid/server/v1/subscription_handler.go`.
