### PR TITLE
[crdb] Remove useless indexes

### DIFF
--- a/NEXT_RELEASE_NOTES.md
+++ b/NEXT_RELEASE_NOTES.md
@@ -47,6 +47,11 @@ The release notes should contain at least the following sections:
 ## Optional migration tasks
 
 * `enable_opentelemetry` has been split into two flags: `enable_metrics` and `enable_tracing`
+* A new pair of migrations for CockroachDB [has been added](https://github.com/interuss/dss/pull/1517) for RID (4.1.0) and SCD (3.4.0) to remove useless indexes.
+  * The DSS will work regardless of the migration status.
+  * This migration will improve performance. If that is not the case for a specific scenario that was missed, please downgrade to the previous version and open an issue.
+  * These indexes are still useful for Yugabyte, so no such migration exists for it.
+  * Details about migrations are available [there](https://interuss.github.io/dss/latest/operations/database-migrations/)
 
 ## Important information
 

--- a/build/db_schemas/rid.libsonnet
+++ b/build/db_schemas/rid.libsonnet
@@ -6,11 +6,13 @@
     "downfrom-v3.1.0-remove_writer_column.sql": importstr "rid/downfrom-v3.1.0-remove_writer_column.sql",
     "downfrom-v3.1.1-remove_index_by_time_subscriptions.sql": importstr "rid/downfrom-v3.1.1-remove_index_by_time_subscriptions.sql",
     "downfrom-v4.0.0-move_rid_to_defaultdb.sql": importstr "rid/downfrom-v4.0.0-move_rid_to_defaultdb.sql",
+    "downfrom-v4.1.0-drop_unused_indexes.sql": importstr "rid/downfrom-v4.1.0-drop_unused_indexes.sql",
     "upto-v1.0.0-create_isa_subs_tables.sql": importstr "rid/upto-v1.0.0-create_isa_subs_tables.sql",
     "upto-v2.0.0-add_inverted_indices.sql": importstr "rid/upto-v2.0.0-add_inverted_indices.sql",
     "upto-v3.0.0-no_change.sql": importstr "rid/upto-v3.0.0-no_change.sql",
     "upto-v3.1.0-add_writer_column.sql": importstr "rid/upto-v3.1.0-add_writer_column.sql",
     "upto-v3.1.1-add_index_by_time_subscriptions.sql": importstr "rid/upto-v3.1.1-add_index_by_time_subscriptions.sql",
     "upto-v4.0.0-rename_defaultdb_to_rid.sql": importstr "rid/upto-v4.0.0-rename_defaultdb_to_rid.sql",
+    "upto-v4.1.0-drop_unused_indexes.sql": importstr "rid/upto-v4.1.0-drop_unused_indexes.sql",
   },
 }

--- a/build/db_schemas/rid/downfrom-v4.1.0-drop_unused_indexes.sql
+++ b/build/db_schemas/rid/downfrom-v4.1.0-drop_unused_indexes.sql
@@ -1,0 +1,4 @@
+CREATE INDEX IF NOT EXISTS owner_idx ON identification_service_areas (owner);
+CREATE INDEX IF NOT EXISTS starts_at_idx ON identification_service_areas (starts_at);
+CREATE INDEX IF NOT EXISTS starts_at_idx ON subscriptions (starts_at);
+UPDATE schema_versions SET schema_version = 'v4.0.0' WHERE onerow_enforcer = TRUE;

--- a/build/db_schemas/rid/upto-v4.1.0-drop_unused_indexes.sql
+++ b/build/db_schemas/rid/upto-v4.1.0-drop_unused_indexes.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS identification_service_areas@owner_idx;
+DROP INDEX IF EXISTS identification_service_areas@starts_at_idx;
+DROP INDEX IF EXISTS subscriptions@starts_at_idx;
+UPDATE schema_versions SET schema_version = 'v4.1.0' WHERE onerow_enforcer = TRUE;

--- a/build/db_schemas/scd.libsonnet
+++ b/build/db_schemas/scd.libsonnet
@@ -6,11 +6,13 @@
     "downfrom-v3.1.0-remove_uss_availability.sql": importstr "scd/downfrom-v3.1.0-remove_uss_availability.sql",
     "downfrom-v3.2.0-remove_ovn_columns.sql": importstr "scd/downfrom-v3.2.0-remove_ovn_columns.sql",
     "downfrom-v3.3.0-remove_locks.sql": importstr "scd/downfrom-v3.3.0-remove_locks.sql",
+    "downfrom-v3.4.0-drop_unused_indexes.sql": importstr "scd/downfrom-v3.4.0-drop_unused_indexes.sql",
     "upto-v1.0.0-create_initial_version.sql": importstr "scd/upto-v1.0.0-create_initial_version.sql",
     "upto-v2.0.0-support_api_1_0_0.sql": importstr "scd/upto-v2.0.0-support_api_1_0_0.sql",
     "upto-v3.0.0-add_inverted_indices.sql": importstr "scd/upto-v3.0.0-add_inverted_indices.sql",
     "upto-v3.1.0-create_uss_availability.sql": importstr "scd/upto-v3.1.0-create_uss_availability.sql",
     "upto-v3.2.0-add_ovn_columns.sql": importstr "scd/upto-v3.2.0-add_ovn_columns.sql",
     "upto-v3.3.0-add_locks.sql": importstr "scd/upto-v3.3.0-add_locks.sql",
+    "upto-v3.4.0-drop_unused_indexes.sql": importstr "scd/upto-v3.4.0-drop_unused_indexes.sql",
   },
 }

--- a/build/db_schemas/scd/downfrom-v3.4.0-drop_unused_indexes.sql
+++ b/build/db_schemas/scd/downfrom-v3.4.0-drop_unused_indexes.sql
@@ -1,0 +1,9 @@
+CREATE INDEX IF NOT EXISTS owner_idx ON scd_operations (owner);
+CREATE INDEX IF NOT EXISTS starts_at_idx ON scd_operations (starts_at);
+CREATE INDEX IF NOT EXISTS altitude_lower_idx ON scd_operations (altitude_lower);
+CREATE INDEX IF NOT EXISTS altitude_upper_idx ON scd_operations (altitude_upper);
+CREATE INDEX IF NOT EXISTS owner_idx ON scd_subscriptions (owner);
+CREATE INDEX IF NOT EXISTS starts_at_idx ON scd_subscriptions (starts_at);
+CREATE INDEX IF NOT EXISTS owner_idx ON scd_constraints (owner);
+CREATE INDEX IF NOT EXISTS starts_at_idx ON scd_constraints (starts_at);
+UPDATE schema_versions SET schema_version = 'v3.3.0' WHERE onerow_enforcer = TRUE;

--- a/build/db_schemas/scd/upto-v3.4.0-drop_unused_indexes.sql
+++ b/build/db_schemas/scd/upto-v3.4.0-drop_unused_indexes.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS scd_operations@owner_idx;
+DROP INDEX IF EXISTS scd_operations@starts_at_idx;
+DROP INDEX IF EXISTS scd_operations@altitude_lower_idx;
+DROP INDEX IF EXISTS scd_operations@altitude_upper_idx;
+DROP INDEX IF EXISTS scd_subscriptions@owner_idx;
+DROP INDEX IF EXISTS scd_subscriptions@starts_at_idx;
+DROP INDEX IF EXISTS scd_constraints@starts_at_idx;
+DROP INDEX IF EXISTS scd_constraints@owner_idx;
+UPDATE schema_versions SET schema_version = 'v3.4.0' WHERE onerow_enforcer = TRUE;

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/default_latest.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/default_latest.tf
@@ -1,5 +1,5 @@
 locals {
-  rid_db_schema = var.desired_rid_db_version == "latest" ? (var.datastore_type == "cockroachdb" ? "4.0.0" : "1.0.1") : var.desired_rid_db_version
-  scd_db_schema = var.desired_scd_db_version == "latest" ? (var.datastore_type == "cockroachdb" ? "3.3.0" : "1.1.0") : var.desired_scd_db_version
+  rid_db_schema = var.desired_rid_db_version == "latest" ? (var.datastore_type == "cockroachdb" ? "4.1.0" : "1.0.1") : var.desired_rid_db_version
+  scd_db_schema = var.desired_scd_db_version == "latest" ? (var.datastore_type == "cockroachdb" ? "3.4.0" : "1.1.0") : var.desired_scd_db_version
   aux_db_schema = var.desired_aux_db_version == "latest" ? "1.1.0" : var.desired_aux_db_version
 }

--- a/deploy/services/helm-charts/dss/templates/schema-manager.yaml
+++ b/deploy/services/helm-charts/dss/templates/schema-manager.yaml
@@ -5,7 +5,7 @@
 {{- $jobVersion := .Release.Revision -}} {{/* Jobs template definition is immutable, using the revision in the name forces the job to be recreated at each helm upgrade. */}}
 
 {{- $waitForDatastore := include "init-container-wait-for-http" (dict "serviceName" "cockroachdb" "url" (printf "http://%s:8080/health" $datastoreHost)) -}}
-{{- $schemas := dict "rid" "4.0.0" "scd" "3.3.0" "aux_" "1.1.0" }}
+{{- $schemas := dict "rid" "4.1.0" "scd" "3.4.0" "aux_" "1.1.0" }}
 
 {{- if .Values.yugabyte.enabled }}
 {{- $waitForDatastore = include "init-container-wait-for-http" (dict "serviceName" "yb-tserver" "url" (printf "http://%s:9000/status" $datastoreHost)) -}}

--- a/deploy/services/tanka/examples/minimum/main.jsonnet
+++ b/deploy/services/tanka/examples/minimum/main.jsonnet
@@ -59,8 +59,8 @@ local metadata = metadataBase {
   schema_manager+: {
     enable: false, // <-- this boolean value is VAR_ENABLE_SCHEMA_MANAGER
     image: 'VAR_DOCKER_IMAGE_NAME',
-    desired_rid_db_version: '4.0.0',
-    desired_scd_db_version: '3.3.0',
+    desired_rid_db_version: '4.1.0',
+    desired_scd_db_version: '3.4.0',
     desired_aux_db_version: '1.1.0',
   },
   prometheus+: {

--- a/deploy/services/tanka/examples/schema_manager/main.jsonnet
+++ b/deploy/services/tanka/examples/schema_manager/main.jsonnet
@@ -17,8 +17,8 @@ local metadata = metadataBase {
   schema_manager+: {
     enable: true, // <-- this boolean value is VAR_ENABLE_SCHEMA_MANAGER
     image: 'VAR_DOCKER_IMAGE_NAME',
-    desired_rid_db_version: '4.0.0',
-    desired_scd_db_version: '3.3.0',
+    desired_rid_db_version: '4.1.0',
+    desired_scd_db_version: '3.4.0',
     desired_aux_db_version: '1.1.0',
   },
 };

--- a/deploy/services/tanka/metadata_base.libsonnet
+++ b/deploy/services/tanka/metadata_base.libsonnet
@@ -88,8 +88,8 @@
   schema_manager: {
     enable: false, // NB: Automatically enabled if should_init is set to true.
     image: error 'must specify image',
-    desired_rid_db_version: '4.0.0',
-    desired_scd_db_version: '3.3.0',
+    desired_rid_db_version: '4.1.0',
+    desired_scd_db_version: '3.4.0',
     desired_aux_db_version: '1.1.0',
   },
   evict: {


### PR DESCRIPTION
This PR contrib to general performance and to #813 by removing useless indexes in CRDB.

Cells index or primary keys should be used looking at queries, making those indexes useless.

ends_at / updated_at are not removed to use indexes when using evict tool.
owner on `rid.subscriptions` is used in `MaxSubscriptionCountInCellsByOwner`

Notice that not the case for yugabyte and nothing changed there.