### PR TITLE
Refactor store/datastore with common interfaces and helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,10 +140,10 @@ test-go-units-crdb: cleanup-test-go-units-crdb
 	go run ./cmds/db-manager/main.go migrate --schemas_dir ./build/db_schemas/rid --db_version latest --datastore_host localhost
 	go run ./cmds/db-manager/main.go migrate --schemas_dir ./build/db_schemas/scd --db_version latest --datastore_host localhost
 	go run ./cmds/db-manager/main.go migrate --schemas_dir ./build/db_schemas/aux_ --db_version latest --datastore_host localhost
-	go test -cover -count=1 -v ./pkg/rid/store/datastore --datastore_host localhost --datastore_port 26257 --datastore_ssl_mode disable --datastore_user root --datastore_db_name rid -test.gocoverdir=$(COVERDATA_DIR)
-	go test -cover -count=1 -v ./pkg/rid/application --datastore_host localhost --datastore_port 26257 --datastore_ssl_mode disable --datastore_user root --datastore_db_name rid -test.gocoverdir=$(COVERDATA_DIR)
-	go test -cover -count=1 -v ./pkg/scd/store/datastore --datastore_host localhost --datastore_port 26257 --datastore_ssl_mode disable --datastore_user root --datastore_db_name scd -test.gocoverdir=$(COVERDATA_DIR)
-	go test -cover -count=1 -v ./pkg/aux_/store/datastore --datastore_host localhost --datastore_port 26257 --datastore_ssl_mode disable --datastore_user root --datastore_db_name aux -test.gocoverdir=$(COVERDATA_DIR)
+	go test -cover -count=1 -v ./pkg/rid/store/datastore --datastore_host localhost --datastore_port 26257 --datastore_ssl_mode disable --datastore_user root -test.gocoverdir=$(COVERDATA_DIR)
+	go test -cover -count=1 -v ./pkg/rid/application --datastore_host localhost --datastore_port 26257 --datastore_ssl_mode disable --datastore_user root -test.gocoverdir=$(COVERDATA_DIR)
+	go test -cover -count=1 -v ./pkg/scd/store/datastore --datastore_host localhost --datastore_port 26257 --datastore_ssl_mode disable --datastore_user root -test.gocoverdir=$(COVERDATA_DIR)
+	go test -cover -count=1 -v ./pkg/aux_/store/datastore --datastore_host localhost --datastore_port 26257 --datastore_ssl_mode disable --datastore_user root -test.gocoverdir=$(COVERDATA_DIR)
 	@docker stop dss-crdb-for-testing > /dev/null
 	@docker rm dss-crdb-for-testing > /dev/null
 

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -24,8 +23,7 @@ import (
 	aux "github.com/interuss/dss/pkg/aux_"
 	auxc "github.com/interuss/dss/pkg/aux_/store/datastore"
 	"github.com/interuss/dss/pkg/build"
-	"github.com/interuss/dss/pkg/datastore"
-	"github.com/interuss/dss/pkg/datastore/flags" // Force command line flag registration
+	"github.com/interuss/dss/pkg/datastoreutils"
 	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/rid/application"
 	rid_v1 "github.com/interuss/dss/pkg/rid/server/v1"
@@ -36,7 +34,6 @@ import (
 	"github.com/interuss/dss/pkg/version"
 	"github.com/interuss/dss/pkg/versioning"
 	"github.com/interuss/stacktrace"
-	"github.com/robfig/cron/v3"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
 )
@@ -65,30 +62,6 @@ var (
 	scdGlobalLock = flag.Bool("enable_scd_global_lock", false, "Experimental: Use a global lock when working with SCD subscriptions. Reduce global throughput but improve throughput with lot of subscriptions in the same areas.")
 )
 
-const (
-	codeRetryable = stacktrace.ErrorCode(1)
-)
-
-func getDBStats(ctx context.Context, db *datastore.Datastore, databaseName string) {
-	logger := logging.WithValuesFromContext(ctx, logging.Logger)
-	statsPtr := db.Pool.Stat()
-	stats := make(map[string]string)
-	stats["DBName"] = databaseName
-	stats["AcquireCount"] = strconv.Itoa(int(statsPtr.AcquireCount()))
-	stats["AcquiredConns"] = strconv.Itoa(int(statsPtr.AcquiredConns()))
-	stats["CanceledAcquireCount"] = strconv.Itoa(int(statsPtr.CanceledAcquireCount()))
-	stats["ConstructingConns"] = strconv.Itoa(int(statsPtr.ConstructingConns()))
-	stats["EmptyAcquireCount"] = strconv.Itoa(int(statsPtr.EmptyAcquireCount()))
-	stats["IdleConns"] = strconv.Itoa(int(statsPtr.IdleConns()))
-	stats["MaxConns"] = strconv.Itoa(int(statsPtr.MaxConns()))
-	stats["TotalConns"] = strconv.Itoa(int(statsPtr.TotalConns()))
-	if stats["TotalConns"] == "0" {
-		logger.Warn("Failed periodic DB Ping (TotalConns=0)", zap.String("Database", databaseName))
-	} else {
-		logger.Info("Successful periodic DB Ping ", zap.String("Database", databaseName))
-	}
-}
-
 func createKeyResolver() (auth.KeyResolver, error) {
 	switch {
 	case *pkFile != "":
@@ -111,24 +84,9 @@ func createKeyResolver() (auth.KeyResolver, error) {
 }
 
 func createAuxServer(ctx context.Context, locality string, publicEndpoint string, scdGlobalLock bool, logger *zap.Logger) (*aux.Server, error) {
-	connectParameters := flags.ConnectParameters()
-	connectParameters.DBName = "aux"
-	datastore, err := datastore.Dial(ctx, connectParameters)
+	auxStore, err := auxc.Dial(ctx, logger)
 	if err != nil {
-		if strings.Contains(err.Error(), "connect: connection refused") {
-			return nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to database for pool information store")
-		}
-		return nil, stacktrace.Propagate(err, "Failed to connect to pool information database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
-	}
-
-	auxStore, err := auxc.NewStore(ctx, datastore, connectParameters.DBName, logger)
-	if err != nil {
-		// TODO: More robustly detect failure to create SCD server is due to a problem that may be temporary
-		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database \"aux\" does not exist") {
-			datastore.Pool.Close()
-			return nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to datastore server for strategic conflict detection store")
-		}
-		return nil, stacktrace.Propagate(err, "Failed to create strategic conflict detection store")
+		return nil, err
 	}
 
 	repo, err := auxStore.Interact(ctx)
@@ -146,25 +104,10 @@ func createAuxServer(ctx context.Context, locality string, publicEndpoint string
 }
 
 func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) (*rid_v1.Server, *rid_v2.Server, error) {
-	connectParameters := flags.ConnectParameters()
-	connectParameters.DBName = "rid"
-	datastore, err := datastore.Dial(ctx, connectParameters)
-	if err != nil {
-		// TODO: More robustly detect failure to create RID server is due to a problem that may be temporary
-		if strings.Contains(err.Error(), "connect: connection refused") {
-			return nil, nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to datastore server for remote ID store")
-		}
-		return nil, nil, stacktrace.Propagate(err, "Failed to connect to remote ID database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
-	}
 
-	ridStore, err := ridc.NewStore(ctx, datastore, connectParameters.DBName, logger)
+	ridStore, err := ridc.Dial(ctx, logger)
 	if err != nil {
-		// TODO: More robustly detect failure to create RID server is due to a problem that may be temporary
-		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database has not been bootstrapped with Schema Manager") {
-			datastore.Pool.Close()
-			return nil, nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to datastore server for remote ID store")
-		}
-		return nil, nil, stacktrace.Propagate(err, "Failed to create remote ID store")
+		return nil, nil, err
 	}
 
 	_, err = ridStore.Interact(ctx)
@@ -172,54 +115,24 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 		return nil, nil, stacktrace.Propagate(err, "Unable to interact with store")
 	}
 
-	// schedule period tasks for RID Server
-	ridCron := cron.New()
-	// schedule printing of DB connection stats every minute for the underlying storage for RID Server
-	if _, err := ridCron.AddFunc("@every 1m", func() { getDBStats(ctx, datastore, connectParameters.DBName) }); err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Failed to schedule periodic db stat check to %s", connectParameters.DBName)
-	}
-	ridCron.Start()
-
 	app := application.NewFromTransactor(ridStore, logger)
 	return &rid_v1.Server{
 			App:               app,
 			Locality:          locality,
 			AllowHTTPBaseUrls: *allowHTTPBaseUrls,
-			Cron:              ridCron,
 		}, &rid_v2.Server{
 			App:               app,
 			Locality:          locality,
 			AllowHTTPBaseUrls: *allowHTTPBaseUrls,
-			Cron:              ridCron,
 		}, nil
 }
 
 func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, error) {
-	connectParameters := flags.ConnectParameters()
-	connectParameters.DBName = scdc.DatabaseName
-	datastore, err := datastore.Dial(ctx, connectParameters)
+
+	scdStore, err := scdc.Dial(ctx, logger, *scdGlobalLock)
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to connect to strategic conflict detection database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
+		return nil, err
 	}
-
-	scdStore, err := scdc.NewStore(ctx, datastore, *scdGlobalLock)
-	if err != nil {
-		// TODO: More robustly detect failure to create SCD server is due to a problem that may be temporary
-		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database \"scd\" does not exist") {
-			datastore.Pool.Close()
-			return nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to datastore server for strategic conflict detection store")
-		}
-		return nil, stacktrace.Propagate(err, "Failed to create strategic conflict detection store")
-	}
-
-	// schedule period tasks for SCD Server
-	scdCron := cron.New()
-	// schedule printing of DB connection stats every minute for the underlying storage for RID Server
-	if _, err := scdCron.AddFunc("@every 1m", func() { getDBStats(ctx, datastore, scdc.DatabaseName) }); err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to schedule periodic db stat check to %s", scdc.DatabaseName)
-	}
-
-	scdCron.Start()
 
 	return &scd.Server{
 		Store:             scdStore,
@@ -299,8 +212,6 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 	if *enableSCD {
 		scdV1Server, err = createSCDServer(ctx, logger)
 		if err != nil {
-			ridV1Server.Cron.Stop()
-			ridV2Server.Cron.Stop()
 			return stacktrace.Propagate(err, "Failed to create strategic conflict detection server")
 		}
 
@@ -436,7 +347,7 @@ func main() {
 	backoff := 0
 	for {
 		if err := RunHTTPServer(ctx, cancel, *address, *locality); err != nil {
-			if stacktrace.GetCode(err) == codeRetryable {
+			if stacktrace.GetCode(err) == datastoreutils.CodeRetryable {
 				logger.Info(fmt.Sprintf("Prerequisites not yet satisfied; waiting %.fs to retry...", backoffs[backoff].Seconds()), zap.Error(err))
 				time.Sleep(backoffs[backoff])
 				if backoff < len(backoffs)-1 {

--- a/cmds/db-manager/cleanup/README.md
+++ b/cmds/db-manager/cleanup/README.md
@@ -46,7 +46,6 @@ Flags:
 
 Global Flags:
       --datastore_application_name string   application name for tagging the connection to the database (default "dss")
-      --datastore_db_name string            database name to connect to
       --datastore_host string               database host to connect to
       --datastore_max_conn_idle_secs int    maximum amount of time in seconds a connection may be idle, default is 30 seconds (default 30)
       --datastore_max_open_conns int        maximum number of open connections to the database, default is 4 (default 4)

--- a/cmds/db-manager/cleanup/evict.go
+++ b/cmds/db-manager/cleanup/evict.go
@@ -6,8 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/interuss/dss/pkg/datastore"
-	datastoreflags "github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/datastoreutils"
 	"github.com/interuss/dss/pkg/logging"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
@@ -54,12 +53,16 @@ func evict(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithTimeout(ctx, *timeout)
 	defer cancel()
 
-	scdStore, err := getSCDStore(ctx)
+	logger := logging.WithValuesFromContext(ctx, logging.Logger)
+
+	datastoreutils.ApplicationName = "db-manager"
+
+	scdStore, err := scdc.Dial(ctx, logger, false)
 	if err != nil {
 		return err
 	}
 
-	ridStore, err := getRIDStore(ctx)
+	ridStore, err := ridc.Dial(ctx, logger)
 	if err != nil {
 		return err
 	}
@@ -104,7 +107,7 @@ func evict(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to execute SCD transaction: %w", err)
 	}
 
-	ridAction := func(r ridrepos.Repository) (err error) {
+	ridAction := func(ctx context.Context, r ridrepos.Repository) (err error) {
 		if *checkRidISAs {
 
 			expiredISAs, err = r.ListExpiredISAs(ctx, *locality, ridThreshold)
@@ -167,45 +170,6 @@ func evict(cmd *cobra.Command, _ []string) error {
 		log.Printf("no entity was deleted, run the command again with the `--delete` flag to do so")
 	}
 	return nil
-}
-
-func getSCDStore(ctx context.Context) (*scdc.Store, error) {
-	connectParameters := datastoreflags.ConnectParameters()
-	connectParameters.ApplicationName = "db-manager"
-	connectParameters.DBName = scdc.DatabaseName
-	datastore, err := datastore.Dial(ctx, connectParameters)
-	if err != nil {
-		logParams := connectParameters
-		logParams.Credentials.Password = "[REDACTED]"
-		return nil, fmt.Errorf("failed to connect to SCD database with %+v: %w", logParams, err)
-	}
-
-	scdStore, err := scdc.NewStore(ctx, datastore, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create strategic conflict detection store with %+v: %w", connectParameters, err)
-	}
-	return scdStore, nil
-}
-
-func getRIDStore(ctx context.Context) (*ridc.Store, error) {
-
-	logger := logging.WithValuesFromContext(ctx, logging.Logger)
-
-	connectParameters := datastoreflags.ConnectParameters()
-	connectParameters.ApplicationName = "db-manager"
-	connectParameters.DBName = "rid"
-	datastore, err := datastore.Dial(ctx, connectParameters)
-	if err != nil {
-		logParams := connectParameters
-		logParams.Credentials.Password = "[REDACTED]"
-		return nil, fmt.Errorf("failed to connect to remote ID database with %+v: %w", logParams, err)
-	}
-
-	ridStore, err := ridc.NewStore(ctx, datastore, connectParameters.DBName, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create remote ID store with %+v: %w", connectParameters, err)
-	}
-	return ridStore, nil
 }
 
 func logExpiredEntity(entity string, entityID dssmodels.ID, threshold time.Time, deleted, hasEndTime bool) {

--- a/pkg/aux_/store/datastore/store.go
+++ b/pkg/aux_/store/datastore/store.go
@@ -3,17 +3,12 @@ package datastore
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach-go/v2/crdb"
-	"github.com/interuss/dss/pkg/datastore/flags"
-	dssql "github.com/interuss/dss/pkg/sql"
-
-	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
-	"github.com/coreos/go-semver/semver"
 	"github.com/interuss/dss/pkg/aux_/repos"
 	"github.com/interuss/dss/pkg/datastore"
+	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/datastoreutils"
 	"github.com/interuss/dss/pkg/logging"
-	"github.com/interuss/stacktrace"
-	"github.com/jackc/pgx/v5"
+	dssql "github.com/interuss/dss/pkg/sql"
 	"github.com/jonboulle/clockwork"
 	"go.uber.org/zap"
 )
@@ -24,11 +19,6 @@ const (
 	currentYugabyteMajorSchemaVersion = 1
 )
 
-var (
-	// DefaultClock is what is used as the Store's clock, returned from Dial.
-	DefaultClock = clockwork.NewRealClock()
-)
-
 type repo struct {
 	dssql.Queryable
 	clock   clockwork.Clock
@@ -36,134 +26,40 @@ type repo struct {
 	version *datastore.Version
 }
 
-// Store is an implementation of store.Store using Cockroach DB or yugabyte as its backend
-// store.
-//
-// TODO: Add the RID/SCD interfaces here, and collapse this store with the
-// outer pkg/cockroach
 type Store struct {
-	db      *datastore.Datastore
-	logger  *zap.Logger
-	clock   clockwork.Clock
-	version *semver.Version
-
-	// DatabaseName is the name of database storing aux data.
-	DatabaseName string
+	datastore.BaseStore[repos.Repository]
 }
 
-// NewStore returns a Store instance connected to a datastore instance via db.
-func NewStore(ctx context.Context, db *datastore.Datastore, dbName string, logger *zap.Logger) (*Store, error) {
-	vs, err := db.GetSchemaVersion(ctx, dbName)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to get database schema version for aux for db : %s", dbName)
-	}
+func NewStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger) (*Store, error) {
 
-	store := &Store{
-		db:           db,
-		logger:       logger,
-		clock:        DefaultClock,
-		version:      vs,
-		DatabaseName: dbName,
-	}
+	s := &Store{}
 
-	if err := store.CheckCurrentMajorSchemaVersion(ctx); err != nil {
-		return nil, stacktrace.Propagate(err, "Aux schema version check failed")
-	}
-
-	return store, nil
-}
-
-// CheckCurrentMajorSchemaVersion checks that store supports the current major schema version.
-func (s *Store) CheckCurrentMajorSchemaVersion(ctx context.Context) error {
-	vs, err := s.GetVersion(ctx)
-	if err != nil {
-		return stacktrace.Propagate(err, "Failed to get database schema version for aux")
-	}
-	if vs == datastore.UnknownVersion {
-		return stacktrace.NewError("Aux database has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas")
-	}
-
-	if s.db.Version.Type == datastore.CockroachDB && currentCrdbMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for aux! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", vs, currentCrdbMajorSchemaVersion)
-	}
-
-	if s.db.Version.Type == datastore.Yugabyte && currentYugabyteMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for aux! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", vs, currentYugabyteMajorSchemaVersion)
-	}
-
-	return nil
-}
-
-// Interact implements store.Interactor interface.
-func (s *Store) Interact(ctx context.Context) (repos.Repository, error) {
-	logger := logging.WithValuesFromContext(ctx, s.logger)
-	return &repo{
-		Queryable: s.db.Pool,
-		clock:     s.clock,
-		logger:    logger,
-		version:   s.db.Version,
-	}, nil
-}
-
-// Transact supplies a new repo, that will perform all of the DB accesses
-// in a Txn, and will retry any Txn's that fail due to retry-able errors
-// (typically contention).
-func (s *Store) Transact(ctx context.Context, f func(repo repos.Repository) error) error {
-	logger := logging.WithValuesFromContext(ctx, s.logger)
-	// TODO: consider what tx opts we want to support.
-	// TODO: we really need to remove the upper cockroach package, and have one
-	// "store" for everything
-
-	ctx = crdb.WithMaxRetries(ctx, flags.ConnectParameters().MaxRetries)
-
-	return crdbpgx.ExecuteTx(ctx, s.db.Pool, pgx.TxOptions{
-		IsoLevel: pgx.Serializable,
-	}, func(tx pgx.Tx) error {
-		// Is this recover still necessary?
-		defer recoverRollbackRepanic(ctx, tx)
-		return f(&repo{
-			Queryable: tx,
-			clock:     s.clock,
-			logger:    logger,
-		})
-	})
-}
-
-// Close closes the underlying DB connection.
-func (s *Store) Close() error {
-	s.db.Pool.Close()
-	return nil
-}
-
-func recoverRollbackRepanic(ctx context.Context, tx pgx.Tx) {
-	if p := recover(); p != nil {
-		if err := tx.Rollback(ctx); err != nil {
-			logging.WithValuesFromContext(ctx, logging.Logger).Error(
-				"failed to rollback transaction", zap.Error(err),
-			)
+	base, err := datastore.NewBaseStore(ctx, db, flags.ConnectParameters().MaxRetries, func(q dssql.Queryable) repos.Repository {
+		return &repo{
+			Queryable: q,
+			clock:     s.Clock,
+			logger:    logging.WithValuesFromContext(ctx, logger),
+			version:   db.Version,
 		}
+	})
+	if err != nil {
+		return nil, err
 	}
+	s.BaseStore = base
+	return s, s.CheckMajorSchemaVersion(ctx, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, db.Pool.Config().ConnConfig.Database)
 }
 
-// CleanUp removes all database tables managed by s.
 func (s *Store) CleanUp(ctx context.Context) error {
-	const query = `
-	DELETE FROM dss_metadata WHERE locality IS NOT NULL;
-    `
-
-	_, err := s.db.Pool.Exec(ctx, query)
+	const query = `DELETE FROM dss_metadata WHERE locality IS NOT NULL;`
+	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
 }
 
-// GetVersion returns the Version string for the Database.
-// If the DB was is not bootstrapped using the schema manager we throw and error
-func (s *Store) GetVersion(ctx context.Context) (*semver.Version, error) {
-	if s.version == nil {
-		vs, err := s.db.GetSchemaVersion(ctx, s.DatabaseName)
-		if err != nil {
-			return nil, stacktrace.Propagate(err, "Failed to get database schema version for aux")
-		}
-		s.version = vs
-	}
-	return s.version, nil
+func Dial(ctx context.Context, logger *zap.Logger) (*Store, error) {
+
+	store, err := datastoreutils.DialStore(ctx, "aux", func(db *datastore.Datastore) (*Store, error) {
+		return NewStore(ctx, db, logger)
+	})
+
+	return store, err
 }

--- a/pkg/aux_/store/datastore/store_test.go
+++ b/pkg/aux_/store/datastore/store_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/interuss/dss/pkg/datastore"
 	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/logging"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 )
@@ -31,13 +32,16 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 }
 
 func newStore(ctx context.Context, t *testing.T, connectParameters datastore.ConnectParameters) (*Store, error) {
+	connectParameters.DBName = "aux"
 	db, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 
-	return &Store{
-		db:    db,
-		clock: fakeClock,
-	}, nil
+	s, err := NewStore(ctx, db, logging.Logger)
+	if err != nil {
+		return nil, err
+	}
+	s.Clock = fakeClock
+	return s, nil
 }
 
 // CleanUp drops all required tables from the store, useful for testing.
@@ -46,6 +50,6 @@ func CleanUp(ctx context.Context, s *Store) error {
 	DELETE FROM dss_metadata WHERE locality IS NOT NULL;
     `
 
-	_, err := s.db.Pool.Exec(ctx, query)
+	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
 }

--- a/pkg/aux_/store/store.go
+++ b/pkg/aux_/store/store.go
@@ -1,35 +1,8 @@
 package store
 
 import (
-	"context"
-	"io"
-
-	"github.com/coreos/go-semver/semver"
 	"github.com/interuss/dss/pkg/aux_/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
 )
 
-// Store provides the means by which to obtain Repos with which to interact with
-// the remote ID backing store.
-type Store interface {
-	io.Closer
-	Interactor
-	Transactor
-
-	// Get store version
-	GetVersion(ctx context.Context) (*semver.Version, error)
-}
-
-// Interactor provides means to get hold of a repos.Repository instance *without* any
-// isolation/atomicity guarantees.
-type Interactor interface {
-	// Interact returns a repos.Repository instance or an error in case of issues.
-	Interact(context.Context) (repos.Repository, error)
-}
-
-// Transactor provides means to get hold of a repos.Repository instance in the context
-// of a transaction, thus guaranteeing isolation/atomicity.
-type Transactor interface {
-	// Transact executes f and provides a repos.Repository instance that guarantees
-	// isolation/atomicity.
-	Transact(ctx context.Context, f func(repos.Repository) error) error
-}
+type Store = dssstore.Store[repos.Repository]

--- a/pkg/datastore/flags/flags.go
+++ b/pkg/datastore/flags/flags.go
@@ -17,7 +17,6 @@ func ConnectParameters() datastore.ConnectParameters {
 
 func init() {
 	flag.StringVar(&connectParameters.ApplicationName, "datastore_application_name", "dss", "application name for tagging the connection to the database")
-	flag.StringVar(&connectParameters.DBName, "datastore_db_name", "", "database name to connect to")
 	flag.StringVar(&connectParameters.Host, "datastore_host", "", "database host to connect to")
 	flag.IntVar(&connectParameters.Port, "datastore_port", 26257, "database port to connect to")
 	flag.StringVar(&connectParameters.SSL.Mode, "datastore_ssl_mode", "disable", "database sslmode")
@@ -28,7 +27,6 @@ func init() {
 	flag.IntVar(&connectParameters.MaxRetries, "datastore_max_retries", 100, "maximum number of attempts to retry a query in case of contention, default is 100")
 
 	flag.StringVar(&connectParameters.ApplicationName, "cockroach_application_name", connectParameters.ApplicationName, "DEPRECATED: use 'datastore_application_name' instead")
-	flag.StringVar(&connectParameters.DBName, "cockroach_db_name", connectParameters.DBName, "DEPRECATED: use 'datastore_db_name' instead")
 	flag.StringVar(&connectParameters.Host, "cockroach_host", connectParameters.Host, "DEPRECATED: use 'datastore_host' instead")
 	flag.IntVar(&connectParameters.Port, "cockroach_port", connectParameters.Port, "DEPRECATED: use 'datastore_port' instead")
 	flag.StringVar(&connectParameters.SSL.Mode, "cockroach_ssl_mode", connectParameters.SSL.Mode, "DEPRECATED: use 'datastore_ssl_mode' instead")

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1,0 +1,84 @@
+package datastore
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach-go/v2/crdb"
+	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
+	"github.com/coreos/go-semver/semver"
+	dssql "github.com/interuss/dss/pkg/sql"
+	"github.com/interuss/stacktrace"
+	"github.com/jackc/pgx/v5"
+	"github.com/jonboulle/clockwork"
+)
+
+type BaseStore[R any] struct {
+	DB           *Datastore
+	Clock        clockwork.Clock
+	databaseName string
+	version      *semver.Version
+	newRepo      func(dssql.Queryable) R
+	maxRetries   int
+}
+
+func NewBaseStore[R any](ctx context.Context, db *Datastore, maxRetries int, newRepo func(dssql.Queryable) R) (BaseStore[R], error) {
+
+	dbName := db.Pool.Config().ConnConfig.Database
+
+	vs, err := db.GetSchemaVersion(ctx, dbName)
+	if err != nil {
+		return BaseStore[R]{}, stacktrace.Propagate(err, "Failed to get schema version for %s", dbName)
+	}
+	return BaseStore[R]{
+		DB:           db,
+		Clock:        clockwork.NewRealClock(),
+		databaseName: dbName,
+		version:      vs,
+		newRepo:      newRepo,
+		maxRetries:   maxRetries,
+	}, nil
+}
+
+func (s *BaseStore[R]) Interact(_ context.Context) (R, error) {
+	return s.newRepo(s.DB.Pool), nil
+}
+
+func (s *BaseStore[R]) Transact(ctx context.Context, f func(context.Context, R) error) error {
+	ctx = crdb.WithMaxRetries(ctx, s.maxRetries)
+	return crdbpgx.ExecuteTx(ctx, s.DB.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
+		return f(ctx, s.newRepo(tx))
+	})
+}
+
+func (s *BaseStore[R]) GetVersion(ctx context.Context) (*semver.Version, error) {
+	if s.version == nil {
+		vs, err := s.DB.GetSchemaVersion(ctx, s.databaseName)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "Failed to get schema version for %s", s.databaseName)
+		}
+		s.version = vs
+	}
+	return s.version, nil
+}
+
+func (s *BaseStore[R]) CheckMajorSchemaVersion(ctx context.Context, crdbExpected, ybExpected int64, module string) error {
+	vs, err := s.GetVersion(ctx)
+	if err != nil {
+		return stacktrace.Propagate(err, "Failed to get schema version for %s", module)
+	}
+	if vs == UnknownVersion {
+		return stacktrace.NewError("%s database not bootstrapped with Schema Manager", module)
+	}
+	if s.DB.Version.Type == CockroachDB && crdbExpected != vs.Major {
+		return stacktrace.NewError("%s: unsupported schema version %s, requires major %d", module, vs, crdbExpected)
+	}
+	if s.DB.Version.Type == Yugabyte && ybExpected != vs.Major {
+		return stacktrace.NewError("%s: unsupported schema version %s, requires major %d", module, vs, ybExpected)
+	}
+	return nil
+}
+
+func (s *BaseStore[R]) Close() error {
+	s.DB.Pool.Close()
+	return nil
+}

--- a/pkg/datastoreutils/dial.go
+++ b/pkg/datastoreutils/dial.go
@@ -1,0 +1,76 @@
+package datastoreutils
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/interuss/dss/pkg/datastore"
+	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/logging"
+	"github.com/interuss/stacktrace"
+	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
+)
+
+const (
+	CodeRetryable = stacktrace.ErrorCode(1)
+)
+
+var ApplicationName = flags.ConnectParameters().ApplicationName
+
+func getDBStats(ctx context.Context, db *datastore.Datastore, databaseName string) {
+	logger := logging.WithValuesFromContext(ctx, logging.Logger)
+	statsPtr := db.Pool.Stat()
+	stats := make(map[string]string)
+	stats["DBName"] = databaseName
+	stats["AcquireCount"] = strconv.Itoa(int(statsPtr.AcquireCount()))
+	stats["AcquiredConns"] = strconv.Itoa(int(statsPtr.AcquiredConns()))
+	stats["CanceledAcquireCount"] = strconv.Itoa(int(statsPtr.CanceledAcquireCount()))
+	stats["ConstructingConns"] = strconv.Itoa(int(statsPtr.ConstructingConns()))
+	stats["EmptyAcquireCount"] = strconv.Itoa(int(statsPtr.EmptyAcquireCount()))
+	stats["IdleConns"] = strconv.Itoa(int(statsPtr.IdleConns()))
+	stats["MaxConns"] = strconv.Itoa(int(statsPtr.MaxConns()))
+	stats["TotalConns"] = strconv.Itoa(int(statsPtr.TotalConns()))
+	if stats["TotalConns"] == "0" {
+		logger.Warn("Failed periodic DB Ping (TotalConns=0)", zap.String("Database", databaseName))
+	} else {
+		logger.Info("Successful periodic DB Ping ", zap.String("Database", databaseName))
+	}
+}
+
+func DialStore[S any](ctx context.Context, dbName string, newStore func(*datastore.Datastore) (S, error)) (S, error) {
+
+	var zero S
+
+	cp := flags.ConnectParameters()
+	cp.DBName = dbName
+	cp.ApplicationName = ApplicationName
+
+	db, err := datastore.Dial(ctx, cp)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "connect: connection refused") {
+			return zero, stacktrace.PropagateWithCode(err, CodeRetryable, "Failed to connect to datastore server for %s", dbName)
+		}
+		return zero, stacktrace.Propagate(err, "Failed to connect to %s database", dbName)
+	}
+	s, err := newStore(db)
+	if err != nil {
+		db.Pool.Close()
+		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), fmt.Sprintf("database \"%s\" does not exist", dbName)) || strings.Contains(err.Error(), "database has not been bootstrapped with Schema Manager") {
+			return zero, stacktrace.PropagateWithCode(err, CodeRetryable, "Failed to create %s store", dbName)
+		}
+		return zero, stacktrace.Propagate(err, "Failed to create %s store", dbName)
+	}
+
+	c := cron.New()
+	if _, err := c.AddFunc("@every 1m", func() { getDBStats(ctx, db, dbName) }); err != nil {
+		db.Pool.Close()
+		return zero, stacktrace.Propagate(err, "Failed to schedule db stats for %s", dbName)
+	}
+	c.Start()
+
+	return s, nil
+}

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -35,8 +35,8 @@ func (s *mockRepo) Interact(ctx context.Context) (repos.Repository, error) {
 	return s, nil
 }
 
-func (s *mockRepo) Transact(ctx context.Context, f func(repo repos.Repository) error) error {
-	return f(s)
+func (s *mockRepo) Transact(ctx context.Context, f func(ctx context.Context, repo repos.Repository) error) error {
+	return f(ctx, s)
 }
 
 func (s *mockRepo) Close() error {
@@ -61,13 +61,14 @@ func setUpStore(ctx context.Context, t *testing.T, logger *zap.Logger) (store.St
 	if connectParameters.DBName != "rid" && connectParameters.DBName != "scd" {
 		connectParameters.DBName = "rid"
 	}
-	ridc.DefaultClock = fakeClock
 	ridDatastore, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 	logger.Info("using datastore.")
 
-	store, err := ridc.NewStore(ctx, ridDatastore, "rid", logger)
+	store, err := ridc.NewStore(ctx, ridDatastore, logger)
 	require.NoError(t, err)
+
+	store.Clock = fakeClock
 
 	return store, func() {
 		require.NoError(t, CleanUp(ctx, store))

--- a/pkg/rid/application/isa.go
+++ b/pkg/rid/application/isa.go
@@ -63,7 +63,7 @@ func (a *app) DeleteISA(ctx context.Context, id dssmodels.ID, owner dssmodels.Ow
 		subs []*ridmodels.Subscription
 	)
 	// The following will automatically retry TXN retry errors.
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		old, err := repo.GetISA(ctx, id, true)
 		switch {
 		case err != nil:
@@ -104,7 +104,7 @@ func (a *app) InsertISA(ctx context.Context, isa *ridmodels.IdentificationServic
 		subs []*ridmodels.Subscription
 	)
 	// The following will automatically retry TXN retry errors.
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		// ensure it doesn't exist yet
 		old, err := repo.GetISA(ctx, isa.ID, false)
 		if err != nil {
@@ -138,7 +138,7 @@ func (a *app) UpdateISA(ctx context.Context, isa *ridmodels.IdentificationServic
 		subs []*ridmodels.Subscription
 	)
 	// The following will automatically retry TXN retry errors.
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		var err error
 
 		old, err := repo.GetISA(ctx, isa.ID, true)

--- a/pkg/rid/application/subscription.go
+++ b/pkg/rid/application/subscription.go
@@ -60,7 +60,7 @@ func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription)
 		return nil, stacktrace.Propagate(err, "Unable to adjust time range")
 	}
 	var sub *ridmodels.Subscription
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 
 		// ensure it doesn't exist yet
 		old, err := repo.GetSubscription(ctx, s.ID)
@@ -98,7 +98,7 @@ func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription)
 func (a *app) UpdateSubscription(ctx context.Context, s *ridmodels.Subscription) (*ridmodels.Subscription, error) {
 	var sub *ridmodels.Subscription
 
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		old, err := repo.GetSubscription(ctx, s.ID)
 		switch {
 		case err != nil:
@@ -145,7 +145,7 @@ func (a *app) UpdateSubscription(ctx context.Context, s *ridmodels.Subscription)
 // DeleteSubscription deletes the Subscription identified by "id" and owned by "owner".
 func (a *app) DeleteSubscription(ctx context.Context, id dssmodels.ID, owner dssmodels.Owner, version *dssmodels.Version) (*ridmodels.Subscription, error) {
 	var ret *ridmodels.Subscription
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		var err error
 		old, err := repo.GetSubscription(ctx, id)
 		switch {

--- a/pkg/rid/server/v1/server.go
+++ b/pkg/rid/server/v1/server.go
@@ -7,7 +7,6 @@ import (
 	restapi "github.com/interuss/dss/pkg/api/ridv1"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/stacktrace"
-	"github.com/robfig/cron/v3"
 
 	"github.com/interuss/dss/pkg/rid/application"
 )
@@ -17,7 +16,6 @@ type Server struct {
 	App               application.App
 	Locality          string
 	AllowHTTPBaseUrls bool
-	Cron              *cron.Cron
 }
 
 func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {

--- a/pkg/rid/store/datastore/store.go
+++ b/pkg/rid/store/datastore/store.go
@@ -3,17 +3,13 @@ package datastore
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/datastoreutils"
 	dssql "github.com/interuss/dss/pkg/sql"
 
-	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
-	"github.com/coreos/go-semver/semver"
 	"github.com/interuss/dss/pkg/datastore"
 	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/rid/repos"
-	"github.com/interuss/stacktrace"
-	"github.com/jackc/pgx/v5"
 	"github.com/jonboulle/clockwork"
 	"go.uber.org/zap"
 )
@@ -24,144 +20,47 @@ const (
 	currentYugabyteMajorSchemaVersion = 1
 )
 
-var (
-	// DefaultClock is what is used as the Store's clock, returned from Dial.
-	DefaultClock = clockwork.NewRealClock()
-)
-
 type repo struct {
 	dssql.Queryable
 	clock  clockwork.Clock
 	logger *zap.Logger
 }
 
-// Store is an implementation of store.Store using Cockroach DB or Yugabyte as its backend
-// store.
-//
-// TODO: Add the SCD interfaces here, and collapse this store with the
-// outer pkg/cockroach
 type Store struct {
-	db      *datastore.Datastore
-	logger  *zap.Logger
-	clock   clockwork.Clock
-	version *semver.Version
-
-	// DatabaseName is the name of database storing remote ID data.
-	DatabaseName string
+	datastore.BaseStore[repos.Repository]
 }
 
-// NewStore returns a Store instance connected to a cockroach or yugabyte instance via db.
-func NewStore(ctx context.Context, db *datastore.Datastore, dbName string, logger *zap.Logger) (*Store, error) {
-	vs, err := db.GetSchemaVersion(ctx, dbName)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to get database schema version for remote ID for db : %s", dbName)
-	}
+func NewStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger) (*Store, error) {
 
-	store := &Store{
-		db:           db,
-		logger:       logger,
-		clock:        DefaultClock,
-		version:      vs,
-		DatabaseName: dbName,
-	}
+	s := &Store{}
 
-	if err := store.CheckCurrentMajorSchemaVersion(ctx); err != nil {
-		return nil, stacktrace.Propagate(err, "Remote ID schema version check failed")
-	}
-
-	return store, nil
-}
-
-// CheckCurrentMajorSchemaVersion checks that store supports the current major schema version.
-func (s *Store) CheckCurrentMajorSchemaVersion(ctx context.Context) error {
-	vs, err := s.GetVersion(ctx)
-	if err != nil {
-		return stacktrace.Propagate(err, "Failed to get database schema version for remote ID")
-	}
-	if vs == datastore.UnknownVersion {
-		return stacktrace.NewError("Remote ID database has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas")
-	}
-
-	if s.db.Version.Type == datastore.CockroachDB && currentCrdbMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for remote ID! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", vs, currentCrdbMajorSchemaVersion)
-	}
-
-	if s.db.Version.Type == datastore.Yugabyte && currentYugabyteMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for remote ID! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", vs, currentYugabyteMajorSchemaVersion)
-	}
-
-	return nil
-}
-
-// Interact implements store.Interactor interface.
-func (s *Store) Interact(ctx context.Context) (repos.Repository, error) {
-	logger := logging.WithValuesFromContext(ctx, s.logger)
-	return &repo{
-		Queryable: s.db.Pool,
-		clock:     s.clock,
-		logger:    logger,
-	}, nil
-}
-
-// Transact supplies a new repo, that will perform all of the DB accesses
-// in a Txn, and will retry any Txn's that fail due to retry-able errors
-// (typically contention).
-func (s *Store) Transact(ctx context.Context, f func(repo repos.Repository) error) error {
-	logger := logging.WithValuesFromContext(ctx, s.logger)
-	// TODO: consider what tx opts we want to support.
-	// TODO: we really need to remove the upper cockroach package, and have one
-	// "store" for everything
-
-	ctx = crdb.WithMaxRetries(ctx, flags.ConnectParameters().MaxRetries)
-
-	return crdbpgx.ExecuteTx(ctx, s.db.Pool, pgx.TxOptions{
-		IsoLevel: pgx.Serializable,
-	}, func(tx pgx.Tx) error {
-		// Is this recover still necessary?
-		defer recoverRollbackRepanic(ctx, tx)
-		return f(&repo{
-			Queryable: tx,
-			clock:     s.clock,
-			logger:    logger,
-		})
-	})
-}
-
-// Close closes the underlying DB connection.
-func (s *Store) Close() error {
-	s.db.Pool.Close()
-	return nil
-}
-
-func recoverRollbackRepanic(ctx context.Context, tx pgx.Tx) {
-	if p := recover(); p != nil {
-		if err := tx.Rollback(ctx); err != nil {
-			logging.WithValuesFromContext(ctx, logging.Logger).Error(
-				"failed to rollback transaction", zap.Error(err),
-			)
+	base, err := datastore.NewBaseStore(ctx, db, flags.ConnectParameters().MaxRetries, func(q dssql.Queryable) repos.Repository {
+		return &repo{
+			Queryable: q,
+			clock:     s.Clock,
+			logger:    logging.WithValuesFromContext(ctx, logger),
 		}
+	})
+	if err != nil {
+		return nil, err
 	}
+	s.BaseStore = base
+	return s, s.CheckMajorSchemaVersion(ctx, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, db.Pool.Config().ConnConfig.Database)
 }
 
-// CleanUp removes all database tables managed by s.
 func (s *Store) CleanUp(ctx context.Context) error {
 	const query = `
 	DELETE FROM subscriptions WHERE id IS NOT NULL;
 	DELETE FROM identification_service_areas WHERE id IS NOT NULL;`
-
-	_, err := s.db.Pool.Exec(ctx, query)
+	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
 }
 
-// GetVersion returns the Version string for the Database.
-// If the DB was is not bootstrapped using the schema manager we throw and error
-func (s *Store) GetVersion(ctx context.Context) (*semver.Version, error) {
-	if s.version == nil {
-		vs, err := s.db.GetSchemaVersion(ctx, s.DatabaseName)
-		if err != nil {
-			return nil, stacktrace.Propagate(err, "Failed to get database schema version for remote ID")
-		}
-		s.version = vs
-	}
-	return s.version, nil
+func Dial(ctx context.Context, logger *zap.Logger) (*Store, error) {
+
+	store, err := datastoreutils.DialStore(ctx, "rid", func(db *datastore.Datastore) (*Store, error) {
+		return NewStore(ctx, db, logger)
+	})
+
+	return store, err
 }

--- a/pkg/rid/store/datastore/store_test.go
+++ b/pkg/rid/store/datastore/store_test.go
@@ -46,15 +46,17 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 }
 
 func newStore(ctx context.Context, t *testing.T, connectParameters datastore.ConnectParameters) (*Store, error) {
+	connectParameters.DBName = "rid"
 	db, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 
-	return &Store{
-		db:           db,
-		logger:       logging.Logger,
-		clock:        fakeClock,
-		DatabaseName: "rid",
-	}, nil
+	s, err := NewStore(ctx, db, logging.Logger)
+	if err != nil {
+		return nil, err
+	}
+	s.Clock = fakeClock
+	return s, nil
+
 }
 
 // CleanUp drops all required tables from the store, useful for testing.
@@ -63,7 +65,7 @@ func CleanUp(ctx context.Context, s *Store) error {
 	DELETE FROM subscriptions WHERE id IS NOT NULL;
 	DELETE FROM identification_service_areas WHERE id IS NOT NULL;`
 
-	_, err := s.db.Pool.Exec(ctx, query)
+	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
 }
 
@@ -101,7 +103,7 @@ func TestTxnRetrier(t *testing.T) {
 	require.NotNil(t, store)
 	defer tearDownStore()
 
-	err := store.Transact(ctx, func(repo repos.Repository) error {
+	err := store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		// can query within this
 		isa, err := repo.InsertISA(ctx, serviceArea)
 		require.NotNil(t, isa)
@@ -122,7 +124,7 @@ func TestTxnRetrier(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
 	defer cancel()
 	count := 0
-	err = store.Transact(ctx, func(repo repos.Repository) error {
+	err = store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		// can query within this
 		count++
 		// Postgre retryable error
@@ -145,13 +147,13 @@ func TestTransactor(t *testing.T) {
 	subscription2 := subscriptionsPool[1].input
 
 	txnCount := 0
-	err := store.Transact(ctx, func(s1 repos.Repository) error {
+	err := store.Transact(ctx, func(ctx context.Context, s1 repos.Repository) error {
 		// We should get to this retry, then return nothing.
 		if txnCount > 0 {
 			return errors.New("already failed")
 		}
 		txnCount++
-		err := store.Transact(ctx, func(s2 repos.Repository) error {
+		err := store.Transact(ctx, func(ctx context.Context, s2 repos.Repository) error {
 			subs, err := s1.SearchSubscriptions(ctx, subscription1.Cells)
 			require.NoError(t, err)
 			require.Len(t, subs, 0)
@@ -203,22 +205,22 @@ func TestBasicTxn(t *testing.T) {
 	subscription1 := subscriptionsPool[0].input
 	subscription2 := subscriptionsPool[1].input
 
-	tx1, err := store.db.Pool.Begin(ctx)
+	tx1, err := store.DB.Pool.Begin(ctx)
 	require.NoError(t, err)
 	s1 := &repo{
 		Queryable: tx1,
 		logger:    logging.Logger,
-		clock:     DefaultClock,
+		clock:     clockwork.NewRealClock(),
 	}
 
-	tx2, err := store.db.Pool.Begin(ctx)
+	tx2, err := store.DB.Pool.Begin(ctx)
 	require.NoError(t, err)
 	s2 := &repo{
 
 		Queryable: tx2,
 		logger:    logging.Logger,
 
-		clock: DefaultClock,
+		clock: clockwork.NewRealClock(),
 	}
 
 	subs, err := s1.SearchSubscriptions(ctx, subscription1.Cells)

--- a/pkg/rid/store/store.go
+++ b/pkg/rid/store/store.go
@@ -1,35 +1,8 @@
 package store
 
 import (
-	"context"
-	"io"
-
-	"github.com/coreos/go-semver/semver"
 	"github.com/interuss/dss/pkg/rid/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
 )
 
-// Store provides the means by which to obtain Repos with which to interact with
-// the remote ID backing store.
-type Store interface {
-	io.Closer
-	Interactor
-	Transactor
-
-	// Get store version
-	GetVersion(ctx context.Context) (*semver.Version, error)
-}
-
-// Interactor provides means to get hold of a repos.Repository instance *without* any
-// isolation/atomicity guarantees.
-type Interactor interface {
-	// Interact returns a repos.Repository instance or an error in case of issues.
-	Interact(context.Context) (repos.Repository, error)
-}
-
-// Transactor provides means to get hold of a repos.Repository instance in the context
-// of a transaction, thus guaranteeing isolation/atomicity.
-type Transactor interface {
-	// Transact executes f and provides a repos.Repository instance that guarantees
-	// isolation/atomicity.
-	Transact(ctx context.Context, f func(repos.Repository) error) error
-}
+type Store = dssstore.Store[repos.Repository]

--- a/pkg/scd/store/datastore/store.go
+++ b/pkg/scd/store/datastore/store.go
@@ -3,16 +3,15 @@ package datastore
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach-go/v2/crdb"
-	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
-	"github.com/coreos/go-semver/semver"
-	"github.com/interuss/dss/pkg/datastore"
 	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/datastoreutils"
+	dssql "github.com/interuss/dss/pkg/sql"
+
+	"github.com/interuss/dss/pkg/datastore"
+	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/scd/repos"
-	dsssql "github.com/interuss/dss/pkg/sql"
-	"github.com/interuss/stacktrace"
-	"github.com/jackc/pgx/v5"
 	"github.com/jonboulle/clockwork"
+	"go.uber.org/zap"
 )
 
 const (
@@ -21,95 +20,41 @@ const (
 	currentYugabyteMajorSchemaVersion = 1
 )
 
-var (
-	// DefaultClock is what is used as the Store's clock, returned from Dial.
-	DefaultClock = clockwork.NewRealClock()
-
-	// DatabaseName is the name of database storing strategic conflict detection data.
-	DatabaseName = "scd"
-)
-
-// repo is an implementation of repos.Repo using
-// a CockroachDB/Yugabyte transaction.
 type repo struct {
-	q          dsssql.Queryable
+	q          dssql.Queryable
 	clock      clockwork.Clock
+	logger     *zap.Logger
 	globalLock bool
 }
 
-// Store is an implementation of an scd.Store using
-// a CockroachDB or Yugabyte database.
 type Store struct {
-	db         *datastore.Datastore
-	clock      clockwork.Clock
-	globalLock bool
+	datastore.BaseStore[repos.Repository]
 }
 
-// NewStore returns a Store instance connected to a cockroach or Yugabyte instance via db.
-func NewStore(ctx context.Context, db *datastore.Datastore, globalLock bool) (*Store, error) {
-	store := &Store{
-		db:         db,
-		clock:      DefaultClock,
-		globalLock: globalLock,
-	}
+func NewStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger, globalLock bool) (*Store, error) {
 
-	if err := store.CheckCurrentMajorSchemaVersion(ctx); err != nil {
-		return nil, stacktrace.Propagate(err, "Strategic conflict detection schema version check failed")
-	}
+	s := &Store{}
 
-	return store, nil
-}
-
-// CheckCurrentMajorSchemaVersion returns nil if s supports the current major schema version.
-func (s *Store) CheckCurrentMajorSchemaVersion(ctx context.Context) error {
-	vs, err := s.GetVersion(ctx)
-	if err != nil {
-		return stacktrace.Propagate(err, "Failed to get database schema version for strategic conflict detection")
-	}
-	if vs == datastore.UnknownVersion {
-		return stacktrace.NewError("Strategic conflict detection database has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
-	}
-
-	if s.db.Version.Type == datastore.CockroachDB && currentCrdbMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for strategic conflict detection! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas", vs, currentCrdbMajorSchemaVersion)
-	}
-
-	if s.db.Version.Type == datastore.Yugabyte && currentYugabyteMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for strategic conflict detection! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas", vs, currentYugabyteMajorSchemaVersion)
-	}
-
-	return nil
-}
-
-// Interact implements store.Interactor interface.
-func (s *Store) Interact(_ context.Context) (repos.Repository, error) {
-	return &repo{
-		q:          s.db.Pool,
-		clock:      s.clock,
-		globalLock: s.globalLock,
-	}, nil
-}
-
-// Transact implements store.Transactor interface.
-func (s *Store) Transact(ctx context.Context, f func(context.Context, repos.Repository) error) error {
-	ctx = crdb.WithMaxRetries(ctx, flags.ConnectParameters().MaxRetries)
-	return crdbpgx.ExecuteTx(ctx, s.db.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
-		return f(ctx, &repo{
-			q:          tx,
-			clock:      s.clock,
-			globalLock: s.globalLock,
-		})
+	base, err := datastore.NewBaseStore(ctx, db, flags.ConnectParameters().MaxRetries, func(q dssql.Queryable) repos.Repository {
+		return &repo{
+			q:          q,
+			clock:      s.Clock,
+			logger:     logging.WithValuesFromContext(ctx, logger),
+			globalLock: globalLock,
+		}
 	})
+	if err != nil {
+		return nil, err
+	}
+	s.BaseStore = base
+	return s, s.CheckMajorSchemaVersion(ctx, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, db.Pool.Config().ConnConfig.Database)
 }
 
-// Close closes the underlying DB connection.
-func (s *Store) Close() error {
-	s.db.Pool.Close()
-	return nil
-}
+func Dial(ctx context.Context, logger *zap.Logger, globalLock bool) (*Store, error) {
 
-// GetVersion returns the Version string for the Database.
-// If the DB was is not bootstrapped using the schema manager we throw and error
-func (s *Store) GetVersion(ctx context.Context) (*semver.Version, error) {
-	return s.db.GetSchemaVersion(ctx, DatabaseName)
+	store, err := datastoreutils.DialStore(ctx, "scd", func(db *datastore.Datastore) (*Store, error) {
+		return NewStore(ctx, db, logger, globalLock)
+	})
+
+	return store, err
 }

--- a/pkg/scd/store/datastore/store_test.go
+++ b/pkg/scd/store/datastore/store_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/interuss/dss/pkg/datastore"
 	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/logging"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 )
@@ -31,13 +32,16 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 }
 
 func newStore(ctx context.Context, t *testing.T, connectParameters datastore.ConnectParameters) (*Store, error) {
+	connectParameters.DBName = "scd"
 	db, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 
-	return &Store{
-		db:    db,
-		clock: fakeClock,
-	}, nil
+	s, err := NewStore(ctx, db, logging.Logger, false)
+	if err != nil {
+		return nil, err
+	}
+	s.Clock = fakeClock
+	return s, nil
 }
 
 // CleanUp drops all required tables from the store, useful for testing.
@@ -48,6 +52,6 @@ func CleanUp(ctx context.Context, s *Store) error {
 	DELETE FROM scd_constraints WHERE id IS NOT NULL;
 	DELETE FROM scd_uss_availability WHERE id IS NOT NULL;`
 
-	_, err := s.db.Pool.Exec(ctx, query)
+	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
 }

--- a/pkg/scd/store/store.go
+++ b/pkg/scd/store/store.go
@@ -1,32 +1,8 @@
 package store
 
 import (
-	"context"
-
 	"github.com/interuss/dss/pkg/scd/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
 )
 
-// Store provides the means by which to obtain Repos with which to interact with
-// the strategic conflict detection backing store.
-type Store interface {
-	Interactor
-	Transactor
-
-	// Close closes the store and releases all of its resources.
-	Close() error
-}
-
-// Interactor provides means to get hold of a repos.Repository instance *without* any
-// isolation/atomicity guarantees.
-type Interactor interface {
-	// Interact returns a repos.Repository instance or an error in case of issues.
-	Interact(context.Context) (repos.Repository, error)
-}
-
-// Transactor provides means to get hold of a repos.Repository instance in the context
-// of a transaction, thus guaranteeing isolation/atomicity.
-type Transactor interface {
-	// Transact executes f and provides a repos.Repository instance that guarantees
-	// isolation/atomicity.
-	Transact(ctx context.Context, f func(context.Context, repos.Repository) error) error
-}
+type Store = dssstore.Store[repos.Repository]

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,0 +1,15 @@
+package store
+
+import (
+	"context"
+	"io"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+type Store[R any] interface {
+	io.Closer
+	Interact(context.Context) (R, error)
+	Transact(ctx context.Context, f func(context.Context, R) error) error
+	GetVersion(ctx context.Context) (*semver.Version, error)
+}


### PR DESCRIPTION
This PR refactor the store / datastore system into common interfaces and helpers.

(Badly) duplicated code has been removed and everything is now normalized.

There are a few remarks / side effects, noted directly in comments.

Quick summary of changes:

* Store interface (`[db]/store/store.go`) moved to a generic one, old one just use the common.
* Base store in `pkg/datastore/store.go` that handle all generic part of old stores (e.g creation, `Interact/Transact`). What is left in `[db]/datatore/store.go` is special elements (eg. the config flag for scd, Cleanup) and call to BaseStore
* New helper in `pkg/datastoreutils/dial.go` that create data stores in a generic way for all DB. Replace all store creation that where in `core-service/db-manager` (and different in both cases).

The rest is unchanged, this don't redo the whole system but improve the current one.
