### PR TITLE
[fix] Add missing locality arg to dss-rid-evict Tanka config

### DIFF
--- a/deploy/services/tanka/evict.libsonnet
+++ b/deploy/services/tanka/evict.libsonnet
@@ -55,6 +55,7 @@ local datastoreparameters = import 'datastoreparameters.libsonnet';
                       rid_isa: metadata.evict.rid.ISAs,
                       rid_sub: metadata.evict.rid.subscriptions,
                       rid_ttl: metadata.evict.rid.ttl,
+                      locality: metadata.locality,
                   } + datastoreparameters.all(metadata),
                   volumeMounts: volumes.all(metadata).schemaMounts,
                 }],


### PR DESCRIPTION
## Problem
The `dss-rid-evict` cron job fails to clean up RID entities despite them existing. It logs "no RID entity older than ..." because `ListExpiredISAs` and `ListExpiredSubscriptions` in `evict.go` (lines 110, 128) filter by `--locality`, which defaults to `""` when not passed  matching nothing.

## Fix
Added `locality: metadata.locality` to the `RIDEvict` args_ block in `evict.libsonnet`, mirroring how `core-service.libsonnet:113` already passes it.

## Verification
- `make evaluate-tanka` (CI) will confirm `--locality` now appears in the   rendered `dss-rid-evict` CronJob manifest
- `make evict-locally` (CI) will confirm end-to-end eviction works

Fixes #1476
