### PR TITLE
[deploy] Add enable_metric flag for DSS + fetch pod metrics in prometheus

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-commons-dss/helm.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/helm.tf
@@ -68,6 +68,7 @@ resource "local_file" "helm_chart_values" {
         publicEndpoint      = "https://${var.app_hostname}"
         enableScd           = var.enable_scd
         enableScdGlobalLock = var.enable_scd_global_lock
+        enableDssMetrics    = var.enable_dss_metrics
         locality            = "zone=${var.locality}"
 
         evict = {
@@ -274,6 +275,7 @@ resource "local_file" "helm_chart_values" {
         publicEndpoint      = "https://${var.app_hostname}"
         enableScd           = var.enable_scd
         enableScdGlobalLock = var.enable_scd_global_lock
+        enableDssMetrics    = var.enable_dss_metrics
         locality            = "zone=${var.locality}"
 
         evict = {

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/tanka.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/tanka.tf
@@ -9,6 +9,7 @@ resource "local_file" "tanka_config_main" {
     VAR_CLUSTER_CONTEXT                      = var.kubernetes_context_name
     VAR_ENABLE_SCD                           = var.enable_scd
     VAR_ENABLE_SCD_GLOBAL_LOCK               = var.enable_scd_global_lock
+    VAR_ENABLE_DSS_METRICS                   = var.enable_dss_metrics
     VAR_DB_HOSTNAME_SUFFIX                   = var.db_hostname_suffix
     VAR_LOCALITY                             = var.locality
     VAR_DATASTORE                            = var.datastore_type

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
@@ -12,6 +12,7 @@ local metadata = metadataBase {
   single_cluster: false,
   enableScd: ${VAR_ENABLE_SCD}, // <-- This boolean value is VAR_ENABLE_SCD
   enableScdGlobalLock: ${VAR_ENABLE_SCD_GLOBAL_LOCK}, // <-- This boolean value is VAR_ENABLE_SCD_GLOBAL_LOCK
+  enableDssMetrics: ${VAR_ENABLE_DSS_METRICS}, // <-- This boolean value is VAR_ENABLE_DSS_METRICS
   datastore: '${VAR_DATASTORE}',
   locality: '${VAR_LOCALITY}',
   cockroach+: {

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/variables.gen.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/variables.gen.tf
@@ -488,3 +488,16 @@ variable "enable_monitoring" {
 }
 
 
+variable "enable_dss_metrics" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  Enable DSS's prometheus metric.
+
+  Require DSS version to be at least 0.23.0.
+
+  Example: `true`
+  EOT
+}
+
+

--- a/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
@@ -165,6 +165,12 @@ Use <code>latest</code> to use the latest schema version.</p>
 <p>Example: <code>3.1.0</code></p>
 <br/>Default value: <code>"latest"</code></td>
             </tr><tr>
+                <td>enable_dss_metrics (<code>bool</code>)</td>
+                <td><p>Enable DSS's prometheus metric.</p>
+<p>Require DSS version to be at least 0.23.0.</p>
+<p>Example: <code>true</code></p>
+<br/>Default value: <code>false</code></td>
+            </tr><tr>
                 <td>enable_monitoring (<code>bool</code>)</td>
                 <td><p>Set to true to enable monitoring stack with prometheus / grafana.</p>
 <p>Example: <code>true</code></p>

--- a/deploy/infrastructure/modules/terraform-aws-dss/main.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/main.tf
@@ -60,6 +60,7 @@ module "terraform-commons-dss" {
   enable_monitoring                = var.enable_monitoring
   enable_scd                       = var.enable_scd
   enable_scd_global_lock           = var.enable_scd_global_lock
+  enable_dss_metrics               = var.enable_dss_metrics
   prometheus_hostname              = var.prometheus_hostname
   ip_prometheus                    = module.terraform-aws-kubernetes.ip_prometheus
 

--- a/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
@@ -602,3 +602,16 @@ variable "enable_monitoring" {
 }
 
 
+variable "enable_dss_metrics" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  Enable DSS's prometheus metric.
+
+  Require DSS version to be at least 0.23.0.
+
+  Example: `true`
+  EOT
+}
+
+

--- a/deploy/infrastructure/modules/terraform-google-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-google-dss/TFVARS.gen.md
@@ -127,6 +127,12 @@ Use <code>latest</code> to use the latest schema version.</p>
 <p>Example: <code>3.1.0</code></p>
 <br/>Default value: <code>"latest"</code></td>
             </tr><tr>
+                <td>enable_dss_metrics (<code>bool</code>)</td>
+                <td><p>Enable DSS's prometheus metric.</p>
+<p>Require DSS version to be at least 0.23.0.</p>
+<p>Example: <code>true</code></p>
+<br/>Default value: <code>false</code></td>
+            </tr><tr>
                 <td>enable_monitoring (<code>bool</code>)</td>
                 <td><p>Set to true to enable monitoring stack with prometheus / grafana.</p>
 <p>Example: <code>true</code></p>

--- a/deploy/infrastructure/modules/terraform-google-dss/main.tf
+++ b/deploy/infrastructure/modules/terraform-google-dss/main.tf
@@ -60,6 +60,7 @@ module "terraform-commons-dss" {
   enable_monitoring                = var.enable_monitoring
   enable_scd                       = var.enable_scd
   enable_scd_global_lock           = var.enable_scd_global_lock
+  enable_dss_metrics               = var.enable_dss_metrics
   prometheus_hostname              = var.prometheus_hostname
   ip_prometheus                    = module.terraform-google-kubernetes.ip_prometheus
 

--- a/deploy/infrastructure/modules/terraform-google-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-google-dss/variables.gen.tf
@@ -604,3 +604,16 @@ variable "enable_monitoring" {
 }
 
 
+variable "enable_dss_metrics" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  Enable DSS's prometheus metric.
+
+  Require DSS version to be at least 0.23.0.
+
+  Example: `true`
+  EOT
+}
+
+

--- a/deploy/infrastructure/utils/definitions/enable_dss_metrics.tf
+++ b/deploy/infrastructure/utils/definitions/enable_dss_metrics.tf
@@ -1,0 +1,11 @@
+variable "enable_dss_metrics" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  Enable DSS's prometheus metric.
+
+  Require DSS version to be at least 0.23.0.
+
+  Example: `true`
+  EOT
+}

--- a/deploy/infrastructure/utils/variables.py
+++ b/deploy/infrastructure/utils/variables.py
@@ -64,6 +64,7 @@ COMMONS_DSS_VARIABLES = GLOBAL_VARIABLES + [
     "evict_rid_isas",
     "evict_rid_subscriptions",
     "enable_monitoring",
+    "enable_dss_metrics",
 ]
 
 # dependencies/terraform-*-kubernetes

--- a/deploy/operations/ci/aws-1/variables.gen.tf
+++ b/deploy/operations/ci/aws-1/variables.gen.tf
@@ -602,3 +602,16 @@ variable "enable_monitoring" {
 }
 
 
+variable "enable_dss_metrics" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  Enable DSS's prometheus metric.
+
+  Require DSS version to be at least 0.23.0.
+
+  Example: `true`
+  EOT
+}
+
+

--- a/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
@@ -35,6 +35,12 @@ spec:
     metadata:
       labels:
         app: {{.Release.Name}}-core-service
+{{ if $dss.conf.enableDssMetrics }}
+      annotations:
+        prometheus.io/path: metrics
+        prometheus.io/port: '8079'
+        prometheus.io/scrape: 'true'
+{{ end }}
     spec:
       initContainers:
         {{- $waitForDatastore | nindent 8 }}
@@ -61,6 +67,9 @@ spec:
             - --dump_requests=true
             - --enable_scd={{$dss.conf.enableScd}}
             - --enable_scd_global_lock={{$dss.conf.enableScdGlobalLock | default false}}
+{{ if $dss.conf.enableDssMetrics }}
+            - --enable_metrics=true
+{{ end }}
             - --gcp_prof_service_name=
             {{- if $dss.conf.jwksEndpoint }}
             - --jwks_endpoint={{ $dss.conf.jwksEndpoint }}
@@ -79,6 +88,10 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+{{ if $dss.conf.enableDssMetrics }}
+            - containerPort: 8079
+              name: metrics
+{{ end }}
           readinessProbe:
             httpGet:
               path: /healthy

--- a/deploy/services/helm-charts/dss/values.example.yaml
+++ b/deploy/services/helm-charts/dss/values.example.yaml
@@ -13,6 +13,7 @@ dss:
     publicEndpoint: https://dss.example.com
     enableScd: true
     enableScdGlobalLock: false
+    enableDssMetrics: false
     locality: zone=interuss-example-google-ew1
 
 cockroachdb:

--- a/deploy/services/helm-charts/dss/values.schema.json
+++ b/deploy/services/helm-charts/dss/values.schema.json
@@ -266,6 +266,9 @@
             "enableScdGlobalLock": {
               "type": "boolean"
             },
+            "enableDssMetrics": {
+              "type": "boolean"
+            },
             "hostname": {
               "type": "string",
               "description": "Public hostname of the dss. Example: dss.example.com"

--- a/deploy/services/helm-charts/dss/values.yaml
+++ b/deploy/services/helm-charts/dss/values.yaml
@@ -225,6 +225,41 @@ prometheus:
             target_label: __name__
           kubernetes_sd_configs:
           - role: endpoints
+        - job_name: K8s-Pods
+          kubernetes_sd_configs:
+          - role: pod
+          tls_config:
+            insecure_skip_verify: true
+          relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            separator: ;
+            regex: "true"
+            replacement: $1
+            action: keep
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            separator: ;
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: $1
+            action: replace
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            separator: ;
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            target_label: __address__
+            replacement: $1:$2
+            action: replace
+          - source_labels: [__meta_kubernetes_namespace]
+            separator: ;
+            regex: (.*)
+            target_label: kubernetes_namespace
+            replacement: $1
+            action: replace
+          - source_labels: [__meta_kubernetes_pod_name]
+            separator: ;
+            regex: (.*)
+            target_label: pod_name
+            replacement: $1
+            action: replace
 
     recording_rules.yml:
       "groups":

--- a/deploy/services/tanka/core-service.libsonnet
+++ b/deploy/services/tanka/core-service.libsonnet
@@ -89,6 +89,13 @@ local awsLoadBalancer(metadata) = base.AWSLoadBalancerWithManagedCert(metadata, 
       },
       spec+: {
         template+: {
+          metadata+: if metadata.enableDssMetrics then {
+            annotations: {
+              'prometheus.io/path': 'metrics',
+              'prometheus.io/port': '8079',
+              'prometheus.io/scrape': 'true',
+            }
+          } else {},
           spec+: {
             volumes: volumes.all(metadata).backendVolumes,
             initContainers: [
@@ -104,7 +111,12 @@ local awsLoadBalancer(metadata) = base.AWSLoadBalancerWithManagedCert(metadata, 
                   containerPort: metadata.backend.port,
                   name: 'http',
                 },
-              ],
+              ] + if metadata.enableDssMetrics then [
+                {
+                  containerPort: 8079,
+                  name: 'metrics',
+                },
+              ] else [],
               volumeMounts: volumes.all(metadata).backendMounts,
               command: ['core-service'],
               args_:: {
@@ -119,9 +131,11 @@ local awsLoadBalancer(metadata) = base.AWSLoadBalancerWithManagedCert(metadata, 
                 enable_scd: metadata.enableScd,
                 enable_scd_global_lock: metadata.enableScdGlobalLock,
               } + datastoreparameters.all(metadata)
-              + if metadata.backend.publicEndpoint != '' then {
+              + (if metadata.backend.publicEndpoint != '' then {
                 public_endpoint: metadata.backend.publicEndpoint,
-              } else {},
+              } else {}) + (if metadata.enableDssMetrics then {
+                enable_metrics: true,
+              } else {}),
               readinessProbe: {
                 httpGet: {
                   path: '/healthy',

--- a/deploy/services/tanka/examples/minikube/main.jsonnet
+++ b/deploy/services/tanka/examples/minikube/main.jsonnet
@@ -10,6 +10,7 @@ local metadata = metadataBase {
   single_cluster: true,
   enableScd: true,
   enableScdGlobalLock: false,
+  enableDssMetrics: false,
   datastore: 'yugabyte',
   locality: 'minikube',
   cockroach+: {

--- a/deploy/services/tanka/examples/minimum/main.jsonnet
+++ b/deploy/services/tanka/examples/minimum/main.jsonnet
@@ -12,6 +12,7 @@ local metadata = metadataBase {
   single_cluster: false,
   enableScd: false, // <-- This boolean value is VAR_ENABLE_SCD
   enableScdGlobalLock: false, // <-- This boolean value is VAR_ENABLE_SCD_GLOBAL_LOCK
+  enableDssMetrics: false, // <-- This boolean value is VAR_ENABLE_DSS_METRICS
   datastore: 'VAR_DATASTORE',
   locality: 'VAR_LOCALITY',
   cockroach+: {

--- a/deploy/services/tanka/metadata_base.libsonnet
+++ b/deploy/services/tanka/metadata_base.libsonnet
@@ -9,6 +9,7 @@
   single_cluster: false,
   enableScd: false,
   enableScdGlobalLock: false,
+  enableDssMetrics: false,
   datastore: 'cockroachdb',
   locality: error 'must supply locality',
   cockroach: {

--- a/deploy/services/tanka/prometheus_configs/scrape-configs.libsonnet
+++ b/deploy/services/tanka/prometheus_configs/scrape-configs.libsonnet
@@ -187,5 +187,42 @@
         insecure_skip_verify: true,
       },
     },
+    {
+      job_name: 'K8s-Pods',
+      kubernetes_sd_configs: [{ role: 'pod' }],
+      relabel_configs: [
+        {
+          source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_scrape'],
+          action: 'keep',
+          regex: true,
+        },
+        {
+          source_labels: ['__meta_kubernetes_pod_annotation_prometheus_io_path'],
+          action: 'replace',
+          target_label: '__metrics_path__',
+          regex: '(.+)',
+        },
+        {
+          source_labels: ['__address__', '__meta_kubernetes_pod_annotation_prometheus_io_port'],
+          action: 'replace',
+          target_label: '__address__',
+          regex: '([^:]+)(?::\\d+)?;(\\d+)',
+          replacement: '$1:$2',
+        },
+        {
+          source_labels: ['__meta_kubernetes_namespace'],
+          action: 'replace',
+          target_label: 'kubernetes_namespace',
+        },
+        {
+          source_labels: ['__meta_kubernetes_pod_name'],
+          action: 'replace',
+          target_label: 'pod_name',
+        },
+      ],
+      tls_config: {
+        insecure_skip_verify: true,
+      },
+    },
   ],
 }

--- a/docs/infrastructure/google-manual.md
+++ b/docs/infrastructure/google-manual.md
@@ -214,6 +214,9 @@ your chosen provider.
         e global throughput but improve throughput with lot of subscriptions in
         the same areas.
 
+    1.  `VAR_ENABLE_DSS_METRICS`: Set this boolean true to enable
+        prometheus-compatible metric endpoint.
+
     1.  `VAR_LOCALITY`: Unique name for your DSS instance.  Currently, we
         recommend "<ORG_NAME>_<CLUSTER_NAME>", and the `=` character is not
         allowed.  However, any unique (among all other participating DSS

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -18,6 +18,8 @@ This can be enabled via:
 - The `monitoring.enabled` option in helm
 - By using tanka, which always enables it
 
+By default, DSS metrics are not enabled; see below, OpenTelemetry section, to activate them.
+
 ### Grafana access
 
 To access the Grafana interface, first ensure that the appropriate
@@ -153,6 +155,9 @@ Point any Prometheus server to the endpoint (by default on port 8079).
 You can use the `--metrics_addr` flag to change the listening port and address.
 
 No dashboard has been created yet, but one is planned.
+
+You can use the `enable_dss_metrics` option in Terraform, `dss.conf.enableDssMetrics` in Helm, or `enableDssMetrics` in Tanka to activate it when using these.
+This will also automatically enable collection by Prometheus if used.
 
 ### Tracing
 


### PR DESCRIPTION
This PR add the `enable_metric` flag in general deploy stack (terraform, helm, tanka).

It set the flag + add annotation for prometheus collection.
Promethus pod collection (instead of just services) as been enabled, as each DSS instance own metrics need to be collected, not as a whole for a service (e.g.: http metrics are individual).

Follow #1505 