### PR TITLE
[terraform] Add option to make GKE cluster deletable

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-google-kubernetes/cluster.tf
+++ b/deploy/infrastructure/dependencies/terraform-google-kubernetes/cluster.tf
@@ -14,6 +14,8 @@ resource "google_container_cluster" "kubernetes_cluster" {
 
   min_master_version = var.kubernetes_version
 
+  deletion_protection = var.google_delete_protection
+
 }
 
 resource "google_container_node_pool" "dss_pool" {

--- a/deploy/infrastructure/dependencies/terraform-google-kubernetes/variables.gen.tf
+++ b/deploy/infrastructure/dependencies/terraform-google-kubernetes/variables.gen.tf
@@ -44,6 +44,17 @@ variable "google_machine_type" {
 }
 
 
+variable "google_delete_protection" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  Setting this to false make the GKE cluster deletable. Use with caution as this removes deletion protection.
+  This setting should only be used to ease the management of test clusters.
+
+  EOT
+}
+
+
 variable "app_hostname" {
   type        = string
   description = <<-EOT

--- a/deploy/infrastructure/modules/terraform-google-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-google-dss/TFVARS.gen.md
@@ -180,6 +180,11 @@ Use <code>latest</code> to use the latest schema version.</p>
                 <td><p>How long expired SCD items should stay before being automatically removed; expressed in Go duration format (https://pkg.go.dev/time#ParseDuration).</p>
 <br/>Default value: <code>"2688h"</code></td>
             </tr><tr>
+                <td>google_delete_protection (<code>bool</code>)</td>
+                <td><p>Setting this to false make the GKE cluster deletable. Use with caution as this removes deletion protection.
+This setting should only be used to ease the management of test clusters.</p>
+<br/>Default value: <code>true</code></td>
+            </tr><tr>
                 <td>google_dns_managed_zone_name (<code>string</code>)</td>
                 <td><p>GCP DNS zone name to automatically manage DNS entries.</p>
 <p>Leave it empty to manage it manually.</p>

--- a/deploy/infrastructure/modules/terraform-google-dss/main.tf
+++ b/deploy/infrastructure/modules/terraform-google-dss/main.tf
@@ -8,6 +8,7 @@ module "terraform-google-kubernetes" {
   datastore_type               = var.datastore_type
   google_dns_managed_zone_name = var.google_dns_managed_zone_name
   google_machine_type          = var.google_machine_type
+  google_delete_protection     = var.google_delete_protection
   node_count                   = var.node_count
   kubernetes_version           = var.kubernetes_version
   prometheus_hostname          = var.prometheus_hostname

--- a/deploy/infrastructure/modules/terraform-google-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-google-dss/variables.gen.tf
@@ -44,6 +44,17 @@ variable "google_machine_type" {
 }
 
 
+variable "google_delete_protection" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  Setting this to false make the GKE cluster deletable. Use with caution as this removes deletion protection.
+  This setting should only be used to ease the management of test clusters.
+
+  EOT
+}
+
+
 variable "app_hostname" {
   type        = string
   description = <<-EOT

--- a/deploy/infrastructure/utils/definitions/google_delete_protection.tf
+++ b/deploy/infrastructure/utils/definitions/google_delete_protection.tf
@@ -1,0 +1,9 @@
+variable "google_delete_protection" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  Setting this to false make the GKE cluster deletable. Use with caution as this removes deletion protection.
+  This setting should only be used to ease the management of test clusters.
+
+  EOT
+}

--- a/deploy/infrastructure/utils/variables.py
+++ b/deploy/infrastructure/utils/variables.py
@@ -77,6 +77,7 @@ GOOGLE_KUBERNETES_VARIABLES = [
     "google_zone",
     "google_dns_managed_zone_name",
     "google_machine_type",
+    "google_delete_protection",
 ] + COMMON_KUBERNETES_VARIABLES
 
 # modules/terraform-google-dss


### PR DESCRIPTION
Add an option to ease debugging of google cluster by making them deletable directly from terraform.