### PR TITLE
[datastore] Normalize datastore initialization across the codebase with a generic dial function

### DIFF
--- a/NEXT_RELEASE_NOTES.md
+++ b/NEXT_RELEASE_NOTES.md
@@ -52,6 +52,9 @@ The release notes should contain at least the following sections:
 
 * The `timeout` configuration flag is now enforced consistently on all HTTP calls. This means that some slow calls that were previously successful will now be cancelled. Please review the value to be applied (the default is 10 seconds) and, if needed, update it to suit your needs.
 * `--datastore_db_name` (and the deprecated version, `--cockroach_db_name`) has been removed. It was not used except for tests and can be removed if you use it.
+* Datastore initialization has been normalized throughout the codebase, with the following changes:
+  * Error messages of `db-manager`'s `cleanup` command are now the same as the `core-service` command.
+  * AUX database is regularly pinged (before that was only the case for the RID and SCD databases).
 
 ## Minimal database schema version
 

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -23,8 +23,7 @@ import (
 	aux "github.com/interuss/dss/pkg/aux_"
 	auxc "github.com/interuss/dss/pkg/aux_/store/datastore"
 	"github.com/interuss/dss/pkg/build"
-	"github.com/interuss/dss/pkg/datastore"
-	"github.com/interuss/dss/pkg/datastore/flags" // Force command line flag registration
+	"github.com/interuss/dss/pkg/datastoreutils"
 	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/rid/application"
 	rid_v1 "github.com/interuss/dss/pkg/rid/server/v1"
@@ -35,7 +34,6 @@ import (
 	"github.com/interuss/dss/pkg/version"
 	"github.com/interuss/dss/pkg/versioning"
 	"github.com/interuss/stacktrace"
-	"github.com/robfig/cron/v3"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
 )
@@ -64,20 +62,6 @@ var (
 	scdGlobalLock = flag.Bool("enable_scd_global_lock", false, "Experimental: Use a global lock when working with SCD subscriptions. Reduce global throughput but improve throughput with lot of subscriptions in the same areas.")
 )
 
-const (
-	codeRetryable = stacktrace.ErrorCode(1)
-)
-
-func checkDatabase(ctx context.Context, db *datastore.Datastore, databaseName string) {
-	logger := logging.WithValuesFromContext(ctx, logging.Logger)
-	statsPtr := db.Pool.Stat()
-	if int(statsPtr.TotalConns()) == 0 {
-		logger.Warn("Failed periodic DB Ping (TotalConns=0)", zap.String("Database", databaseName))
-	} else {
-		logger.Info("Successful periodic DB Ping", zap.String("Database", databaseName))
-	}
-}
-
 func createKeyResolver() (auth.KeyResolver, error) {
 	switch {
 	case *pkFile != "":
@@ -100,24 +84,9 @@ func createKeyResolver() (auth.KeyResolver, error) {
 }
 
 func createAuxServer(ctx context.Context, locality string, publicEndpoint string, scdGlobalLock bool, logger *zap.Logger) (*aux.Server, error) {
-	connectParameters := flags.ConnectParameters()
-	connectParameters.DBName = "aux"
-	datastore, err := datastore.Dial(ctx, connectParameters)
+	auxStore, err := auxc.Dial(ctx, logger, true)
 	if err != nil {
-		if strings.Contains(err.Error(), "connect: connection refused") {
-			return nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to database for pool information store")
-		}
-		return nil, stacktrace.Propagate(err, "Failed to connect to pool information database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
-	}
-
-	auxStore, err := auxc.NewStore(ctx, datastore, logger)
-	if err != nil {
-		// TODO: More robustly detect failure to create SCD server is due to a problem that may be temporary
-		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database \"aux\" does not exist") {
-			datastore.Pool.Close()
-			return nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to datastore server for strategic conflict detection store")
-		}
-		return nil, stacktrace.Propagate(err, "Failed to create strategic conflict detection store")
+		return nil, err
 	}
 
 	repo, err := auxStore.Interact(ctx)
@@ -135,39 +104,16 @@ func createAuxServer(ctx context.Context, locality string, publicEndpoint string
 }
 
 func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) (*rid_v1.Server, *rid_v2.Server, error) {
-	connectParameters := flags.ConnectParameters()
-	connectParameters.DBName = "rid"
-	datastore, err := datastore.Dial(ctx, connectParameters)
-	if err != nil {
-		// TODO: More robustly detect failure to create RID server is due to a problem that may be temporary
-		if strings.Contains(err.Error(), "connect: connection refused") {
-			return nil, nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to datastore server for remote ID store")
-		}
-		return nil, nil, stacktrace.Propagate(err, "Failed to connect to remote ID database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
-	}
 
-	ridStore, err := ridc.NewStore(ctx, datastore, logger)
+	ridStore, err := ridc.Dial(ctx, logger, true)
 	if err != nil {
-		// TODO: More robustly detect failure to create RID server is due to a problem that may be temporary
-		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database has not been bootstrapped with Schema Manager") {
-			datastore.Pool.Close()
-			return nil, nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to datastore server for remote ID store")
-		}
-		return nil, nil, stacktrace.Propagate(err, "Failed to create remote ID store")
+		return nil, nil, err
 	}
 
 	_, err = ridStore.Interact(ctx)
 	if err != nil {
 		return nil, nil, stacktrace.Propagate(err, "Unable to interact with store")
 	}
-
-	// schedule period tasks for RID Server
-	ridCron := cron.New()
-	// schedule printing of DB status every minute for the underlying storage
-	if _, err := ridCron.AddFunc("@every 1m", func() { checkDatabase(ctx, datastore, "rid") }); err != nil {
-		return nil, nil, stacktrace.Propagate(err, "Failed to schedule periodic db stat check to %s", "rid")
-	}
-	ridCron.Start()
 
 	app := application.NewFromTransactor(ridStore, logger)
 	return &rid_v1.Server{
@@ -182,31 +128,11 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 }
 
 func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, error) {
-	connectParameters := flags.ConnectParameters()
-	connectParameters.DBName = "scd"
-	datastore, err := datastore.Dial(ctx, connectParameters)
+
+	scdStore, err := scdc.Dial(ctx, logger, true, *scdGlobalLock)
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to connect to strategic conflict detection database; verify your database configuration is current with https://github.com/interuss/dss/tree/master/build#upgrading-database-schemas")
+		return nil, err
 	}
-
-	scdStore, err := scdc.NewStore(ctx, datastore, logger, *scdGlobalLock)
-	if err != nil {
-		// TODO: More robustly detect failure to create SCD server is due to a problem that may be temporary
-		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "database \"scd\" does not exist") {
-			datastore.Pool.Close()
-			return nil, stacktrace.PropagateWithCode(err, codeRetryable, "Failed to connect to datastore server for strategic conflict detection store")
-		}
-		return nil, stacktrace.Propagate(err, "Failed to create strategic conflict detection store")
-	}
-
-	// schedule period tasks for SCD Server
-	scdCron := cron.New()
-	// schedule printing of DB status every minute for the underlying storage
-	if _, err := scdCron.AddFunc("@every 1m", func() { checkDatabase(ctx, datastore, "scd") }); err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to schedule periodic db stat check to %s", "scd")
-	}
-
-	scdCron.Start()
 
 	return &scd.Server{
 		Store:             scdStore,
@@ -286,8 +212,6 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 	if *enableSCD {
 		scdV1Server, err = createSCDServer(ctx, logger)
 		if err != nil {
-			ridV1Server.Cron.Stop()
-			ridV2Server.Cron.Stop()
 			return stacktrace.Propagate(err, "Failed to create strategic conflict detection server")
 		}
 
@@ -423,7 +347,7 @@ func main() {
 	backoff := 0
 	for {
 		if err := RunHTTPServer(ctx, cancel, *address, *locality); err != nil {
-			if stacktrace.GetCode(err) == codeRetryable {
+			if stacktrace.GetCode(err) == datastoreutils.CodeRetryable {
 				logger.Info(fmt.Sprintf("Prerequisites not yet satisfied; waiting %.fs to retry...", backoffs[backoff].Seconds()), zap.Error(err))
 				time.Sleep(backoffs[backoff])
 				if backoff < len(backoffs)-1 {

--- a/cmds/db-manager/cleanup/evict.go
+++ b/cmds/db-manager/cleanup/evict.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/interuss/dss/pkg/datastore"
-	datastoreflags "github.com/interuss/dss/pkg/datastore/flags"
 	"github.com/interuss/dss/pkg/logging"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
@@ -54,12 +52,14 @@ func evict(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := context.WithTimeout(ctx, *timeout)
 	defer cancel()
 
-	scdStore, err := getSCDStore(ctx)
+	logger := logging.WithValuesFromContext(ctx, logging.Logger)
+
+	scdStore, err := scdc.Dial(ctx, logger, false, false)
 	if err != nil {
 		return err
 	}
 
-	ridStore, err := getRIDStore(ctx)
+	ridStore, err := ridc.Dial(ctx, logger, false)
 	if err != nil {
 		return err
 	}
@@ -167,45 +167,6 @@ func evict(cmd *cobra.Command, _ []string) error {
 		log.Printf("no entity was deleted, run the command again with the `--delete` flag to do so")
 	}
 	return nil
-}
-
-func getSCDStore(ctx context.Context) (*scdc.Store, error) {
-	logger := logging.WithValuesFromContext(ctx, logging.Logger)
-
-	connectParameters := datastoreflags.ConnectParameters()
-	connectParameters.DBName = "scd"
-	datastore, err := datastore.Dial(ctx, connectParameters)
-	if err != nil {
-		logParams := connectParameters
-		logParams.Credentials.Password = "[REDACTED]"
-		return nil, fmt.Errorf("failed to connect to SCD database with %+v: %w", logParams, err)
-	}
-
-	scdStore, err := scdc.NewStore(ctx, datastore, logger, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create strategic conflict detection store with %+v: %w", connectParameters, err)
-	}
-	return scdStore, nil
-}
-
-func getRIDStore(ctx context.Context) (*ridc.Store, error) {
-
-	logger := logging.WithValuesFromContext(ctx, logging.Logger)
-
-	connectParameters := datastoreflags.ConnectParameters()
-	connectParameters.DBName = "rid"
-	datastore, err := datastore.Dial(ctx, connectParameters)
-	if err != nil {
-		logParams := connectParameters
-		logParams.Credentials.Password = "[REDACTED]"
-		return nil, fmt.Errorf("failed to connect to remote ID database with %+v: %w", logParams, err)
-	}
-
-	ridStore, err := ridc.NewStore(ctx, datastore, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create remote ID store with %+v: %w", connectParameters, err)
-	}
-	return ridStore, nil
 }
 
 func logExpiredEntity(entity string, entityID dssmodels.ID, threshold time.Time, deleted, hasEndTime bool) {

--- a/pkg/aux_/store/datastore/store.go
+++ b/pkg/aux_/store/datastore/store.go
@@ -6,6 +6,7 @@ import (
 	"github.com/interuss/dss/pkg/aux_/repos"
 	"github.com/interuss/dss/pkg/datastore"
 	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/datastoreutils"
 	"github.com/interuss/dss/pkg/logging"
 	dssql "github.com/interuss/dss/pkg/sql"
 	"github.com/jonboulle/clockwork"
@@ -29,7 +30,7 @@ type Store struct {
 	datastore.Store[repos.Repository]
 }
 
-func NewStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger) (*Store, error) {
+func newStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger) (*Store, error) {
 
 	s := &Store{}
 
@@ -52,4 +53,13 @@ func (s *Store) CleanUp(ctx context.Context) error {
 	const query = `DELETE FROM dss_metadata WHERE locality IS NOT NULL;`
 	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
+}
+
+func Dial(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*Store, error) {
+
+	store, err := datastoreutils.DialStore(ctx, "aux", withCheckCron, func(db *datastore.Datastore) (*Store, error) {
+		return newStore(ctx, db, logger)
+	})
+
+	return store, err
 }

--- a/pkg/aux_/store/datastore/store_test.go
+++ b/pkg/aux_/store/datastore/store_test.go
@@ -24,7 +24,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	// Reset the clock for every test.
 	fakeClock = clockwork.NewFakeClock()
 
-	store, err := newStore(ctx, t, connectParameters)
+	store, err := newTestStore(ctx, t, connectParameters)
 	require.NoError(t, err)
 	return store, func() {
 		require.NoError(t, CleanUp(ctx, store))
@@ -32,11 +32,11 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	}
 }
 
-func newStore(ctx context.Context, t *testing.T, connectParameters datastore.ConnectParameters) (*Store, error) {
+func newTestStore(ctx context.Context, t *testing.T, connectParameters datastore.ConnectParameters) (*Store, error) {
 	db, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 
-	s, err := NewStore(ctx, db, logging.Logger)
+	s, err := newStore(ctx, db, logging.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -62,7 +62,7 @@ func (s *Store[R]) GetVersion(ctx context.Context) (*semver.Version, error) {
 	return s.version, nil
 }
 
-func (s *Store[R]) CheckMajorSchemaVersion(ctx context.Context, crdbExpected, ybExpected int64, module string) error { // TODO: Make it internal, pass parameters to NewStore
+func (s *Store[R]) CheckMajorSchemaVersion(ctx context.Context, crdbExpected, ybExpected int64, module string) error { // TODO: Make it internal, pass parameters to newStore
 	vs, err := s.GetVersion(ctx)
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to get schema version for %s", module)

--- a/pkg/datastoreutils/dial.go
+++ b/pkg/datastoreutils/dial.go
@@ -1,0 +1,66 @@
+package datastoreutils
+
+// TODO: Remove import loop with flags and move to base datastore package, see https://github.com/interuss/dss/pull/1409#discussion_r3044201890
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/interuss/dss/pkg/datastore"
+	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/logging"
+	"github.com/interuss/stacktrace"
+	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
+)
+
+const (
+	CodeRetryable = stacktrace.ErrorCode(1)
+)
+
+func checkDatabase(ctx context.Context, db *datastore.Datastore, databaseName string) {
+	logger := logging.WithValuesFromContext(ctx, logging.Logger)
+	statsPtr := db.Pool.Stat()
+	if int(statsPtr.TotalConns()) == 0 {
+		logger.Warn("Failed periodic DB Ping (TotalConns=0)", zap.String("Database", databaseName))
+	} else {
+		logger.Info("Successful periodic DB Ping", zap.String("Database", databaseName))
+	}
+}
+
+func DialStore[S any](ctx context.Context, dbName string, withCheckCron bool, newStore func(*datastore.Datastore) (S, error)) (S, error) {
+
+	var zero S
+
+	cp := flags.ConnectParameters()
+	cp.DBName = dbName
+
+	db, err := datastore.Dial(ctx, cp)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "connect: connection refused") {
+			return zero, stacktrace.PropagateWithCode(err, CodeRetryable, "Failed to connect to datastore server for %s", dbName)
+		}
+		return zero, stacktrace.Propagate(err, "Failed to connect to %s database", dbName)
+	}
+	s, err := newStore(db)
+	if err != nil {
+		db.Pool.Close()
+		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), fmt.Sprintf("database \"%s\" does not exist", dbName)) || strings.Contains(err.Error(), "database has not been bootstrapped with Schema Manager") {
+			return zero, stacktrace.PropagateWithCode(err, CodeRetryable, "Failed to create %s store", dbName)
+		}
+		return zero, stacktrace.Propagate(err, "Failed to create %s store", dbName)
+	}
+
+	if withCheckCron {
+		c := cron.New()
+		if _, err := c.AddFunc("@every 1m", func() { checkDatabase(ctx, db, dbName) }); err != nil {
+			db.Pool.Close()
+			return zero, stacktrace.Propagate(err, "Failed to schedule db check for %s", dbName)
+		}
+		c.Start()
+	}
+
+	return s, nil
+}

--- a/pkg/rid/server/v1/server.go
+++ b/pkg/rid/server/v1/server.go
@@ -7,7 +7,6 @@ import (
 	restapi "github.com/interuss/dss/pkg/api/ridv1"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/stacktrace"
-	"github.com/robfig/cron/v3"
 
 	"github.com/interuss/dss/pkg/rid/application"
 )
@@ -17,7 +16,6 @@ type Server struct {
 	App               application.App
 	Locality          string
 	AllowHTTPBaseUrls bool
-	Cron              *cron.Cron
 }
 
 func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {

--- a/pkg/rid/store/datastore/store.go
+++ b/pkg/rid/store/datastore/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/datastoreutils"
 	dssql "github.com/interuss/dss/pkg/sql"
 
 	"github.com/interuss/dss/pkg/datastore"
@@ -53,4 +54,13 @@ func (s *Store) CleanUp(ctx context.Context) error {
 	DELETE FROM identification_service_areas WHERE id IS NOT NULL;`
 	_, err := s.DB.Pool.Exec(ctx, query)
 	return err
+}
+
+func Dial(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*Store, error) {
+
+	store, err := datastoreutils.DialStore(ctx, "rid", withCheckCron, func(db *datastore.Datastore) (*Store, error) {
+		return NewStore(ctx, db, logger)
+	})
+
+	return store, err
 }

--- a/pkg/rid/store/datastore/store_test.go
+++ b/pkg/rid/store/datastore/store_test.go
@@ -34,7 +34,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	// Reset the clock for every test.
 	fakeClock = clockwork.NewFakeClock()
 
-	store, err := newStore(ctx, t, connectParameters)
+	store, err := newTestStore(ctx, t, connectParameters)
 	require.NoError(t, err)
 	return store, func() {
 		require.NoError(t, CleanUp(ctx, store))
@@ -42,7 +42,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	}
 }
 
-func newStore(ctx context.Context, t *testing.T, connectParameters datastore.ConnectParameters) (*Store, error) {
+func newTestStore(ctx context.Context, t *testing.T, connectParameters datastore.ConnectParameters) (*Store, error) {
 	db, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 

--- a/pkg/scd/store/datastore/store.go
+++ b/pkg/scd/store/datastore/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/interuss/dss/pkg/datastore/flags"
+	"github.com/interuss/dss/pkg/datastoreutils"
 	dssql "github.com/interuss/dss/pkg/sql"
 
 	"github.com/interuss/dss/pkg/datastore"
@@ -30,7 +31,7 @@ type Store struct {
 	datastore.Store[repos.Repository]
 }
 
-func NewStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger, globalLock bool) (*Store, error) {
+func newStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger, globalLock bool) (*Store, error) {
 
 	s := &Store{}
 
@@ -47,4 +48,13 @@ func NewStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger, 
 	}
 	s.Store = base
 	return s, s.CheckMajorSchemaVersion(ctx, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, db.Pool.Config().ConnConfig.Database)
+}
+
+func Dial(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool) (*Store, error) {
+
+	store, err := datastoreutils.DialStore(ctx, "scd", withCheckCron, func(db *datastore.Datastore) (*Store, error) {
+		return newStore(ctx, db, logger, globalLock)
+	})
+
+	return store, err
 }

--- a/pkg/scd/store/datastore/store_test.go
+++ b/pkg/scd/store/datastore/store_test.go
@@ -24,7 +24,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	// Reset the clock for every test.
 	fakeClock = clockwork.NewFakeClock()
 
-	store, err := newStore(ctx, t, connectParameters)
+	store, err := newTestStore(ctx, t, connectParameters)
 	require.NoError(t, err)
 	return store, func() {
 		require.NoError(t, CleanUp(ctx, store))
@@ -32,11 +32,11 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	}
 }
 
-func newStore(ctx context.Context, t *testing.T, connectParameters datastore.ConnectParameters) (*Store, error) {
+func newTestStore(ctx context.Context, t *testing.T, connectParameters datastore.ConnectParameters) (*Store, error) {
 	db, err := datastore.Dial(ctx, connectParameters)
 	require.NoError(t, err)
 
-	s, err := NewStore(ctx, db, logging.Logger, false)
+	s, err := newStore(ctx, db, logging.Logger, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Follow #1408 , extracted from #1403

Move to a generic `dial` function, normalizing `datastore.Dial` calls, checks of errors and (optional) cron creation.