### PR TITLE
Add .gitkeep file to docker ignore to prevent -dirty version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ build/workspace
 !build/workspace/.gitkeep
 **/.terraform
 **/coverdata
+!build/dev/startup/coverdata/.gitkeep


### PR DESCRIPTION
This PR fix #1431 , applying it suggestion to "unignore" the `.gitkeep file in `build/dev/startup/coverdata/`.

Tested locally, `-dirty` tag is not present anymore:

```
docker run -it docker.io/interuss-local/dss core-service
{"level":"info","ts":"2026-04-15T06:54:24.582Z","caller":"core-service/main.go:147","msg":"version","address":":8080","version":"0.0.0+54668503"}
(...)
```

