### PR TITLE
[rid/datastore/ListExpired(Subscriptions|ISAs)] Properly escape writer; Fix removal of expired entities with NULL writer (empty locality)

### DIFF
--- a/NEXT_RELEASE_NOTES.md
+++ b/NEXT_RELEASE_NOTES.md
@@ -48,6 +48,8 @@ The release notes should contain at least the following sections:
 
 ## Important information
 
+* Fixed a bug where the `evict` command ignored entries without a locality. If your DSS instance does not have a locality set, the next `evict` run may be slow while it processes the backlog of old entries.
+
 ## Minimal database schema version
 
 | Schema  | CockroachDB | Yugabyte |

--- a/pkg/rid/store/datastore/identification_service_area.go
+++ b/pkg/rid/store/datastore/identification_service_area.go
@@ -213,23 +213,29 @@ func (r *repo) SearchISAs(ctx context.Context, cells s2.CellUnion, earliest *tim
 // ListExpiredISAs lists all expired ISAs based on writer.
 // The function queries both empty writer and null writer when passing empty string as a writer.
 func (r *repo) ListExpiredISAs(ctx context.Context, writer string, threshold time.Time) ([]*ridmodels.IdentificationServiceArea, error) {
-	writerQuery := "'" + writer + "'"
 	if len(writer) == 0 {
-		writerQuery = "'' OR writer = NULL"
+		isasInCellsQuery := fmt.Sprintf(`
+            SELECT
+                %s
+            FROM
+                identification_service_areas
+            WHERE
+                ends_at <= $1
+            AND
+                (writer = '' OR writer IS NULL)
+            LIMIT $2`, isaFields)
+		return r.fetchISAs(ctx, isasInCellsQuery, threshold, dssmodels.MaxResultLimit)
 	}
 
-	var (
-		isasInCellsQuery = fmt.Sprintf(`
-	SELECT
-		%s
-	FROM
-		identification_service_areas
-	WHERE
-		ends_at <= $1
-	AND
-		(writer = %s)
-	LIMIT $2`, isaFields, writerQuery)
-	)
-
-	return r.fetchISAs(ctx, isasInCellsQuery, threshold, dssmodels.MaxResultLimit)
+	isasInCellsQuery := fmt.Sprintf(`
+        SELECT
+            %s
+        FROM
+            identification_service_areas
+        WHERE
+            ends_at <= $1
+        AND
+            writer = $2
+        LIMIT $3`, isaFields)
+	return r.fetchISAs(ctx, isasInCellsQuery, threshold, writer, dssmodels.MaxResultLimit)
 }

--- a/pkg/rid/store/datastore/subscriptions.go
+++ b/pkg/rid/store/datastore/subscriptions.go
@@ -274,22 +274,27 @@ func (r *repo) SearchSubscriptionsByOwner(ctx context.Context, cells s2.CellUnio
 // ListExpiredSubscriptions lists all expired Subscriptions based on writer.
 // The function queries both empty writer and null writer when passing empty string as a writer.
 func (r *repo) ListExpiredSubscriptions(ctx context.Context, writer string, threshold time.Time) ([]*ridmodels.Subscription, error) {
-	writerQuery := "'" + writer + "'"
 	if len(writer) == 0 {
-		writerQuery = "'' OR writer = NULL"
+		query := fmt.Sprintf(`
+            SELECT
+                %s
+            FROM
+                subscriptions
+            WHERE
+                ends_at <= $1
+            AND
+                (writer = '' OR writer IS NULL)`, subscriptionFields)
+		return r.process(ctx, query, threshold)
 	}
 
-	var (
-		query = fmt.Sprintf(`
-	SELECT
-		%s
-	FROM
-		subscriptions
-	WHERE
-		ends_at <= $1
-	AND
-		(writer = %s)`, subscriptionFields, writerQuery)
-	)
-
-	return r.process(ctx, query, threshold)
+	query := fmt.Sprintf(`
+        SELECT
+            %s
+        FROM
+            subscriptions
+        WHERE
+            ends_at <= $1
+        AND
+            writer = $2`, subscriptionFields)
+	return r.process(ctx, query, threshold, writer)
 }


### PR DESCRIPTION
I noticed that `List*` directly inject the `writer` parameter into the SQL query.

That not great at it could lead to SQL injections (and won't works with special values). Right now it's only used by `evict` and is coming from a flag, not from http queries, so it's not a security issue. However, it seems safer to escape it, for best practices and avoid potential issue when used in the future in other contexts.

This also fix the case with "", the `= NULL` condition won't match NULL values.