### PR TITLE
[terraform] Upgrade to kubernetes version 1.35

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/variables.gen.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/variables.gen.tf
@@ -134,12 +134,12 @@ variable "kubernetes_version" {
   description = <<-EOT
   Desired version of the Kubernetes cluster control plane and nodes.
 
-  Supported versions: 1.28 to 1.34
+  Supported versions: 1.28 to 1.35
   EOT
 
   validation {
-    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34"], var.kubernetes_version)
-    error_message = "Supported versions: 1.28 to 1.34"
+    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35"], var.kubernetes_version)
+    error_message = "Supported versions: 1.28 to 1.35"
   }
 }
 

--- a/deploy/infrastructure/dependencies/terraform-google-kubernetes/variables.gen.tf
+++ b/deploy/infrastructure/dependencies/terraform-google-kubernetes/variables.gen.tf
@@ -125,12 +125,12 @@ variable "kubernetes_version" {
   description = <<-EOT
   Desired version of the Kubernetes cluster control plane and nodes.
 
-  Supported versions: 1.28 to 1.34
+  Supported versions: 1.28 to 1.35
   EOT
 
   validation {
-    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34"], var.kubernetes_version)
-    error_message = "Supported versions: 1.28 to 1.34"
+    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35"], var.kubernetes_version)
+    error_message = "Supported versions: 1.28 to 1.35"
   }
 }
 

--- a/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
@@ -250,7 +250,7 @@ For docker hub private repository, use <code>docker.io</code> as <code>DOCKER_RE
             </tr><tr>
                 <td>kubernetes_version (<code>string</code>)</td>
                 <td><p>Desired version of the Kubernetes cluster control plane and nodes.</p>
-<p>Supported versions: 1.28 to 1.34</p>
+<p>Supported versions: 1.28 to 1.35</p>
 </td>
             </tr><tr>
                 <td>locality (<code>string</code>)</td>

--- a/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
@@ -134,12 +134,12 @@ variable "kubernetes_version" {
   description = <<-EOT
   Desired version of the Kubernetes cluster control plane and nodes.
 
-  Supported versions: 1.28 to 1.34
+  Supported versions: 1.28 to 1.35
   EOT
 
   validation {
-    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34"], var.kubernetes_version)
-    error_message = "Supported versions: 1.28 to 1.34"
+    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35"], var.kubernetes_version)
+    error_message = "Supported versions: 1.28 to 1.35"
   }
 }
 

--- a/deploy/infrastructure/modules/terraform-google-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-google-dss/TFVARS.gen.md
@@ -246,7 +246,7 @@ For docker hub private repository, use <code>docker.io</code> as <code>DOCKER_RE
             </tr><tr>
                 <td>kubernetes_version (<code>string</code>)</td>
                 <td><p>Desired version of the Kubernetes cluster control plane and nodes.</p>
-<p>Supported versions: 1.28 to 1.34</p>
+<p>Supported versions: 1.28 to 1.35</p>
 </td>
             </tr><tr>
                 <td>locality (<code>string</code>)</td>

--- a/deploy/infrastructure/modules/terraform-google-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-google-dss/variables.gen.tf
@@ -125,12 +125,12 @@ variable "kubernetes_version" {
   description = <<-EOT
   Desired version of the Kubernetes cluster control plane and nodes.
 
-  Supported versions: 1.28 to 1.34
+  Supported versions: 1.28 to 1.35
   EOT
 
   validation {
-    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34"], var.kubernetes_version)
-    error_message = "Supported versions: 1.28 to 1.34"
+    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35"], var.kubernetes_version)
+    error_message = "Supported versions: 1.28 to 1.35"
   }
 }
 

--- a/deploy/infrastructure/utils/definitions/kubernetes_version.tf
+++ b/deploy/infrastructure/utils/definitions/kubernetes_version.tf
@@ -3,11 +3,11 @@ variable "kubernetes_version" {
   description = <<-EOT
   Desired version of the Kubernetes cluster control plane and nodes.
 
-  Supported versions: 1.28 to 1.34
+  Supported versions: 1.28 to 1.35
   EOT
 
   validation {
-    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34"], var.kubernetes_version)
-    error_message = "Supported versions: 1.28 to 1.34"
+    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35"], var.kubernetes_version)
+    error_message = "Supported versions: 1.28 to 1.35"
   }
 }

--- a/deploy/operations/ci/aws-1/variables.gen.tf
+++ b/deploy/operations/ci/aws-1/variables.gen.tf
@@ -134,12 +134,12 @@ variable "kubernetes_version" {
   description = <<-EOT
   Desired version of the Kubernetes cluster control plane and nodes.
 
-  Supported versions: 1.28 to 1.34
+  Supported versions: 1.28 to 1.35
   EOT
 
   validation {
-    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34"], var.kubernetes_version)
-    error_message = "Supported versions: 1.28 to 1.34"
+    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35"], var.kubernetes_version)
+    error_message = "Supported versions: 1.28 to 1.35"
   }
 }
 

--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -99,7 +99,7 @@ CockroachDB requires to upgrade one minor version at a time, therefore the follo
 
 Migrations of GKE clusters are managed using terraform.
 
-#### 1.24 to 1.34
+#### 1.24 to 1.35
 
 For each intermediate version up to the target version (eg. if you upgrade from 1.27 to 1.30, apply thoses
 instructions for 1.28, 1.29, 1.30), do:
@@ -124,7 +124,7 @@ Before proceeding, always check on the cluster page the *Upgrade Insights* tab w
 availability of Kubernetes resources in each version. The following sections omit this check if no resource is
 expected to be reported in the context of a standard deployment performed with the tools in this repository.
 
-#### 1.25 to 1.34
+#### 1.25 to 1.35
 
 1. Before migrating to 1.29, upgrade aws-load-balancer-controller helm chart on your cluster using `terraform apply`. Changes introduced by [PR #1167](https://github.com/interuss/dss/pull/1167).
 You can verify if the operation has succeeded by running `helm list -n kube-system`. The APP VERSION shall be `2.12`.


### PR DESCRIPTION
Upgrade to kubernetes version 1.35.

Tested as usual with AWS/Helm GKE/Tanka cluster.