### PR TITLE
[tooling]: Generate all openapi-to-go files; make setAuthError generated only when needed

### DIFF
--- a/cmds/dummy-oauth/api/common.gen.go
+++ b/cmds/dummy-oauth/api/common.gen.go
@@ -62,6 +62,8 @@ type Route struct {
 	Method  string
 	Pattern *regexp.Regexp
 	Handler Handler
+	Name    string
+	Path    string
 }
 
 type PartialRouter interface {

--- a/cmds/dummy-oauth/api/dummyoauth/server.gen.go
+++ b/cmds/dummy-oauth/api/dummyoauth/server.gen.go
@@ -3,7 +3,12 @@ package dummyoauth
 
 import (
 	"context"
+	"fmt"
 	"github.com/interuss/dss/cmds/dummy-oauth/api"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -15,10 +20,28 @@ type APIRouter struct {
 	Authorizer     api.Authorizer
 }
 
+var tracer = otel.Tracer("dummyoauth.api")
+
 // *dummyoauth.APIRouter (type defined above) implements the api.PartialRouter interface
 func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	for _, route := range s.Routes {
 		if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
+
+			if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+				labeler.Add(semconv.HTTPRoute(route.Path))
+			}
+
+			// We retrieve the current span from the otelhttp handler to set its name property.
+			span := trace.SpanFromContext(r.Context())
+
+			if span.IsRecording() { // If the span is not recording, the name cannot be changed. This also likely means the otelhttp handler is not present (tracing disabled).
+				span.SetName(fmt.Sprintf("%s %s", r.Method, route.Path))
+			}
+
+			ctx, span := tracer.Start(r.Context(), route.Name)
+			defer span.End()
+			r = r.WithContext(ctx)
+
 			route.Handler(route.Pattern, w, r)
 			return true
 		}
@@ -28,32 +51,29 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 
 func (s *APIRouter) GetToken(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetTokenRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetTokenSecurity)
+	var response GetTokenResponseSet
 
 	// Copy query parameters
 	query := r.URL.Query()
-	// TODO: Change to query.Has after Go 1.17
-	if query.Get("intended_audience") != "" {
+	if query.Has("intended_audience") {
 		v := query.Get("intended_audience")
 		req.IntendedAudience = &v
 	}
-	if query.Get("scope") != "" {
+	if query.Has("scope") {
 		v := query.Get("scope")
 		req.Scope = &v
 	}
-	if query.Get("issuer") != "" {
+	if query.Has("issuer") {
 		v := query.Get("issuer")
 		req.Issuer = &v
 	}
-	if query.Get("expire") != "" {
+	if query.Has("expire") {
 		i, err := strconv.ParseInt(query.Get("expire"), 10, 64)
 		if err == nil {
 			req.Expire = &i
 		}
 	}
-	if query.Get("sub") != "" {
+	if query.Has("sub") {
 		v := query.Get("sub")
 		req.Sub = &v
 	}
@@ -61,7 +81,7 @@ func (s *APIRouter) GetToken(exp *regexp.Regexp, w http.ResponseWriter, r *http.
 	// Call implementation
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
-	response := s.Implementation.GetToken(ctx, &req)
+	response = s.Implementation.GetToken(ctx, &req)
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -83,7 +103,7 @@ func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {
 	router := APIRouter{Implementation: impl, Authorizer: auth, Routes: make([]*api.Route, 1)}
 
 	pattern := regexp.MustCompile("^/token$")
-	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetToken}
+	router.Routes[0] = &api.Route{Method: http.MethodGet, Pattern: pattern, Handler: router.GetToken, Name: "dummyoauth.GetToken", Path: "/token"}
 
 	return router
 }

--- a/interfaces/openapi-to-go-server/example/api/rid/server.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/rid/server.gen.go
@@ -6,7 +6,11 @@ import (
 	"encoding/json"
 	"example/api"
 	"fmt"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/stacktrace"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"regexp"
@@ -25,10 +29,14 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	for _, route := range s.Routes {
 		if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
 
+			if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+				labeler.Add(semconv.HTTPRoute(route.Path))
+			}
+
+			// We retrieve the current span from the otelhttp handler to set its name property.
 			span := trace.SpanFromContext(r.Context())
 
-			if span.IsRecording() {
-				// Current span is the one from the otelhttp handler
+			if span.IsRecording() { // If the span is not recording, the name cannot be changed. This also likely means the otelhttp handler is not present (tracing disabled).
 				span.SetName(fmt.Sprintf("%s %s", r.Method, route.Path))
 			}
 
@@ -45,9 +53,7 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 
 func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req SearchIdentificationServiceAreasRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, SearchIdentificationServiceAreasSecurity)
+	var response SearchIdentificationServiceAreasResponseSet
 
 	// Copy query parameters
 	query := r.URL.Query()
@@ -64,10 +70,17 @@ func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.
 		req.LatestTime = &v
 	}
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.SearchIdentificationServiceAreas(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, SearchIdentificationServiceAreasSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.SearchIdentificationServiceAreas(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -99,18 +112,23 @@ func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) GetIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetIdentificationServiceAreaSecurity)
+	var response GetIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = EntityUUID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -142,9 +160,7 @@ func (s *APIRouter) GetIdentificationServiceArea(exp *regexp.Regexp, w http.Resp
 
 func (s *APIRouter) CreateIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateIdentificationServiceAreaSecurity)
+	var response CreateIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -155,10 +171,17 @@ func (s *APIRouter) CreateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -194,9 +217,7 @@ func (s *APIRouter) CreateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 
 func (s *APIRouter) UpdateIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateIdentificationServiceAreaSecurity)
+	var response UpdateIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -208,10 +229,17 @@ func (s *APIRouter) UpdateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -247,19 +275,24 @@ func (s *APIRouter) UpdateIdentificationServiceArea(exp *regexp.Regexp, w http.R
 
 func (s *APIRouter) DeleteIdentificationServiceArea(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteIdentificationServiceAreaRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteIdentificationServiceAreaSecurity)
+	var response DeleteIdentificationServiceAreaResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = EntityUUID(pathMatch[1])
 	req.Version = pathMatch[2]
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteIdentificationServiceArea(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteIdentificationServiceAreaSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteIdentificationServiceArea(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -295,9 +328,7 @@ func (s *APIRouter) DeleteIdentificationServiceArea(exp *regexp.Regexp, w http.R
 
 func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req SearchSubscriptionsRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, SearchSubscriptionsSecurity)
+	var response SearchSubscriptionsResponseSet
 
 	// Copy query parameters
 	query := r.URL.Query()
@@ -306,10 +337,17 @@ func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWrite
 		req.Area = &v
 	}
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.SearchSubscriptions(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, SearchSubscriptionsSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.SearchSubscriptions(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -341,18 +379,23 @@ func (s *APIRouter) SearchSubscriptions(exp *regexp.Regexp, w http.ResponseWrite
 
 func (s *APIRouter) GetSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetSubscriptionSecurity)
+	var response GetSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = SubscriptionUUID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -384,9 +427,7 @@ func (s *APIRouter) GetSubscription(exp *regexp.Regexp, w http.ResponseWriter, r
 
 func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateSubscriptionSecurity)
+	var response CreateSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -397,10 +438,17 @@ func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -436,9 +484,7 @@ func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateSubscriptionSecurity)
+	var response UpdateSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -450,10 +496,17 @@ func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -489,19 +542,24 @@ func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteSubscriptionSecurity)
+	var response DeleteSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Id = SubscriptionUUID(pathMatch[1])
 	req.Version = pathMatch[2]
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -533,6 +591,20 @@ func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter
 		return
 	}
 	api.WriteJSON(w, 500, api.InternalServerErrorBody{ErrorMessage: "Handler implementation did not set a response"})
+}
+
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
 }
 
 func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {

--- a/interfaces/openapi-to-go-server/example/api/scd/server.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/scd/server.gen.go
@@ -6,7 +6,11 @@ import (
 	"encoding/json"
 	"example/api"
 	"fmt"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/stacktrace"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"regexp"
@@ -25,10 +29,14 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 	for _, route := range s.Routes {
 		if route.Method == r.Method && route.Pattern.MatchString(r.URL.Path) {
 
+			if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+				labeler.Add(semconv.HTTPRoute(route.Path))
+			}
+
+			// We retrieve the current span from the otelhttp handler to set its name property.
 			span := trace.SpanFromContext(r.Context())
 
-			if span.IsRecording() {
-				// Current span is the one from the otelhttp handler
+			if span.IsRecording() { // If the span is not recording, the name cannot be changed. This also likely means the otelhttp handler is not present (tracing disabled).
 				span.SetName(fmt.Sprintf("%s %s", r.Method, route.Path))
 			}
 
@@ -45,19 +53,24 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 
 func (s *APIRouter) QueryOperationalIntentReferences(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req QueryOperationalIntentReferencesRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, QueryOperationalIntentReferencesSecurity)
+	var response QueryOperationalIntentReferencesResponseSet
 
 	// Parse request body
 	req.Body = new(QueryOperationalIntentReferenceParameters)
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.QueryOperationalIntentReferences(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, QueryOperationalIntentReferencesSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.QueryOperationalIntentReferences(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -93,18 +106,23 @@ func (s *APIRouter) QueryOperationalIntentReferences(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) GetOperationalIntentReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetOperationalIntentReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetOperationalIntentReferenceSecurity)
+	var response GetOperationalIntentReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Entityid = EntityID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetOperationalIntentReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetOperationalIntentReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetOperationalIntentReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -140,9 +158,7 @@ func (s *APIRouter) GetOperationalIntentReference(exp *regexp.Regexp, w http.Res
 
 func (s *APIRouter) CreateOperationalIntentReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateOperationalIntentReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateOperationalIntentReferenceSecurity)
+	var response CreateOperationalIntentReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -153,10 +169,17 @@ func (s *APIRouter) CreateOperationalIntentReference(exp *regexp.Regexp, w http.
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateOperationalIntentReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateOperationalIntentReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateOperationalIntentReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response201 != nil {
@@ -200,9 +223,7 @@ func (s *APIRouter) CreateOperationalIntentReference(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) UpdateOperationalIntentReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateOperationalIntentReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateOperationalIntentReferenceSecurity)
+	var response UpdateOperationalIntentReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -214,10 +235,17 @@ func (s *APIRouter) UpdateOperationalIntentReference(exp *regexp.Regexp, w http.
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateOperationalIntentReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateOperationalIntentReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateOperationalIntentReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -261,19 +289,24 @@ func (s *APIRouter) UpdateOperationalIntentReference(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) DeleteOperationalIntentReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteOperationalIntentReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteOperationalIntentReferenceSecurity)
+	var response DeleteOperationalIntentReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Entityid = EntityID(pathMatch[1])
 	req.Ovn = EntityOVN(pathMatch[2])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteOperationalIntentReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteOperationalIntentReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteOperationalIntentReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -317,19 +350,24 @@ func (s *APIRouter) DeleteOperationalIntentReference(exp *regexp.Regexp, w http.
 
 func (s *APIRouter) QueryConstraintReferences(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req QueryConstraintReferencesRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, QueryConstraintReferencesSecurity)
+	var response QueryConstraintReferencesResponseSet
 
 	// Parse request body
 	req.Body = new(QueryConstraintReferenceParameters)
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.QueryConstraintReferences(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, QueryConstraintReferencesSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.QueryConstraintReferences(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -365,18 +403,23 @@ func (s *APIRouter) QueryConstraintReferences(exp *regexp.Regexp, w http.Respons
 
 func (s *APIRouter) GetConstraintReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetConstraintReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetConstraintReferenceSecurity)
+	var response GetConstraintReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Entityid = EntityID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetConstraintReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetConstraintReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetConstraintReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -412,9 +455,7 @@ func (s *APIRouter) GetConstraintReference(exp *regexp.Regexp, w http.ResponseWr
 
 func (s *APIRouter) CreateConstraintReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateConstraintReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateConstraintReferenceSecurity)
+	var response CreateConstraintReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -425,10 +466,17 @@ func (s *APIRouter) CreateConstraintReference(exp *regexp.Regexp, w http.Respons
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateConstraintReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateConstraintReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateConstraintReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response201 != nil {
@@ -468,9 +516,7 @@ func (s *APIRouter) CreateConstraintReference(exp *regexp.Regexp, w http.Respons
 
 func (s *APIRouter) UpdateConstraintReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateConstraintReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateConstraintReferenceSecurity)
+	var response UpdateConstraintReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -482,10 +528,17 @@ func (s *APIRouter) UpdateConstraintReference(exp *regexp.Regexp, w http.Respons
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateConstraintReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateConstraintReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateConstraintReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -525,19 +578,24 @@ func (s *APIRouter) UpdateConstraintReference(exp *regexp.Regexp, w http.Respons
 
 func (s *APIRouter) DeleteConstraintReference(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteConstraintReferenceRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteConstraintReferenceSecurity)
+	var response DeleteConstraintReferenceResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Entityid = EntityID(pathMatch[1])
 	req.Ovn = EntityOVN(pathMatch[2])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteConstraintReference(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteConstraintReferenceSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteConstraintReference(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -577,19 +635,24 @@ func (s *APIRouter) DeleteConstraintReference(exp *regexp.Regexp, w http.Respons
 
 func (s *APIRouter) QuerySubscriptions(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req QuerySubscriptionsRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, QuerySubscriptionsSecurity)
+	var response QuerySubscriptionsResponseSet
 
 	// Parse request body
 	req.Body = new(QuerySubscriptionParameters)
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.QuerySubscriptions(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, QuerySubscriptionsSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.QuerySubscriptions(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -625,18 +688,23 @@ func (s *APIRouter) QuerySubscriptions(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) GetSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetSubscriptionSecurity)
+	var response GetSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Subscriptionid = SubscriptionID(pathMatch[1])
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -672,9 +740,7 @@ func (s *APIRouter) GetSubscription(exp *regexp.Regexp, w http.ResponseWriter, r
 
 func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req CreateSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, CreateSubscriptionSecurity)
+	var response CreateSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -685,10 +751,17 @@ func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.CreateSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, CreateSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.CreateSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -724,9 +797,7 @@ func (s *APIRouter) CreateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req UpdateSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, UpdateSubscriptionSecurity)
+	var response UpdateSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -738,10 +809,17 @@ func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.UpdateSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, UpdateSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.UpdateSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -777,19 +855,24 @@ func (s *APIRouter) UpdateSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req DeleteSubscriptionRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, DeleteSubscriptionSecurity)
+	var response DeleteSubscriptionResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.Subscriptionid = SubscriptionID(pathMatch[1])
 	req.Version = pathMatch[2]
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.DeleteSubscription(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, DeleteSubscriptionSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.DeleteSubscription(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -829,19 +912,24 @@ func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) MakeDssReport(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req MakeDssReportRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, MakeDssReportSecurity)
+	var response MakeDssReportResponseSet
 
 	// Parse request body
 	req.Body = new(ErrorReport)
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.MakeDssReport(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, MakeDssReportSecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.MakeDssReport(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response201 != nil {
@@ -873,18 +961,23 @@ func (s *APIRouter) MakeDssReport(exp *regexp.Regexp, w http.ResponseWriter, r *
 
 func (s *APIRouter) GetUssAvailability(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req GetUssAvailabilityRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, GetUssAvailabilitySecurity)
+	var response GetUssAvailabilityResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
 	req.UssId = pathMatch[1]
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.GetUssAvailability(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, GetUssAvailabilitySecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.GetUssAvailability(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -916,9 +1009,7 @@ func (s *APIRouter) GetUssAvailability(exp *regexp.Regexp, w http.ResponseWriter
 
 func (s *APIRouter) SetUssAvailability(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
 	var req SetUssAvailabilityRequest
-
-	// Authorize request
-	req.Auth = s.Authorizer.Authorize(w, r, SetUssAvailabilitySecurity)
+	var response SetUssAvailabilityResponseSet
 
 	// Parse path parameters
 	pathMatch := exp.FindStringSubmatch(r.URL.Path)
@@ -929,10 +1020,17 @@ func (s *APIRouter) SetUssAvailability(exp *regexp.Regexp, w http.ResponseWriter
 	defer r.Body.Close()
 	req.BodyParseError = json.NewDecoder(r.Body).Decode(req.Body)
 
-	// Call implementation
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-	response := s.Implementation.SetUssAvailability(ctx, &req)
+	// Authorize request
+	req.Auth = s.Authorizer.Authorize(w, r, SetUssAvailabilitySecurity)
+	// Verify authorization
+	if req.Auth.Error != nil {
+		setAuthError(r.Context(), stacktrace.Propagate(req.Auth.Error, "Auth failed"), &response.Response401, &response.Response403, &response.Response500)
+	} else {
+		// Call implementation
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		response = s.Implementation.SetUssAvailability(ctx, &req)
+	}
 
 	// Write response to client
 	if response.Response200 != nil {
@@ -964,6 +1062,20 @@ func (s *APIRouter) SetUssAvailability(exp *regexp.Regexp, w http.ResponseWriter
 		return
 	}
 	api.WriteJSON(w, 500, api.InternalServerErrorBody{ErrorMessage: "Handler implementation did not set a response"})
+}
+
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
 }
 
 func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {

--- a/interfaces/openapi-to-go-server/example/go.mod
+++ b/interfaces/openapi-to-go-server/example/go.mod
@@ -1,3 +1,31 @@
 module example
 
-go 1.14
+go 1.25.0
+
+require (
+	github.com/interuss/dss v0.0.1
+	github.com/interuss/stacktrace v1.0.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang/protobuf v1.4.2 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
+	go.uber.org/zap v1.15.0 // indirect
+	golang.org/x/net v0.30.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/text v0.19.0 // indirect
+	golang.org/x/tools v0.26.0 // indirect
+	google.golang.org/genproto v0.0.0-20200519141106-08726f379972 // indirect
+	google.golang.org/grpc v1.29.1 // indirect
+	google.golang.org/protobuf v1.23.0 // indirect
+)

--- a/interfaces/openapi-to-go-server/generate.py
+++ b/interfaces/openapi-to-go-server/generate.py
@@ -110,12 +110,10 @@ def _generate_apis(
                     "fmt",
                     "go.opentelemetry.io/otel",
                     "go.opentelemetry.io/otel/trace",
-                    "github.com/interuss/stacktrace",
                     "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+                    'semconv "go.opentelemetry.io/otel/semconv/v1.40.0"',
                 ]
-            )
-            + '\n    dsserr "github.com/interuss/dss/pkg/errors"'
-            + '\n    semconv "go.opentelemetry.io/otel/semconv/v1.40.0"',
+            ),
             "<API_PACKAGE>": api_package,
             "<ROUTES>": "\n".join(routes),
             "<ROUTING>": "\n".join(rendering.routing(api, api_package)),

--- a/interfaces/openapi-to-go-server/rendering.py
+++ b/interfaces/openapi-to-go-server/rendering.py
@@ -29,7 +29,9 @@ def indent(lines: List[str], level: int) -> List[str]:
 
 
 def imports(import_list: List[str]) -> str:
-    return "\n".join(indent(['"{}"'.format(i) for i in import_list], 2))
+    return "\n".join(
+        indent(['"{}"'.format(i) if '"' not in i else i for i in import_list], 2)
+    )
 
 
 def template_content(template_name: str, template_vars: Dict[str, str]) -> str:
@@ -277,6 +279,7 @@ def routes(
     """
     lines: List[str] = []
     imports: Set[str] = set()
+    need_auth_error = False
 
     # Define a top-level routed HTTP handler function for each operation
     for operation in api.operations:
@@ -390,6 +393,7 @@ def routes(
         )
 
         if operation.security.options:
+            need_auth_error = True
             # Authorize & verify the call
             body.extend(comment(["Authorize request"]))
             body.append(
@@ -449,6 +453,54 @@ def routes(
 
         lines.append("}")
         lines.append("")
+
+    if need_auth_error:
+        lines.append(
+            "func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {"
+        )
+
+        body: List[str] = []
+
+        body.append("switch stacktrace.GetCode(authErr) {")
+        body.append("case dsserr.Unauthenticated:")
+        body.extend(
+            indent(
+                [
+                    '*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}'
+                ],
+                1,
+            )
+        )
+        body.append("case dsserr.PermissionDenied:")
+        body.extend(
+            indent(
+                [
+                    '*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}'
+                ],
+                1,
+            )
+        )
+        body.append("default:")
+        body.extend(indent(["if authErr == nil {"], 1))
+        body.extend(indent(['authErr = stacktrace.NewError("Unknown error")'], 2))
+        body.extend(indent(["}"], 1))
+        body.extend(
+            indent(
+                [
+                    '*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}'
+                ],
+                1,
+            )
+        )
+        body.append("}")
+
+        lines.extend(indent(body, 1))
+        lines.append("}")
+        lines.append("")
+
+        imports.add("github.com/interuss/stacktrace")
+        imports.add('dsserr "github.com/interuss/dss/pkg/errors"')
+
     if lines:
         lines.pop()
 

--- a/interfaces/openapi-to-go-server/templates/server.go.template
+++ b/interfaces/openapi-to-go-server/templates/server.go.template
@@ -37,23 +37,6 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
     return false
 }
 
-
-func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
-	switch stacktrace.GetCode(authErr) {
-	case dsserr.Unauthenticated:
-        *resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
-	case dsserr.PermissionDenied:
-        *resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
-	default:
-
-		if authErr == nil {
-			authErr = stacktrace.NewError("Unknown error")
-		}
-
-		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
-	}
-}
-
 <ROUTES>
 
 func MakeAPIRouter(impl Implementation, auth <API_PACKAGE>.Authorizer) APIRouter {

--- a/pkg/api/auxv1/server.gen.go
+++ b/pkg/api/auxv1/server.gen.go
@@ -4,9 +4,6 @@ package auxv1
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"regexp"
-
 	"github.com/interuss/dss/pkg/api"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/stacktrace"
@@ -14,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
+	"net/http"
+	"regexp"
 )
 
 type APIRouter struct {
@@ -49,22 +48,6 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 		}
 	}
 	return false
-}
-
-func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
-	switch stacktrace.GetCode(authErr) {
-	case dsserr.Unauthenticated:
-		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
-	case dsserr.PermissionDenied:
-		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
-	default:
-
-		if authErr == nil {
-			authErr = stacktrace.NewError("Unknown error")
-		}
-
-		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
-	}
 }
 
 func (s *APIRouter) GetVersion(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
@@ -358,6 +341,20 @@ func (s *APIRouter) GetScdLockMode(exp *regexp.Regexp, w http.ResponseWriter, r 
 		return
 	}
 	api.WriteJSON(w, 500, api.InternalServerErrorBody{ErrorMessage: "Handler implementation did not set a response"})
+}
+
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
 }
 
 func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {

--- a/pkg/api/ridv1/server.gen.go
+++ b/pkg/api/ridv1/server.gen.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"regexp"
-
 	"github.com/interuss/dss/pkg/api"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/stacktrace"
@@ -15,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
+	"net/http"
+	"regexp"
 )
 
 type APIRouter struct {
@@ -50,22 +49,6 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 		}
 	}
 	return false
-}
-
-func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
-	switch stacktrace.GetCode(authErr) {
-	case dsserr.Unauthenticated:
-		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
-	case dsserr.PermissionDenied:
-		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
-	default:
-
-		if authErr == nil {
-			authErr = stacktrace.NewError("Unknown error")
-		}
-
-		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
-	}
 }
 
 func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
@@ -608,6 +591,20 @@ func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter
 		return
 	}
 	api.WriteJSON(w, 500, api.InternalServerErrorBody{ErrorMessage: "Handler implementation did not set a response"})
+}
+
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
 }
 
 func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {

--- a/pkg/api/ridv2/server.gen.go
+++ b/pkg/api/ridv2/server.gen.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"regexp"
-
 	"github.com/interuss/dss/pkg/api"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/stacktrace"
@@ -15,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
+	"net/http"
+	"regexp"
 )
 
 type APIRouter struct {
@@ -50,22 +49,6 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 		}
 	}
 	return false
-}
-
-func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
-	switch stacktrace.GetCode(authErr) {
-	case dsserr.Unauthenticated:
-		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
-	case dsserr.PermissionDenied:
-		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
-	default:
-
-		if authErr == nil {
-			authErr = stacktrace.NewError("Unknown error")
-		}
-
-		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
-	}
 }
 
 func (s *APIRouter) SearchIdentificationServiceAreas(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
@@ -608,6 +591,20 @@ func (s *APIRouter) DeleteSubscription(exp *regexp.Regexp, w http.ResponseWriter
 		return
 	}
 	api.WriteJSON(w, 500, api.InternalServerErrorBody{ErrorMessage: "Handler implementation did not set a response"})
+}
+
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
 }
 
 func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {

--- a/pkg/api/scdv1/server.gen.go
+++ b/pkg/api/scdv1/server.gen.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"regexp"
-
 	"github.com/interuss/dss/pkg/api"
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/stacktrace"
@@ -15,6 +12,8 @@ import (
 	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
+	"net/http"
+	"regexp"
 )
 
 type APIRouter struct {
@@ -50,22 +49,6 @@ func (s *APIRouter) Handle(w http.ResponseWriter, r *http.Request) bool {
 		}
 	}
 	return false
-}
-
-func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
-	switch stacktrace.GetCode(authErr) {
-	case dsserr.Unauthenticated:
-		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
-	case dsserr.PermissionDenied:
-		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
-	default:
-
-		if authErr == nil {
-			authErr = stacktrace.NewError("Unknown error")
-		}
-
-		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
-	}
 }
 
 func (s *APIRouter) QueryOperationalIntentReferences(exp *regexp.Regexp, w http.ResponseWriter, r *http.Request) {
@@ -1079,6 +1062,20 @@ func (s *APIRouter) SetUssAvailability(exp *regexp.Regexp, w http.ResponseWriter
 		return
 	}
 	api.WriteJSON(w, 500, api.InternalServerErrorBody{ErrorMessage: "Handler implementation did not set a response"})
+}
+
+func setAuthError(ctx context.Context, authErr error, resp401 **ErrorResponse, resp403 **ErrorResponse, resp500 **api.InternalServerErrorBody) {
+	switch stacktrace.GetCode(authErr) {
+	case dsserr.Unauthenticated:
+		*resp401 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authentication failed"))}
+	case dsserr.PermissionDenied:
+		*resp403 = &ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Authorization failed"))}
+	default:
+		if authErr == nil {
+			authErr = stacktrace.NewError("Unknown error")
+		}
+		*resp500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(authErr, "Could not perform authorization"))}
+	}
 }
 
 func MakeAPIRouter(impl Implementation, auth api.Authorizer) APIRouter {


### PR DESCRIPTION
This PR follow #1454 because generated files changed.

I noticed when working on previous PR that some files generated by `openapi-to-go` have not been updated correctly (`make apis` vs `make dss_api`).

This:

* Make `openapi-to-go` working with dummy-oauth
  * There are no authorization and requiered structs for `setAuthError`)
  * `setAuthError` is only created when needed
* Update example's go.mod
* Generate everything

Follow up PR will enforce up-to-date generated files in CI.