### PR TITLE
[datastore] Use a generic datastore

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -110,7 +110,7 @@ func createAuxServer(ctx context.Context, locality string, publicEndpoint string
 		return nil, stacktrace.Propagate(err, "Failed to connect to pool information database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
 	}
 
-	auxStore, err := auxc.NewStore(ctx, datastore, connectParameters.DBName, logger)
+	auxStore, err := auxc.NewStore(ctx, datastore, logger)
 	if err != nil {
 		// TODO: More robustly detect failure to create SCD server is due to a problem that may be temporary
 		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database \"aux\" does not exist") {
@@ -146,7 +146,7 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 		return nil, nil, stacktrace.Propagate(err, "Failed to connect to remote ID database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
 	}
 
-	ridStore, err := ridc.NewStore(ctx, datastore, connectParameters.DBName, logger)
+	ridStore, err := ridc.NewStore(ctx, datastore, logger)
 	if err != nil {
 		// TODO: More robustly detect failure to create RID server is due to a problem that may be temporary
 		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database has not been bootstrapped with Schema Manager") {
@@ -164,8 +164,8 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 	// schedule period tasks for RID Server
 	ridCron := cron.New()
 	// schedule printing of DB status every minute for the underlying storage
-	if _, err := ridCron.AddFunc("@every 1m", func() { checkDatabase(ctx, datastore, connectParameters.DBName) }); err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Failed to schedule periodic db stat check to %s", connectParameters.DBName)
+	if _, err := ridCron.AddFunc("@every 1m", func() { checkDatabase(ctx, datastore, "rid") }); err != nil {
+		return nil, nil, stacktrace.Propagate(err, "Failed to schedule periodic db stat check to %s", "rid")
 	}
 	ridCron.Start()
 
@@ -174,24 +174,22 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 			App:               app,
 			Locality:          locality,
 			AllowHTTPBaseUrls: *allowHTTPBaseUrls,
-			Cron:              ridCron,
 		}, &rid_v2.Server{
 			App:               app,
 			Locality:          locality,
 			AllowHTTPBaseUrls: *allowHTTPBaseUrls,
-			Cron:              ridCron,
 		}, nil
 }
 
 func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, error) {
 	connectParameters := flags.ConnectParameters()
-	connectParameters.DBName = scdc.DatabaseName
+	connectParameters.DBName = "scd"
 	datastore, err := datastore.Dial(ctx, connectParameters)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "Failed to connect to strategic conflict detection database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
 	}
 
-	scdStore, err := scdc.NewStore(ctx, datastore, *scdGlobalLock)
+	scdStore, err := scdc.NewStore(ctx, datastore, logger, *scdGlobalLock)
 	if err != nil {
 		// TODO: More robustly detect failure to create SCD server is due to a problem that may be temporary
 		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database \"scd\" does not exist") {
@@ -204,8 +202,8 @@ func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, erro
 	// schedule period tasks for SCD Server
 	scdCron := cron.New()
 	// schedule printing of DB status every minute for the underlying storage
-	if _, err := scdCron.AddFunc("@every 1m", func() { checkDatabase(ctx, datastore, scdc.DatabaseName) }); err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to schedule periodic db stat check to %s", scdc.DatabaseName)
+	if _, err := scdCron.AddFunc("@every 1m", func() { checkDatabase(ctx, datastore, "scd") }); err != nil {
+		return nil, stacktrace.Propagate(err, "Failed to schedule periodic db stat check to %s", "scd")
 	}
 
 	scdCron.Start()

--- a/cmds/db-manager/cleanup/evict.go
+++ b/cmds/db-manager/cleanup/evict.go
@@ -170,8 +170,10 @@ func evict(cmd *cobra.Command, _ []string) error {
 }
 
 func getSCDStore(ctx context.Context) (*scdc.Store, error) {
+	logger := logging.WithValuesFromContext(ctx, logging.Logger)
+
 	connectParameters := datastoreflags.ConnectParameters()
-	connectParameters.DBName = scdc.DatabaseName
+	connectParameters.DBName = "scd"
 	datastore, err := datastore.Dial(ctx, connectParameters)
 	if err != nil {
 		logParams := connectParameters
@@ -179,7 +181,7 @@ func getSCDStore(ctx context.Context) (*scdc.Store, error) {
 		return nil, fmt.Errorf("failed to connect to SCD database with %+v: %w", logParams, err)
 	}
 
-	scdStore, err := scdc.NewStore(ctx, datastore, false)
+	scdStore, err := scdc.NewStore(ctx, datastore, logger, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create strategic conflict detection store with %+v: %w", connectParameters, err)
 	}
@@ -199,7 +201,7 @@ func getRIDStore(ctx context.Context) (*ridc.Store, error) {
 		return nil, fmt.Errorf("failed to connect to remote ID database with %+v: %w", logParams, err)
 	}
 
-	ridStore, err := ridc.NewStore(ctx, datastore, connectParameters.DBName, logger)
+	ridStore, err := ridc.NewStore(ctx, datastore, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create remote ID store with %+v: %w", connectParameters, err)
 	}

--- a/pkg/aux_/store/datastore/store.go
+++ b/pkg/aux_/store/datastore/store.go
@@ -3,17 +3,11 @@ package datastore
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach-go/v2/crdb"
-	"github.com/interuss/dss/pkg/datastore/flags"
-	dssql "github.com/interuss/dss/pkg/sql"
-
-	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
-	"github.com/coreos/go-semver/semver"
 	"github.com/interuss/dss/pkg/aux_/repos"
 	"github.com/interuss/dss/pkg/datastore"
+	"github.com/interuss/dss/pkg/datastore/flags"
 	"github.com/interuss/dss/pkg/logging"
-	"github.com/interuss/stacktrace"
-	"github.com/jackc/pgx/v5"
+	dssql "github.com/interuss/dss/pkg/sql"
 	"github.com/jonboulle/clockwork"
 	"go.uber.org/zap"
 )
@@ -24,11 +18,6 @@ const (
 	currentYugabyteMajorSchemaVersion = 1
 )
 
-var (
-	// DefaultClock is what is used as the Store's clock, returned from Dial.
-	DefaultClock = clockwork.NewRealClock()
-)
-
 type repo struct {
 	dssql.Queryable
 	clock   clockwork.Clock
@@ -36,134 +25,31 @@ type repo struct {
 	version *datastore.Version
 }
 
-// Store is an implementation of store.Store using Cockroach DB or yugabyte as its backend
-// store.
-//
-// TODO: Add the RID/SCD interfaces here, and collapse this store with the
-// outer pkg/cockroach
 type Store struct {
-	db      *datastore.Datastore
-	logger  *zap.Logger
-	clock   clockwork.Clock
-	version *semver.Version
-
-	// DatabaseName is the name of database storing aux data.
-	DatabaseName string
+	datastore.Store[repos.Repository]
 }
 
-// NewStore returns a Store instance connected to a datastore instance via db.
-func NewStore(ctx context.Context, db *datastore.Datastore, dbName string, logger *zap.Logger) (*Store, error) {
-	vs, err := db.GetSchemaVersion(ctx, dbName)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to get database schema version for aux for db : %s", dbName)
-	}
+func NewStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger) (*Store, error) {
 
-	store := &Store{
-		db:           db,
-		logger:       logger,
-		clock:        DefaultClock,
-		version:      vs,
-		DatabaseName: dbName,
-	}
+	s := &Store{}
 
-	if err := store.CheckCurrentMajorSchemaVersion(ctx); err != nil {
-		return nil, stacktrace.Propagate(err, "Aux schema version check failed")
-	}
-
-	return store, nil
-}
-
-// CheckCurrentMajorSchemaVersion checks that store supports the current major schema version.
-func (s *Store) CheckCurrentMajorSchemaVersion(ctx context.Context) error {
-	vs, err := s.GetVersion(ctx)
-	if err != nil {
-		return stacktrace.Propagate(err, "Failed to get database schema version for aux")
-	}
-	if vs == datastore.UnknownVersion {
-		return stacktrace.NewError("Aux database has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas")
-	}
-
-	if s.db.Version.Type == datastore.CockroachDB && currentCrdbMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for aux! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", vs, currentCrdbMajorSchemaVersion)
-	}
-
-	if s.db.Version.Type == datastore.Yugabyte && currentYugabyteMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for aux! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", vs, currentYugabyteMajorSchemaVersion)
-	}
-
-	return nil
-}
-
-// Interact implements store.Interactor interface.
-func (s *Store) Interact(ctx context.Context) (repos.Repository, error) {
-	logger := logging.WithValuesFromContext(ctx, s.logger)
-	return &repo{
-		Queryable: s.db.Pool,
-		clock:     s.clock,
-		logger:    logger,
-		version:   s.db.Version,
-	}, nil
-}
-
-// Transact supplies a new repo, that will perform all of the DB accesses
-// in a Txn, and will retry any Txn's that fail due to retry-able errors
-// (typically contention).
-func (s *Store) Transact(ctx context.Context, f func(ctx context.Context, repo repos.Repository) error) error {
-	logger := logging.WithValuesFromContext(ctx, s.logger)
-	// TODO: consider what tx opts we want to support.
-	// TODO: we really need to remove the upper cockroach package, and have one
-	// "store" for everything
-
-	ctx = crdb.WithMaxRetries(ctx, flags.ConnectParameters().MaxRetries)
-
-	return crdbpgx.ExecuteTx(ctx, s.db.Pool, pgx.TxOptions{
-		IsoLevel: pgx.Serializable,
-	}, func(tx pgx.Tx) error {
-		// Is this recover still necessary?
-		defer recoverRollbackRepanic(ctx, tx)
-		return f(ctx, &repo{
-			Queryable: tx,
-			clock:     s.clock,
-			logger:    logger,
-		})
+	base, err := datastore.NewStore(ctx, db, flags.ConnectParameters().MaxRetries, func(q dssql.Queryable) repos.Repository {
+		return &repo{
+			Queryable: q,
+			clock:     s.Clock,
+			logger:    logging.WithValuesFromContext(ctx, logger),
+			version:   db.Version,
+		}
 	})
-}
-
-// Close closes the underlying DB connection.
-func (s *Store) Close() error {
-	s.db.Pool.Close()
-	return nil
-}
-
-func recoverRollbackRepanic(ctx context.Context, tx pgx.Tx) {
-	if p := recover(); p != nil {
-		if err := tx.Rollback(ctx); err != nil {
-			logging.WithValuesFromContext(ctx, logging.Logger).Error(
-				"failed to rollback transaction", zap.Error(err),
-			)
-		}
+	if err != nil {
+		return nil, err
 	}
+	s.Store = base
+	return s, s.CheckMajorSchemaVersion(ctx, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, db.Pool.Config().ConnConfig.Database)
 }
 
-// CleanUp removes all database tables managed by s.
 func (s *Store) CleanUp(ctx context.Context) error {
-	const query = `
-	DELETE FROM dss_metadata WHERE locality IS NOT NULL;
-    `
-
-	_, err := s.db.Pool.Exec(ctx, query)
+	const query = `DELETE FROM dss_metadata WHERE locality IS NOT NULL;`
+	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
-}
-
-// GetVersion returns the Version string for the Database.
-// If the DB was is not bootstrapped using the schema manager we throw and error
-func (s *Store) GetVersion(ctx context.Context) (*semver.Version, error) {
-	if s.version == nil {
-		vs, err := s.db.GetSchemaVersion(ctx, s.DatabaseName)
-		if err != nil {
-			return nil, stacktrace.Propagate(err, "Failed to get database schema version for aux")
-		}
-		s.version = vs
-	}
-	return s.version, nil
 }

--- a/pkg/aux_/store/datastore/store_test.go
+++ b/pkg/aux_/store/datastore/store_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/interuss/dss/pkg/datastore"
 	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/logging"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 )
@@ -35,10 +36,13 @@ func newStore(ctx context.Context, t *testing.T, connectParameters datastore.Con
 	db, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 
-	return &Store{
-		db:    db,
-		clock: fakeClock,
-	}, nil
+	s, err := NewStore(ctx, db, logging.Logger)
+	if err != nil {
+		return nil, err
+	}
+	s.Clock = fakeClock
+
+	return s, nil
 }
 
 // CleanUp drops all required tables from the store, useful for testing.
@@ -47,6 +51,6 @@ func CleanUp(ctx context.Context, s *Store) error {
 	DELETE FROM dss_metadata WHERE locality IS NOT NULL;
     `
 
-	_, err := s.db.Pool.Exec(ctx, query)
+	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
 }

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1,0 +1,85 @@
+package datastore
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach-go/v2/crdb"
+	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
+	"github.com/coreos/go-semver/semver"
+	dsssql "github.com/interuss/dss/pkg/sql"
+	"github.com/interuss/stacktrace"
+	"github.com/jackc/pgx/v5"
+	"github.com/jonboulle/clockwork"
+)
+
+type Store[R any] struct {
+	DB         *Datastore
+	Clock      clockwork.Clock
+	version    *semver.Version
+	newRepo    func(dsssql.Queryable) R
+	maxRetries int
+}
+
+func NewStore[R any](ctx context.Context, db *Datastore, maxRetries int, newRepo func(dsssql.Queryable) R) (Store[R], error) {
+
+	dbName := db.Pool.Config().ConnConfig.Database
+
+	vs, err := db.GetSchemaVersion(ctx, dbName)
+	if err != nil {
+		return Store[R]{}, stacktrace.Propagate(err, "Failed to get schema version for %s", dbName)
+	}
+	return Store[R]{
+		DB:         db,
+		Clock:      clockwork.NewRealClock(),
+		version:    vs,
+		newRepo:    newRepo,
+		maxRetries: maxRetries,
+	}, nil
+}
+
+func (s *Store[R]) Interact(_ context.Context) (R, error) {
+	return s.newRepo(s.DB.Pool), nil
+}
+
+func (s *Store[R]) Transact(ctx context.Context, f func(context.Context, R) error) error {
+	ctx = crdb.WithMaxRetries(ctx, s.maxRetries)
+	return crdbpgx.ExecuteTx(ctx, s.DB.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
+		return f(ctx, s.newRepo(tx))
+	})
+}
+
+func (s *Store[R]) GetVersion(ctx context.Context) (*semver.Version, error) {
+
+	dbName := s.DB.Pool.Config().ConnConfig.Database
+
+	if s.version == nil {
+		vs, err := s.DB.GetSchemaVersion(ctx, dbName)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "Failed to get schema version for %s", dbName)
+		}
+		s.version = vs
+	}
+	return s.version, nil
+}
+
+func (s *Store[R]) CheckMajorSchemaVersion(ctx context.Context, crdbExpected, ybExpected int64, module string) error { // TODO: Make it internal, pass parameters to NewStore
+	vs, err := s.GetVersion(ctx)
+	if err != nil {
+		return stacktrace.Propagate(err, "Failed to get schema version for %s", module)
+	}
+	if vs == UnknownVersion {
+		return stacktrace.NewError("%s has not been bootstrapped with Schema Manager, please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", module)
+	}
+	if s.DB.Version.Type == CockroachDB && crdbExpected != vs.Major {
+		return stacktrace.NewError("Unsupported schema version for %s: Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", module, vs, crdbExpected)
+	}
+	if s.DB.Version.Type == Yugabyte && ybExpected != vs.Major {
+		return stacktrace.NewError("Unsupported schema version for %s: Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", module, vs, ybExpected)
+	}
+	return nil
+}
+
+func (s *Store[R]) Close() error {
+	s.DB.Pool.Close()
+	return nil
+}

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -58,16 +58,17 @@ func setUpStore(ctx context.Context, t *testing.T, logger *zap.Logger) (store.St
 			},
 		}, func() {}
 	}
-	if connectParameters.DBName != "rid" && connectParameters.DBName != "scd" {
-		connectParameters.DBName = "rid"
-	}
-	ridc.DefaultClock = fakeClock
+
+	connectParameters.DBName = "rid"
+
 	ridDatastore, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 	logger.Info("using datastore.")
 
-	store, err := ridc.NewStore(ctx, ridDatastore, "rid", logger)
+	store, err := ridc.NewStore(ctx, ridDatastore, logger)
 	require.NoError(t, err)
+
+	store.Clock = fakeClock
 
 	return store, func() {
 		require.NoError(t, CleanUp(ctx, store))

--- a/pkg/rid/store/datastore/store.go
+++ b/pkg/rid/store/datastore/store.go
@@ -3,17 +3,12 @@ package datastore
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/interuss/dss/pkg/datastore/flags"
 	dssql "github.com/interuss/dss/pkg/sql"
 
-	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
-	"github.com/coreos/go-semver/semver"
 	"github.com/interuss/dss/pkg/datastore"
 	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/rid/repos"
-	"github.com/interuss/stacktrace"
-	"github.com/jackc/pgx/v5"
 	"github.com/jonboulle/clockwork"
 	"go.uber.org/zap"
 )
@@ -24,144 +19,38 @@ const (
 	currentYugabyteMajorSchemaVersion = 1
 )
 
-var (
-	// DefaultClock is what is used as the Store's clock, returned from Dial.
-	DefaultClock = clockwork.NewRealClock()
-)
-
 type repo struct {
 	dssql.Queryable
 	clock  clockwork.Clock
 	logger *zap.Logger
 }
 
-// Store is an implementation of store.Store using Cockroach DB or Yugabyte as its backend
-// store.
-//
-// TODO: Add the SCD interfaces here, and collapse this store with the
-// outer pkg/cockroach
 type Store struct {
-	db      *datastore.Datastore
-	logger  *zap.Logger
-	clock   clockwork.Clock
-	version *semver.Version
-
-	// DatabaseName is the name of database storing remote ID data.
-	DatabaseName string
+	datastore.Store[repos.Repository]
 }
 
-// NewStore returns a Store instance connected to a cockroach or yugabyte instance via db.
-func NewStore(ctx context.Context, db *datastore.Datastore, dbName string, logger *zap.Logger) (*Store, error) {
-	vs, err := db.GetSchemaVersion(ctx, dbName)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to get database schema version for remote ID for db : %s", dbName)
-	}
+func NewStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger) (*Store, error) {
 
-	store := &Store{
-		db:           db,
-		logger:       logger,
-		clock:        DefaultClock,
-		version:      vs,
-		DatabaseName: dbName,
-	}
+	s := &Store{}
 
-	if err := store.CheckCurrentMajorSchemaVersion(ctx); err != nil {
-		return nil, stacktrace.Propagate(err, "Remote ID schema version check failed")
-	}
-
-	return store, nil
-}
-
-// CheckCurrentMajorSchemaVersion checks that store supports the current major schema version.
-func (s *Store) CheckCurrentMajorSchemaVersion(ctx context.Context) error {
-	vs, err := s.GetVersion(ctx)
-	if err != nil {
-		return stacktrace.Propagate(err, "Failed to get database schema version for remote ID")
-	}
-	if vs == datastore.UnknownVersion {
-		return stacktrace.NewError("Remote ID database has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas")
-	}
-
-	if s.db.Version.Type == datastore.CockroachDB && currentCrdbMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for remote ID! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", vs, currentCrdbMajorSchemaVersion)
-	}
-
-	if s.db.Version.Type == datastore.Yugabyte && currentYugabyteMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for remote ID! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#updgrading-database-schemas", vs, currentYugabyteMajorSchemaVersion)
-	}
-
-	return nil
-}
-
-// Interact implements store.Interactor interface.
-func (s *Store) Interact(ctx context.Context) (repos.Repository, error) {
-	logger := logging.WithValuesFromContext(ctx, s.logger)
-	return &repo{
-		Queryable: s.db.Pool,
-		clock:     s.clock,
-		logger:    logger,
-	}, nil
-}
-
-// Transact supplies a new repo, that will perform all of the DB accesses
-// in a Txn, and will retry any Txn's that fail due to retry-able errors
-// (typically contention).
-func (s *Store) Transact(ctx context.Context, f func(ctx context.Context, repo repos.Repository) error) error {
-	logger := logging.WithValuesFromContext(ctx, s.logger)
-	// TODO: consider what tx opts we want to support.
-	// TODO: we really need to remove the upper cockroach package, and have one
-	// "store" for everything
-
-	ctx = crdb.WithMaxRetries(ctx, flags.ConnectParameters().MaxRetries)
-
-	return crdbpgx.ExecuteTx(ctx, s.db.Pool, pgx.TxOptions{
-		IsoLevel: pgx.Serializable,
-	}, func(tx pgx.Tx) error {
-		// Is this recover still necessary?
-		defer recoverRollbackRepanic(ctx, tx)
-		return f(ctx, &repo{
-			Queryable: tx,
-			clock:     s.clock,
-			logger:    logger,
-		})
-	})
-}
-
-// Close closes the underlying DB connection.
-func (s *Store) Close() error {
-	s.db.Pool.Close()
-	return nil
-}
-
-func recoverRollbackRepanic(ctx context.Context, tx pgx.Tx) {
-	if p := recover(); p != nil {
-		if err := tx.Rollback(ctx); err != nil {
-			logging.WithValuesFromContext(ctx, logging.Logger).Error(
-				"failed to rollback transaction", zap.Error(err),
-			)
+	base, err := datastore.NewStore(ctx, db, flags.ConnectParameters().MaxRetries, func(q dssql.Queryable) repos.Repository {
+		return &repo{
+			Queryable: q,
+			clock:     s.Clock,
+			logger:    logging.WithValuesFromContext(ctx, logger),
 		}
+	})
+	if err != nil {
+		return nil, err
 	}
+	s.Store = base
+	return s, s.CheckMajorSchemaVersion(ctx, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, db.Pool.Config().ConnConfig.Database)
 }
 
-// CleanUp removes all database tables managed by s.
 func (s *Store) CleanUp(ctx context.Context) error {
 	const query = `
 	DELETE FROM subscriptions WHERE id IS NOT NULL;
 	DELETE FROM identification_service_areas WHERE id IS NOT NULL;`
-
-	_, err := s.db.Pool.Exec(ctx, query)
+	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
-}
-
-// GetVersion returns the Version string for the Database.
-// If the DB was is not bootstrapped using the schema manager we throw and error
-func (s *Store) GetVersion(ctx context.Context) (*semver.Version, error) {
-	if s.version == nil {
-		vs, err := s.db.GetSchemaVersion(ctx, s.DatabaseName)
-		if err != nil {
-			return nil, stacktrace.Propagate(err, "Failed to get database schema version for remote ID")
-		}
-		s.version = vs
-	}
-	return s.version, nil
 }

--- a/pkg/rid/store/datastore/store_test.go
+++ b/pkg/rid/store/datastore/store_test.go
@@ -29,11 +29,8 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	connectParameters := flags.ConnectParameters()
 	if connectParameters.Host == "" || connectParameters.Port == 0 {
 		t.Skip()
-	} else {
-		if connectParameters.DBName != "rid" && connectParameters.DBName != "scd" && connectParameters.DBName != "aux" {
-			connectParameters.DBName = "rid"
-		}
 	}
+	connectParameters.DBName = "rid"
 	// Reset the clock for every test.
 	fakeClock = clockwork.NewFakeClock()
 
@@ -49,12 +46,13 @@ func newStore(ctx context.Context, t *testing.T, connectParameters datastore.Con
 	db, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 
-	return &Store{
-		db:           db,
-		logger:       logging.Logger,
-		clock:        fakeClock,
-		DatabaseName: "rid",
-	}, nil
+	s, err := NewStore(ctx, db, logging.Logger)
+	if err != nil {
+		return nil, err
+	}
+	s.Clock = fakeClock
+
+	return s, nil
 }
 
 // CleanUp drops all required tables from the store, useful for testing.
@@ -63,7 +61,7 @@ func CleanUp(ctx context.Context, s *Store) error {
 	DELETE FROM subscriptions WHERE id IS NOT NULL;
 	DELETE FROM identification_service_areas WHERE id IS NOT NULL;`
 
-	_, err := s.db.Pool.Exec(ctx, query)
+	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
 }
 
@@ -203,22 +201,22 @@ func TestBasicTxn(t *testing.T) {
 	subscription1 := subscriptionsPool[0].input
 	subscription2 := subscriptionsPool[1].input
 
-	tx1, err := store.db.Pool.Begin(ctx)
+	tx1, err := store.DB.Pool.Begin(ctx)
 	require.NoError(t, err)
 	s1 := &repo{
 		Queryable: tx1,
 		logger:    logging.Logger,
-		clock:     DefaultClock,
+		clock:     clockwork.NewRealClock(),
 	}
 
-	tx2, err := store.db.Pool.Begin(ctx)
+	tx2, err := store.DB.Pool.Begin(ctx)
 	require.NoError(t, err)
 	s2 := &repo{
 
 		Queryable: tx2,
 		logger:    logging.Logger,
 
-		clock: DefaultClock,
+		clock: clockwork.NewRealClock(),
 	}
 
 	subs, err := s1.SearchSubscriptions(ctx, subscription1.Cells)

--- a/pkg/scd/store/datastore/store.go
+++ b/pkg/scd/store/datastore/store.go
@@ -3,16 +3,14 @@ package datastore
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach-go/v2/crdb"
-	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
-	"github.com/coreos/go-semver/semver"
-	"github.com/interuss/dss/pkg/datastore"
 	"github.com/interuss/dss/pkg/datastore/flags"
+	dssql "github.com/interuss/dss/pkg/sql"
+
+	"github.com/interuss/dss/pkg/datastore"
+	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/scd/repos"
-	dsssql "github.com/interuss/dss/pkg/sql"
-	"github.com/interuss/stacktrace"
-	"github.com/jackc/pgx/v5"
 	"github.com/jonboulle/clockwork"
+	"go.uber.org/zap"
 )
 
 const (
@@ -21,95 +19,32 @@ const (
 	currentYugabyteMajorSchemaVersion = 1
 )
 
-var (
-	// DefaultClock is what is used as the Store's clock, returned from Dial.
-	DefaultClock = clockwork.NewRealClock()
-
-	// DatabaseName is the name of database storing strategic conflict detection data.
-	DatabaseName = "scd"
-)
-
-// repo is an implementation of repos.Repo using
-// a CockroachDB/Yugabyte transaction.
 type repo struct {
-	q          dsssql.Queryable
+	q          dssql.Queryable
 	clock      clockwork.Clock
+	logger     *zap.Logger
 	globalLock bool
 }
 
-// Store is an implementation of an scd.Store using
-// a CockroachDB or Yugabyte database.
 type Store struct {
-	db         *datastore.Datastore
-	clock      clockwork.Clock
-	globalLock bool
+	datastore.Store[repos.Repository]
 }
 
-// NewStore returns a Store instance connected to a cockroach or Yugabyte instance via db.
-func NewStore(ctx context.Context, db *datastore.Datastore, globalLock bool) (*Store, error) {
-	store := &Store{
-		db:         db,
-		clock:      DefaultClock,
-		globalLock: globalLock,
-	}
+func NewStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger, globalLock bool) (*Store, error) {
 
-	if err := store.CheckCurrentMajorSchemaVersion(ctx); err != nil {
-		return nil, stacktrace.Propagate(err, "Strategic conflict detection schema version check failed")
-	}
+	s := &Store{}
 
-	return store, nil
-}
-
-// CheckCurrentMajorSchemaVersion returns nil if s supports the current major schema version.
-func (s *Store) CheckCurrentMajorSchemaVersion(ctx context.Context) error {
-	vs, err := s.GetVersion(ctx)
-	if err != nil {
-		return stacktrace.Propagate(err, "Failed to get database schema version for strategic conflict detection")
-	}
-	if vs == datastore.UnknownVersion {
-		return stacktrace.NewError("Strategic conflict detection database has not been bootstrapped with Schema Manager, Please check https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
-	}
-
-	if s.db.Version.Type == datastore.CockroachDB && currentCrdbMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for strategic conflict detection! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas", vs, currentCrdbMajorSchemaVersion)
-	}
-
-	if s.db.Version.Type == datastore.Yugabyte && currentYugabyteMajorSchemaVersion != vs.Major {
-		return stacktrace.NewError("Unsupported schema version for strategic conflict detection! Got %s, requires major version of %d. Please check https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas", vs, currentYugabyteMajorSchemaVersion)
-	}
-
-	return nil
-}
-
-// Interact implements store.Interactor interface.
-func (s *Store) Interact(_ context.Context) (repos.Repository, error) {
-	return &repo{
-		q:          s.db.Pool,
-		clock:      s.clock,
-		globalLock: s.globalLock,
-	}, nil
-}
-
-// Transact implements store.Transactor interface.
-func (s *Store) Transact(ctx context.Context, f func(context.Context, repos.Repository) error) error {
-	ctx = crdb.WithMaxRetries(ctx, flags.ConnectParameters().MaxRetries)
-	return crdbpgx.ExecuteTx(ctx, s.db.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
-		return f(ctx, &repo{
-			q:          tx,
-			clock:      s.clock,
-			globalLock: s.globalLock,
-		})
+	base, err := datastore.NewStore(ctx, db, flags.ConnectParameters().MaxRetries, func(q dssql.Queryable) repos.Repository {
+		return &repo{
+			q:          q,
+			clock:      s.Clock,
+			logger:     logging.WithValuesFromContext(ctx, logger),
+			globalLock: globalLock,
+		}
 	})
-}
-
-// Close closes the underlying DB connection.
-func (s *Store) Close() error {
-	s.db.Pool.Close()
-	return nil
-}
-
-// GetVersion returns the Version string for the Database.
-// If the DB was is not bootstrapped using the schema manager we throw and error
-func (s *Store) GetVersion(ctx context.Context) (*semver.Version, error) {
-	return s.db.GetSchemaVersion(ctx, DatabaseName)
+	if err != nil {
+		return nil, err
+	}
+	s.Store = base
+	return s, s.CheckMajorSchemaVersion(ctx, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, db.Pool.Config().ConnConfig.Database)
 }

--- a/pkg/scd/store/datastore/store_test.go
+++ b/pkg/scd/store/datastore/store_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/interuss/dss/pkg/datastore"
 	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/logging"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 )
@@ -35,10 +36,13 @@ func newStore(ctx context.Context, t *testing.T, connectParameters datastore.Con
 	db, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 
-	return &Store{
-		db:    db,
-		clock: fakeClock,
-	}, nil
+	s, err := NewStore(ctx, db, logging.Logger, false)
+	if err != nil {
+		return nil, err
+	}
+	s.Clock = fakeClock
+
+	return s, nil
 }
 
 // CleanUp drops all required tables from the store, useful for testing.
@@ -49,6 +53,6 @@ func CleanUp(ctx context.Context, s *Store) error {
 	DELETE FROM scd_constraints WHERE id IS NOT NULL;
 	DELETE FROM scd_uss_availability WHERE id IS NOT NULL;`
 
-	_, err := s.db.Pool.Exec(ctx, query)
+	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
 }


### PR DESCRIPTION
Move datastores to a generic one, with common function in a `BaseStore`.

Pre-cleanup DBName with harcoded strings, but final cleanup (with total removal on cmd side) will come in a later PR. 