### PR TITLE
 [datastore] Remove cleanup functions 

### DIFF
--- a/pkg/aux_/store/datastore/store.go
+++ b/pkg/aux_/store/datastore/store.go
@@ -49,12 +49,6 @@ func newStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger) 
 	return s, s.CheckMajorSchemaVersion(ctx, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, db.Pool.Config().ConnConfig.Database)
 }
 
-func (s *Store) CleanUp(ctx context.Context) error {
-	const query = `DELETE FROM dss_metadata WHERE locality IS NOT NULL;`
-	_, err := s.DB.Pool.Exec(ctx, query)
-	return err
-}
-
 func Dial(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*Store, error) {
 
 	store, err := datastoreutils.DialStore(ctx, "aux", withCheckCron, func(db *datastore.Datastore) (*Store, error) {

--- a/pkg/aux_/store/datastore/store_test.go
+++ b/pkg/aux_/store/datastore/store_test.go
@@ -27,7 +27,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	store, err := newTestStore(ctx, t, connectParameters)
 	require.NoError(t, err)
 	return store, func() {
-		require.NoError(t, CleanUp(ctx, store))
+		require.NoError(t, cleanUp(ctx, store))
 		require.NoError(t, store.Close())
 	}
 }
@@ -45,8 +45,8 @@ func newTestStore(ctx context.Context, t *testing.T, connectParameters datastore
 	return s, nil
 }
 
-// CleanUp drops all required tables from the store, useful for testing.
-func CleanUp(ctx context.Context, s *Store) error {
+// cleanUp drops all required tables from the store, useful for testing.
+func cleanUp(ctx context.Context, s *Store) error {
 	const query = `
 	DELETE FROM dss_metadata WHERE locality IS NOT NULL;
     `

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -71,12 +71,18 @@ func setUpStore(ctx context.Context, t *testing.T, logger *zap.Logger) (store.St
 	store.Clock = fakeClock
 
 	return store, func() {
-		require.NoError(t, CleanUp(ctx, store))
+		require.NoError(t, cleanUp(ctx, store))
 		require.NoError(t, store.Close())
 	}
 }
 
-// CleanUp drops all required tables from the store, useful for testing.
-func CleanUp(ctx context.Context, s *ridc.Store) error {
-	return s.CleanUp(ctx)
+// cleanUp drops all required tables from the store, useful for testing.
+func cleanUp(ctx context.Context, s *ridc.Store) error {
+	const query = `
+    DELETE FROM subscriptions WHERE id IS NOT NULL;
+    DELETE FROM identification_service_areas WHERE id IS NOT NULL;`
+
+	_, err := s.DB.Pool.Exec(ctx, query)
+	return err
+
 }

--- a/pkg/rid/store/datastore/store.go
+++ b/pkg/rid/store/datastore/store.go
@@ -48,14 +48,6 @@ func NewStore(ctx context.Context, db *datastore.Datastore, logger *zap.Logger) 
 	return s, s.CheckMajorSchemaVersion(ctx, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, db.Pool.Config().ConnConfig.Database)
 }
 
-func (s *Store) CleanUp(ctx context.Context) error {
-	const query = `
-	DELETE FROM subscriptions WHERE id IS NOT NULL;
-	DELETE FROM identification_service_areas WHERE id IS NOT NULL;`
-	_, err := s.DB.Pool.Exec(ctx, query)
-	return err
-}
-
 func Dial(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*Store, error) {
 
 	store, err := datastoreutils.DialStore(ctx, "rid", withCheckCron, func(db *datastore.Datastore) (*Store, error) {

--- a/pkg/rid/store/datastore/store_test.go
+++ b/pkg/rid/store/datastore/store_test.go
@@ -37,7 +37,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	store, err := newTestStore(ctx, t, connectParameters)
 	require.NoError(t, err)
 	return store, func() {
-		require.NoError(t, CleanUp(ctx, store))
+		require.NoError(t, cleanUp(ctx, store))
 		require.NoError(t, store.Close())
 	}
 }
@@ -55,8 +55,8 @@ func newTestStore(ctx context.Context, t *testing.T, connectParameters datastore
 	return s, nil
 }
 
-// CleanUp drops all required tables from the store, useful for testing.
-func CleanUp(ctx context.Context, s *Store) error {
+// cleanUp drops all required tables from the store, useful for testing.
+func cleanUp(ctx context.Context, s *Store) error {
 	const query = `
 	DELETE FROM subscriptions WHERE id IS NOT NULL;
 	DELETE FROM identification_service_areas WHERE id IS NOT NULL;`

--- a/pkg/scd/store/datastore/store_test.go
+++ b/pkg/scd/store/datastore/store_test.go
@@ -27,7 +27,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	store, err := newTestStore(ctx, t, connectParameters)
 	require.NoError(t, err)
 	return store, func() {
-		require.NoError(t, CleanUp(ctx, store))
+		require.NoError(t, cleanUp(ctx, store))
 		require.NoError(t, store.Close())
 	}
 }
@@ -45,8 +45,8 @@ func newTestStore(ctx context.Context, t *testing.T, connectParameters datastore
 	return s, nil
 }
 
-// CleanUp drops all required tables from the store, useful for testing.
-func CleanUp(ctx context.Context, s *Store) error {
+// cleanUp drops all required tables from the store, useful for testing.
+func cleanUp(ctx context.Context, s *Store) error {
 	const query = `
 	DELETE FROM scd_subscriptions WHERE id IS NOT NULL;
 	DELETE FROM scd_operations WHERE id IS NOT NULL;


### PR DESCRIPTION
Follow #1408 

Removed the cleanup functions. In aux and scd, they were unused. In rid, they were only used for testing, so the function has been moved there (following the scd convention).