### PR TITLE
[tooling] Improve shell-lint to ignore git-ignored files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ hygiene:
 
 .PHONY: shell-lint
 shell-lint:
-	echo "===== Checking DSS shell lint =====" && find . -name '*.sh' | grep -v '^./interfaces/astm-utm' | grep -v '^./build/workspace' | xargs docker run --rm -v $(CURDIR):/dss -w /dss koalaman/shellcheck
+	echo "===== Checking DSS shell lint =====" && find . -name '*.sh' | grep -v '^./interfaces/astm-utm' | git check-ignore --stdin --no-index -n -v --non-matching | grep '^::' | cut -f2 | xargs docker run --rm -v $(CURDIR):/dss -w /dss koalaman/shellcheck
 
 .PHONY: go-lint
 go-lint:


### PR DESCRIPTION
Same as https://github.com/interuss/monitoring/pull/1430 but here to prevent potential future problem: use gitignore to exclude files from shell linting.

Removed `build/workspace` as it's gitignored.

Note: `interfaces/astm-utm` is not ignored so I didn't remove it, but right now there are no bash file in that folder.