### PR TITLE
[store] Use a common interface for scd/rid/aux stores

### DIFF
--- a/cmds/db-manager/cleanup/evict.go
+++ b/cmds/db-manager/cleanup/evict.go
@@ -104,7 +104,7 @@ func evict(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to execute SCD transaction: %w", err)
 	}
 
-	ridAction := func(r ridrepos.Repository) (err error) {
+	ridAction := func(ctx context.Context, r ridrepos.Repository) (err error) {
 		if *checkRidISAs {
 
 			expiredISAs, err = r.ListExpiredISAs(ctx, *locality, ridThreshold)

--- a/pkg/aux_/store/datastore/store.go
+++ b/pkg/aux_/store/datastore/store.go
@@ -108,7 +108,7 @@ func (s *Store) Interact(ctx context.Context) (repos.Repository, error) {
 // Transact supplies a new repo, that will perform all of the DB accesses
 // in a Txn, and will retry any Txn's that fail due to retry-able errors
 // (typically contention).
-func (s *Store) Transact(ctx context.Context, f func(repo repos.Repository) error) error {
+func (s *Store) Transact(ctx context.Context, f func(ctx context.Context, repo repos.Repository) error) error {
 	logger := logging.WithValuesFromContext(ctx, s.logger)
 	// TODO: consider what tx opts we want to support.
 	// TODO: we really need to remove the upper cockroach package, and have one
@@ -121,7 +121,7 @@ func (s *Store) Transact(ctx context.Context, f func(repo repos.Repository) erro
 	}, func(tx pgx.Tx) error {
 		// Is this recover still necessary?
 		defer recoverRollbackRepanic(ctx, tx)
-		return f(&repo{
+		return f(ctx, &repo{
 			Queryable: tx,
 			clock:     s.clock,
 			logger:    logger,

--- a/pkg/aux_/store/store.go
+++ b/pkg/aux_/store/store.go
@@ -1,35 +1,8 @@
 package store
 
 import (
-	"context"
-	"io"
-
-	"github.com/coreos/go-semver/semver"
 	"github.com/interuss/dss/pkg/aux_/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
 )
 
-// Store provides the means by which to obtain Repos with which to interact with
-// the remote ID backing store.
-type Store interface {
-	io.Closer
-	Interactor
-	Transactor
-
-	// Get store version
-	GetVersion(ctx context.Context) (*semver.Version, error)
-}
-
-// Interactor provides means to get hold of a repos.Repository instance *without* any
-// isolation/atomicity guarantees.
-type Interactor interface {
-	// Interact returns a repos.Repository instance or an error in case of issues.
-	Interact(context.Context) (repos.Repository, error)
-}
-
-// Transactor provides means to get hold of a repos.Repository instance in the context
-// of a transaction, thus guaranteeing isolation/atomicity.
-type Transactor interface {
-	// Transact executes f and provides a repos.Repository instance that guarantees
-	// isolation/atomicity.
-	Transact(ctx context.Context, f func(repos.Repository) error) error
-}
+type Store = dssstore.Store[repos.Repository]

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -35,8 +35,8 @@ func (s *mockRepo) Interact(ctx context.Context) (repos.Repository, error) {
 	return s, nil
 }
 
-func (s *mockRepo) Transact(ctx context.Context, f func(repo repos.Repository) error) error {
-	return f(s)
+func (s *mockRepo) Transact(ctx context.Context, f func(ctx context.Context, repo repos.Repository) error) error {
+	return f(ctx, s)
 }
 
 func (s *mockRepo) Close() error {

--- a/pkg/rid/application/isa.go
+++ b/pkg/rid/application/isa.go
@@ -63,7 +63,7 @@ func (a *app) DeleteISA(ctx context.Context, id dssmodels.ID, owner dssmodels.Ow
 		subs []*ridmodels.Subscription
 	)
 	// The following will automatically retry TXN retry errors.
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		old, err := repo.GetISA(ctx, id, true)
 		switch {
 		case err != nil:
@@ -104,7 +104,7 @@ func (a *app) InsertISA(ctx context.Context, isa *ridmodels.IdentificationServic
 		subs []*ridmodels.Subscription
 	)
 	// The following will automatically retry TXN retry errors.
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		// ensure it doesn't exist yet
 		old, err := repo.GetISA(ctx, isa.ID, false)
 		if err != nil {
@@ -138,7 +138,7 @@ func (a *app) UpdateISA(ctx context.Context, isa *ridmodels.IdentificationServic
 		subs []*ridmodels.Subscription
 	)
 	// The following will automatically retry TXN retry errors.
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		var err error
 
 		old, err := repo.GetISA(ctx, isa.ID, true)

--- a/pkg/rid/application/subscription.go
+++ b/pkg/rid/application/subscription.go
@@ -60,7 +60,7 @@ func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription)
 		return nil, stacktrace.Propagate(err, "Unable to adjust time range")
 	}
 	var sub *ridmodels.Subscription
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 
 		// ensure it doesn't exist yet
 		old, err := repo.GetSubscription(ctx, s.ID)
@@ -98,7 +98,7 @@ func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription)
 func (a *app) UpdateSubscription(ctx context.Context, s *ridmodels.Subscription) (*ridmodels.Subscription, error) {
 	var sub *ridmodels.Subscription
 
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		old, err := repo.GetSubscription(ctx, s.ID)
 		switch {
 		case err != nil:
@@ -145,7 +145,7 @@ func (a *app) UpdateSubscription(ctx context.Context, s *ridmodels.Subscription)
 // DeleteSubscription deletes the Subscription identified by "id" and owned by "owner".
 func (a *app) DeleteSubscription(ctx context.Context, id dssmodels.ID, owner dssmodels.Owner, version *dssmodels.Version) (*ridmodels.Subscription, error) {
 	var ret *ridmodels.Subscription
-	err := a.store.Transact(ctx, func(repo repos.Repository) error {
+	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		var err error
 		old, err := repo.GetSubscription(ctx, id)
 		switch {

--- a/pkg/rid/store/datastore/store.go
+++ b/pkg/rid/store/datastore/store.go
@@ -106,7 +106,7 @@ func (s *Store) Interact(ctx context.Context) (repos.Repository, error) {
 // Transact supplies a new repo, that will perform all of the DB accesses
 // in a Txn, and will retry any Txn's that fail due to retry-able errors
 // (typically contention).
-func (s *Store) Transact(ctx context.Context, f func(repo repos.Repository) error) error {
+func (s *Store) Transact(ctx context.Context, f func(ctx context.Context, repo repos.Repository) error) error {
 	logger := logging.WithValuesFromContext(ctx, s.logger)
 	// TODO: consider what tx opts we want to support.
 	// TODO: we really need to remove the upper cockroach package, and have one
@@ -119,7 +119,7 @@ func (s *Store) Transact(ctx context.Context, f func(repo repos.Repository) erro
 	}, func(tx pgx.Tx) error {
 		// Is this recover still necessary?
 		defer recoverRollbackRepanic(ctx, tx)
-		return f(&repo{
+		return f(ctx, &repo{
 			Queryable: tx,
 			clock:     s.clock,
 			logger:    logger,

--- a/pkg/rid/store/datastore/store_test.go
+++ b/pkg/rid/store/datastore/store_test.go
@@ -101,7 +101,7 @@ func TestTxnRetrier(t *testing.T) {
 	require.NotNil(t, store)
 	defer tearDownStore()
 
-	err := store.Transact(ctx, func(repo repos.Repository) error {
+	err := store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		// can query within this
 		isa, err := repo.InsertISA(ctx, serviceArea)
 		require.NotNil(t, isa)
@@ -122,7 +122,7 @@ func TestTxnRetrier(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
 	defer cancel()
 	count := 0
-	err = store.Transact(ctx, func(repo repos.Repository) error {
+	err = store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
 		// can query within this
 		count++
 		// Postgre retryable error
@@ -145,13 +145,13 @@ func TestTransactor(t *testing.T) {
 	subscription2 := subscriptionsPool[1].input
 
 	txnCount := 0
-	err := store.Transact(ctx, func(s1 repos.Repository) error {
+	err := store.Transact(ctx, func(ctx context.Context, s1 repos.Repository) error {
 		// We should get to this retry, then return nothing.
 		if txnCount > 0 {
 			return errors.New("already failed")
 		}
 		txnCount++
-		err := store.Transact(ctx, func(s2 repos.Repository) error {
+		err := store.Transact(ctx, func(ctx context.Context, s2 repos.Repository) error {
 			subs, err := s1.SearchSubscriptions(ctx, subscription1.Cells)
 			require.NoError(t, err)
 			require.Len(t, subs, 0)

--- a/pkg/rid/store/store.go
+++ b/pkg/rid/store/store.go
@@ -1,35 +1,8 @@
 package store
 
 import (
-	"context"
-	"io"
-
-	"github.com/coreos/go-semver/semver"
 	"github.com/interuss/dss/pkg/rid/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
 )
 
-// Store provides the means by which to obtain Repos with which to interact with
-// the remote ID backing store.
-type Store interface {
-	io.Closer
-	Interactor
-	Transactor
-
-	// Get store version
-	GetVersion(ctx context.Context) (*semver.Version, error)
-}
-
-// Interactor provides means to get hold of a repos.Repository instance *without* any
-// isolation/atomicity guarantees.
-type Interactor interface {
-	// Interact returns a repos.Repository instance or an error in case of issues.
-	Interact(context.Context) (repos.Repository, error)
-}
-
-// Transactor provides means to get hold of a repos.Repository instance in the context
-// of a transaction, thus guaranteeing isolation/atomicity.
-type Transactor interface {
-	// Transact executes f and provides a repos.Repository instance that guarantees
-	// isolation/atomicity.
-	Transact(ctx context.Context, f func(repos.Repository) error) error
-}
+type Store = dssstore.Store[repos.Repository]

--- a/pkg/scd/store/store.go
+++ b/pkg/scd/store/store.go
@@ -1,32 +1,8 @@
 package store
 
 import (
-	"context"
-
 	"github.com/interuss/dss/pkg/scd/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
 )
 
-// Store provides the means by which to obtain Repos with which to interact with
-// the strategic conflict detection backing store.
-type Store interface {
-	Interactor
-	Transactor
-
-	// Close closes the store and releases all of its resources.
-	Close() error
-}
-
-// Interactor provides means to get hold of a repos.Repository instance *without* any
-// isolation/atomicity guarantees.
-type Interactor interface {
-	// Interact returns a repos.Repository instance or an error in case of issues.
-	Interact(context.Context) (repos.Repository, error)
-}
-
-// Transactor provides means to get hold of a repos.Repository instance in the context
-// of a transaction, thus guaranteeing isolation/atomicity.
-type Transactor interface {
-	// Transact executes f and provides a repos.Repository instance that guarantees
-	// isolation/atomicity.
-	Transact(ctx context.Context, f func(context.Context, repos.Repository) error) error
-}
+type Store = dssstore.Store[repos.Repository]

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,0 +1,15 @@
+package store
+
+import (
+	"context"
+	"io"
+
+	"github.com/coreos/go-semver/semver"
+)
+
+type Store[R any] interface {
+	io.Closer
+	Interact(context.Context) (R, error)
+	Transact(ctx context.Context, f func(context.Context, R) error) error
+	GetVersion(ctx context.Context) (*semver.Version, error)
+}


### PR DESCRIPTION
Extracted from https://github.com/interuss/dss/pull/1403

Normalize store interfaces into a common one.

Add context to transactions for aux/rid.

Fix tests accordingly.

More normalization to come in future PR on that interface.