### PR TITLE
[ci] Update 'actions/checkout''s version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         echo "Branch: ${{ github.ref }}"
         docker images
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Python lint
@@ -49,7 +49,7 @@ jobs:
         docker images
         go env
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Deployment infrastructure tests
@@ -97,7 +97,7 @@ jobs:
           docker images
           go env
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Build dss image
@@ -128,7 +128,7 @@ jobs:
         echo "Branch: ${{ github.ref }}"
         docker images
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Tests
@@ -147,7 +147,7 @@ jobs:
         echo "Branch: ${{ github.ref }}"
         docker images
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Check migrations

--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -9,20 +9,20 @@ jobs:
     name: Clone on Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Checkout on Windows
         run: echo "Project successfully cloned on ${{ runner.os }}. See `Set up Job` stage for more details about the Runner."
   macos:
     name: Clone on Mac
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Checkout on Mac
         run: echo "Project successfully cloned on ${{ runner.os }}. See `Set up Job` stage for more details about the Runner."
   ubuntu:
     name: Clone on Ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Checkout on Ubuntu
         run: echo "Project successfully cloned on ${{ runner.os }}. See `Set up Job` stage for more details about the Runner."

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'interuss/dss'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Configure Git Credentials

--- a/.github/workflows/dss-deploy.yml
+++ b/.github/workflows/dss-deploy.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Branch: ${{ github.ref }}"
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dss-publish.yml
+++ b/.github/workflows/dss-publish.yml
@@ -37,7 +37,7 @@ jobs:
           cosign version
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This PR update `actions/checkout` to the latest version.

Lastly, the CI started to emit warnings:

"Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/"

This should fix the issue.

Based on usage and quick scan of the changelog, update shouldn't an impact. Running CI is the validation step.