### PR TITLE
[store] Add store type flag

### DIFF
--- a/pkg/aux_/store/store.go
+++ b/pkg/aux_/store/store.go
@@ -6,6 +6,8 @@ import (
 	"github.com/interuss/dss/pkg/aux_/repos"
 	auxsqlstore "github.com/interuss/dss/pkg/aux_/store/sqlstore"
 	dssstore "github.com/interuss/dss/pkg/store"
+	"github.com/interuss/dss/pkg/store/params"
+	"github.com/interuss/stacktrace"
 	"go.uber.org/zap"
 )
 
@@ -16,5 +18,11 @@ type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the aux store backend.
 func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
-	return auxsqlstore.Init(ctx, logger, withCheckCron)
+	storeType := params.GetStoreParameters().StoreType
+	switch storeType {
+	case "sql":
+		return auxsqlstore.Init(ctx, logger, withCheckCron)
+	default:
+		return nil, stacktrace.NewError("Unsupported store type %q for aux", storeType)
+	}
 }

--- a/pkg/aux_/store/store.go
+++ b/pkg/aux_/store/store.go
@@ -18,8 +18,7 @@ type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the aux store backend.
 func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
-	storeType := params.GetStoreParameters().StoreType
-	switch storeType {
+	switch storeType := params.GetStoreParameters().StoreType; storeType {
 	case "sql":
 		return auxsqlstore.Init(ctx, logger, withCheckCron)
 	default:

--- a/pkg/rid/store/store.go
+++ b/pkg/rid/store/store.go
@@ -6,6 +6,8 @@ import (
 	"github.com/interuss/dss/pkg/rid/repos"
 	ridsqlstore "github.com/interuss/dss/pkg/rid/store/sqlstore"
 	dssstore "github.com/interuss/dss/pkg/store"
+	"github.com/interuss/dss/pkg/store/params"
+	"github.com/interuss/stacktrace"
 	"go.uber.org/zap"
 )
 
@@ -15,5 +17,11 @@ type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the rid store backend.
 func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
-	return ridsqlstore.Init(ctx, logger, withCheckCron)
+	storeType := params.GetStoreParameters().StoreType
+	switch storeType {
+	case "sql":
+		return ridsqlstore.Init(ctx, logger, withCheckCron)
+	default:
+		return nil, stacktrace.NewError("Unsupported store type %q for rid", storeType)
+	}
 }

--- a/pkg/scd/store/store.go
+++ b/pkg/scd/store/store.go
@@ -6,6 +6,8 @@ import (
 	"github.com/interuss/dss/pkg/scd/repos"
 	scdsqlstore "github.com/interuss/dss/pkg/scd/store/sqlstore"
 	dssstore "github.com/interuss/dss/pkg/store"
+	"github.com/interuss/dss/pkg/store/params"
+	"github.com/interuss/stacktrace"
 	"go.uber.org/zap"
 )
 
@@ -15,5 +17,11 @@ type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the scd store backend.
 func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool) (Store, error) {
-	return scdsqlstore.Init(ctx, logger, withCheckCron, globalLock)
+	storeType := params.GetStoreParameters().StoreType
+	switch storeType {
+	case "sql":
+		return scdsqlstore.Init(ctx, logger, withCheckCron, globalLock)
+	default:
+		return nil, stacktrace.NewError("Unsupported store type %q for scd", storeType)
+	}
 }

--- a/pkg/store/params/params.go
+++ b/pkg/store/params/params.go
@@ -1,0 +1,25 @@
+package params
+
+import (
+	"flag"
+)
+
+type (
+	// StoreParameters bundles up parameters used to configure store at a generic/top level.
+	StoreParameters struct {
+		StoreType string
+	}
+)
+
+var (
+	storeParameters StoreParameters
+)
+
+func init() {
+	flag.StringVar(&storeParameters.StoreType, "store_type", "sql", "Store type. Use 'sql' for CockroachDB/YugabyteDB")
+}
+
+// ConnectParameters returns a ConnectParameters instance that gets populated from well-known CLI flags.
+func GetStoreParameters() StoreParameters {
+	return storeParameters
+}


### PR DESCRIPTION
This is a series of PRs, aiming to fix #1418 with better organization of datastore interfaces.

PRs are chained, and composed of the following:

#1444 : Merge datastore.Store and datastore.Datastore
#1445 : Move initialization into clean datastore.Store interface and use generic stores
#1446 : Rename datastore to sqlstore
#1447 : Move 'CodeRetryable' to generic store package
#1448 : Add 'store_type' flag
#1449 : Show example of new datastore type (not to be merged, demo only).

---

This PR adds a `store_type` flag into the generic store area, and allows specific stores to choose their specific implementation based on the flag.

No change in practice for this one, but the goal is to prepare for future types.