### PR TITLE
[helm/tanka] Normalize wait container for schema, jobs and core-service

### DIFF
--- a/deploy/services/helm-charts/dss/templates/dss-evict.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-evict.yaml
@@ -1,7 +1,17 @@
 {{- $image := .Values.dss.image }}
+
+{{- $datastoreImage := (include "datastoreImage" .) -}}
 {{- $datastoreHost := (include "datastoreHost" .) -}}
 {{- $datastorePort := (include "datastorePort" .) -}}
 {{- $datastoreUser := (include "datastoreUser" .) -}}
+
+{{- $waitForDatastore := include "init-container-wait-for-http" (dict "serviceName" "cockroachdb" "url" (printf "http://%s:8080/health" $datastoreHost)) -}}
+{{- if .Values.yugabyte.enabled }}
+{{- $waitForDatastore = include "init-container-wait-for-http" (dict "serviceName" "yb-tserver" "url" (printf "http://%s:9000/status" $datastoreHost)) -}}
+{{- end -}}
+
+{{- $waitForRIDSchema := include "init-container-wait-for-schema" (dict "schemaName" "rid" "datastoreImage" $datastoreImage "datastorePort" $datastorePort "datastoreHost" $datastoreHost "cockroachdbEnabled" .Values.cockroachdb.enabled ) -}}
+{{- $waitForSCDSchema := include "init-container-wait-for-schema" (dict "schemaName" "scd" "datastoreImage" $datastoreImage "datastorePort" $datastorePort "datastoreHost" $datastoreHost "cockroachdbEnabled" .Values.cockroachdb.enabled ) -}}
 
 ---
 apiVersion: batch/v1
@@ -19,6 +29,9 @@ spec:
     spec:
       template:
         spec:
+          initContainers:
+            {{- $waitForDatastore | nindent 12 }}
+            {{- $waitForSCDSchema | nindent 12 }}
           containers:
             - args:
                 - --scd_oir={{ $.Values.dss.conf.evict.scd.operationalIntents }}
@@ -71,6 +84,9 @@ spec:
     spec:
       template:
         spec:
+          initContainers:
+            {{- $waitForDatastore | nindent 12 }}
+            {{- $waitForRIDSchema | nindent 12 }}
           containers:
             - args:
                 - --scd_oir=false

--- a/deploy/services/tanka/base.libsonnet
+++ b/deploy/services/tanka/base.libsonnet
@@ -1,4 +1,5 @@
 local util = import 'util.libsonnet';
+local volumes = import 'volumes.libsonnet';
 
 {
   _Object(apiVersion, kind, metadata, name):: {
@@ -286,5 +287,30 @@ local util = import 'util.libsonnet';
   },
 
   Secret(metadata, name): $._Object('v1', 'Secret', metadata, name) {
+  },
+
+  WaitForDatastore(metadata): {
+    name: "wait-for-datastore",
+    image: "alpine:3.17.3",
+    command: [
+      'sh',
+      '-c',
+      if metadata.datastore == "cockroachdb" then
+        "until wget -nv http://cockroachdb-balanced." + metadata.namespace + ":8080/health; do echo waiting for datastore; sleep 2; done" else
+        "until wget -nv http://yb-tservers." + metadata.namespace + ":9000/status; do echo waiting for datastore; sleep 2; done"
+    ]
+  },
+
+  WaitForSchema(metadata, table): {
+    name: "wait-for-schema-" + table,
+    image: if metadata.datastore == "cockroachdb" then metadata.cockroach.image else metadata.yugabyte.image,
+    command: [
+      'sh',
+      '-c',
+      if metadata.datastore == "cockroachdb" then
+        "/cockroach/cockroach sql --certs-dir /cockroach/cockroach-certs/ --host cockroachdb-balanced." + metadata.namespace + " --port \"" + metadata.cockroach.grpc_port + "\" --format raw -e \"SELECT * FROM crdb_internal.databases where name = '" + table + "';\" | grep " + table else
+        "ysqlsh --host yb-tservers." + metadata.namespace + " --port \"5433\" \"sslmode=require sslcert=/opt/yugabyte-certs/client.yugabyte.crt sslkey=/opt/yugabyte-certs/client.yugabyte.key sslrootcert=/opt/yugabyte-certs/ca.crt\" -c \"SELECT datname FROM pg_database where datname = '" + table + "';\" | grep " + table
+    ],
+    volumeMounts: volumes.all(metadata).backendMounts,
   },
 }

--- a/deploy/services/tanka/core-service.libsonnet
+++ b/deploy/services/tanka/core-service.libsonnet
@@ -91,6 +91,11 @@ local awsLoadBalancer(metadata) = base.AWSLoadBalancerWithManagedCert(metadata, 
         template+: {
           spec+: {
             volumes: volumes.all(metadata).backendVolumes,
+            initContainers: [
+              base.WaitForDatastore(metadata),
+              base.WaitForSchema(metadata, "rid"),
+              base.WaitForSchema(metadata, "scd"),
+            ],
             soloContainer:: base.Container('core-service') {
               image: metadata.backend.image,
               imagePullPolicy: if metadata.cloud_provider == "minikube" then 'IfNotPresent' else 'Always',

--- a/deploy/services/tanka/evict.libsonnet
+++ b/deploy/services/tanka/evict.libsonnet
@@ -13,8 +13,12 @@ local datastoreparameters = import 'datastoreparameters.libsonnet';
           spec: {
             template: {
               spec: {
-                volumes: volumes.all(metadata).schemaVolumes,
+                volumes: volumes.all(metadata).backendVolumes,
                 restartPolicy: "Never",
+                initContainers: [
+                  base.WaitForDatastore(metadata),
+                  base.WaitForSchema(metadata, "scd"),
+                ],
                 containers: [base.Container('dss-scd-evict') {
                   image: metadata.schema_manager.image,
                   imagePullPolicy: if metadata.cloud_provider == "minikube" then 'IfNotPresent' else 'Always',
@@ -27,7 +31,7 @@ local datastoreparameters = import 'datastoreparameters.libsonnet';
                       scd_ttl: metadata.evict.scd.ttl,
                       locality: metadata.locality,
                   } + datastoreparameters.all(metadata),
-                  volumeMounts: volumes.all(metadata).schemaMounts,
+                  volumeMounts: volumes.all(metadata).backendMounts,
                 }],
               },
             },
@@ -44,8 +48,12 @@ local datastoreparameters = import 'datastoreparameters.libsonnet';
           spec: {
             template: {
               spec: {
-                volumes: volumes.all(metadata).schemaVolumes,
+                volumes: volumes.all(metadata).backendVolumes,
                 restartPolicy: "Never",
+                initContainers: [
+                  base.WaitForDatastore(metadata),
+                  base.WaitForSchema(metadata, "rid"),
+                ],
                 containers: [base.Container('dss-rid-evict') {
                   image: metadata.schema_manager.image,
                   imagePullPolicy: if metadata.cloud_provider == "minikube" then 'IfNotPresent' else 'Always',
@@ -58,7 +66,7 @@ local datastoreparameters = import 'datastoreparameters.libsonnet';
                       rid_ttl: metadata.evict.rid.ttl,
                       locality: metadata.locality,
                   } + datastoreparameters.all(metadata),
-                  volumeMounts: volumes.all(metadata).schemaMounts,
+                  volumeMounts: volumes.all(metadata).backendMounts,
                 }],
               },
             },

--- a/deploy/services/tanka/schema-manager.libsonnet
+++ b/deploy/services/tanka/schema-manager.libsonnet
@@ -11,6 +11,9 @@ local datastoreparameters = import 'datastoreparameters.libsonnet';
         template+: {
           spec+: {
             volumes: volumes.all(metadata).schemaVolumes,
+            initContainers: [
+              base.WaitForDatastore(metadata),
+            ],
             soloContainer:: base.Container('rid-schema-manager') {
               image: metadata.schema_manager.image,
               imagePullPolicy: if metadata.cloud_provider == "minikube" then 'IfNotPresent' else 'Always',
@@ -30,6 +33,9 @@ local datastoreparameters = import 'datastoreparameters.libsonnet';
         template+: {
           spec+: {
             volumes: volumes.all(metadata).schemaVolumes,
+            initContainers: [
+              base.WaitForDatastore(metadata),
+            ],
             soloContainer:: base.Container('scd-schema-manager') {
               image: metadata.schema_manager.image,
               imagePullPolicy: if metadata.cloud_provider == "minikube" then 'IfNotPresent' else 'Always',
@@ -49,6 +55,9 @@ local datastoreparameters = import 'datastoreparameters.libsonnet';
         template+: {
           spec+: {
             volumes: volumes.all(metadata).schemaVolumes,
+            initContainers: [
+              base.WaitForDatastore(metadata),
+            ],
             soloContainer:: base.Container('aux-schema-manager') {
               image: metadata.schema_manager.image,
               imagePullPolicy: if metadata.cloud_provider == "minikube" then 'IfNotPresent' else 'Always',


### PR DESCRIPTION
This PR normalize initcontainer / waiting scripts for all schema, jobs, core-service, across helm and tanka.

Before that, support was partial and generated useless error / restart / job failures. This improve the overall situation, even if some edge cases still exists (e.g. tables present, but schema not ready, leading to 1 restart/error.)

Tested in AKS/GKE Helm-Tanka Yugabyte & CRDB setup.