### PR TITLE
[datastore] Stop crons on ctx's cancels, cancel ctx when error occur during RunHTTPServer

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -164,6 +164,9 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 		versioningV1Server = &versioning.Server{}
 	)
 
+	ctx, ctxCancel := context.WithCancel(ctx)
+	defer ctxCancel()
+
 	// Initialize aux
 	auxV1Server, err = createAuxServer(ctx, locality, *publicEndpoint, *scdGlobalLock, logger)
 	if err != nil {

--- a/pkg/datastoreutils/dial.go
+++ b/pkg/datastoreutils/dial.go
@@ -60,6 +60,11 @@ func DialStore[S any](ctx context.Context, dbName string, withCheckCron bool, ne
 			return zero, stacktrace.Propagate(err, "Failed to schedule db check for %s", dbName)
 		}
 		c.Start()
+
+		go func() {
+			<-ctx.Done()
+			c.Stop()
+		}()
 	}
 
 	return s, nil


### PR DESCRIPTION
This follow #1409 

Cron where partially manually canceled in original code in one case. That case has been removed in #1409 .

This now fix the situation by canceling cron on context's cancel and by canceling context in all error return path of `RunHTTPServer`, ensuring they are canceled correctly.

(e.g. scd's cron was never canceled in original code)