### PR TITLE
Auth: Move authentification validation in generated code

### DIFF
--- a/interfaces/openapi-to-go-server/generate.py
+++ b/interfaces/openapi-to-go-server/generate.py
@@ -110,8 +110,10 @@ def _generate_apis(
                     "fmt",
                     "go.opentelemetry.io/otel",
                     "go.opentelemetry.io/otel/trace",
+                    "github.com/interuss/stacktrace",
                 ]
-            ),
+            )
+            + '\n    dsserr "github.com/interuss/dss/pkg/errors"',
             "<API_PACKAGE>": api_package,
             "<ROUTES>": "\n".join(routes),
             "<ROUTING>": "\n".join(rendering.routing(api, api_package)),

--- a/interfaces/openapi-to-go-server/rendering.py
+++ b/interfaces/openapi-to-go-server/rendering.py
@@ -290,17 +290,9 @@ def routes(
 
         body: List[str] = []
 
-        # Create object to hold the processed input to the operation
+        # Create object to hold the processed input and output to the operation
         body.append("var req {}".format(operation.request_type_name))
-        body.append("")
-
-        # Attempt to authorize access to the operation
-        body.extend(comment(["Authorize request"]))
-        body.append(
-            "req.Auth = s.Authorizer.Authorize(w, r, {}Security)".format(
-                operation.interface_name
-            )
-        )
+        body.append("var response {}".format(operation.response_type_name))
         body.append("")
 
         # Parse any path parameters
@@ -385,20 +377,48 @@ def routes(
 
         # Actually invoke the API Implementation with the processed request to obtain the response
         imports.add("context")
-        body.extend(comment(["Call implementation"]))
-        body.append("ctx, cancel := context.WithCancel(r.Context())")
-        body.append("defer cancel()")
-        body.append(
-            "response := s.Implementation.{}(ctx, &req)".format(
-                operation.interface_name
-            )
+
+        body.append("")
+
+        call_block = []
+
+        call_block.extend(comment(["Call implementation"]))
+        call_block.append("ctx, cancel := context.WithCancel(r.Context())")
+        call_block.append("defer cancel()")
+        call_block.append(
+            "response = s.Implementation.{}(ctx, &req)".format(operation.interface_name)
         )
+
+        if operation.security.options:
+            # Authorize & verify the call
+            body.extend(comment(["Authorize request"]))
+            body.append(
+                "req.Auth = s.Authorizer.Authorize(w, r, {}Security)".format(
+                    operation.interface_name
+                )
+            )
+
+            body.extend(comment(["Verify authorization"]))
+            body.append("if req.Auth.Error != nil {")
+            body.extend(
+                indent(
+                    [
+                        'setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)'
+                    ],
+                    1,
+                )
+            )
+            body.append("} else {")
+            body.extend(indent(call_block, 1))
+            body.append("}")
+        else:
+            body.extend(call_block)
         body.append("")
 
         # Write the first populated response discovered and finish the handler
         body.extend(comment(["Write response to client"]))
         responses = [r for r in operation.responses]
-        if ensure_500 and 500 not in {r.code for r in responses}:
+        if ensure_500 and 500 not in {r.code for r in operation.responses}:
             responses.append(
                 operations.Response(
                     code=500,

--- a/interfaces/openapi-to-go-server/templates/server.go.template
+++ b/interfaces/openapi-to-go-server/templates/server.go.template
@@ -33,6 +33,23 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
     return false
 }
 
+
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+        *resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+        *resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
+}
+
 <ROUTES>
 
 func MakeAPIRouter(impl Implementation, auth <API_PACKAGE>.Authorizer) APIRouter {

--- a/pkg/api/auxv1/server.gen.go
+++ b/pkg/api/auxv1/server.gen.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/interuss/dss/pkg/api"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/stacktrace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"net/http"
@@ -42,16 +44,30 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	return false
 }
 
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
+}
+
 func (s *APIRouter) GetVersion(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetVersionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetVersionSecurity)
+	var response GetVersionResponseSet
 
 	// Call implementation
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
-	response := s.Implementation.GetVersion(ctx, &req)
+	response = s.Implementation.GetVersion(ctx, &req)
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -67,9 +83,7 @@ func (s *APIRouter) GetVersion(exp *regexp.Regexp, w http.ResponseWriter, r *htt
 
 func (s *APIRouter) ValidateOauth(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req ValidateOauthRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, ValidateOauthSecurity)
+	var response ValidateOauthResponseSet
 
 	// Copy query parameters
 	query := r.URL.Query()
@@ -78,10 +92,17 @@ func (s *APIRouter) ValidateOauth(exp *regexp.Regexp, w http.ResponseWriter, r *
 		req.Owner = &v
 	}
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.ValidateOauth(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, ValidateOauthSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.ValidateOauth(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -105,14 +126,19 @@ func (s *APIRouter) ValidateOauth(exp *regexp.Regexp, w http.ResponseWriter, r *
 
 func (s *APIRouter) GetPool(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetPoolRequest
+	var response GetPoolResponseSet
 
 	// Authorize request
 	req.Auth = s.Authorizer.Authorize(w, r, GetPoolSecurity)
-
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetPool(ctx, &req)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetPool(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -140,14 +166,19 @@ func (s *APIRouter) GetPool(exp *regexp.Regexp, w http.ResponseWriter, r *http.R
 
 func (s *APIRouter) GetDSSInstances(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetDSSInstancesRequest
+	var response GetDSSInstancesResponseSet
 
 	// Authorize request
 	req.Auth = s.Authorizer.Authorize(w, r, GetDSSInstancesSecurity)
-
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetDSSInstances(ctx, &req)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetDSSInstances(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -175,9 +206,7 @@ func (s *APIRouter) GetDSSInstances(exp *regexp.Regexp, w http.ResponseWriter, r
 
 func (s *APIRouter) PutDSSInstancesHeartbeat(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req PutDSSInstancesHeartbeatRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, PutDSSInstancesHeartbeatSecurity)
+	var response PutDSSInstancesHeartbeatResponseSet
 
 	// Copy query parameters
 	query := r.URL.Query()
@@ -194,10 +223,17 @@ func (s *APIRouter) PutDSSInstancesHeartbeat(exp *regexp.Regexp, w http.Response
 		req.NextHeartbeatExpectedBefore = &v
 	}
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.PutDSSInstancesHeartbeat(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, PutDSSInstancesHeartbeatSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.PutDSSInstancesHeartbeat(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response201 != nil {
@@ -229,14 +265,12 @@ func (s *APIRouter) PutDSSInstancesHeartbeat(exp *regexp.Regexp, w http.Response
 
 func (s *APIRouter) GetAcceptedCAs(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetAcceptedCAsRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetAcceptedCAsSecurity)
+	var response GetAcceptedCAsResponseSet
 
 	// Call implementation
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
-	response := s.Implementation.GetAcceptedCAs(ctx, &req)
+	response = s.Implementation.GetAcceptedCAs(ctx, &req)
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -256,14 +290,12 @@ func (s *APIRouter) GetAcceptedCAs(exp *regexp.Regexp, w http.ResponseWriter, r 
 
 func (s *APIRouter) GetInstanceCAs(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetInstanceCAsRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetInstanceCAsSecurity)
+	var response GetInstanceCAsResponseSet
 
 	// Call implementation
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
-	response := s.Implementation.GetInstanceCAs(ctx, &req)
+	response = s.Implementation.GetInstanceCAs(ctx, &req)
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -283,14 +315,19 @@ func (s *APIRouter) GetInstanceCAs(exp *regexp.Regexp, w http.ResponseWriter, r 
 
 func (s *APIRouter) GetScdLockMode(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetScdLockModeRequest
+	var response GetScdLockModeResponseSet
 
 	// Authorize request
 	req.Auth = s.Authorizer.Authorize(w, r, GetScdLockModeSecurity)
-
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetScdLockMode(ctx, &req)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetScdLockMode(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {

--- a/pkg/api/ridv1/server.gen.go
+++ b/pkg/api/ridv1/server.gen.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/interuss/dss/pkg/api"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/stacktrace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"net/http"
@@ -43,11 +45,25 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	return false
 }
 
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
+}
+
 func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req SearchIdentificationServiceAreasRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, SearchIdentificationServiceAreasSecurity)
+	var response SearchIdentificationServiceAreasResponseSet
 
 	// Copy query parameters
 	query := r.URL.Query()
@@ -64,10 +80,17 @@ func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.
 		req.LatestTime = &v
 	}
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.SearchIdentificationServiceAreas(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, SearchIdentificationServiceAreasSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.SearchIdentificationServiceAreas(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -99,18 +122,23 @@ func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) GetIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetIdentificationServiceAreaSecurity)
+	var response GetIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = EntityUUID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -142,9 +170,7 @@ func (s *APIRouter) GetIdentificationServiceArea(exp *regexp.Regexp, w http.Resp
 
 func (s *APIRouter) CreateIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateIdentificationServiceAreaSecurity)
+	var response CreateIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -155,10 +181,17 @@ func (s *APIRouter) CreateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -194,9 +227,7 @@ func (s *APIRouter) CreateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 
 func (s *APIRouter) UpdateIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateIdentificationServiceAreaSecurity)
+	var response UpdateIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -208,10 +239,17 @@ func (s *APIRouter) UpdateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -247,19 +285,24 @@ func (s *APIRouter) UpdateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 
 func (s *APIRouter) DeleteIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteIdentificationServiceAreaSecurity)
+	var response DeleteIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = EntityUUID(pathMatch[1])
 	req.Version = pathMatch[2]
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -295,9 +338,7 @@ func (s *APIRouter) DeleteIdentificationServiceArea(exp *regexp.Regexp, w http.R
 
 func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req SearchSubscriptionsRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, SearchSubscriptionsSecurity)
+	var response SearchSubscriptionsResponseSet
 
 	// Copy query parameters
 	query := r.URL.Query()
@@ -306,10 +347,17 @@ func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWrite
 		req.Area = &v
 	}
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.SearchSubscriptions(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, SearchSubscriptionsSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.SearchSubscriptions(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -341,18 +389,23 @@ func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWrite
 
 func (s *APIRouter) GetSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetSubscriptionSecurity)
+	var response GetSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = SubscriptionUUID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -384,9 +437,7 @@ func (s *APIRouter) GetSubscription(exp *regexp.Regexp, w http.ResponseWriter, r
 
 func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateSubscriptionSecurity)
+	var response CreateSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -397,10 +448,17 @@ func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -436,9 +494,7 @@ func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateSubscriptionSecurity)
+	var response UpdateSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -450,10 +506,17 @@ func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -489,19 +552,24 @@ func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteSubscriptionSecurity)
+	var response DeleteSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = SubscriptionUUID(pathMatch[1])
 	req.Version = pathMatch[2]
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {

--- a/pkg/api/ridv2/server.gen.go
+++ b/pkg/api/ridv2/server.gen.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/interuss/dss/pkg/api"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/stacktrace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"net/http"
@@ -43,11 +45,25 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	return false
 }
 
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
+}
+
 func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req SearchIdentificationServiceAreasRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, SearchIdentificationServiceAreasSecurity)
+	var response SearchIdentificationServiceAreasResponseSet
 
 	// Copy query parameters
 	query := r.URL.Query()
@@ -64,10 +80,17 @@ func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.
 		req.LatestTime = &v
 	}
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.SearchIdentificationServiceAreas(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, SearchIdentificationServiceAreasSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.SearchIdentificationServiceAreas(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -99,18 +122,23 @@ func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) GetIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetIdentificationServiceAreaSecurity)
+	var response GetIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = EntityUUID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -142,9 +170,7 @@ func (s *APIRouter) GetIdentificationServiceArea(exp *regexp.Regexp, w http.Resp
 
 func (s *APIRouter) CreateIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateIdentificationServiceAreaSecurity)
+	var response CreateIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -155,10 +181,17 @@ func (s *APIRouter) CreateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -194,9 +227,7 @@ func (s *APIRouter) CreateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 
 func (s *APIRouter) UpdateIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateIdentificationServiceAreaSecurity)
+	var response UpdateIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -208,10 +239,17 @@ func (s *APIRouter) UpdateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -247,19 +285,24 @@ func (s *APIRouter) UpdateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 
 func (s *APIRouter) DeleteIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteIdentificationServiceAreaSecurity)
+	var response DeleteIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = EntityUUID(pathMatch[1])
 	req.Version = pathMatch[2]
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -295,9 +338,7 @@ func (s *APIRouter) DeleteIdentificationServiceArea(exp *regexp.Regexp, w http.R
 
 func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req SearchSubscriptionsRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, SearchSubscriptionsSecurity)
+	var response SearchSubscriptionsResponseSet
 
 	// Copy query parameters
 	query := r.URL.Query()
@@ -306,10 +347,17 @@ func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWrite
 		req.Area = &v
 	}
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.SearchSubscriptions(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, SearchSubscriptionsSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.SearchSubscriptions(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -341,18 +389,23 @@ func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWrite
 
 func (s *APIRouter) GetSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetSubscriptionSecurity)
+	var response GetSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = SubscriptionUUID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -384,9 +437,7 @@ func (s *APIRouter) GetSubscription(exp *regexp.Regexp, w http.ResponseWriter, r
 
 func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateSubscriptionSecurity)
+	var response CreateSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -397,10 +448,17 @@ func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -436,9 +494,7 @@ func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateSubscriptionSecurity)
+	var response UpdateSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -450,10 +506,17 @@ func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -489,19 +552,24 @@ func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteSubscriptionSecurity)
+	var response DeleteSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = SubscriptionUUID(pathMatch[1])
 	req.Version = pathMatch[2]
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {

--- a/pkg/api/scdv1/server.gen.go
+++ b/pkg/api/scdv1/server.gen.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/interuss/dss/pkg/api"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/stacktrace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"net/http"
@@ -43,21 +45,42 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	return false
 }
 
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
+}
+
 func (s *APIRouter) QueryOperationalIntentReferences(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req QueryOperationalIntentReferencesRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, QueryOperationalIntentReferencesSecurity)
+	var response QueryOperationalIntentReferencesResponseSet
 
 	// Parse request body
 	req.Body = new(QueryOperationalIntentReferenceParameters)
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.QueryOperationalIntentReferences(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, QueryOperationalIntentReferencesSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.QueryOperationalIntentReferences(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -93,18 +116,23 @@ func (s *APIRouter) QueryOperationalIntentReferences(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) GetOperationalIntentReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetOperationalIntentReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetOperationalIntentReferenceSecurity)
+	var response GetOperationalIntentReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Entityid = EntityID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetOperationalIntentReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetOperationalIntentReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetOperationalIntentReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -140,9 +168,7 @@ func (s *APIRouter) GetOperationalIntentReference(exp *regexp.Regexp, w http.Res
 
 func (s *APIRouter) CreateOperationalIntentReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateOperationalIntentReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateOperationalIntentReferenceSecurity)
+	var response CreateOperationalIntentReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -153,10 +179,17 @@ func (s *APIRouter) CreateOperationalIntentReference(exp *regexp.Regexp, w http.
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateOperationalIntentReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateOperationalIntentReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateOperationalIntentReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response201 != nil {
@@ -200,9 +233,7 @@ func (s *APIRouter) CreateOperationalIntentReference(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) UpdateOperationalIntentReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateOperationalIntentReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateOperationalIntentReferenceSecurity)
+	var response UpdateOperationalIntentReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -214,10 +245,17 @@ func (s *APIRouter) UpdateOperationalIntentReference(exp *regexp.Regexp, w http.
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateOperationalIntentReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateOperationalIntentReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateOperationalIntentReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -261,19 +299,24 @@ func (s *APIRouter) UpdateOperationalIntentReference(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) DeleteOperationalIntentReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteOperationalIntentReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteOperationalIntentReferenceSecurity)
+	var response DeleteOperationalIntentReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Entityid = EntityID(pathMatch[1])
 	req.Ovn = EntityOVN(pathMatch[2])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteOperationalIntentReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteOperationalIntentReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteOperationalIntentReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -317,19 +360,24 @@ func (s *APIRouter) DeleteOperationalIntentReference(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) QueryConstraintReferences(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req QueryConstraintReferencesRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, QueryConstraintReferencesSecurity)
+	var response QueryConstraintReferencesResponseSet
 
 	// Parse request body
 	req.Body = new(QueryConstraintReferenceParameters)
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.QueryConstraintReferences(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, QueryConstraintReferencesSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.QueryConstraintReferences(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -365,18 +413,23 @@ func (s *APIRouter) QueryConstraintReferences(exp *regexp.Regexp, w http.Respons
 
 func (s *APIRouter) GetConstraintReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetConstraintReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetConstraintReferenceSecurity)
+	var response GetConstraintReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Entityid = EntityID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetConstraintReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetConstraintReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetConstraintReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -412,9 +465,7 @@ func (s *APIRouter) GetConstraintReference(exp *regexp.Regexp, w http.ResponseWr
 
 func (s *APIRouter) CreateConstraintReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateConstraintReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateConstraintReferenceSecurity)
+	var response CreateConstraintReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -425,10 +476,17 @@ func (s *APIRouter) CreateConstraintReference(exp *regexp.Regexp, w http.Respons
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateConstraintReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateConstraintReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateConstraintReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response201 != nil {
@@ -468,9 +526,7 @@ func (s *APIRouter) CreateConstraintReference(exp *regexp.Regexp, w http.Respons
 
 func (s *APIRouter) UpdateConstraintReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateConstraintReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateConstraintReferenceSecurity)
+	var response UpdateConstraintReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -482,10 +538,17 @@ func (s *APIRouter) UpdateConstraintReference(exp *regexp.Regexp, w http.Respons
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateConstraintReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateConstraintReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateConstraintReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -525,19 +588,24 @@ func (s *APIRouter) UpdateConstraintReference(exp *regexp.Regexp, w http.Respons
 
 func (s *APIRouter) DeleteConstraintReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteConstraintReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteConstraintReferenceSecurity)
+	var response DeleteConstraintReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Entityid = EntityID(pathMatch[1])
 	req.Ovn = EntityOVN(pathMatch[2])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteConstraintReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteConstraintReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteConstraintReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -577,19 +645,24 @@ func (s *APIRouter) DeleteConstraintReference(exp *regexp.Regexp, w http.Respons
 
 func (s *APIRouter) QuerySubscriptions(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req QuerySubscriptionsRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, QuerySubscriptionsSecurity)
+	var response QuerySubscriptionsResponseSet
 
 	// Parse request body
 	req.Body = new(QuerySubscriptionParameters)
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.QuerySubscriptions(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, QuerySubscriptionsSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.QuerySubscriptions(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -625,18 +698,23 @@ func (s *APIRouter) QuerySubscriptions(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) GetSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetSubscriptionSecurity)
+	var response GetSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Subscriptionid = SubscriptionID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -672,9 +750,7 @@ func (s *APIRouter) GetSubscription(exp *regexp.Regexp, w http.ResponseWriter, r
 
 func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateSubscriptionSecurity)
+	var response CreateSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -685,10 +761,17 @@ func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -724,9 +807,7 @@ func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateSubscriptionSecurity)
+	var response UpdateSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -738,10 +819,17 @@ func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -777,19 +865,24 @@ func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteSubscriptionSecurity)
+	var response DeleteSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Subscriptionid = SubscriptionID(pathMatch[1])
 	req.Version = pathMatch[2]
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -829,19 +922,24 @@ func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) MakeDssReport(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req MakeDssReportRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, MakeDssReportSecurity)
+	var response MakeDssReportResponseSet
 
 	// Parse request body
 	req.Body = new(ErrorReport)
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.MakeDssReport(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, MakeDssReportSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.MakeDssReport(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response201 != nil {
@@ -873,18 +971,23 @@ func (s *APIRouter) MakeDssReport(exp *regexp.Regexp, w http.ResponseWriter, r *
 
 func (s *APIRouter) GetUssAvailability(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetUssAvailabilityRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetUssAvailabilitySecurity)
+	var response GetUssAvailabilityResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.UssId = pathMatch[1]
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetUssAvailability(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetUssAvailabilitySecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetUssAvailability(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -916,9 +1019,7 @@ func (s *APIRouter) GetUssAvailability(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) SetUssAvailability(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req SetUssAvailabilityRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, SetUssAvailabilitySecurity)
+	var response SetUssAvailabilityResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -929,10 +1030,17 @@ func (s *APIRouter) SetUssAvailability(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.SetUssAvailability(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, SetUssAvailabilitySecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.SetUssAvailability(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {

--- a/pkg/aux_/pool.go
+++ b/pkg/aux_/pool.go
@@ -12,10 +12,6 @@ import (
 
 func (a *Server) GetPool(ctx context.Context, req *restapi.GetPoolRequest) restapi.GetPoolResponseSet {
 	resp := restapi.GetPoolResponseSet{}
-	if req.Auth.Error != nil {
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	repo, err := a.Store.Interact(ctx)
 	if err != nil {

--- a/pkg/aux_/pool_participants.go
+++ b/pkg/aux_/pool_participants.go
@@ -15,11 +15,6 @@ func (a *Server) GetDSSInstances(ctx context.Context, req *restapi.GetDSSInstanc
 
 	resp := restapi.GetDSSInstancesResponseSet{}
 
-	if req.Auth.Error != nil {
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
-
 	repo, err := a.Store.Interact(ctx)
 	if err != nil {
 		resp.Response500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(err, "Unable to interact with the store"))}
@@ -74,11 +69,6 @@ func (a *Server) GetDSSInstances(ctx context.Context, req *restapi.GetDSSInstanc
 func (a *Server) PutDSSInstancesHeartbeat(ctx context.Context, req *restapi.PutDSSInstancesHeartbeatRequest) restapi.PutDSSInstancesHeartbeatResponseSet {
 
 	resp := restapi.PutDSSInstancesHeartbeatResponseSet{}
-
-	if req.Auth.Error != nil {
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	repo, err := a.Store.Interact(ctx)
 	if err != nil {

--- a/pkg/aux_/scd_lock_mode.go
+++ b/pkg/aux_/scd_lock_mode.go
@@ -4,17 +4,9 @@ import (
 	"context"
 
 	restapi "github.com/interuss/dss/pkg/api/auxv1"
-	"github.com/interuss/stacktrace"
 )
 
 func (a *Server) GetScdLockMode(ctx context.Context, req *restapi.GetScdLockModeRequest) restapi.GetScdLockModeResponseSet {
-
-	resp := restapi.GetScdLockModeResponseSet{}
-
-	if req.Auth.Error != nil {
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	return restapi.GetScdLockModeResponseSet{Response200: &restapi.SCDLockModeResponse{GlobalLock: &a.ScdGlobalLock}}
 }

--- a/pkg/aux_/server.go
+++ b/pkg/aux_/server.go
@@ -19,22 +19,6 @@ type Server struct {
 	ScdGlobalLock bool
 }
 
-func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {
-	switch stacktrace.GetCode(authErr) {
-	case dsserr.Unauthenticated:
-		*resp401 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
-	case dsserr.PermissionDenied:
-		*resp403 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
-	default:
-
-		if authErr == nil {
-			authErr = stacktrace.NewError("Unknown error")
-		}
-
-		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
-	}
-}
-
 // GetVersion returns information about the version of the server.
 func (a *Server) GetVersion(context.Context, *restapi.GetVersionRequest) restapi.GetVersionResponseSet {
 	return restapi.GetVersionResponseSet{Response200: &restapi.VersionResponse{
@@ -43,19 +27,6 @@ func (a *Server) GetVersion(context.Context, *restapi.GetVersionRequest) restapi
 
 // ValidateOauth will exercise validating the Oauth token
 func (a *Server) ValidateOauth(ctx context.Context, req *restapi.ValidateOauthRequest) restapi.ValidateOauthResponseSet {
-
-	if req.Auth.Error != nil {
-		resp := restapi.ValidateOauthResponseSet{}
-		switch stacktrace.GetCode(req.Auth.Error) {
-		case dsserr.Unauthenticated:
-			resp.Response401 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(req.Auth.Error, "Authentication failed"))}
-		case dsserr.PermissionDenied:
-			resp.Response403 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(req.Auth.Error, "Authorization failed"))}
-		default:
-			resp.Response500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(req.Auth.Error, "Could not perform authorization"))}
-		}
-		return resp
-	}
 
 	if req.Auth.ClientID == nil {
 		return restapi.ValidateOauthResponseSet{Response403: &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.NewErrorWithCode(dsserr.PermissionDenied, "Missing owner"))}}

--- a/pkg/rid/server/v1/isa_handler.go
+++ b/pkg/rid/server/v1/isa_handler.go
@@ -19,12 +19,6 @@ import (
 func (s *Server) GetIdentificationServiceArea(ctx context.Context, req *restapi.GetIdentificationServiceAreaRequest,
 ) restapi.GetIdentificationServiceAreaResponseSet {
 
-	if req.Auth.Error != nil {
-		resp := restapi.GetIdentificationServiceAreaResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
-
 	id, err := dssmodels.IDFromString(string(req.Id))
 	if err != nil {
 		return restapi.GetIdentificationServiceAreaResponseSet{Response400: &restapi.ErrorResponse{
@@ -47,12 +41,6 @@ func (s *Server) GetIdentificationServiceArea(ctx context.Context, req *restapi.
 // CreateIdentificationServiceArea creates an ISA
 func (s *Server) CreateIdentificationServiceArea(ctx context.Context, req *restapi.CreateIdentificationServiceAreaRequest,
 ) restapi.CreateIdentificationServiceAreaResponseSet {
-
-	if req.Auth.Error != nil {
-		resp := restapi.CreateIdentificationServiceAreaResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.Auth.ClientID == nil {
 		return restapi.CreateIdentificationServiceAreaResponseSet{Response403: &restapi.ErrorResponse{
@@ -128,12 +116,6 @@ func (s *Server) CreateIdentificationServiceArea(ctx context.Context, req *resta
 // UpdateIdentificationServiceArea updates an existing ISA.
 func (s *Server) UpdateIdentificationServiceArea(ctx context.Context, req *restapi.UpdateIdentificationServiceAreaRequest,
 ) restapi.UpdateIdentificationServiceAreaResponseSet {
-
-	if req.Auth.Error != nil {
-		resp := restapi.UpdateIdentificationServiceAreaResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	version, err := dssmodels.VersionFromString(req.Version)
 	if err != nil {
@@ -211,12 +193,6 @@ func (s *Server) UpdateIdentificationServiceArea(ctx context.Context, req *resta
 func (s *Server) DeleteIdentificationServiceArea(ctx context.Context, req *restapi.DeleteIdentificationServiceAreaRequest,
 ) restapi.DeleteIdentificationServiceAreaResponseSet {
 
-	if req.Auth.Error != nil {
-		resp := restapi.DeleteIdentificationServiceAreaResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
-
 	if req.Auth.ClientID == nil {
 		return restapi.DeleteIdentificationServiceAreaResponseSet{Response403: &restapi.ErrorResponse{
 			Message: dsserr.Handle(ctx, stacktrace.NewErrorWithCode(dsserr.PermissionDenied, "Missing owner"))}}
@@ -259,12 +235,6 @@ func (s *Server) DeleteIdentificationServiceArea(ctx context.Context, req *resta
 // SearchIdentificationServiceAreas queries for all ISAs in the bounds.
 func (s *Server) SearchIdentificationServiceAreas(ctx context.Context, req *restapi.SearchIdentificationServiceAreasRequest,
 ) restapi.SearchIdentificationServiceAreasResponseSet {
-
-	if req.Auth.Error != nil {
-		resp := restapi.SearchIdentificationServiceAreasResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.Area == nil {
 		return restapi.SearchIdentificationServiceAreasResponseSet{Response400: &restapi.ErrorResponse{

--- a/pkg/rid/server/v1/server.go
+++ b/pkg/rid/server/v1/server.go
@@ -1,13 +1,6 @@
 package v1
 
 import (
-	"context"
-
-	"github.com/interuss/dss/pkg/api"
-	restapi "github.com/interuss/dss/pkg/api/ridv1"
-	dsserr "github.com/interuss/dss/pkg/errors"
-	"github.com/interuss/stacktrace"
-
 	"github.com/interuss/dss/pkg/rid/application"
 )
 
@@ -16,18 +9,4 @@ type Server struct {
 	App               application.App
 	Locality          string
 	AllowHTTPBaseUrls bool
-}
-
-func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {
-	switch stacktrace.GetCode(authErr) {
-	case dsserr.Unauthenticated:
-		*resp401 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
-	case dsserr.PermissionDenied:
-		*resp403 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
-	default:
-		if authErr == nil {
-			authErr = stacktrace.NewError("Unknown error")
-		}
-		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
-	}
 }

--- a/pkg/rid/server/v1/subscription_handler.go
+++ b/pkg/rid/server/v1/subscription_handler.go
@@ -18,12 +18,6 @@ import (
 func (s *Server) DeleteSubscription(ctx context.Context, req *restapi.DeleteSubscriptionRequest,
 ) restapi.DeleteSubscriptionResponseSet {
 
-	if req.Auth.Error != nil {
-		resp := restapi.DeleteSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
-
 	if req.Auth.ClientID == nil {
 		return restapi.DeleteSubscriptionResponseSet{Response403: &restapi.ErrorResponse{
 			Message: dsserr.Handle(ctx, stacktrace.NewErrorWithCode(dsserr.PermissionDenied, "Missing owner"))}}
@@ -63,12 +57,6 @@ func (s *Server) DeleteSubscription(ctx context.Context, req *restapi.DeleteSubs
 // SearchSubscriptions queries for existing subscriptions in the given bounds.
 func (s *Server) SearchSubscriptions(ctx context.Context, req *restapi.SearchSubscriptionsRequest,
 ) restapi.SearchSubscriptionsResponseSet {
-
-	if req.Auth.Error != nil {
-		resp := restapi.SearchSubscriptionsResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.Auth.ClientID == nil {
 		return restapi.SearchSubscriptionsResponseSet{Response403: &restapi.ErrorResponse{
@@ -114,12 +102,6 @@ func (s *Server) SearchSubscriptions(ctx context.Context, req *restapi.SearchSub
 func (s *Server) GetSubscription(ctx context.Context, req *restapi.GetSubscriptionRequest,
 ) restapi.GetSubscriptionResponseSet {
 
-	if req.Auth.Error != nil {
-		resp := restapi.GetSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
-
 	id, err := dssmodels.IDFromString(string(req.Id))
 	if err != nil {
 		return restapi.GetSubscriptionResponseSet{Response400: &restapi.ErrorResponse{
@@ -142,12 +124,6 @@ func (s *Server) GetSubscription(ctx context.Context, req *restapi.GetSubscripti
 // CreateSubscription creates a single subscription.
 func (s *Server) CreateSubscription(ctx context.Context, req *restapi.CreateSubscriptionRequest,
 ) restapi.CreateSubscriptionResponseSet {
-
-	if req.Auth.Error != nil {
-		resp := restapi.CreateSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.Auth.ClientID == nil {
 		return restapi.CreateSubscriptionResponseSet{Response403: &restapi.ErrorResponse{
@@ -240,12 +216,6 @@ func (s *Server) CreateSubscription(ctx context.Context, req *restapi.CreateSubs
 // UpdateSubscription updates a single subscription.
 func (s *Server) UpdateSubscription(ctx context.Context, req *restapi.UpdateSubscriptionRequest,
 ) restapi.UpdateSubscriptionResponseSet {
-
-	if req.Auth.Error != nil {
-		resp := restapi.UpdateSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	version, err := dssmodels.VersionFromString(req.Version)
 	if err != nil {

--- a/pkg/rid/server/v2/isa_handler.go
+++ b/pkg/rid/server/v2/isa_handler.go
@@ -18,11 +18,6 @@ import (
 // GetIdentificationServiceArea returns a single ISA for a given ID.
 func (s *Server) GetIdentificationServiceArea(ctx context.Context, req *restapi.GetIdentificationServiceAreaRequest,
 ) restapi.GetIdentificationServiceAreaResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.GetIdentificationServiceAreaResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	id, err := dssmodels.IDFromString(string(req.Id))
 	if err != nil {
@@ -46,11 +41,6 @@ func (s *Server) GetIdentificationServiceArea(ctx context.Context, req *restapi.
 // CreateIdentificationServiceArea creates an ISA
 func (s *Server) CreateIdentificationServiceArea(ctx context.Context, req *restapi.CreateIdentificationServiceAreaRequest,
 ) restapi.CreateIdentificationServiceAreaResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.CreateIdentificationServiceAreaResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.Auth.ClientID == nil {
 		return restapi.CreateIdentificationServiceAreaResponseSet{Response403: &restapi.ErrorResponse{
@@ -122,11 +112,6 @@ func (s *Server) CreateIdentificationServiceArea(ctx context.Context, req *resta
 // UpdateIdentificationServiceArea updates an existing ISA.
 func (s *Server) UpdateIdentificationServiceArea(ctx context.Context, req *restapi.UpdateIdentificationServiceAreaRequest,
 ) restapi.UpdateIdentificationServiceAreaResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.UpdateIdentificationServiceAreaResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	version, err := dssmodels.VersionFromString(req.Version)
 	if err != nil {
@@ -199,11 +184,6 @@ func (s *Server) UpdateIdentificationServiceArea(ctx context.Context, req *resta
 // DeleteIdentificationServiceArea deletes an existing ISA.
 func (s *Server) DeleteIdentificationServiceArea(ctx context.Context, req *restapi.DeleteIdentificationServiceAreaRequest,
 ) restapi.DeleteIdentificationServiceAreaResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.DeleteIdentificationServiceAreaResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.Auth.ClientID == nil {
 		return restapi.DeleteIdentificationServiceAreaResponseSet{Response403: &restapi.ErrorResponse{
@@ -248,11 +228,6 @@ func (s *Server) DeleteIdentificationServiceArea(ctx context.Context, req *resta
 // SearchIdentificationServiceAreas queries for all ISAs in the bounds.
 func (s *Server) SearchIdentificationServiceAreas(ctx context.Context, req *restapi.SearchIdentificationServiceAreasRequest,
 ) restapi.SearchIdentificationServiceAreasResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.SearchIdentificationServiceAreasResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.Area == nil {
 		return restapi.SearchIdentificationServiceAreasResponseSet{Response400: &restapi.ErrorResponse{

--- a/pkg/rid/server/v2/server.go
+++ b/pkg/rid/server/v2/server.go
@@ -1,12 +1,6 @@
 package server
 
 import (
-	"context"
-
-	"github.com/interuss/dss/pkg/api"
-	restapi "github.com/interuss/dss/pkg/api/ridv2"
-	dsserr "github.com/interuss/dss/pkg/errors"
-	"github.com/interuss/stacktrace"
 	"github.com/robfig/cron/v3"
 
 	"github.com/interuss/dss/pkg/rid/application"
@@ -18,18 +12,4 @@ type Server struct {
 	Locality          string
 	AllowHTTPBaseUrls bool
 	Cron              *cron.Cron
-}
-
-func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {
-	switch stacktrace.GetCode(authErr) {
-	case dsserr.Unauthenticated:
-		*resp401 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
-	case dsserr.PermissionDenied:
-		*resp403 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
-	default:
-		if authErr == nil {
-			authErr = stacktrace.NewError("Unknown error")
-		}
-		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
-	}
 }

--- a/pkg/rid/server/v2/subscription_handler.go
+++ b/pkg/rid/server/v2/subscription_handler.go
@@ -17,11 +17,6 @@ import (
 // DeleteSubscription deletes an existing subscription.
 func (s *Server) DeleteSubscription(ctx context.Context, req *restapi.DeleteSubscriptionRequest,
 ) restapi.DeleteSubscriptionResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.DeleteSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.Auth.ClientID == nil {
 		return restapi.DeleteSubscriptionResponseSet{Response403: &restapi.ErrorResponse{
@@ -62,11 +57,6 @@ func (s *Server) DeleteSubscription(ctx context.Context, req *restapi.DeleteSubs
 // SearchSubscriptions queries for existing subscriptions in the given bounds.
 func (s *Server) SearchSubscriptions(ctx context.Context, req *restapi.SearchSubscriptionsRequest,
 ) restapi.SearchSubscriptionsResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.SearchSubscriptionsResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.Auth.ClientID == nil {
 		return restapi.SearchSubscriptionsResponseSet{Response403: &restapi.ErrorResponse{
@@ -111,11 +101,6 @@ func (s *Server) SearchSubscriptions(ctx context.Context, req *restapi.SearchSub
 // GetSubscription gets a single subscription based on ID.
 func (s *Server) GetSubscription(ctx context.Context, req *restapi.GetSubscriptionRequest,
 ) restapi.GetSubscriptionResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.GetSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	id, err := dssmodels.IDFromString(string(req.Id))
 	if err != nil {
@@ -139,11 +124,6 @@ func (s *Server) GetSubscription(ctx context.Context, req *restapi.GetSubscripti
 // CreateSubscription creates a single subscription.
 func (s *Server) CreateSubscription(ctx context.Context, req *restapi.CreateSubscriptionRequest,
 ) restapi.CreateSubscriptionResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.CreateSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.Auth.ClientID == nil {
 		return restapi.CreateSubscriptionResponseSet{Response403: &restapi.ErrorResponse{
@@ -232,11 +212,6 @@ func (s *Server) CreateSubscription(ctx context.Context, req *restapi.CreateSubs
 // UpdateSubscription updates a single subscription.
 func (s *Server) UpdateSubscription(ctx context.Context, req *restapi.UpdateSubscriptionRequest,
 ) restapi.UpdateSubscriptionResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.UpdateSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	version, err := dssmodels.VersionFromString(req.Version)
 	if err != nil {

--- a/pkg/scd/constraints_handler.go
+++ b/pkg/scd/constraints_handler.go
@@ -19,11 +19,6 @@ import (
 // the specified version.
 func (a *Server) DeleteConstraintReference(ctx context.Context, req *restapi.DeleteConstraintReferenceRequest,
 ) restapi.DeleteConstraintReferenceResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.DeleteConstraintReferenceResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	// Retrieve Constraint ID
 	id, err := dssmodels.IDFromString(string(req.Entityid))
@@ -131,11 +126,6 @@ func (a *Server) DeleteConstraintReference(ctx context.Context, req *restapi.Del
 // GetConstraintReference returns a single constraint ref for the given ID.
 func (a *Server) GetConstraintReference(ctx context.Context, req *restapi.GetConstraintReferenceRequest,
 ) restapi.GetConstraintReferenceResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.GetConstraintReferenceResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	id, err := dssmodels.IDFromString(string(req.Entityid))
 	if err != nil {
@@ -185,11 +175,6 @@ func (a *Server) GetConstraintReference(ctx context.Context, req *restapi.GetCon
 
 func (a *Server) CreateConstraintReference(ctx context.Context, req *restapi.CreateConstraintReferenceRequest,
 ) restapi.CreateConstraintReferenceResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.CreateConstraintReferenceResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.BodyParseError != nil {
 		return restapi.CreateConstraintReferenceResponseSet{Response400: &restapi.ErrorResponse{
@@ -222,11 +207,6 @@ func (a *Server) CreateConstraintReference(ctx context.Context, req *restapi.Cre
 
 func (a *Server) UpdateConstraintReference(ctx context.Context, req *restapi.UpdateConstraintReferenceRequest,
 ) restapi.UpdateConstraintReferenceResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.UpdateConstraintReferenceResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.BodyParseError != nil {
 		return restapi.UpdateConstraintReferenceResponseSet{Response400: &restapi.ErrorResponse{
@@ -436,11 +416,6 @@ func validateAndReturnConstraintUpsertParams(
 // bounds.
 func (a *Server) QueryConstraintReferences(ctx context.Context, req *restapi.QueryConstraintReferencesRequest,
 ) restapi.QueryConstraintReferencesResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.QueryConstraintReferencesResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.BodyParseError != nil {
 		return restapi.QueryConstraintReferencesResponseSet{Response400: &restapi.ErrorResponse{

--- a/pkg/scd/dss_report_handler.go
+++ b/pkg/scd/dss_report_handler.go
@@ -3,6 +3,7 @@ package scd
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/google/uuid"
 	"github.com/interuss/dss/pkg/api"
 	restapi "github.com/interuss/dss/pkg/api/scdv1"
@@ -46,11 +47,6 @@ func (h *JSONLoggingReceivedReportHandler) Handle(ctx context.Context, req *rest
 // MakeDssReport creates an error report about a DSS.
 func (a *Server) MakeDssReport(ctx context.Context, req *restapi.MakeDssReportRequest,
 ) restapi.MakeDssReportResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.MakeDssReportResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.BodyParseError != nil {
 		return restapi.MakeDssReportResponseSet{Response400: &restapi.ErrorResponse{

--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -51,11 +51,6 @@ func subscriptionIsImplicitAndOnlyAttachedToOIR(ctx context.Context, r repos.Rep
 // the specified version.
 func (a *Server) DeleteOperationalIntentReference(ctx context.Context, req *restapi.DeleteOperationalIntentReferenceRequest,
 ) restapi.DeleteOperationalIntentReferenceResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.DeleteOperationalIntentReferenceResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	// Retrieve OperationalIntent ID
 	id, err := dssmodels.IDFromString(string(req.Entityid))
@@ -193,11 +188,6 @@ func (a *Server) DeleteOperationalIntentReference(ctx context.Context, req *rest
 // GetOperationalIntentReference returns a single operation intent ref for the given ID.
 func (a *Server) GetOperationalIntentReference(ctx context.Context, req *restapi.GetOperationalIntentReferenceRequest,
 ) restapi.GetOperationalIntentReferenceResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.GetOperationalIntentReferenceResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	id, err := dssmodels.IDFromString(string(req.Entityid))
 	if err != nil {
@@ -248,11 +238,6 @@ func (a *Server) GetOperationalIntentReference(ctx context.Context, req *restapi
 // bounds.
 func (a *Server) QueryOperationalIntentReferences(ctx context.Context, req *restapi.QueryOperationalIntentReferencesRequest,
 ) restapi.QueryOperationalIntentReferencesResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.QueryOperationalIntentReferencesResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.BodyParseError != nil {
 		return restapi.QueryOperationalIntentReferencesResponseSet{Response400: &restapi.ErrorResponse{
@@ -318,11 +303,6 @@ func (a *Server) QueryOperationalIntentReferences(ctx context.Context, req *rest
 
 func (a *Server) CreateOperationalIntentReference(ctx context.Context, req *restapi.CreateOperationalIntentReferenceRequest,
 ) restapi.CreateOperationalIntentReferenceResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.CreateOperationalIntentReferenceResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.BodyParseError != nil {
 		return restapi.CreateOperationalIntentReferenceResponseSet{Response400: &restapi.ErrorResponse{
@@ -354,11 +334,6 @@ func (a *Server) CreateOperationalIntentReference(ctx context.Context, req *rest
 
 func (a *Server) UpdateOperationalIntentReference(ctx context.Context, req *restapi.UpdateOperationalIntentReferenceRequest,
 ) restapi.UpdateOperationalIntentReferenceResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.UpdateOperationalIntentReferenceResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.BodyParseError != nil {
 		return restapi.UpdateOperationalIntentReferenceResponseSet{Response400: &restapi.ErrorResponse{

--- a/pkg/scd/server.go
+++ b/pkg/scd/server.go
@@ -1,14 +1,9 @@
 package scd
 
 import (
-	"context"
-
-	"github.com/interuss/dss/pkg/api"
 	restapi "github.com/interuss/dss/pkg/api/scdv1"
-	dsserr "github.com/interuss/dss/pkg/errors"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	scdstore "github.com/interuss/dss/pkg/scd/store"
-	"github.com/interuss/stacktrace"
 )
 
 func makeSubscribersToNotify(subscriptions []*scdmodels.Subscription) []restapi.SubscriberToNotify {
@@ -37,18 +32,4 @@ type Server struct {
 	Store             scdstore.Store
 	DSSReportHandler  ReceivedReportHandler
 	AllowHTTPBaseUrls bool
-}
-
-func setAuthError(ctx context.Context, authErr error, resp401, resp403 **restapi.ErrorResponse, resp500 **api.InternalServerErrorBody) {
-	switch stacktrace.GetCode(authErr) {
-	case dsserr.Unauthenticated:
-		*resp401 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
-	case dsserr.PermissionDenied:
-		*resp403 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
-	default:
-		if authErr == nil {
-			authErr = stacktrace.NewError("Unknown error")
-		}
-		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
-	}
 }

--- a/pkg/scd/subscriptions_handler.go
+++ b/pkg/scd/subscriptions_handler.go
@@ -22,11 +22,6 @@ var (
 
 func (a *Server) CreateSubscription(ctx context.Context, req *restapi.CreateSubscriptionRequest,
 ) restapi.CreateSubscriptionResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.CreateSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.BodyParseError != nil {
 		return restapi.CreateSubscriptionResponseSet{Response400: &restapi.ErrorResponse{
@@ -59,11 +54,6 @@ func (a *Server) CreateSubscription(ctx context.Context, req *restapi.CreateSubs
 
 func (a *Server) UpdateSubscription(ctx context.Context, req *restapi.UpdateSubscriptionRequest,
 ) restapi.UpdateSubscriptionResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.UpdateSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.BodyParseError != nil {
 		return restapi.UpdateSubscriptionResponseSet{Response400: &restapi.ErrorResponse{
@@ -298,11 +288,6 @@ func (a *Server) PutSubscription(ctx context.Context, manager string, subscripti
 // GetSubscription returns a single subscription for the given ID.
 func (a *Server) GetSubscription(ctx context.Context, req *restapi.GetSubscriptionRequest,
 ) restapi.GetSubscriptionResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.GetSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	// Retrieve Subscription ID
 	id, err := dssmodels.IDFromString(string(req.Subscriptionid))
@@ -379,11 +364,6 @@ func (a *Server) GetSubscription(ctx context.Context, req *restapi.GetSubscripti
 func (a *Server) QuerySubscriptions(ctx context.Context, req *restapi.QuerySubscriptionsRequest,
 ) restapi.QuerySubscriptionsResponseSet {
 	nowMarker := time.Now()
-	if req.Auth.Error != nil {
-		resp := restapi.QuerySubscriptionsResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.BodyParseError != nil {
 		return restapi.QuerySubscriptionsResponseSet{Response400: &restapi.ErrorResponse{
@@ -468,11 +448,6 @@ func (a *Server) QuerySubscriptions(ctx context.Context, req *restapi.QuerySubsc
 // DeleteSubscription deletes a single subscription for a given ID.
 func (a *Server) DeleteSubscription(ctx context.Context, req *restapi.DeleteSubscriptionRequest,
 ) restapi.DeleteSubscriptionResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.DeleteSubscriptionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	// Retrieve Subscription ID
 	id, err := dssmodels.IDFromString(string(req.Subscriptionid))

--- a/pkg/scd/uss_availability_handler.go
+++ b/pkg/scd/uss_availability_handler.go
@@ -25,11 +25,6 @@ func GetDefaultAvailabilityResponse(id dssmodels.Manager) *restapi.UssAvailabili
 
 func (a *Server) GetUssAvailability(ctx context.Context, req *restapi.GetUssAvailabilityRequest,
 ) restapi.GetUssAvailabilityResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.GetUssAvailabilityResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	id := dssmodels.ManagerFromString(req.UssId)
 	if id == "" {
@@ -72,11 +67,6 @@ func (a *Server) GetUssAvailability(ctx context.Context, req *restapi.GetUssAvai
 
 func (a *Server) SetUssAvailability(ctx context.Context, req *restapi.SetUssAvailabilityRequest,
 ) restapi.SetUssAvailabilityResponseSet {
-	if req.Auth.Error != nil {
-		resp := restapi.SetUssAvailabilityResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
 
 	if req.UssId == "" {
 		return restapi.SetUssAvailabilityResponseSet{Response400: &restapi.ErrorResponse{

--- a/pkg/versioning/server.go
+++ b/pkg/versioning/server.go
@@ -3,25 +3,14 @@ package versioning
 import (
 	"context"
 
-	"github.com/interuss/dss/pkg/api"
 	versioning "github.com/interuss/dss/pkg/api/versioningv1"
-	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/version"
-	"github.com/interuss/stacktrace"
 )
 
 type Server struct {
 }
 
 func (s *Server) GetVersion(ctx context.Context, req *versioning.GetVersionRequest) versioning.GetVersionResponseSet {
-	// This should take care of unauthenticated requests as well as
-	// any request without the proper scope.
-	if req.Auth.Error != nil {
-		resp := versioning.GetVersionResponseSet{}
-		setAuthError(ctx, stacktrace.Propagate(req.Auth.Error, "Auth failed"), &resp.Response401, &resp.Response403, &resp.Response500)
-		return resp
-	}
-
 	// The DSS has no notion of particular system identities: whatever the request, we will
 	// always return the current version of the DSS binary.
 	versionStr := version.Current().String()
@@ -30,20 +19,5 @@ func (s *Server) GetVersion(ctx context.Context, req *versioning.GetVersionReque
 			SystemIdentity: &req.SystemIdentity,
 			SystemVersion:  (*versioning.VersionIdentifier)(&versionStr),
 		},
-	}
-}
-
-func setAuthError(ctx context.Context, authErr error, resp401, resp403 **api.EmptyResponseBody, resp500 **api.InternalServerErrorBody) {
-	switch stacktrace.GetCode(authErr) {
-	case dsserr.Unauthenticated:
-		*resp401 = &api.EmptyResponseBody{}
-	case dsserr.PermissionDenied:
-		*resp403 = &api.EmptyResponseBody{}
-	default:
-
-		if authErr == nil {
-			authErr = stacktrace.NewError("Unknown error")
-		}
-		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
 	}
 }


### PR DESCRIPTION
This move up authentication checks in generated code, ensuring it's enforced everywhere automatically, preventing situation like #1422 

Minor side effects, but recorded here to simplify review:

* `ValidateOauth` call was not using the `setAuthError` helper, this is now normalized
* Call that don't needed authentication are not calling `s.Authorizer.Authorize` anymore (who was just storing a used error dues to missing authentication)