### PR TITLE
[Raft] Add consensus logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ go
 
 # terraform
 .terraform*
+
+# raft
+raft_data/

--- a/pkg/raftstore/consensus/config.go
+++ b/pkg/raftstore/consensus/config.go
@@ -1,0 +1,26 @@
+package consensus
+
+import (
+	"go.etcd.io/raft/v3"
+)
+
+const (
+	defaultClusterID uint64 = 1
+
+	defaultElectionTick  = 20
+	defaultHeartbeatTick = 1
+
+	defaultMaxSizePerMsg   = 1024 * 1024
+	defaultMaxInflightMsgs = 4096 / 8
+)
+
+func defaultConfig(storage raft.Storage) *raft.Config {
+	return &raft.Config{
+		ID:              defaultClusterID,
+		ElectionTick:    defaultElectionTick,
+		HeartbeatTick:   defaultHeartbeatTick,
+		MaxSizePerMsg:   defaultMaxSizePerMsg,
+		MaxInflightMsgs: defaultMaxInflightMsgs,
+		Storage:         storage,
+	}
+}

--- a/pkg/raftstore/consensus/consensus.go
+++ b/pkg/raftstore/consensus/consensus.go
@@ -2,10 +2,13 @@ package consensus
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
+	"time"
 
 	"github.com/interuss/stacktrace"
 	"go.etcd.io/etcd/client/pkg/v3/types"
@@ -14,41 +17,113 @@ import (
 	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/raftpb"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
 	defaultClusterID uint64 = 1
 )
 
+var errRemovedFromCluster = stacktrace.NewError("I have been removed from the cluster !")
+
 type Consensus struct {
 	logger *zap.Logger
 
+	id   uint64
 	node raft.Node
+
+	removedPeers map[uint64]bool
 
 	transport *rafthttp.Transport
 	server    *http.Server
 
 	storage *storage
-	errorC  chan error
+	errCh   chan error
+
+	commitChs map[string]chan EntryCommit
+	tracker   *proposalsTracker
+
+	confState     raftpb.ConfState
+	snapshotIndex uint64
+	appliedIndex  uint64
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+}
+
+func peersList(peers map[uint64]*url.URL) []raft.Peer {
+	result := make([]raft.Peer, 0, len(peers))
+	for id := range peers {
+		result = append(result, raft.Peer{ID: id})
+	}
+	return result
 }
 
 func NewConsensus(logger *zap.Logger, nodeID uint64, peers map[uint64]*url.URL, dataDir string) (*Consensus, error) {
-	storage, _, err := newStorage(logger.With(zap.String("component", "storage")), dataDir, nodeID)
+	storage, old, err := newstorage(logger.With(zap.String("component", "storage")), dataDir, nodeID)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to initialize storage")
+	}
+
+	var node raft.Node
+	config := defaultConfig(storage)
+	if old {
+		node = raft.RestartNode(config)
+	} else {
+		node = raft.StartNode(config, peersList(peers))
 	}
 
 	consensus := &Consensus{
 		logger: logger,
 
+		id:   nodeID,
+		node: node,
+
+		removedPeers: make(map[uint64]bool),
+
 		storage: storage,
-		errorC:  make(chan error, 1),
+		errCh:   make(chan error, 1),
+
+		commitChs: make(map[string]chan EntryCommit),
+		tracker:   newProposalsTracker(),
+
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
 	}
 
 	err = consensus.initTransport(logger.With(zap.String("component", "transport")), nodeID, defaultClusterID, peers)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to initialize transport")
 	}
+
+	snap, err := consensus.storage.Snapshot()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to get snapshot from storage")
+	}
+
+	consensus.confState = snap.Metadata.ConfState
+	consensus.snapshotIndex = snap.Metadata.Index
+	consensus.appliedIndex = snap.Metadata.Index
+
+	go func() {
+		defer close(consensus.doneCh)
+		err := consensus.handleReady()
+		if err != nil {
+			consensus.logger.Error("consensus loop exited with error", zap.Error(err))
+			select {
+			case consensus.errCh <- err:
+			default:
+			}
+		}
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if shutdownErr := consensus.server.Shutdown(shutdownCtx); shutdownErr != nil {
+			consensus.logger.Error("failed to shutdown http server", zap.Error(shutdownErr))
+		}
+		consensus.transport.Stop()
+		consensus.node.Stop()
+	}()
 
 	return consensus, nil
 }
@@ -63,7 +138,7 @@ func (c *Consensus) initTransport(logger *zap.Logger, nodeID uint64, clusterID u
 		Raft:        c,
 		ServerStats: v2stats.NewServerStats(nodeIDStr, nodeIDStr),
 		LeaderStats: v2stats.NewLeaderStats(logger, nodeIDStr),
-		ErrorC:      c.errorC,
+		ErrorC:      make(chan error),
 	}
 
 	err := transport.Start()
@@ -94,12 +169,258 @@ func (c *Consensus) initTransport(logger *zap.Logger, nodeID uint64, clusterID u
 		err := c.server.ListenAndServe()
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Error("http server error", zap.Error(err))
-			c.errorC <- err
+			c.transport.ErrorC <- err
 		}
 	}()
 
 	c.transport = transport
 	return nil
+}
+
+// handleReady processes the Ready channel of the Raft node and applies committed entries to the state machine
+func (c *Consensus) handleReady() error {
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.stopCh:
+			return nil
+		case <-ticker.C:
+			c.node.Tick()
+		case err := <-c.transport.ErrorC:
+			return stacktrace.Propagate(err, "transport error")
+		case rd, ok := <-c.node.Ready():
+			if !ok {
+				return stacktrace.NewError("could not read from Ready(), shutting down handler")
+			}
+
+			err := c.storage.handleReceivedState(rd.Snapshot, rd.HardState, rd.Entries)
+			if err != nil {
+				return stacktrace.Propagate(err, "failed to handle received snapshot")
+			}
+
+			if !raft.IsEmptySnap(rd.Snapshot) {
+				if rd.Snapshot.Metadata.Index <= c.appliedIndex {
+					return stacktrace.NewError("snapshot index %d is not greater than applied index %d", rd.Snapshot.Metadata.Index, c.appliedIndex)
+				}
+
+				err = c.dispatchSnapshot(rd.Snapshot.Data)
+				if err != nil {
+					return stacktrace.Propagate(err, "failed to dispatch snapshot")
+				}
+
+				c.confState = rd.Snapshot.Metadata.ConfState
+				c.snapshotIndex = rd.Snapshot.Metadata.Index
+				c.appliedIndex = rd.Snapshot.Metadata.Index
+			}
+
+			c.transport.Send(c.checkUpdateConfState(rd.Messages))
+
+			entries, err := c.entriesToApply(rd.CommittedEntries)
+			if err != nil {
+				return stacktrace.Propagate(err, "failed to get entries to apply")
+			}
+
+			err = c.publishEntries(entries)
+			if err != nil {
+				if errors.Is(err, errRemovedFromCluster) {
+					c.logger.Info("removing self from cluster")
+					return nil
+				}
+
+				return stacktrace.Propagate(err, "failed to publish entries")
+			}
+
+			c.node.Advance()
+		}
+	}
+}
+
+func (c *Consensus) publishEntries(entries []raftpb.Entry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	c.logger.Info("publishing entries", zap.Int("numEntries", len(entries)), zap.Uint64("firstIndex", entries[0].Index), zap.Uint64("lastIndex", entries[len(entries)-1].Index))
+
+	var triggerSnapshot bool
+	var err error
+	var wg sync.WaitGroup
+	for _, entry := range entries {
+		switch entry.Type {
+		case raftpb.EntryNormal:
+			err := c.processNormalEntry(entry.Data, &wg)
+			if err != nil {
+				return stacktrace.Propagate(err, "failed to process normal entry")
+			}
+		case raftpb.EntryConfChange:
+			err := c.processConfigChangeEntry(entry.Data)
+			if err != nil {
+				return stacktrace.Propagate(err, "failed to process config change entry")
+			}
+		case raftpb.EntryConfChangeV2:
+			triggerSnapshot, err = c.processConfigChangeV2Entry(entry.Data)
+			if err != nil {
+				return stacktrace.Propagate(err, "failed to process config change v2 entry")
+			}
+		}
+	}
+
+	// wait for all entries to be applied before updating the applied index and potentially triggering a snapshot
+	wg.Wait()
+	c.appliedIndex = entries[len(entries)-1].Index
+
+	if triggerSnapshot || c.appliedIndex-c.snapshotIndex >= snapshotCatchUpEntriesN {
+		err := c.storage.triggerSnapshot(c.appliedIndex, &c.confState)
+		if err != nil {
+			return stacktrace.Propagate(err, "failed to trigger snapshot")
+		}
+	}
+
+	return nil
+}
+
+// processNormalEntry unmarshals the entry into a proposal and starts a goroutine
+// that untracks it once applied then passes it as an EntryCommit to the commit channel.
+func (c *Consensus) processNormalEntry(data []byte, wg *sync.WaitGroup) error {
+	if len(data) <= 0 {
+		return nil
+	}
+
+	prop := Proposal{}
+	err := json.Unmarshal(data, &prop)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to unmarshal committed proposal")
+	}
+
+	//if readOnly proposal and we did not initiate it, skip it (noop)
+	if prop.ReadOnly && !c.tracker.isPending(prop.ID) {
+		return nil
+	}
+
+	applyDoneC := make(chan ProposalResult, 1)
+	wg.Go(func() {
+		res := <-applyDoneC
+		if c.tracker.isPending(prop.ID) {
+			c.tracker.untrack(prop.ID, res)
+		}
+	})
+
+	ch, ok := c.commitChs[prop.DBName]
+	if !ok {
+		return stacktrace.NewError("no commit channel found for %s", prop.DBName)
+	}
+
+	ch <- EntryCommit{Prop: prop, Done: applyDoneC}
+	return nil
+}
+
+func (c *Consensus) dispatchSnapshot(snapshotData []byte) error {
+	var snapshot map[string][]byte
+	err := json.Unmarshal(snapshotData, &snapshot)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to unmarshal snapshot data")
+	}
+
+	var eg errgroup.Group
+	for name, data := range snapshot {
+		eg.Go(func() error {
+			ch, ok := c.commitChs[name]
+			if !ok {
+				return stacktrace.NewError("no commit channel found for %s", name)
+			}
+
+			ch <- EntryCommit{SnapshotData: data}
+			return nil
+		})
+	}
+
+	return eg.Wait()
+}
+
+// raftpb.ConfChange is still used internally by Raft, we just need to apply the change to the node.
+// Changes requested by clients are processed by processConfigChangeV2Entry.
+func (c *Consensus) processConfigChangeEntry(data []byte) error {
+	var cc raftpb.ConfChange
+	err := cc.Unmarshal(data)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to unmarshal config change data")
+	}
+
+	c.confState = *c.node.ApplyConfChange(cc)
+	return nil
+}
+
+func (c *Consensus) processConfigChangeV2Entry(data []byte) (bool, error) {
+	var cc raftpb.ConfChangeV2
+	err := cc.Unmarshal(data)
+	if err != nil {
+		return false, stacktrace.Propagate(err, "failed to unmarshal config change data")
+	}
+
+	confChangeContext := &ConfigChangeContext{}
+	err = json.Unmarshal(cc.Context, confChangeContext)
+	if err != nil {
+		return false, stacktrace.Propagate(err, "failed to unmarshal config change context data")
+	}
+
+	var triggerSnapshot bool
+	c.confState = *c.node.ApplyConfChange(cc)
+	for _, change := range cc.Changes {
+		switch change.Type {
+		case raftpb.ConfChangeAddNode:
+			url, ok := confChangeContext.Urls[change.NodeID]
+			if !ok {
+				c.logger.Warn("ignoring conf change add node, url not found in the map", zap.Uint64("node-id", change.NodeID))
+				continue
+			}
+
+			c.transport.AddPeer(types.ID(change.NodeID), []string{url})
+
+			//trigger snapshot to avoid nodes removing themselves after rejoining
+			triggerSnapshot = true
+		case raftpb.ConfChangeRemoveNode:
+			if change.NodeID == c.id {
+				return false, errRemovedFromCluster
+			}
+
+			c.removedPeers[change.NodeID] = true
+			c.transport.RemovePeer(types.ID(change.NodeID))
+		}
+	}
+
+	return triggerSnapshot, nil
+}
+
+func (c *Consensus) entriesToApply(entries []raftpb.Entry) ([]raftpb.Entry, error) {
+	if len(entries) == 0 {
+		return entries, nil
+	}
+
+	result := make([]raftpb.Entry, 0)
+
+	firstIdx := entries[0].Index
+	if firstIdx > c.appliedIndex+1 {
+		return nil, stacktrace.NewError("first index of committed entry[%d] should <= progress.appliedIndex[%d]+1", firstIdx, c.appliedIndex)
+	}
+
+	if c.appliedIndex-firstIdx+1 < uint64(len(entries)) {
+		result = entries[c.appliedIndex-firstIdx+1:]
+	}
+
+	return result, nil
+}
+
+// checkUpdateConfState checks if any of the messages to be sent contain a snapshot
+// and updates the ConfState in the snapshot as it could be outdated.
+func (c *Consensus) checkUpdateConfState(msgs []raftpb.Message) []raftpb.Message {
+	for _, msg := range msgs {
+		if msg.Type == raftpb.MsgSnap {
+			msg.Snapshot.Metadata.ConfState = c.confState
+		}
+	}
+	return msgs
 }
 
 // Process implements the rafthttp.Raft interface.
@@ -123,6 +444,27 @@ func (c *Consensus) ReportSnapshot(id uint64, status raft.SnapshotStatus) {
 }
 
 // RegisterStore allows registering a snapshot provider function for a specific store
+// and initializes the corresponding commit channel.
 func (c *Consensus) RegisterStore(name string, provider snapshotProvider) {
 	c.storage.registerSnapshotProvider(name, provider)
+	c.commitChs[name] = make(chan EntryCommit)
+}
+
+// Stop signals the consensus loop to exit and waits for all cleanup (HTTP server,
+// transport, raft node) to complete. Safe to call from multiple goroutines.
+func (c *Consensus) Stop() {
+	c.stopOnce.Do(func() { close(c.stopCh) })
+	<-c.doneCh
+}
+
+// Err returns a channel that receives the first fatal error from the consensus
+// loop, if any. The channel is buffered; callers should drain it after Stop.
+func (c *Consensus) Err() <-chan error {
+	return c.errCh
+}
+
+// Done returns a channel that is closed when the consensus loop has fully
+// stopped (whether via Stop, a fatal error, or removal from the cluster).
+func (c *Consensus) Done() <-chan struct{} {
+	return c.doneCh
 }

--- a/pkg/raftstore/consensus/consensus.go
+++ b/pkg/raftstore/consensus/consensus.go
@@ -16,11 +16,14 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultClusterID uint64 = 1
+const (
+	defaultClusterID uint64 = 1
+)
 
 type Consensus struct {
-	node        raft.Node
-	raftStorage *raft.MemoryStorage
+	logger *zap.Logger
+
+	node raft.Node
 
 	transport *rafthttp.Transport
 	server    *http.Server
@@ -29,12 +32,20 @@ type Consensus struct {
 	errorC  chan error
 }
 
-func NewConsensus(logger *zap.Logger, nodeID uint64, peers map[uint64]*url.URL) (*Consensus, error) {
-	consensus := &Consensus{
-		errorC: make(chan error, 1),
+func NewConsensus(logger *zap.Logger, nodeID uint64, peers map[uint64]*url.URL, dataDir string) (*Consensus, error) {
+	storage, _, err := newStorage(logger.With(zap.String("component", "storage")), dataDir, nodeID)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to initialize storage")
 	}
 
-	err := consensus.initTransport(logger.With(zap.String("component", "transport")), nodeID, defaultClusterID, peers)
+	consensus := &Consensus{
+		logger: logger,
+
+		storage: storage,
+		errorC:  make(chan error, 1),
+	}
+
+	err = consensus.initTransport(logger.With(zap.String("component", "transport")), nodeID, defaultClusterID, peers)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to initialize transport")
 	}
@@ -109,4 +120,9 @@ func (c *Consensus) ReportUnreachable(id uint64) {
 // ReportSnapshot implements the rafthttp.Raft interface.
 func (c *Consensus) ReportSnapshot(id uint64, status raft.SnapshotStatus) {
 	c.node.ReportSnapshot(id, status)
+}
+
+// RegisterStore allows registering a snapshot provider function for a specific store
+func (c *Consensus) RegisterStore(name string, provider snapshotProvider) {
+	c.storage.registerSnapshotProvider(name, provider)
 }

--- a/pkg/raftstore/consensus/proposal.go
+++ b/pkg/raftstore/consensus/proposal.go
@@ -1,0 +1,95 @@
+package consensus
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type EntryCommit struct {
+	Prop Proposal
+	Done chan ProposalResult
+
+	SnapshotData []byte
+}
+
+type ConfigChangeContext struct {
+	ID   string            `json:"id"`
+	Urls map[uint64]string `json:"urls"`
+}
+
+func newConfigChangeContext(urls map[uint64]string) ConfigChangeContext {
+	return ConfigChangeContext{
+		ID:   uuid.NewString(),
+		Urls: urls,
+	}
+}
+
+type Proposal struct {
+	ID          string            `json:"id"`
+	DBName      string            `json:"dbname"`
+	Timestamp   time.Time         `json:"timestamp"`
+	RequestType string            `json:"request_type"`
+	Value       []byte            `json:"value"`
+	ReadOnly    bool              `json:"read_only"`
+	Parameters  map[string][]byte `json:"parameters,omitempty"`
+}
+
+type ProposalResult struct {
+	Result any
+	Error  error
+}
+
+func newProposal(timestamp time.Time, requestType string, value []byte, readOnly bool, parameters map[string][]byte) Proposal {
+	proposalTimestamp := timestamp
+	if proposalTimestamp.IsZero() {
+		proposalTimestamp = time.Now().UTC()
+	}
+
+	return Proposal{
+		ID:          uuid.NewString(),
+		Timestamp:   proposalTimestamp,
+		RequestType: requestType,
+		Value:       value,
+		ReadOnly:    readOnly,
+		Parameters:  parameters,
+	}
+}
+
+type proposalsTracker struct {
+	sync.Mutex
+	pending map[string]chan ProposalResult
+}
+
+func newProposalsTracker() *proposalsTracker {
+	return &proposalsTracker{
+		pending: make(map[string]chan ProposalResult),
+	}
+}
+
+func (p *proposalsTracker) isPending(id string) bool {
+	p.Lock()
+	defer p.Unlock()
+
+	_, ok := p.pending[id]
+	return ok
+}
+
+func (p *proposalsTracker) track(id string) chan ProposalResult {
+	p.Lock()
+	defer p.Unlock()
+
+	applied := make(chan ProposalResult, 1)
+	p.pending[id] = applied
+	return applied
+}
+
+func (p *proposalsTracker) untrack(id string, result ProposalResult) {
+	p.Lock()
+	defer p.Unlock()
+
+	applied := p.pending[id]
+	applied <- result
+	delete(p.pending, id)
+}

--- a/pkg/raftstore/consensus/storage.go
+++ b/pkg/raftstore/consensus/storage.go
@@ -1,12 +1,245 @@
 package consensus
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/interuss/stacktrace"
+	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
 	"go.etcd.io/etcd/server/v3/storage/wal"
+	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
+	"go.etcd.io/raft/v3"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.uber.org/zap"
 )
 
-// storage persists the Raft log and snapshots.
+const snapshotCatchUpEntriesN uint64 = 10000
+
+// snapshotProvider is a function that returns the snapshot data to be included in the Raft snapshot.
+// We use a snapshotProvider from each component (scd, rid and aux).
+type snapshotProvider func() ([]byte, error)
+
+// storage persists the Raft log and snapshots and manages the raft in-memory storage.
 type storage struct {
-	wal         *wal.WAL
-	snapshotter *snap.Snapshotter
+	logger *zap.Logger
+
+	*raft.MemoryStorage
+
+	wal *wal.WAL
+
+	snapper   *snap.Snapshotter
+	providers map[string]snapshotProvider
+}
+
+func newStorage(logger *zap.Logger, dataDir string, nodeID uint64) (*storage, bool, error) {
+	// load the latest snapshot
+	snapshotPath := path.Join(dataDir, fmt.Sprintf("snapshot_%d", nodeID))
+	if !fileutil.Exist(snapshotPath) {
+		err := os.MkdirAll(snapshotPath, 0o750)
+		if err != nil {
+			return nil, false, stacktrace.Propagate(err, "failed to create directory `%s`for snapshot storage", snapshotPath)
+		}
+	}
+
+	walPath := path.Join(dataDir, fmt.Sprintf("wal_%d", nodeID))
+
+	snapper := snap.New(logger, snapshotPath)
+	snapshot, err := loadSnapshot(logger, walPath, snapper)
+	if err != nil {
+		return nil, false, stacktrace.Propagate(err, "failed to load snapshot")
+	}
+
+	// load the wal entries
+	var w *wal.WAL
+	ok := wal.Exist(walPath)
+	if !ok {
+		err := os.MkdirAll(walPath, 0o750)
+		if err != nil {
+			return nil, false, stacktrace.Propagate(err, "failed to create directory `%s` for wal storage", walPath)
+		}
+
+		w, err := wal.Create(logger, walPath, nil)
+		if err != nil {
+			return nil, false, stacktrace.Propagate(err, "failed to create wal at %s", walPath)
+		}
+
+		err = w.Close()
+		if err != nil {
+			return nil, false, stacktrace.Propagate(err, "failed to close wal at %s", walPath)
+		}
+	}
+
+	// open the wal at the given snapshot and get all subsequent entries
+	w, err = wal.Open(logger, walPath, walpb.Snapshot{
+		Index:     snapshot.Metadata.Index,
+		Term:      snapshot.Metadata.Term,
+		ConfState: &snapshot.Metadata.ConfState,
+	})
+	if err != nil {
+		return nil, false, stacktrace.Propagate(err, "failed to open wal at %s with index %d, term %d and confstate %v", walPath, snapshot.Metadata.Index, snapshot.Metadata.Term, snapshot.Metadata.ConfState)
+	}
+
+	_, state, entries, err := w.ReadAll()
+	if err != nil {
+		return nil, false, stacktrace.Propagate(err, "failed to read wal state and entries")
+	}
+
+	// initialize the raft memory storage with the loaded snapshot and wal entries
+	raftMemoryStorage := raft.NewMemoryStorage()
+	if !raft.IsEmptySnap(*snapshot) {
+		err = raftMemoryStorage.ApplySnapshot(*snapshot)
+		if err != nil {
+			return nil, false, stacktrace.Propagate(err, "failed to apply snapshot to raft memory storage")
+		}
+	}
+
+	err = raftMemoryStorage.SetHardState(state)
+	if err != nil {
+		return nil, false, stacktrace.Propagate(err, "failed to set hard state to raft memory storage")
+	}
+
+	err = raftMemoryStorage.Append(entries)
+	if err != nil {
+		return nil, false, stacktrace.Propagate(err, "failed to append entries to raft memory storage")
+	}
+
+	logger.Info("Loaded previous hardstate and entries to Raft memory storage", zap.Any("hard-state", state), zap.Int("entries-number", len(entries)))
+
+	return &storage{
+		logger: logger,
+
+		MemoryStorage: raftMemoryStorage,
+
+		wal: w,
+
+		snapper:   snapper,
+		providers: make(map[string]snapshotProvider),
+	}, ok, nil
+}
+
+func loadSnapshot(logger *zap.Logger, walPath string, snapshotter *snap.Snapshotter) (*raftpb.Snapshot, error) {
+	if !wal.Exist(walPath) {
+		return &raftpb.Snapshot{}, nil
+	}
+
+	entries, err := wal.ValidSnapshotEntries(logger, walPath)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to get valid snapshot entries")
+	}
+
+	snapshot, err := snapshotter.LoadNewestAvailable(entries)
+	if err != nil {
+		if errors.Is(err, snap.ErrNoSnapshot) {
+			return &raftpb.Snapshot{}, nil
+		}
+
+		return nil, stacktrace.Propagate(err, "failed to load newest available snapshot")
+	}
+
+	logger.Info("Loaded snapshot", zap.Uint64("index", snapshot.Metadata.Index), zap.Uint64("term", snapshot.Metadata.Term))
+	return snapshot, nil
+}
+
+// save saves the given snapshot to the snapshotter and the wal.
+func (s *storage) save(snapshot raftpb.Snapshot) error {
+	err := s.snapper.SaveSnap(snapshot)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to save snapshot")
+	}
+
+	err = s.wal.SaveSnapshot(walpb.Snapshot{
+		Index:     snapshot.Metadata.Index,
+		Term:      snapshot.Metadata.Term,
+		ConfState: &snapshot.Metadata.ConfState,
+	})
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to save snapshot to wal")
+	}
+
+	return s.wal.ReleaseLockTo(snapshot.Metadata.Index)
+}
+
+func (s *storage) registerSnapshotProvider(name string, provider func() ([]byte, error)) {
+	s.providers[name] = provider
+}
+
+// getSnapshot calls all registered snapshot providers and combines their data into a single snapshot.
+func (s *storage) getSnapshot() ([]byte, error) {
+	parts := make(map[string][]byte)
+	for name, provider := range s.providers {
+		data, err := provider()
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "failed to get snapshot data from %q", name)
+		}
+
+		parts[name] = data
+	}
+
+	return json.Marshal(parts)
+}
+
+// snapshotter returns the snapshotter used by the storage.
+func (s *storage) snapshotter() *snap.Snapshotter {
+	return s.snapper
+}
+
+func (s *storage) triggerSnapshot(appliedIndex uint64, confState *raftpb.ConfState) error {
+	s.logger.Info("triggering snapshot", zap.Uint64("appliedIndex", appliedIndex))
+	data, err := s.getSnapshot()
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to get snapshot data")
+	}
+
+	snap, err := s.CreateSnapshot(appliedIndex, confState, data)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to create snapshot from raft memory storage")
+	}
+
+	err = s.save(snap)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to save snapshot")
+	}
+
+	compactIndex := uint64(1)
+	if appliedIndex > snapshotCatchUpEntriesN {
+		compactIndex = appliedIndex - snapshotCatchUpEntriesN
+	}
+
+	err = s.Compact(compactIndex)
+	if err != nil && !errors.Is(err, raft.ErrCompacted) {
+		return stacktrace.Propagate(err, "failed to compact raft memory storage at index %d", compactIndex)
+	}
+
+	return nil
+}
+
+func (s *storage) handleReceivedState(snapshot raftpb.Snapshot, hardState raftpb.HardState, entries []raftpb.Entry) error {
+	if !raft.IsEmptySnap(snapshot) {
+		err := s.save(snapshot)
+		if err != nil {
+			return stacktrace.Propagate(err, "failed to save snapshot")
+		}
+	}
+
+	err := s.wal.Save(hardState, entries)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to save WAL entries")
+	}
+
+	if !raft.IsEmptySnap(snapshot) {
+		err := s.ApplySnapshot(snapshot)
+		if err != nil {
+			return stacktrace.Propagate(err, "failed to apply snapshot")
+		}
+	}
+
+	if err := s.Append(entries); err != nil {
+		return stacktrace.Propagate(err, "failed to append entries to raft storage")
+	}
+
+	return nil
 }

--- a/pkg/raftstore/params/params.go
+++ b/pkg/raftstore/params/params.go
@@ -9,11 +9,14 @@ import (
 	"github.com/interuss/stacktrace"
 )
 
+const defaultDataDir = "raft_data"
+
 type (
 	// ConnectParameters bundles up parameters used for connecting nodes in a raftstore cluster.
 	ConnectParameters struct {
-		ID    uint64
-		Peers string
+		ID      uint64
+		Peers   string
+		DataDir string
 	}
 )
 
@@ -58,6 +61,7 @@ var (
 func init() {
 	flag.Uint64Var(&connectParameters.ID, "raft_node_id", 0, "raft node ID for this instance (must be non-zero and unique within the cluster)")
 	flag.StringVar(&connectParameters.Peers, "raft_peers", "", `comma-separated "nodeID=peerURL" pairs for all cluster members, including the current node, e.g. "1=http://node1:9021,2=http://node2:9021,3=http://node3:9021"`)
+	flag.StringVar(&connectParameters.DataDir, "raft_data_directory", defaultDataDir, "directory for raft data (snapshot and WAL storage)")
 }
 
 // GetConnectParameters returns a ConnectParameters instance that gets populated from well-known CLI flags.

--- a/pkg/raftstore/store.go
+++ b/pkg/raftstore/store.go
@@ -31,7 +31,7 @@ func Init[R any](logger *zap.Logger, newRepo func() R) (*Store[R], error) {
 			return
 		}
 
-		sharedConsensus, sharedConsensusErr = consensus.NewConsensus(logger, params.ID, peers)
+		sharedConsensus, sharedConsensusErr = consensus.NewConsensus(logger, params.ID, peers, params.DataDir)
 		if sharedConsensusErr != nil {
 			sharedConsensusErr = stacktrace.Propagate(sharedConsensusErr, "failed to initialize consensus")
 		}
@@ -39,6 +39,11 @@ func Init[R any](logger *zap.Logger, newRepo func() R) (*Store[R], error) {
 	if sharedConsensusErr != nil {
 		return nil, sharedConsensusErr
 	}
+
+	// TODO: implement
+	sharedConsensus.RegisterStore("provider", func() ([]byte, error) {
+		return nil, nil
+	})
 
 	return &Store[R]{
 		newRepo:   newRepo,


### PR DESCRIPTION
This PR is based on #1470. 
To keep it readable, it only contains part of the consensus logic with some stub functions to be implemented in a follow-up PR. 
It defines the default configuration for Raft with similar values as etcd (to be tuned later).
It also completes the initialization of consensus and the `handleReady()` goroutine. 