### PR TITLE
[certificates] Add CI hygiene checks, minor fixes on python hygiene checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,25 +50,41 @@ check-hygiene: python-lint hygiene shell-lint go-lint terraform-lint
 
 .PHONY: python-lint
 python-lint: openapi-to-go-server
-	docker run -u "$(USER_GROUP)" --entrypoint uv \
+	docker run --rm -u "$(USER_GROUP)" --entrypoint uv \
 	    -v "$(CURDIR)/interfaces/openapi-to-go-server:/app/" \
 			interuss/openapi-to-go-server \
             run ruff check
-	docker run -u "$(USER_GROUP)" --entrypoint uv \
+	docker run --rm -u "$(USER_GROUP)" --entrypoint uv \
 	    -v "$(CURDIR)/interfaces/openapi-to-go-server:/app/" \
 			interuss/openapi-to-go-server \
             run ruff format --check
+	docker run --rm -u "$(USER_GROUP)" \
+	    -v "$(CURDIR)/deploy/operations/certificates-management:/app/" \
+			ghcr.io/astral-sh/ruff:0.15.10 \
+            check /app/ --no-cache
+	docker run --rm -u "$(USER_GROUP)" \
+	    -v "$(CURDIR)/deploy/operations/certificates-management:/app/" \
+			ghcr.io/astral-sh/ruff:0.15.10 \
+            format --check /app/ --no-cache
 
-.PHONY: openapi-to-go-server
-python-format:
-	docker run -u "$(USER_GROUP)" --entrypoint uv \
+.PHONY: python-format
+python-format: openapi-to-go-server
+	docker run --rm -u "$(USER_GROUP)" --entrypoint uv \
 	    -v "$(CURDIR)/interfaces/openapi-to-go-server:/app/" \
 			interuss/openapi-to-go-server \
             run ruff check --fix
-	docker run -u "$(USER_GROUP)" --entrypoint uv \
+	docker run --rm -u "$(USER_GROUP)" --entrypoint uv \
 	    -v "$(CURDIR)/interfaces/openapi-to-go-server:/app/" \
 			interuss/openapi-to-go-server \
             run ruff format
+	docker run --rm -u "$(USER_GROUP)" \
+	    -v "$(CURDIR)/deploy/operations/certificates-management:/app/" \
+			ghcr.io/astral-sh/ruff:0.15.10 \
+            check /app/ --fix --no-cache
+	docker run --rm -u "$(USER_GROUP)" \
+	    -v "$(CURDIR)/deploy/operations/certificates-management:/app/" \
+			ghcr.io/astral-sh/ruff:0.15.10 \
+            format /app/ --no-cache
 
 .PHONY: hygiene
 hygiene:

--- a/deploy/operations/certificates-management/apply.py
+++ b/deploy/operations/certificates-management/apply.py
@@ -3,13 +3,13 @@ import os
 
 import logging
 
-l = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def do_apply(cluster):
-    l.debug("Applying kubernetes configuration")
+    logger.debug("Applying kubernetes configuration")
 
-    l.debug(f"Creating namespace {cluster.namespace}")
+    logger.debug(f"Creating namespace {cluster.namespace}")
 
     try:
         subprocess.check_call(
@@ -25,10 +25,10 @@ def do_apply(cluster):
             stderr=subprocess.DEVNULL,
         )
 
-        l.info(f"Created namespace {cluster.namespace}")
+        logger.info(f"Created namespace {cluster.namespace}")
 
     except subprocess.CalledProcessError:  # We do assume everything else works
-        l.debug(f"Namespace {cluster.namespace} already exists")
+        logger.debug(f"Namespace {cluster.namespace} already exists")
 
     for secret_name in [
         "yb-master-yugabyte-tls-cert",
@@ -54,10 +54,10 @@ def do_apply(cluster):
                 stderr=subprocess.DEVNULL,
             )
 
-            l.info(f"Deleted old secret '{secret_name}'")
+            logger.info(f"Deleted old secret '{secret_name}'")
 
         except subprocess.CalledProcessError:  # We do assume everything else works
-            l.debug(f"Secret '{secret_name}' not present on the cluster")
+            logger.debug(f"Secret '{secret_name}' not present on the cluster")
 
     for secret_name, folder in [
         ("yb-master-yugabyte-tls-cert", cluster.master_certs_dir),
@@ -87,4 +87,4 @@ def do_apply(cluster):
             stdout=subprocess.DEVNULL,
         )
 
-        l.info(f"Created secret '{secret_name}'")
+        logger.info(f"Created secret '{secret_name}'")

--- a/deploy/operations/certificates-management/ca_pool.py
+++ b/deploy/operations/certificates-management/ca_pool.py
@@ -8,7 +8,7 @@ import tempfile
 
 from utils import get_cert_display_name, get_cert_serial
 
-l = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def build_pool_hash(cluster):
@@ -31,7 +31,7 @@ def build_pool_hash(cluster):
 def add_cas(cluster, certificate):
     folder = cluster.ca_pool_dir
 
-    l.debug("Getting new CA metadata")
+    logger.debug("Getting new CA metadata")
 
     with tempfile.NamedTemporaryFile(delete_on_close=False) as tf:
         tf.write(certificate.encode("utf-8"))
@@ -45,17 +45,17 @@ def add_cas(cluster, certificate):
         target_file = os.path.join(folder, filename)
 
         if os.path.exists(target_file):
-            l.info(f"CA {name} already present in the pool")
+            logger.info(f"CA {name} already present in the pool")
             return
 
-        l.info(f"Adding CA {name} in the pool")
+        logger.info(f"Adding CA {name} in the pool")
 
         with open(target_file, "w") as f:
             f.write(certificate)
 
 
 def regenerate_ca_files(cluster):
-    l.debug("Regenerating CA files from all CA in the pool")
+    logger.debug("Regenerating CA files from all CA in the pool")
 
     CAs = []
     for filename in os.listdir(cluster.ca_pool_dir):
@@ -76,7 +76,7 @@ def regenerate_ca_files(cluster):
 
     h = build_pool_hash(cluster)
 
-    l.info(f"Regenerated CA files from the CA pool. Current pool hash: {h}")
+    logger.info(f"Regenerated CA files from the CA pool. Current pool hash: {h}")
 
 
 def do_add_cas(cluster, certificates):
@@ -106,9 +106,9 @@ def do_remove_cas(cluster, certificates_or_serial):
 
             if os.path.isfile(target):
                 os.unlink(target)
-                l.info(f"Removed certificate {name}")
+                logger.info(f"Removed certificate {name}")
             else:
-                l.info(f"Certificate {name} not present in pool")
+                logger.info(f"Certificate {name} not present in pool")
 
     for filename in sorted(os.listdir(cluster.ca_pool_dir)):
         if filename.endswith(".crt") and filename != "ca.crt":
@@ -122,7 +122,7 @@ def do_remove_cas(cluster, certificates_or_serial):
                 or name.startswith(certificates_or_serial)
             ):
                 os.unlink(os.path.join(cluster.ca_pool_dir, filename))
-                l.info(f"Removed certificate {name}")
+                logger.info(f"Removed certificate {name}")
 
     regenerate_ca_files(cluster)
 

--- a/deploy/operations/certificates-management/dss-certs.py
+++ b/deploy/operations/certificates-management/dss-certs.py
@@ -17,7 +17,7 @@ from ca_pool import (
     do_remove_cas,
 )
 
-l = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -149,9 +149,9 @@ def main():
     elif args.action == "destroy":
         if input("Are you sure? You will loose all your certificates! [yN]") == "y":
             shutil.rmtree(cluster.directory)
-            l.warning("Destroyed cluster certificates")
+            logger.warning("Destroyed cluster certificates")
         else:
-            l.info("Cancelled removal")
+            logger.info("Cancelled removal")
 
 
 if __name__ == "__main__":

--- a/deploy/operations/certificates-management/init.py
+++ b/deploy/operations/certificates-management/init.py
@@ -7,11 +7,11 @@ from ca_pool import do_add_cas
 from nodes import do_generate_nodes
 from utils import get_cert_display_name
 
-l = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def generate_ca_config(cluster):
-    l.debug("Creating CA configuration files")
+    logger.debug("Creating CA configuration files")
 
     with open(cluster.ca_conf, "w") as f:
         f.write(
@@ -22,7 +22,7 @@ def generate_ca_config(cluster):
 [ my_ca ]
 default_days = 3650
 
-serial = {cluster.ca_key_dir}/serial.txt
+serial = {cluster.ca_key_dir}/serialogger.txt
 database = {cluster.ca_key_dir}/index.txt
 default_md = sha256
 policy = my_policy
@@ -48,26 +48,26 @@ basicConstraints = critical,CA:true,pathlen:1
 """
         )
 
-    with open(f"{cluster.ca_key_dir}/serial.txt", "w") as f:
+    with open(f"{cluster.ca_key_dir}/serialogger.txt", "w") as f:
         f.write("0001")
 
     with open(f"{cluster.ca_key_dir}/index.txt", "w") as f:
         f.write("")
 
-    l.info("Created CA configuration files")
+    logger.info("Created CA configuration files")
 
 
 def generate_ca_key(cluster):
-    l.debug("Generating CA private key")
+    logger.debug("Generating CA private key")
     subprocess.check_call(
         ["openssl", "genrsa", "-out", cluster.ca_key_file, "4096"],
         stdout=subprocess.DEVNULL,
     )
-    l.info("Generated CA private key")
+    logger.info("Generated CA private key")
 
 
 def generate_ca_cert(cluster):
-    l.debug("Generating CA certificate")
+    logger.debug("Generating CA certificate")
     subprocess.check_call(
         [
             "openssl",
@@ -88,7 +88,7 @@ def generate_ca_cert(cluster):
 
     name = get_cert_display_name(cluster.ca_cert_file)
 
-    l.info(f"Generated CA certificate '{name}'")
+    logger.info(f"Generated CA certificate '{name}'")
 
 
 def generate_ca(cluster):
@@ -98,7 +98,7 @@ def generate_ca(cluster):
 
 
 def make_directories(cluster):
-    l.debug("Creating directories")
+    logger.debug("Creating directories")
 
     if not os.path.exists("workspace"):
         os.makedirs("workspace")
@@ -111,13 +111,13 @@ def make_directories(cluster):
     os.mkdir(cluster.client_certs_dir)
     os.mkdir(cluster.ca_pool_dir)
 
-    l.info("Created directories")
+    logger.info("Created directories")
 
 
 def generate_clients(cluster):
     for client in cluster.clients:
         if cluster.is_client_ready(client):
-            l.info(f"Client '{client}' certificates already generated")
+            logger.info(f"Client '{client}' certificates already generated")
             continue
         generate_client_config(cluster, client)
         generate_client_key(cluster, client)
@@ -126,7 +126,7 @@ def generate_clients(cluster):
 
 
 def generate_client_config(cluster, client):
-    l.debug(f"Creating client '{client}' configuration file")
+    logger.debug(f"Creating client '{client}' configuration file")
 
     with open(cluster.get_client_conf_file(client), "w") as f:
         f.write(
@@ -140,21 +140,21 @@ commonName = {client}
 """
         )
 
-    l.info(f"Created client '{client}' configuration file")
+    logger.info(f"Created client '{client}' configuration file")
 
 
 def generate_client_key(cluster, client):
-    l.debug(f"Generating client '{client}' private key")
+    logger.debug(f"Generating client '{client}' private key")
 
     subprocess.check_call(
         ["openssl", "genrsa", "-out", cluster.get_client_key_file(client), "4096"]
     )
 
-    l.info(f"Generated client '{client}' private key")
+    logger.info(f"Generated client '{client}' private key")
 
 
 def generate_client_csr(cluster, client):
-    l.debug(f"Generating client '{client}' certificate request")
+    logger.debug(f"Generating client '{client}' certificate request")
 
     subprocess.check_call(
         [
@@ -171,11 +171,11 @@ def generate_client_csr(cluster, client):
         stdout=subprocess.DEVNULL,
     )
 
-    l.info(f"Generated client '{client}' certificate request")
+    logger.info(f"Generated client '{client}' certificate request")
 
 
 def generate_client_cert(cluster, client):
-    l.debug(f"Generating client '{client}' certificate")
+    logger.debug(f"Generating client '{client}' certificate")
 
     subprocess.check_call(
         [
@@ -207,19 +207,19 @@ def generate_client_cert(cluster, client):
 
     name = get_cert_display_name(cluster.get_client_cert_file(client))
 
-    l.info(f"Generated client '{client}' certificate '{name}'")
+    logger.info(f"Generated client '{client}' certificate '{name}'")
 
 
 def do_init(cluster):
     """Initialize a new cluster"""
 
-    l.info("Initialization of a new cluster")
+    logger.info("Initialization of a new cluster")
 
     if cluster.is_ready:
-        l.error("Cluster is already initialized, unable to continue")
+        logger.error("Cluster is already initialized, unable to continue")
         sys.exit(1)
     else:
-        l.debug("Cluster is not already initialized, continuing")
+        logger.debug("Cluster is not already initialized, continuing")
 
     make_directories(cluster)
     generate_ca(cluster)
@@ -231,7 +231,7 @@ def do_init(cluster):
 
     do_generate_nodes(cluster)
 
-    l.info(
+    logger.info(
         "The new cluster certificates are ready! Don't forget to 'apply' the configuration."
     )
 
@@ -241,6 +241,6 @@ def do_generate_clients(cluster):
 
     generate_clients(cluster)
 
-    l.info(
+    logger.info(
         f"{len(cluster.clients)} client certificates ready. Don't forget to 'apply' the configuration."
     )

--- a/deploy/operations/certificates-management/nodes.py
+++ b/deploy/operations/certificates-management/nodes.py
@@ -5,9 +5,11 @@ import shutil
 
 from utils import get_cert_display_name
 
+logger = logging.getLogger(__name__)
+
 
 def generate_node_config(cluster, node_type, node_id):
-    l.debug(f"Creating {node_type} #{node_id} configuration file")
+    logger.debug(f"Creating {node_type} #{node_id} configuration file")
 
     short_name = cluster.get_node_short_name(node_type, node_id)
     short_name_group = cluster.get_node_short_name_group(node_type, node_id)
@@ -46,11 +48,11 @@ DNS.7 = yb-{node_type}s.{cluster.namespace}.svc.cluster.local
             f.write(f"""DNS.8 = {public_address}
 """)
 
-    l.info(f"Created {node_type} #{node_id} configuration file")
+    logger.info(f"Created {node_type} #{node_id} configuration file")
 
 
 def generate_node_key(cluster, node_type, node_id):
-    l.debug(f"Generating {node_type} #{node_id} private key")
+    logger.debug(f"Generating {node_type} #{node_id} private key")
 
     file = cluster.get_node_key_file(node_type, node_id)
 
@@ -69,11 +71,11 @@ def generate_node_key(cluster, node_type, node_id):
     if second_file:
         shutil.copy(file, second_file)
 
-    l.info(f"Generated {node_type} #{node_id} private key")
+    logger.info(f"Generated {node_type} #{node_id} private key")
 
 
 def generate_node_csr(cluster, node_type, node_id):
-    l.debug(f"Generating {node_type} #{node_id} certificate request")
+    logger.debug(f"Generating {node_type} #{node_id} certificate request")
 
     subprocess.check_call(
         [
@@ -90,11 +92,11 @@ def generate_node_csr(cluster, node_type, node_id):
         stdout=subprocess.DEVNULL,
     )
 
-    l.info(f"Generated {node_type} #{node_id} certificate request")
+    logger.info(f"Generated {node_type} #{node_id} certificate request")
 
 
 def generate_node_cert(cluster, node_type, node_id):
-    l.debug(f"Generating {node_type} #{node_id} certificate")
+    logger.debug(f"Generating {node_type} #{node_id} certificate")
 
     file = cluster.get_node_cert_file(node_type, node_id)
 
@@ -135,12 +137,12 @@ def generate_node_cert(cluster, node_type, node_id):
 
     name = get_cert_display_name(cluster.get_node_cert_file(node_type, node_id))
 
-    l.info(f"Generated {node_type} #{node_id} certificate '{name}'")
+    logger.info(f"Generated {node_type} #{node_id} certificate '{name}'")
 
 
 def generate_node(cluster, node_type, node_id):
     if cluster.is_node_ready(node_type, node_id):
-        l.debug(f"{node_type} #{node_id} certificates already generated")
+        logger.debug(f"{node_type} #{node_id} certificates already generated")
         return
 
     generate_node_config(cluster, node_type, node_id)
@@ -151,19 +153,16 @@ def generate_node(cluster, node_type, node_id):
     shutil.copy(cluster.ca_pool_ca, getattr(cluster, f"{node_type}_ca"))
 
 
-l = logging.getLogger(__name__)
-
-
 def do_generate_nodes(cluster):
     """Generate certificates for all nodes (master and tserver)"""
 
-    l.info("Generation of nodes certificates")
+    logger.info("Generation of nodes certificates")
 
     if not cluster.is_ready:
-        l.error("Cluster is not already initialized, unable to continue")
+        logger.error("Cluster is not already initialized, unable to continue")
         sys.exit(1)
     else:
-        l.debug("Cluster is initialized, continuing")
+        logger.debug("Cluster is initialized, continuing")
 
     for node_type in ["master", "tserver"]:
         for node_id in range(0, int(cluster.nodes_count)):
@@ -171,4 +170,4 @@ def do_generate_nodes(cluster):
 
     generate_node(cluster, "prometheus", "")
 
-    l.info("All nodes certificates are ready")
+    logger.info("All nodes certificates are ready")

--- a/deploy/operations/certificates-management/utils.py
+++ b/deploy/operations/certificates-management/utils.py
@@ -4,7 +4,7 @@ import ssl
 import sys
 import unicodedata
 
-l = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def slugify(text):
@@ -21,7 +21,7 @@ def get_cert_display_name(path):
             path
         )  # We do use an internal function, to avoid installing dependencies
     except Exception as e:
-        l.error(e)
+        logger.error(e)
         sys.exit(1)
 
     serial = cert_dict.get("serialNumber", "")
@@ -45,7 +45,7 @@ def get_cert_serial(path):
             path
         )  # We do use an internal function, to avoid installing dependencies
     except Exception as e:
-        l.error(e)
+        logger.error(e)
         sys.exit(1)
 
     return cert_dict["serialNumber"]


### PR DESCRIPTION
This PR add hygiene fixes for certificate manager.

A hygiene warning has been fixed (`l` -> `logger`)

It also side fix some minus elements on python checks:

* Added `--rm` to docker run to remove docker containers
* Fix `PHONY` tag for python-format