### PR TITLE
[tanka] Remove useless yugabyte hooks

### DIFF
--- a/deploy/services/tanka/yugabyte-auxiliary.libsonnet
+++ b/deploy/services/tanka/yugabyte-auxiliary.libsonnet
@@ -111,24 +111,6 @@ local yugabyteLB(metadata, name, ip) =
           ]
         }
       },
-      MasterHooks: base.ConfigMap(metadata, 'dss-dss-yugabyte-master-hooks') {
-        data: {
-          ['yb-master-%s-pre_debug_hook.sh' % id]: "echo 'hello-from-pre' "
-          for id in std.range(0, std.length(metadata.yugabyte.masterNodeIPs) - 1)
-        } + {
-          ['yb-master-%s-post_debug_hook.sh' % id]: "echo 'hello-from-post' "
-          for id in std.range(0, std.length(metadata.yugabyte.masterNodeIPs) - 1)
-        }
-      },
-      TServerHooks: base.ConfigMap(metadata, 'dss-dss-yugabyte-tserver-hooks') {
-        data: {
-          ['yb-tserver-%s-pre_debug_hook.sh' % id]: "echo 'hello-from-pre' "
-          for id in std.range(0, std.length(metadata.yugabyte.tserverNodeIPs) - 1)
-        } + {
-          ['yb-tserver-%s-post_debug_hook.sh' % id]: "echo 'hello-from-post' "
-          for id in std.range(0, std.length(metadata.yugabyte.tserverNodeIPs) - 1)
-        }
-      },
       masters: base.Service(metadata, 'yb-masters') {
         app:: 'yb-master',
         spec+: {

--- a/deploy/services/tanka/yugabyte.libsonnet
+++ b/deploy/services/tanka/yugabyte.libsonnet
@@ -62,12 +62,6 @@ local volumes = import 'volumes.libsonnet';
               podAntiAffinity: {},
             },
             volumes: [{
-              name: "debug-hooks-volume",
-              configMap: {
-                name: "dss-dss-yugabyte-master-hooks",
-                defaultMode: 493, # 0755
-              },
-            }, {
               name: "master-gflags",
               secret: {
                 secretName: "dss-dss-yugabyte-master-gflags",
@@ -230,9 +224,6 @@ local volumes = import 'volumes.libsonnet';
                   name: "master-gflags",
                   mountPath: "/opt/master/conf",
                 }, {
-                  name: "debug-hooks-volume",
-                  mountPath: "/opt/debug_hooks_config",
-                }, {
                   name: "datadir0",
                   mountPath: "/mnt/disk0",
                 }, {
@@ -389,12 +380,6 @@ local volumes = import 'volumes.libsonnet';
               podAntiAffinity: {},
             },
             volumes: [{
-              name: "debug-hooks-volume",
-              configMap: {
-                name: "dss-dss-yugabyte-tserver-hooks",
-                defaultMode: 493, # 0755
-              },
-            }, {
               name: "tserver-gflags",
               secret: {
                 secretName: "dss-dss-yugabyte-tserver-gflags",
@@ -597,9 +582,6 @@ local volumes = import 'volumes.libsonnet';
                 }, {
                   name: "tserver-gflags",
                   mountPath: "/opt/tserver/conf",
-                }, {
-                  name: "debug-hooks-volume",
-                  mountPath: "/opt/debug_hooks_config",
                 }, {
                   name: "datadir0",
                   mountPath: "/mnt/disk0",


### PR DESCRIPTION
Simply states by removing useless debug hooks from yugabyte.

Tested in usual AWS/GKE deployment.