### PR TITLE
[Raft] Add Raft transport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26.2
 require (
 	cloud.google.com/go/profiler v0.4.0
 	github.com/cockroachdb/cockroach-go/v2 v2.3.8
-	github.com/coreos/etcd v3.3.27+incompatible
 	github.com/coreos/go-semver v0.3.1
 	github.com/exaring/otelpgx v0.10.0
 	github.com/go-jose/go-jose/v4 v4.1.4
@@ -21,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	go.etcd.io/etcd v3.3.27+incompatible
+	go.etcd.io/etcd/client/pkg/v3 v3.6.11
 	go.etcd.io/etcd/server/v3 v3.6.11
 	go.etcd.io/raft/v3 v3.6.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0
@@ -43,8 +42,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
-	github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -70,7 +67,6 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.11 // indirect
-	go.etcd.io/etcd/client/pkg/v3 v3.6.11 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.6.11 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,14 +24,8 @@ github.com/cockroachdb/cockroach-go/v2 v2.3.8 h1:53yoUo4+EtrC1NrAEgnnad4AS3ntNvG
 github.com/cockroachdb/cockroach-go/v2 v2.3.8/go.mod h1:9uH5jK4yQ3ZQUT9IXe4I2fHzMIF5+JC/oOdzTRgJYJk=
 github.com/cockroachdb/datadriven v1.0.2 h1:H9MtNqVoVhvd9nCBwOyDjUEdZCREqbIdCJD93PBm/jA=
 github.com/cockroachdb/datadriven v1.0.2/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
-github.com/coreos/etcd v3.3.27+incompatible h1:QIudLb9KeBsE5zyYxd1mjzRSkzLg9Wf9QlRwFgd6oTA=
-github.com/coreos/etcd v3.3.27+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
-github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
-github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb h1:GIzvVQ9UkUlOhSDlqmrQAAAUd6R3E+caIisNEyWXvNE=
-github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -147,8 +141,6 @@ github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 h1:S2dVYn90KE98chq
 github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.etcd.io/etcd v3.3.27+incompatible h1:5hMrpf6REqTHV2LW2OclNpRtxI0k9ZplMemJsMSWju0=
-go.etcd.io/etcd v3.3.27+incompatible/go.mod h1:yaeTdrJi5lOmYerz05bd8+V7KubZs8YSFZfzsF9A6aI=
 go.etcd.io/etcd/api/v3 v3.6.11 h1:XFGTgrJ8nak3kB4NgMG8t7NT+lEeuuvKQAqUHKVgkWQ=
 go.etcd.io/etcd/api/v3 v3.6.11/go.mod h1:HYfTh0jyh+uFgp6gMbxJteIDYY97yMuYz85Rnw6Gy9o=
 go.etcd.io/etcd/client/pkg/v3 v3.6.11 h1:e41mp315Yn3QMGPmEzCyLsMINgJXTY/dX8kM++1csxU=

--- a/pkg/aux_/store/raftstore/store.go
+++ b/pkg/aux_/store/raftstore/store.go
@@ -3,11 +3,12 @@ package raftstore
 import (
 	"github.com/interuss/dss/pkg/aux_/repos"
 	"github.com/interuss/dss/pkg/raftstore"
+	"go.uber.org/zap"
 )
 
 // repo is a full implementation of aux_.repos.Repository for Raft-based storage.
 type repo struct{}
 
-func Init() (*raftstore.Store[repos.Repository], error) {
-	return raftstore.Init[repos.Repository](func() repos.Repository { return &repo{} }), nil
+func Init(logger *zap.Logger) (*raftstore.Store[repos.Repository], error) {
+	return raftstore.Init[repos.Repository](logger, func() repos.Repository { return &repo{} })
 }

--- a/pkg/aux_/store/store.go
+++ b/pkg/aux_/store/store.go
@@ -23,7 +23,7 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, e
 	case params.SQLStoreType:
 		return auxsqlstore.Init(ctx, logger, withCheckCron)
 	case params.RaftStoreType:
-		return auxraftstore.Init()
+		return auxraftstore.Init(logger)
 	default:
 		return nil, stacktrace.NewError("Unsupported store type %q for aux", storeType)
 	}

--- a/pkg/raftstore/consensus/consensus.go
+++ b/pkg/raftstore/consensus/consensus.go
@@ -1,15 +1,112 @@
 package consensus
 
 import (
-	"go.etcd.io/etcd/rafthttp"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/interuss/stacktrace"
+	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp"
+	v2stats "go.etcd.io/etcd/server/v3/etcdserver/api/v2stats"
 	"go.etcd.io/raft/v3"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.uber.org/zap"
 )
+
+const defaultClusterID uint64 = 1
 
 type Consensus struct {
 	node        raft.Node
 	raftStorage *raft.MemoryStorage
 
 	transport *rafthttp.Transport
+	server    *http.Server
 
 	storage *storage
+	errorC  chan error
+}
+
+func NewConsensus(logger *zap.Logger, nodeID uint64, peers map[uint64]*url.URL) (*Consensus, error) {
+	consensus := &Consensus{
+		errorC: make(chan error, 1),
+	}
+
+	err := consensus.initTransport(logger.With(zap.String("component", "transport")), nodeID, defaultClusterID, peers)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to initialize transport")
+	}
+
+	return consensus, nil
+}
+
+func (c *Consensus) initTransport(logger *zap.Logger, nodeID uint64, clusterID uint64, peers map[uint64]*url.URL) error {
+	nodeIDStr := fmt.Sprintf("%d", nodeID)
+
+	transport := &rafthttp.Transport{
+		Logger:      logger,
+		ID:          types.ID(nodeID),
+		ClusterID:   types.ID(clusterID),
+		Raft:        c,
+		ServerStats: v2stats.NewServerStats(nodeIDStr, nodeIDStr),
+		LeaderStats: v2stats.NewLeaderStats(logger, nodeIDStr),
+		ErrorC:      c.errorC,
+	}
+
+	err := transport.Start()
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to start transport")
+	}
+
+	var listeningAddr string
+	for peerID, peerURL := range peers {
+		if peerID == nodeID {
+			listeningAddr = ":" + peerURL.Port()
+			continue
+		}
+
+		transport.AddPeer(types.ID(peerID), []string{peerURL.String()})
+	}
+
+	if listeningAddr == "" {
+		return stacktrace.NewError("node ID %d not found in peers map", nodeID)
+	}
+
+	c.server = &http.Server{
+		Addr:    listeningAddr,
+		Handler: transport.Handler(),
+	}
+
+	go func() {
+		err := c.server.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("http server error", zap.Error(err))
+			c.errorC <- err
+		}
+	}()
+
+	c.transport = transport
+	return nil
+}
+
+// Process implements the rafthttp.Raft interface.
+func (c *Consensus) Process(ctx context.Context, m raftpb.Message) error {
+	return c.node.Step(ctx, m)
+}
+
+// IsIDRemoved implements the rafthttp.Raft interface.
+func (c *Consensus) IsIDRemoved(id uint64) bool {
+	return false
+}
+
+// ReportUnreachable implements the rafthttp.Raft interface.
+func (c *Consensus) ReportUnreachable(id uint64) {
+	c.node.ReportUnreachable(id)
+}
+
+// ReportSnapshot implements the rafthttp.Raft interface.
+func (c *Consensus) ReportSnapshot(id uint64, status raft.SnapshotStatus) {
+	c.node.ReportSnapshot(id, status)
 }

--- a/pkg/raftstore/consensus/storage.go
+++ b/pkg/raftstore/consensus/storage.go
@@ -1,7 +1,7 @@
 package consensus
 
 import (
-	"github.com/coreos/etcd/snap"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
 	"go.etcd.io/etcd/server/v3/storage/wal"
 )
 

--- a/pkg/raftstore/params/params.go
+++ b/pkg/raftstore/params/params.go
@@ -1,0 +1,66 @@
+package params
+
+import (
+	"flag"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/interuss/stacktrace"
+)
+
+type (
+	// ConnectParameters bundles up parameters used for connecting nodes in a raftstore cluster.
+	ConnectParameters struct {
+		ID    uint64
+		Peers string
+	}
+)
+
+// PeerMap parses the Peers string into a map of node ID to peer URL.
+func (c ConnectParameters) PeerMap() (map[uint64]*url.URL, error) {
+	peers := make(map[uint64]*url.URL)
+
+	for entry := range strings.SplitSeq(c.Peers, ",") {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) != 2 {
+			return nil, stacktrace.NewError("invalid peer entry %s: must be in format nodeID=peerURL", entry)
+		}
+
+		id, err := strconv.ParseUint(parts[0], 10, 64)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "invalid peer ID %s", parts[0])
+		}
+
+		if id == 0 {
+			return nil, stacktrace.NewError("invalid peer ID 0: peer IDs must be greater than 0")
+		}
+
+		if _, exists := peers[id]; exists {
+			return nil, stacktrace.NewError("duplicate peer ID %d", id)
+		}
+
+		peerURL, err := url.Parse(parts[1])
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "invalid peer URL %s", parts[1])
+		}
+
+		peers[id] = peerURL
+	}
+
+	return peers, nil
+}
+
+var (
+	connectParameters ConnectParameters
+)
+
+func init() {
+	flag.Uint64Var(&connectParameters.ID, "raft_node_id", 0, "raft node ID for this instance (must be non-zero and unique within the cluster)")
+	flag.StringVar(&connectParameters.Peers, "raft_peers", "", `comma-separated "nodeID=peerURL" pairs for all cluster members, including the current node, e.g. "1=http://node1:9021,2=http://node2:9021,3=http://node3:9021"`)
+}
+
+// GetConnectParameters returns a ConnectParameters instance that gets populated from well-known CLI flags.
+func GetConnectParameters() ConnectParameters {
+	return connectParameters
+}

--- a/pkg/raftstore/params/params_test.go
+++ b/pkg/raftstore/params/params_test.go
@@ -1,0 +1,95 @@
+package params
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerMap(t *testing.T) {
+	tests := []struct {
+		name      string
+		peers     string
+		want      map[uint64]*url.URL
+		wantError bool
+	}{
+		{
+			name:  "valid single peer",
+			peers: "1=http://node1:9021",
+			want:  map[uint64]*url.URL{1: mustParseURL("http://node1:9021")},
+		},
+		{
+			name:  "valid multiple peers",
+			peers: "1=http://node1:9021,2=http://node2:9021,3=http://node3:9021",
+			want: map[uint64]*url.URL{
+				1: mustParseURL("http://node1:9021"),
+				2: mustParseURL("http://node2:9021"),
+				3: mustParseURL("http://node3:9021"),
+			},
+		},
+		{
+			name:  "valid URL with equals sign in query string",
+			peers: "1=http://node1:9021?token=abc123",
+			want:  map[uint64]*url.URL{1: mustParseURL("http://node1:9021?token=abc123")},
+		},
+		{
+			name:      "invalid empty peers string",
+			peers:     "",
+			wantError: true,
+		},
+		{
+			name:      "invalid entry format",
+			peers:     "invalidentry",
+			wantError: true,
+		},
+		{
+			name:      "invalid non-numeric node ID",
+			peers:     "abc=http://node1:9021",
+			wantError: true,
+		},
+		{
+			name:      "invalid negative node ID",
+			peers:     "-1=http://node1:9021",
+			wantError: true,
+		},
+		{
+			name:      "mixed valid and invalid entries",
+			peers:     "1=http://node1:9021,badentry",
+			wantError: true,
+		},
+		{
+			name:      "invalid zero peer ID",
+			peers:     "0=http://node1:9021",
+			wantError: true,
+		},
+		{
+			name:      "duplicate peer IDs",
+			peers:     "1=http://node1:9021,1=http://node2:9021",
+			wantError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := ConnectParameters{Peers: tc.peers}
+			got, err := c.PeerMap()
+			if tc.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}

--- a/pkg/raftstore/store.go
+++ b/pkg/raftstore/store.go
@@ -2,14 +2,48 @@ package raftstore
 
 import (
 	"context"
+	"sync"
+
+	"github.com/interuss/dss/pkg/raftstore/consensus"
+	raftparams "github.com/interuss/dss/pkg/raftstore/params"
+	"github.com/interuss/stacktrace"
+	"go.uber.org/zap"
+)
+
+var (
+	sharedConsensus     *consensus.Consensus
+	sharedConsensusOnce sync.Once
+	sharedConsensusErr  error
 )
 
 type Store[R any] struct {
-	newRepo func() R
+	newRepo   func() R
+	consensus *consensus.Consensus
 }
 
-func Init[R any](newRepo func() R) *Store[R] {
-	return &Store[R]{newRepo: newRepo}
+func Init[R any](logger *zap.Logger, newRepo func() R) (*Store[R], error) {
+	// scd, rid and aux will share the same consensus instance, so we initialize it once.
+	sharedConsensusOnce.Do(func() {
+		params := raftparams.GetConnectParameters()
+		peers, err := params.PeerMap()
+		if err != nil {
+			sharedConsensusErr = stacktrace.Propagate(err, "failed to parse peer map")
+			return
+		}
+
+		sharedConsensus, sharedConsensusErr = consensus.NewConsensus(logger, params.ID, peers)
+		if sharedConsensusErr != nil {
+			sharedConsensusErr = stacktrace.Propagate(sharedConsensusErr, "failed to initialize consensus")
+		}
+	})
+	if sharedConsensusErr != nil {
+		return nil, sharedConsensusErr
+	}
+
+	return &Store[R]{
+		newRepo:   newRepo,
+		consensus: sharedConsensus,
+	}, nil
 }
 
 // Transact proposes the entry to Raft and blocks until it is committed and applied.

--- a/pkg/rid/store/raftstore/store.go
+++ b/pkg/rid/store/raftstore/store.go
@@ -3,11 +3,12 @@ package raftstore
 import (
 	"github.com/interuss/dss/pkg/raftstore"
 	"github.com/interuss/dss/pkg/rid/repos"
+	"go.uber.org/zap"
 )
 
 // repo is a full implementation of rid.repos.Repository for Raft-based storage.
 type repo struct{}
 
-func Init() (*raftstore.Store[repos.Repository], error) {
-	return raftstore.Init[repos.Repository](func() repos.Repository { return &repo{} }), nil
+func Init(logger *zap.Logger) (*raftstore.Store[repos.Repository], error) {
+	return raftstore.Init[repos.Repository](logger, func() repos.Repository { return &repo{} })
 }

--- a/pkg/rid/store/store.go
+++ b/pkg/rid/store/store.go
@@ -23,7 +23,7 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, e
 	case params.SQLStoreType:
 		return ridsqlstore.Init(ctx, logger, withCheckCron)
 	case params.RaftStoreType:
-		return ridraftstore.Init()
+		return ridraftstore.Init(logger)
 	default:
 		return nil, stacktrace.NewError("Unsupported store type %q for rid", storeType)
 	}

--- a/pkg/scd/store/raftstore/store.go
+++ b/pkg/scd/store/raftstore/store.go
@@ -3,11 +3,12 @@ package raftstore
 import (
 	"github.com/interuss/dss/pkg/raftstore"
 	"github.com/interuss/dss/pkg/scd/repos"
+	"go.uber.org/zap"
 )
 
 // repo is a full implementation of scd.repos.Repository for Raft-based storage.
 type repo struct{}
 
-func Init() (*raftstore.Store[repos.Repository], error) {
-	return raftstore.Init[repos.Repository](func() repos.Repository { return &repo{} }), nil
+func Init(logger *zap.Logger) (*raftstore.Store[repos.Repository], error) {
+	return raftstore.Init[repos.Repository](logger, func() repos.Repository { return &repo{} })
 }

--- a/pkg/scd/store/store.go
+++ b/pkg/scd/store/store.go
@@ -23,7 +23,7 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLoc
 	case params.SQLStoreType:
 		return scdsqlstore.Init(ctx, logger, withCheckCron, globalLock)
 	case params.RaftStoreType:
-		return scdraftstore.Init()
+		return scdraftstore.Init(logger)
 	default:
 		return nil, stacktrace.NewError("Unsupported store type %q for scd", storeType)
 	}

--- a/pkg/sqlstore/params/params.go
+++ b/pkg/sqlstore/params/params.go
@@ -63,7 +63,7 @@ func init() {
 	flag.IntVar(&connectParameters.MaxRetries, "cockroach_max_retries", connectParameters.MaxRetries, "DEPRECATED: use 'datastore_max_retries' instead")
 }
 
-// ConnectParameters returns a ConnectParameters instance that gets populated from well-known CLI flags.
+// GetConnectParameters returns a ConnectParameters instance that gets populated from well-known CLI flags.
 func GetConnectParameters() ConnectParameters {
 	return connectParameters
 }

--- a/pkg/store/params/params.go
+++ b/pkg/store/params/params.go
@@ -25,7 +25,7 @@ func init() {
 	flag.StringVar(&storeParameters.StoreType, "store_type", SQLStoreType, fmt.Sprintf("Store type. Use '%s' for CockroachDB/YugabyteDB and '%s' for Raft-based store.", SQLStoreType, RaftStoreType))
 }
 
-// ConnectParameters returns a ConnectParameters instance that gets populated from well-known CLI flags.
+// GetStoreParameters returns a StoreParameters instance that gets populated from well-known CLI flags.
 func GetStoreParameters() StoreParameters {
 	return storeParameters
 }


### PR DESCRIPTION
Adds the Raft transport implementation based on [rafthttp](https://pkg.go.dev/go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp). 
It also fixes some import issues. 

At this point, it is possible to start a cluster of connected nodes using:
```
go run ./cmds/core-service \                         
  --store_type=raft \
  --raft_node_id=1 --raft_peers="1=http://localhost:9021,2=http://localhost:9022,3=http://localhost:9023" \
  --accepted_jwt_audiences=dss --public_key_files=build/test-certs/auth2.pem
```

`rafthttp` is used by etcd's own implementation and is optimized for Raft.
The alternative to this is to implement a grpc based transport from scratch. With the prototype naive implementation, the overall performance was not affected by the type of transport used so we prefer the more practical choice here. This decision can be revisited later if needed since etcd/raft is completely transport agnostic. 

Implements #1699