### PR TITLE
[db-manager] Honor datastore_application_name flag instead of overriding it

### DIFF
--- a/NEXT_RELEASE_NOTES.md
+++ b/NEXT_RELEASE_NOTES.md
@@ -46,6 +46,8 @@ The release notes should contain at least the following sections:
 
 ## Optional migration tasks
 
+* `db-manager`'s `cleanup` and `migrate` commands no longer override the application name parameter. To tag these connections, use the `datastore_application_name` flag, which is now honoured by these commands (defaults to `dss`).
+
 ## Important information
 
 * The `timeout` configuration flag is now enforced consistently on all HTTP calls. This means that some slow calls that were previously successful will now be cancelled. Please review the value to be applied (the default is 10 seconds) and, if needed, update it to suit your needs.

--- a/cmds/db-manager/cleanup/evict.go
+++ b/cmds/db-manager/cleanup/evict.go
@@ -171,7 +171,6 @@ func evict(cmd *cobra.Command, _ []string) error {
 
 func getSCDStore(ctx context.Context) (*scdc.Store, error) {
 	connectParameters := datastoreflags.ConnectParameters()
-	connectParameters.ApplicationName = "db-manager"
 	connectParameters.DBName = scdc.DatabaseName
 	datastore, err := datastore.Dial(ctx, connectParameters)
 	if err != nil {
@@ -192,7 +191,6 @@ func getRIDStore(ctx context.Context) (*ridc.Store, error) {
 	logger := logging.WithValuesFromContext(ctx, logging.Logger)
 
 	connectParameters := datastoreflags.ConnectParameters()
-	connectParameters.ApplicationName = "db-manager"
 	connectParameters.DBName = "rid"
 	datastore, err := datastore.Dial(ctx, connectParameters)
 	if err != nil {

--- a/cmds/db-manager/migration/migrate.go
+++ b/cmds/db-manager/migration/migrate.go
@@ -228,7 +228,6 @@ func migrate(cmd *cobra.Command, _ []string) error {
 func connectTo(ctx context.Context, dbName string) (*datastore.Datastore, error) {
 	// Connect to database server
 	connectParameters := datastoreflags.ConnectParameters()
-	connectParameters.ApplicationName = "db-manager"
 	connectParameters.DBName = dbName
 	return datastore.Dial(ctx, connectParameters)
 }


### PR DESCRIPTION
Extracted from https://github.com/interuss/dss/pull/1403

Remove override, that was making the flag useless and complexity data stores normalization.