### PR TITLE
 [tooling]: Enforce in CI generation of gen.go files 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
       run: make go-lint
     - name: Terraform lint
       run: make terraform-lint
+    - name: Ensure files don't change when generating apis
+      run: |
+        git diff --exit-code -- '*.gen.go'  # Should not have been changed by previous steps
+        make apis
+        git diff --exit-code -- '*.gen.go'  # Should not have been changed my make apis
+    - name: Ensure files don't change when running hygiene
+      run: |
+        git diff --exit-code
 
   dss-tests:
     name: DSS tests

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ openapi-to-go-server:
 	docker image build -t interuss/openapi-to-go-server ./interfaces/openapi-to-go-server
 
 dss_apis: openapi-to-go-server
-	docker container run -u "$(USER_GROUP)" -it \
+	docker container run -u "$(USER_GROUP)" --rm \
       	-v "$(CURDIR)/interfaces/aux_/aux_.yaml:/resources/auxv1.yaml" \
       	-v "$(CURDIR)/interfaces/astm-utm/Protocol/utm.yaml:/resources/scdv1.yaml" \
       	-v "$(CURDIR)/interfaces/rid/v1/remoteid/augmented.yaml:/resources/ridv1.yaml" \
@@ -133,7 +133,7 @@ example_apis: openapi-to-go-server
 	$(CURDIR)/interfaces/openapi-to-go-server/generate_example.sh
 
 dummy_oauth_api: openapi-to-go-server
-	docker container run -it \
+	docker container run --rm \
 		-v $(CURDIR)/interfaces/dummy-oauth/dummy-oauth.yaml:/resources/dummy-oauth.yaml \
 		-v $(CURDIR)/cmds/dummy-oauth:/resources/output \
 		interuss/openapi-to-go-server \

--- a/interfaces/openapi-to-go-server/generate_example.sh
+++ b/interfaces/openapi-to-go-server/generate_example.sh
@@ -12,7 +12,7 @@ cd "${BASEDIR}" || exit
 
 docker image build -t interuss/openapi-to-go-server .
 
-docker container run -it \
+docker container run --rm \
   	-v "$(pwd)/../astm-utm/Protocol/utm.yaml:/resources/utm.yaml" \
   	-v "$(pwd)/../rid/v1/remoteid/augmented.yaml:/resources/rid.yaml" \
 	  -v "$(pwd)/example:/resources/example" \


### PR DESCRIPTION
This PR follows #1455 

It does enforce that *.gen.go files have been generated and don't change.

Minor side fix on docker run command, that set `-it` for no reason and that make it failing in ci. Changed to `--rm` because locally it's building up useless containers quickly.