### PR TITLE
[interfaces] Remove invalid default value in aux API

### DIFF
--- a/interfaces/aux_/aux_.yaml
+++ b/interfaces/aux_/aux_.yaml
@@ -82,7 +82,6 @@ components:
           type: string
           format: date-time
           example: '1985-04-12T23:45:00Z'
-          default: ''
       required:
       - timestamp
       - source


### PR DESCRIPTION
The presence of this default value causes the auto-conversion of this API into Python in uas_standards to produce an unusable object; this PR intends to fix that problem.