### PR TITLE
[core] Use better timeout handler and log timeouts

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -335,9 +335,9 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 
 	// the middlewares are wrapped and, therefore, executed in the opposite order
 	handler := healthyEndpointMiddleware(logger, &multiRouter)
-	handler = logging.HTTPMiddleware(logger, *dumpRequests, handler)
 	handler = authorizer.TokenMiddleware(handler)
-	handler = timeoutMiddleware(*timeout, handler)
+	handler = http.TimeoutHandler(handler, *timeout, "request timeout")
+	handler = logging.HTTPMiddleware(logger, *dumpRequests, handler)
 
 	if *enableOpenTelemetry {
 		// We use the default settings; the APIRouter handler will override the span value accordingly, as it has more information.
@@ -401,18 +401,6 @@ func healthyEndpointMiddleware(logger *zap.Logger, next http.Handler) http.Handl
 		} else {
 			next.ServeHTTP(w, r)
 		}
-	})
-}
-
-func timeoutMiddleware(timeout time.Duration, next http.Handler) http.Handler {
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(r.Context(), timeout)
-		defer cancel()
-
-		r = r.WithContext(ctx)
-
-		next.ServeHTTP(w, r)
 	})
 }
 

--- a/pkg/logging/http.go
+++ b/pkg/logging/http.go
@@ -113,6 +113,7 @@ func HTTPMiddleware(logger *zap.Logger, dump bool, handler http.Handler) http.Ha
 			zap.String("peer_address", r.RemoteAddr),
 			zap.Time("start_time", start),
 			zap.Duration("duration", time.Since(start)),
+			zap.NamedError("ctx_err", r.Context().Err()),
 		)
 	})
 }


### PR DESCRIPTION
This PR does do things:

- It use timeout handler from library ensuring timeout is applied in all conditions (e.g. for things not relying on context like a time.sleep)
- It move logging handler before timeout handler to logs timeout
- It add `ctx_err` in logging, to add more information about why a error occured.

This will now log:

Client timeout:

```
local-dss-core-service-1      | 2026-06-09T08:51:36.507Z        info    logging/http.go:108     GET /aux/v1/version HTTP/1.1    {"address": ":8082", "req_dump": "", "resp_dump": "", "req_headers": {"Accept":["*/*"],"User-Agent":["curl/8.20.0"]}, "resp_status_code": 503, "resp_status_text": "Service Unavailable", "peer_address": "172.18.0.1:49040", "start_time": "2026-06-09T08:51:36.007Z", "duration": "500.58864ms", "ctx_err": "context canceled"}
```

Server timeout:

```
local-dss-core-service-1      | 2026-06-09T08:51:26.229Z        info    logging/http.go:108     GET /aux/v1/version HTTP/1.1    {"address": ":8082", "req_dump": "", "resp_dump": "request timeout", "req_headers": {"Accept":["*/*"],"User-Agent":["curl/8.20.0"]}, "resp_status_code": 503, "resp_status_text": "Service Unavailable", "peer_address": "172.18.0.1:46320", "start_time": "2026-06-09T08:51:25.229Z", "duration": "1.000564838s"}
```

Contribute to #1513 