### PR TITLE
[aux] Fill nil on empty body on PutDSSInstancesHeartbeat

### DIFF
--- a/pkg/aux_/pool_participants.go
+++ b/pkg/aux_/pool_participants.go
@@ -86,6 +86,11 @@ func (a *Server) PutDSSInstancesHeartbeat(ctx context.Context, req *restapi.PutD
 		return resp
 	}
 
+	if req.Source == nil {
+		resp.Response400 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(err, "Source not set"))}
+		return resp
+	}
+
 	heartbeat := models.Heartbeat{
 		Source:   *req.Source,
 		Reporter: *req.Auth.ClientID,


### PR DESCRIPTION
I noticed during some auth test that the endpoint crash instead of returning a 500 with an empty body, dues to a nil pointer being used. This PR fixes it.