### PR TITLE
[store] Revork init structure; use Store interfaces instead of datastore.Store interfaces

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -21,16 +21,16 @@ import (
 	apiversioningv1 "github.com/interuss/dss/pkg/api/versioningv1"
 	"github.com/interuss/dss/pkg/auth"
 	aux "github.com/interuss/dss/pkg/aux_"
-	auxc "github.com/interuss/dss/pkg/aux_/store/datastore"
+	auxs "github.com/interuss/dss/pkg/aux_/store"
 	"github.com/interuss/dss/pkg/build"
 	"github.com/interuss/dss/pkg/datastore"
 	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/rid/application"
 	rid_v1 "github.com/interuss/dss/pkg/rid/server/v1"
 	rid_v2 "github.com/interuss/dss/pkg/rid/server/v2"
-	ridc "github.com/interuss/dss/pkg/rid/store/datastore"
+	rids "github.com/interuss/dss/pkg/rid/store"
 	"github.com/interuss/dss/pkg/scd"
-	scdc "github.com/interuss/dss/pkg/scd/store/datastore"
+	scds "github.com/interuss/dss/pkg/scd/store"
 	"github.com/interuss/dss/pkg/version"
 	"github.com/interuss/dss/pkg/versioning"
 	"github.com/interuss/stacktrace"
@@ -84,7 +84,7 @@ func createKeyResolver() (auth.KeyResolver, error) {
 }
 
 func createAuxServer(ctx context.Context, locality string, publicEndpoint string, scdGlobalLock bool, logger *zap.Logger) (*aux.Server, error) {
-	auxStore, err := auxc.Dial(ctx, logger, true)
+	auxStore, err := auxs.Init(ctx, logger, true)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func createAuxServer(ctx context.Context, locality string, publicEndpoint string
 
 func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) (*rid_v1.Server, *rid_v2.Server, error) {
 
-	ridStore, err := ridc.Dial(ctx, logger, true)
+	ridStore, err := rids.Init(ctx, logger, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -129,7 +129,7 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 
 func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, error) {
 
-	scdStore, err := scdc.Dial(ctx, logger, true, *scdGlobalLock)
+	scdStore, err := scds.Init(ctx, logger, true, *scdGlobalLock)
 	if err != nil {
 		return nil, err
 	}

--- a/cmds/db-manager/cleanup/evict.go
+++ b/cmds/db-manager/cleanup/evict.go
@@ -10,10 +10,10 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
 	ridrepos "github.com/interuss/dss/pkg/rid/repos"
-	ridc "github.com/interuss/dss/pkg/rid/store/datastore"
+	rids "github.com/interuss/dss/pkg/rid/store"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	scdrepos "github.com/interuss/dss/pkg/scd/repos"
-	scdc "github.com/interuss/dss/pkg/scd/store/datastore"
+	scds "github.com/interuss/dss/pkg/scd/store"
 	"github.com/interuss/stacktrace"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -54,12 +54,12 @@ func evict(cmd *cobra.Command, _ []string) error {
 
 	logger := logging.WithValuesFromContext(ctx, logging.Logger)
 
-	scdStore, err := scdc.Dial(ctx, logger, false, false)
+	scdStore, err := scds.Init(ctx, logger, false, false)
 	if err != nil {
 		return err
 	}
 
-	ridStore, err := ridc.Dial(ctx, logger, false)
+	ridStore, err := rids.Init(ctx, logger, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/aux_/store/datastore/store.go
+++ b/pkg/aux_/store/datastore/store.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/interuss/dss/pkg/aux_/repos"
 	"github.com/interuss/dss/pkg/datastore"
-	"github.com/interuss/dss/pkg/datastore/params"
 	"github.com/interuss/dss/pkg/logging"
 	dssql "github.com/interuss/dss/pkg/sql"
 	"github.com/jonboulle/clockwork"
@@ -25,36 +24,20 @@ type repo struct {
 	version *datastore.Version
 }
 
-// aux_.store.datastore.Store is a concrete store.Store[aux_.repos.Repository] providing the
+// Init initializes the SQL-backed rid store. It return a concrete datastore.Store[aux_.repos.Repository] providing the
 // ability to interact with a database-backed store of aux information.
-type Store struct {
-	datastore.Store[repos.Repository]
-}
-
-func newStore(ctx context.Context, db *datastore.Store[repos.Repository], logger *zap.Logger) (*Store, error) {
-
-	s := &Store{}
-
-	base, err := datastore.NewStore(ctx, db, params.GetConnectParameters().MaxRetries, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, func(q dssql.Queryable) repos.Repository {
-		return &repo{
-			Queryable: q,
-			clock:     s.Clock,
-			logger:    logging.WithValuesFromContext(ctx, logger),
-			version:   db.Version,
-		}
-	})
-	if err != nil {
-		return nil, err
-	}
-	s.Store = base
-	return s, nil
-}
-
-func Dial(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*Store, error) {
-
-	store, err := datastore.DialStore(ctx, "aux", withCheckCron, func(db *datastore.Store[repos.Repository]) (*Store, error) {
-		return newStore(ctx, db, logger)
-	})
-
-	return store, err
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*datastore.Store[repos.Repository], error) {
+	return datastore.Init(ctx, datastore.Config[repos.Repository]{
+		DBName:                 "aux",
+		CrdbMajorSchemaVersion: currentCrdbMajorSchemaVersion,
+		YbMajorSchemaVersion:   currentYugabyteMajorSchemaVersion,
+		NewRepo: func(q dssql.Queryable, clock clockwork.Clock, version *datastore.Version) repos.Repository {
+			return &repo{
+				Queryable: q,
+				clock:     clock,
+				logger:    logging.WithValuesFromContext(ctx, logger),
+				version:   version,
+			}
+		},
+	}, withCheckCron)
 }

--- a/pkg/aux_/store/datastore/store_test.go
+++ b/pkg/aux_/store/datastore/store_test.go
@@ -16,7 +16,7 @@ var (
 	fakeClock = clockwork.NewFakeClock()
 )
 
-func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
+func setUpStore(ctx context.Context, t *testing.T) (*datastore.Store[repos.Repository], func()) {
 	connectParameters := params.GetConnectParameters()
 	if connectParameters.Host == "" || connectParameters.Port == 0 {
 		t.Skip()
@@ -33,11 +33,9 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	}
 }
 
-func newTestStore(ctx context.Context, t *testing.T, connectParameters params.ConnectParameters) (*Store, error) {
-	db, err := datastore.Dial[repos.Repository](ctx, connectParameters)
-	require.NoError(t, err)
+func newTestStore(ctx context.Context, t *testing.T, connectParameters params.ConnectParameters) (*datastore.Store[repos.Repository], error) {
+	s, err := Init(ctx, logging.Logger, false)
 
-	s, err := newStore(ctx, db, logging.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +45,7 @@ func newTestStore(ctx context.Context, t *testing.T, connectParameters params.Co
 }
 
 // cleanUp drops all required tables from the store, useful for testing.
-func cleanUp(ctx context.Context, s *Store) error {
+func cleanUp(ctx context.Context, s *datastore.Store[repos.Repository]) error {
 	const query = `
 	DELETE FROM dss_metadata WHERE locality IS NOT NULL;
     `

--- a/pkg/aux_/store/store.go
+++ b/pkg/aux_/store/store.go
@@ -1,11 +1,20 @@
 package store
 
 import (
+	"context"
+
 	"github.com/interuss/dss/pkg/aux_/repos"
+	auxdatastore "github.com/interuss/dss/pkg/aux_/store/datastore"
 	dssstore "github.com/interuss/dss/pkg/store"
+	"go.uber.org/zap"
 )
 
 // aux_.store.Store is a generic means to obtain an aux Repository (repo containing auxiliary
 // information not related to standardized services like RID or SCD specifically) to perform
 // aux-specific operations on any type of data backing the DSS may ever use.
 type Store = dssstore.Store[repos.Repository]
+
+// Init selects and initializes the aux store backend.
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
+	return auxdatastore.Init(ctx, logger, withCheckCron)
+}

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -160,7 +160,10 @@ func Init[R any](ctx context.Context, cfg Config[R], withCheckCron bool) (*Store
 			return nil, stacktrace.Propagate(err, "Failed to schedule db check for %s", cfg.DBName)
 		}
 		c.Start()
-		go func() { <-ctx.Done(); c.Stop() }()
+		go func() {
+		   <-ctx.Done()
+		   c.Stop()
+		}()
 	}
 
 	return db, nil

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -38,38 +38,13 @@ type Store[R any] struct {
 	maxRetries    int
 }
 
-func NewStore[R any](ctx context.Context, db *Store[R], maxRetries int, crdbExpected int64, ybExpected int64, newRepo func(dsssql.Queryable) R) (Store[R], error) {
-
-	dbName := db.Pool.Config().ConnConfig.Database
-
-	vs, err := db.GetSchemaVersion(ctx, dbName)
-	if err != nil {
-		return Store[R]{}, stacktrace.Propagate(err, "Failed to get schema version for %s", dbName)
-	}
-
-	if err := checkMajorSchemaVersion(ctx, db, vs, crdbExpected, ybExpected); err != nil {
-		return Store[R]{}, err
-	}
-
-	return Store[R]{
-		Pool:          db.Pool,
-		Version:       db.Version,
-		Clock:         clockwork.NewRealClock(),
-		schemaVersion: vs,
-		newRepo:       newRepo,
-		maxRetries:    maxRetries,
-	}, nil
-}
-
-func (s *Store[R]) Interact(_ context.Context) (R, error) {
-	return s.newRepo(s.Pool), nil
-}
-
-func (s *Store[R]) Transact(ctx context.Context, f func(context.Context, R) error) error {
-	ctx = crdb.WithMaxRetries(ctx, s.maxRetries)
-	return crdbpgx.ExecuteTx(ctx, s.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
-		return f(ctx, s.newRepo(tx))
-	})
+// Config describes everything a SQL-backed store needs to be initialized for a
+// given specific package (rid, scd, aux, ...).
+type Config[R any] struct {
+	DBName                 string
+	CrdbMajorSchemaVersion int64
+	YbMajorSchemaVersion   int64
+	NewRepo                func(q dsssql.Queryable, clock clockwork.Clock, v *Version) R
 }
 
 func checkMajorSchemaVersion[R any](ctx context.Context, db *Store[R], vs *semver.Version, crdbExpected int64, ybExpected int64) error {
@@ -85,11 +60,6 @@ func checkMajorSchemaVersion[R any](ctx context.Context, db *Store[R], vs *semve
 	return nil
 }
 
-func (s *Store[R]) Close() error {
-	s.Pool.Close()
-	return nil
-}
-
 func checkDatabase[R any](ctx context.Context, db *Store[R], databaseName string) {
 	logger := logging.WithValuesFromContext(ctx, logging.Logger)
 	statsPtr := db.Pool.Stat()
@@ -98,47 +68,6 @@ func checkDatabase[R any](ctx context.Context, db *Store[R], databaseName string
 	} else {
 		logger.Info("Successful periodic DB Ping", zap.String("Database", databaseName))
 	}
-}
-
-func DialStore[R any, S any](ctx context.Context, dbName string, withCheckCron bool, newStore func(*Store[R]) (S, error)) (S, error) {
-
-	var zero S
-
-	cp := params.GetConnectParameters()
-	cp.DBName = dbName
-
-	db, err := Dial[R](ctx, cp)
-
-	if err != nil {
-		if strings.Contains(err.Error(), "connect: connection refused") {
-			return zero, stacktrace.PropagateWithCode(err, CodeRetryable, "Failed to connect to datastore server for %s", dbName)
-		}
-		return zero, stacktrace.Propagate(err, "Failed to connect to %s database", dbName)
-	}
-	s, err := newStore(db)
-	if err != nil {
-		db.Pool.Close()
-		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), fmt.Sprintf("database \"%s\" does not exist", dbName)) || strings.Contains(err.Error(), "database has not been bootstrapped with Schema Manager") {
-			return zero, stacktrace.PropagateWithCode(err, CodeRetryable, "Failed to create %s store", dbName)
-		}
-		return zero, stacktrace.Propagate(err, "Failed to create %s store", dbName)
-	}
-
-	if withCheckCron {
-		c := cron.New()
-		if _, err := c.AddFunc("@every 1m", func() { checkDatabase(ctx, db, dbName) }); err != nil {
-			db.Pool.Close()
-			return zero, stacktrace.Propagate(err, "Failed to schedule db check for %s", dbName)
-		}
-		c.Start()
-
-		go func() {
-			<-ctx.Done()
-			c.Stop()
-		}()
-	}
-
-	return s, nil
 }
 
 func Dial[R any](ctx context.Context, connParams params.ConnectParameters) (*Store[R], error) {
@@ -187,6 +116,70 @@ func Dial[R any](ctx context.Context, connParams params.ConnectParameters) (*Sto
 	}
 
 	return nil, stacktrace.NewError("%s is not implemented yet", version.Type)
+}
+
+// Init dials the database described by the global connect parameters (plus
+// cfg.DBName), checks its schema version, and returns a ready-to-use Store[R].
+// If withCheckCron is true, a periodic health-check cron is started.
+func Init[R any](ctx context.Context, cfg Config[R], withCheckCron bool) (*Store[R], error) {
+	cp := params.GetConnectParameters()
+	cp.DBName = cfg.DBName
+
+	db, err := Dial[R](ctx, cp)
+	if err != nil {
+		if strings.Contains(err.Error(), "connect: connection refused") {
+			return nil, stacktrace.PropagateWithCode(err, CodeRetryable, "Failed to connect to datastore server for %s", cfg.DBName)
+		}
+		return nil, stacktrace.Propagate(err, "Failed to connect to %s database", cfg.DBName)
+	}
+
+	vs, err := db.GetSchemaVersion(ctx, cfg.DBName)
+
+	if err == nil {
+		err = checkMajorSchemaVersion(ctx, db, vs, cfg.CrdbMajorSchemaVersion, cfg.YbMajorSchemaVersion)
+	}
+	if err != nil {
+		db.Pool.Close()
+		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), fmt.Sprintf("database \"%s\" does not exist", cfg.DBName)) || strings.Contains(err.Error(), "database has not been bootstrapped with Schema Manager") {
+			return nil, stacktrace.PropagateWithCode(err, CodeRetryable, "Failed to create %s store", cfg.DBName)
+		}
+		return nil, stacktrace.Propagate(err, "Failed to create %s store", cfg.DBName)
+	}
+
+	db.Clock = clockwork.NewRealClock()
+	db.schemaVersion = vs
+	db.maxRetries = cp.MaxRetries
+	db.newRepo = func(q dsssql.Queryable) R {
+		return cfg.NewRepo(q, db.Clock, db.Version)
+	}
+
+	if withCheckCron {
+		c := cron.New()
+		if _, err := c.AddFunc("@every 1m", func() { checkDatabase(ctx, db, cfg.DBName) }); err != nil {
+			db.Pool.Close()
+			return nil, stacktrace.Propagate(err, "Failed to schedule db check for %s", cfg.DBName)
+		}
+		c.Start()
+		go func() { <-ctx.Done(); c.Stop() }()
+	}
+
+	return db, nil
+}
+
+func (s *Store[R]) Interact(_ context.Context) (R, error) {
+	return s.newRepo(s.Pool), nil
+}
+
+func (s *Store[R]) Transact(ctx context.Context, f func(context.Context, R) error) error {
+	ctx = crdb.WithMaxRetries(ctx, s.maxRetries)
+	return crdbpgx.ExecuteTx(ctx, s.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
+		return f(ctx, s.newRepo(tx))
+	})
+}
+
+func (s *Store[R]) Close() error {
+	s.Pool.Close()
+	return nil
 }
 
 func (s *Store[R]) CreateDatabase(ctx context.Context, dbName string) error {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -161,8 +161,8 @@ func Init[R any](ctx context.Context, cfg Config[R], withCheckCron bool) (*Store
 		}
 		c.Start()
 		go func() {
-		   <-ctx.Done()
-		   c.Stop()
+			<-ctx.Done()
+			c.Stop()
 		}()
 	}
 

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -61,12 +61,9 @@ func setUpStore(ctx context.Context, t *testing.T, logger *zap.Logger) (store.St
 
 	connectParameters.DBName = "rid"
 
-	ridDatastore, err := datastore.Dial[repos.Repository](ctx, connectParameters)
+	store, err := ridc.Init(ctx, logger, false)
 	require.NoError(t, err)
 	logger.Info("using datastore.")
-
-	store, err := ridc.NewStore(ctx, ridDatastore, logger)
-	require.NoError(t, err)
 
 	store.Clock = fakeClock
 
@@ -77,7 +74,7 @@ func setUpStore(ctx context.Context, t *testing.T, logger *zap.Logger) (store.St
 }
 
 // cleanUp drops all required tables from the store, useful for testing.
-func cleanUp(ctx context.Context, s *ridc.Store) error {
+func cleanUp(ctx context.Context, s *datastore.Store[repos.Repository]) error {
 	const query = `
     DELETE FROM subscriptions WHERE id IS NOT NULL;
     DELETE FROM identification_service_areas WHERE id IS NOT NULL;`

--- a/pkg/rid/store/datastore/store.go
+++ b/pkg/rid/store/datastore/store.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/interuss/dss/pkg/datastore/params"
 	dssql "github.com/interuss/dss/pkg/sql"
 
 	"github.com/interuss/dss/pkg/datastore"
@@ -27,35 +26,19 @@ type repo struct {
 	logger *zap.Logger
 }
 
-// rid.store.datastore.Store is a a full implementation of store.Store[rid.repos.Repository]
-// for data backings that use a database such as CockroachDB or YugabyteDB.
-type Store struct {
-	datastore.Store[repos.Repository]
-}
-
-func NewStore(ctx context.Context, db *datastore.Store[repos.Repository], logger *zap.Logger) (*Store, error) {
-
-	s := &Store{}
-
-	base, err := datastore.NewStore(ctx, db, params.GetConnectParameters().MaxRetries, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, func(q dssql.Queryable) repos.Repository {
-		return &repo{
-			Queryable: q,
-			clock:     s.Clock,
-			logger:    logging.WithValuesFromContext(ctx, logger),
-		}
-	})
-	if err != nil {
-		return nil, err
-	}
-	s.Store = base
-	return s, nil
-}
-
-func Dial(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*Store, error) {
-
-	store, err := datastore.DialStore(ctx, "rid", withCheckCron, func(db *datastore.Store[repos.Repository]) (*Store, error) {
-		return NewStore(ctx, db, logger)
-	})
-
-	return store, err
+// Init initializes the SQL-backed rid store. It return a concrete datastore.Store[rid.repos.Repository] providing the
+// ability to interact with a database-backed store of rid information.
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*datastore.Store[repos.Repository], error) {
+	return datastore.Init(ctx, datastore.Config[repos.Repository]{
+		DBName:                 "rid",
+		CrdbMajorSchemaVersion: currentCrdbMajorSchemaVersion,
+		YbMajorSchemaVersion:   currentYugabyteMajorSchemaVersion,
+		NewRepo: func(q dssql.Queryable, clock clockwork.Clock, _ *datastore.Version) repos.Repository {
+			return &repo{
+				Queryable: q,
+				clock:     clock,
+				logger:    logging.WithValuesFromContext(ctx, logger),
+			}
+		},
+	}, withCheckCron)
 }

--- a/pkg/rid/store/datastore/store_test.go
+++ b/pkg/rid/store/datastore/store_test.go
@@ -25,7 +25,7 @@ var (
 	writer    = "writer"
 )
 
-func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
+func setUpStore(ctx context.Context, t *testing.T) (*datastore.Store[repos.Repository], func()) {
 	connectParameters := params.GetConnectParameters()
 	if connectParameters.Host == "" || connectParameters.Port == 0 {
 		t.Skip()
@@ -42,11 +42,9 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	}
 }
 
-func newTestStore(ctx context.Context, t *testing.T, connectParameters params.ConnectParameters) (*Store, error) {
-	db, err := datastore.Dial[repos.Repository](ctx, connectParameters)
-	require.NoError(t, err)
+func newTestStore(ctx context.Context, t *testing.T, connectParameters params.ConnectParameters) (*datastore.Store[repos.Repository], error) {
+	s, err := Init(ctx, logging.Logger, false)
 
-	s, err := NewStore(ctx, db, logging.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +54,7 @@ func newTestStore(ctx context.Context, t *testing.T, connectParameters params.Co
 }
 
 // cleanUp drops all required tables from the store, useful for testing.
-func cleanUp(ctx context.Context, s *Store) error {
+func cleanUp(ctx context.Context, s *datastore.Store[repos.Repository]) error {
 	const query = `
 	DELETE FROM subscriptions WHERE id IS NOT NULL;
 	DELETE FROM identification_service_areas WHERE id IS NOT NULL;`

--- a/pkg/rid/store/store.go
+++ b/pkg/rid/store/store.go
@@ -1,10 +1,19 @@
 package store
 
 import (
+	"context"
+
 	"github.com/interuss/dss/pkg/rid/repos"
+	riddatastore "github.com/interuss/dss/pkg/rid/store/datastore"
 	dssstore "github.com/interuss/dss/pkg/store"
+	"go.uber.org/zap"
 )
 
 // rid.store.Store is a generic means to obtain an RID rid.repos.Repository to perform RID-specific
 // operations on any type of data backing the DSS may ever use.
 type Store = dssstore.Store[repos.Repository]
+
+// Init selects and initializes the rid store backend.
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
+	return riddatastore.Init(ctx, logger, withCheckCron)
+}

--- a/pkg/scd/store/datastore/store.go
+++ b/pkg/scd/store/datastore/store.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/interuss/dss/pkg/datastore/params"
 	dssql "github.com/interuss/dss/pkg/sql"
 
 	"github.com/interuss/dss/pkg/datastore"
@@ -28,36 +27,20 @@ type repo struct {
 	globalLock bool
 }
 
-// scd.store.datastore.Store is a a full implementation of store.Store[scd.repos.Repository]
-// for data backings that use a database such as CockroachDB or YugabyteDB.
-type Store struct {
-	datastore.Store[repos.Repository]
-}
-
-func newStore(ctx context.Context, db *datastore.Store[repos.Repository], logger *zap.Logger, globalLock bool) (*Store, error) {
-
-	s := &Store{}
-
-	base, err := datastore.NewStore(ctx, db, params.GetConnectParameters().MaxRetries, currentCrdbMajorSchemaVersion, currentYugabyteMajorSchemaVersion, func(q dssql.Queryable) repos.Repository {
-		return &repo{
-			q:          q,
-			clock:      s.Clock,
-			logger:     logging.WithValuesFromContext(ctx, logger),
-			globalLock: globalLock,
-		}
-	})
-	if err != nil {
-		return nil, err
-	}
-	s.Store = base
-	return s, nil
-}
-
-func Dial(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool) (*Store, error) {
-
-	store, err := datastore.DialStore(ctx, "scd", withCheckCron, func(db *datastore.Store[repos.Repository]) (*Store, error) {
-		return newStore(ctx, db, logger, globalLock)
-	})
-
-	return store, err
+// Init initializes the SQL-backed sid store. It return a concrete datastore.Store[sid.repos.Repository] providing the
+// ability to interact with a database-backed store of sid information.
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool) (*datastore.Store[repos.Repository], error) {
+	return datastore.Init(ctx, datastore.Config[repos.Repository]{
+		DBName:                 "scd",
+		CrdbMajorSchemaVersion: currentCrdbMajorSchemaVersion,
+		YbMajorSchemaVersion:   currentYugabyteMajorSchemaVersion,
+		NewRepo: func(q dssql.Queryable, clock clockwork.Clock, _ *datastore.Version) repos.Repository {
+			return &repo{
+				q:          q,
+				clock:      clock,
+				logger:     logging.WithValuesFromContext(ctx, logger),
+				globalLock: globalLock,
+			}
+		},
+	}, withCheckCron)
 }

--- a/pkg/scd/store/datastore/store_test.go
+++ b/pkg/scd/store/datastore/store_test.go
@@ -16,7 +16,7 @@ var (
 	fakeClock = clockwork.NewFakeClock()
 )
 
-func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
+func setUpStore(ctx context.Context, t *testing.T) (*datastore.Store[repos.Repository], func()) {
 	connectParameters := params.GetConnectParameters()
 	if connectParameters.Host == "" || connectParameters.Port == 0 {
 		t.Skip()
@@ -33,11 +33,9 @@ func setUpStore(ctx context.Context, t *testing.T) (*Store, func()) {
 	}
 }
 
-func newTestStore(ctx context.Context, t *testing.T, connectParameters params.ConnectParameters) (*Store, error) {
-	db, err := datastore.Dial[repos.Repository](ctx, connectParameters)
-	require.NoError(t, err)
+func newTestStore(ctx context.Context, t *testing.T, connectParameters params.ConnectParameters) (*datastore.Store[repos.Repository], error) {
+	s, err := Init(ctx, logging.Logger, false, false)
 
-	s, err := newStore(ctx, db, logging.Logger, false)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +45,7 @@ func newTestStore(ctx context.Context, t *testing.T, connectParameters params.Co
 }
 
 // cleanUp drops all required tables from the store, useful for testing.
-func cleanUp(ctx context.Context, s *Store) error {
+func cleanUp(ctx context.Context, s *datastore.Store[repos.Repository]) error {
 	const query = `
 	DELETE FROM scd_subscriptions WHERE id IS NOT NULL;
 	DELETE FROM scd_operations WHERE id IS NOT NULL;

--- a/pkg/scd/store/store.go
+++ b/pkg/scd/store/store.go
@@ -1,10 +1,19 @@
 package store
 
 import (
+	"context"
+
 	"github.com/interuss/dss/pkg/scd/repos"
+	scddatastore "github.com/interuss/dss/pkg/scd/store/datastore"
 	dssstore "github.com/interuss/dss/pkg/store"
+	"go.uber.org/zap"
 )
 
 // scd.store.Store is a generic means to obtain an SCD scd.repos.Repository to perform SCD-specific
 // operations on any type of data backing the DSS may ever use.
 type Store = dssstore.Store[repos.Repository]
+
+// Init selects and initializes the scd store backend.
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool) (Store, error) {
+	return scddatastore.Init(ctx, logger, withCheckCron, globalLock)
+}


### PR DESCRIPTION
This is a series of PRs, aiming to fix #1418 with better organization of datastore interfaces.

PRs are chained, and composed of the following:

#1444 : Merge datastore.Store and datastore.Datastore
#1445 : Move initialization into clean datastore.Store interface and use generic stores
#1446 : Rename datastore to sqlstore
#1447 : Move 'CodeRetryable' to generic store package
#1448 : Add 'store_type' flag
#1449 : Show example of new datastore type (not to be merged, demo only).

---

This PR is the 'core' of the proposal.

It reworks init functions to be cleaner, with a config object, helping specific stores (rid/*) tell the generic init function what to do.

`Dial` functions and `datastore.Store` structs in specific stores have been removed. Initialization is now done in `store.Store` functions and uses only `(rid/*).Store` interfaces. Usages have been updated (but are just a type change).
