### PR TITLE
[store] Move CodeRetryable to generic store

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -30,7 +30,7 @@ import (
 	rids "github.com/interuss/dss/pkg/rid/store"
 	"github.com/interuss/dss/pkg/scd"
 	scds "github.com/interuss/dss/pkg/scd/store"
-	"github.com/interuss/dss/pkg/sqlstore"
+	"github.com/interuss/dss/pkg/store"
 	"github.com/interuss/dss/pkg/version"
 	"github.com/interuss/dss/pkg/versioning"
 	"github.com/interuss/stacktrace"
@@ -350,7 +350,7 @@ func main() {
 	backoff := 0
 	for {
 		if err := RunHTTPServer(ctx, cancel, *address, *locality); err != nil {
-			if stacktrace.GetCode(err) == sqlstore.CodeRetryable {
+			if stacktrace.GetCode(err) == store.CodeRetryable {
 				logger.Info(fmt.Sprintf("Prerequisites not yet satisfied; waiting %.fs to retry...", backoffs[backoff].Seconds()), zap.Error(err))
 				time.Sleep(backoffs[backoff])
 				if backoff < len(backoffs)-1 {

--- a/pkg/sqlstore/store.go
+++ b/pkg/sqlstore/store.go
@@ -13,16 +13,13 @@ import (
 	"github.com/interuss/dss/pkg/logging"
 	dsssql "github.com/interuss/dss/pkg/sql"
 	"github.com/interuss/dss/pkg/sqlstore/params"
+	"github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jonboulle/clockwork"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
-)
-
-const (
-	CodeRetryable = stacktrace.ErrorCode(1)
 )
 
 var UnknownVersion = &semver.Version{}
@@ -128,7 +125,7 @@ func Init[R any](ctx context.Context, cfg Config[R], withCheckCron bool) (*Store
 	db, err := Dial[R](ctx, cp)
 	if err != nil {
 		if strings.Contains(err.Error(), "connect: connection refused") {
-			return nil, stacktrace.PropagateWithCode(err, CodeRetryable, "Failed to connect to database server for %s", cfg.DBName)
+			return nil, stacktrace.PropagateWithCode(err, store.CodeRetryable, "Failed to connect to database server for %s", cfg.DBName)
 		}
 		return nil, stacktrace.Propagate(err, "Failed to connect to %s database", cfg.DBName)
 	}
@@ -141,7 +138,7 @@ func Init[R any](ctx context.Context, cfg Config[R], withCheckCron bool) (*Store
 	if err != nil {
 		db.Pool.Close()
 		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), fmt.Sprintf("database \"%s\" does not exist", cfg.DBName)) || strings.Contains(err.Error(), "database has not been bootstrapped with Schema Manager") {
-			return nil, stacktrace.PropagateWithCode(err, CodeRetryable, "Failed to create %s store", cfg.DBName)
+			return nil, stacktrace.PropagateWithCode(err, store.CodeRetryable, "Failed to create %s store", cfg.DBName)
 		}
 		return nil, stacktrace.Propagate(err, "Failed to create %s store", cfg.DBName)
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"io"
+
+	"github.com/interuss/stacktrace"
 )
 
 // store.Store is the generic means to access and interact with any type of data backing the DSS
@@ -16,3 +18,7 @@ type Store[R any] interface {
 	// on the R Repo by f will be applied or rejected atomically.
 	Transact(ctx context.Context, f func(context.Context, R) error) error
 }
+
+const (
+	CodeRetryable = stacktrace.ErrorCode(1)
+)


### PR DESCRIPTION
This is a series of PRs, aiming to fix #1418 with better organization of datastore interfaces.

PRs are chained, and composed of the following:

#1444 : Merge datastore.Store and datastore.Datastore
#1445 : Move initialization into clean datastore.Store interface and use generic stores
#1446 : Rename datastore to sqlstore
#1447 : Move 'CodeRetryable' to generic store package
#1448 : Add 'store_type' flag
#1449 : Show example of new datastore type (not to be merged, demo only).

---

Very small PR that moves `CodeRetryable` out into the generic part of the store system, as it can be used in every store type case.