### PR TITLE
[scd] Update and fetch notification_index in one query

### DIFF
--- a/pkg/scd/constraints_handler.go
+++ b/pkg/scd/constraints_handler.go
@@ -57,8 +57,15 @@ func (a *Server) DeleteConstraintReference(ctx context.Context, req *restapi.Del
 				"Current version is %s but client specified version %s", old.OVN, ovn)
 		}
 
-		// Find Subscriptions that may overlap the Constraint's Volume4D
-		allsubs, err := r.SearchSubscriptions(ctx, &dssmodels.Volume4D{
+		// Delete Constraint in repo
+		err = r.DeleteConstraint(ctx, id)
+		if err != nil {
+			return stacktrace.Propagate(err, "Unable to delete Constraint from repo")
+		}
+
+		// Find the Subscriptions interested in Constraints and increment their
+		// notification indices.
+		subs, err := r.IncrementNotificationIndicesForConstraints(ctx, &dssmodels.Volume4D{
 			StartTime: old.StartTime,
 			EndTime:   old.EndTime,
 			SpatialVolume: &dssmodels.Volume3D{
@@ -68,26 +75,6 @@ func (a *Server) DeleteConstraintReference(ctx context.Context, req *restapi.Del
 					return old.Cells, nil
 				}),
 			}})
-		if err != nil {
-			return stacktrace.Propagate(err, "Unable to search Subscriptions in repo")
-		}
-
-		// Limit Subscription notifications to only those interested in Constraints
-		subs := repos.Subscriptions{}
-		for _, sub := range allsubs {
-			if sub.NotifyForConstraints {
-				subs = append(subs, sub)
-			}
-		}
-
-		// Delete Constraint in repo
-		err = r.DeleteConstraint(ctx, id)
-		if err != nil {
-			return stacktrace.Propagate(err, "Unable to delete Constraint from repo")
-		}
-
-		// Increment notification indices for relevant Subscriptions
-		err = subs.IncrementNotificationIndices(ctx, r)
 		if err != nil {
 			return stacktrace.Propagate(err, "Unable to increment notification indices")
 		}
@@ -303,22 +290,9 @@ func (a *Server) PutConstraintReference(ctx context.Context, manager string, ent
 			return err
 		}
 
-		// Find Subscriptions that may need to be notified
-		allsubs, err := r.SearchSubscriptions(ctx, notifyVol4)
-		if err != nil {
-			return err
-		}
-
-		// Limit Subscription notifications to only those interested in Constraints
-		subs := repos.Subscriptions{}
-		for _, sub := range allsubs {
-			if sub.NotifyForConstraints {
-				subs = append(subs, sub)
-			}
-		}
-
-		// Increment notification indices for relevant Subscriptions
-		err = subs.IncrementNotificationIndices(ctx, r)
+		// Find the Subscriptions interested in Constraints and increment their
+		// notification indices.
+		subs, err := r.IncrementNotificationIndicesForConstraints(ctx, notifyVol4)
 		if err != nil {
 			return err
 		}

--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -627,22 +627,11 @@ func getRelevantSubscriptionsAndIncrementIndices(
 	notifyVolume *dssmodels.Volume4D,
 ) (repos.Subscriptions, error) {
 
-	// Find Subscriptions that may need to be notified
-	allsubs, err := r.SearchSubscriptions(ctx, notifyVolume)
+	// Find the Subscriptions interested in OperationalIntents and increment their
+	// notification indices
+	subs, err := r.IncrementNotificationIndicesForOperationalIntents(ctx, notifyVolume)
+
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "Failed to search for impacted subscriptions.")
-	}
-
-	// Limit Subscription notifications to only those interested in OperationalIntents
-	subs := repos.Subscriptions{}
-	for _, sub := range allsubs {
-		if sub.NotifyForOperationalIntents {
-			subs = append(subs, sub)
-		}
-	}
-
-	// Increment notification indices for relevant Subscriptions
-	if err := subs.IncrementNotificationIndices(ctx, r); err != nil {
 		return nil, stacktrace.Propagate(err, "Failed to increment notification indices of relevant subscriptions")
 	}
 

--- a/pkg/scd/repos/repos.go
+++ b/pkg/scd/repos/repos.go
@@ -56,10 +56,15 @@ type Subscription interface {
 	// exist.
 	DeleteSubscription(ctx context.Context, id dssmodels.ID) error
 
-	// IncrementNotificationIndices increments the notification index of each
-	// specified Subscription and returns the resulting corresponding
-	// notification indices.
-	IncrementNotificationIndices(ctx context.Context, subscriptionIds []dssmodels.ID) ([]int, error)
+	// IncrementNotificationIndicesForOperationalIntents finds the Subscriptions in
+	// v4d that want operational intent notifications, increments their notification
+	// index and returns them with the new index.
+	IncrementNotificationIndicesForOperationalIntents(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error)
+
+	// IncrementNotificationIndicesForConstraints finds the Subscriptions in
+	// v4d that want constraint notifications, increments their notification
+	// index and returns them with the new index.
+	IncrementNotificationIndicesForConstraints(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error)
 
 	// LockSubscriptionsOnCells locks the subscriptions of interest on specific cells and, optionnaly, specific subscriptions via their IDs
 	LockSubscriptionsOnCells(ctx context.Context, cells s2.CellUnion, subscriptionIds []dssmodels.ID, startTime *time.Time, endTime *time.Time) error
@@ -107,22 +112,4 @@ type Repository interface {
 	Subscription
 	Constraint
 	UssAvailability
-}
-
-// IncrementNotificationIndices is a utility function that extracts the IDs from
-// a list of Subscriptions before calling the underlying repo function, and then
-// updates the Subscription objects with the new notification indices.
-func (subs Subscriptions) IncrementNotificationIndices(ctx context.Context, r Repository) error {
-	subIds := make([]dssmodels.ID, len(subs))
-	for i, sub := range subs {
-		subIds[i] = sub.ID
-	}
-	newIndices, err := r.IncrementNotificationIndices(ctx, subIds)
-	if err != nil {
-		return err
-	}
-	for i, newIndex := range newIndices {
-		subs[i].NotificationIndex = newIndex
-	}
-	return nil
 }

--- a/pkg/scd/store/raftstore/subscriptions.go
+++ b/pkg/scd/store/raftstore/subscriptions.go
@@ -27,8 +27,12 @@ func (r *repo) DeleteSubscription(_ context.Context, id dssmodels.ID) error {
 	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "DeleteSubscription not implemented for raftstore")
 }
 
-func (r *repo) IncrementNotificationIndices(_ context.Context, subscriptionIds []dssmodels.ID) ([]int, error) {
-	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "IncrementNotificationIndices not implemented for raftstore")
+func (r *repo) IncrementNotificationIndicesForOperationalIntents(_ context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "IncrementNotificationIndicesForOperationalIntents not implemented for raftstore")
+}
+
+func (r *repo) IncrementNotificationIndicesForConstraints(_ context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "IncrementNotificationIndicesForConstraints not implemented for raftstore")
 }
 
 func (r *repo) LockSubscriptionsOnCells(_ context.Context, cells s2.CellUnion, subscriptionIds []dssmodels.ID, startTime *time.Time, endTime *time.Time) error {

--- a/pkg/scd/store/sqlstore/subscriptions.go
+++ b/pkg/scd/store/sqlstore/subscriptions.go
@@ -293,50 +293,67 @@ func (c *repo) SearchSubscriptions(ctx context.Context, v4d *dssmodels.Volume4D)
 	return subscriptions, nil
 }
 
-// Implements scd.repos.Subscription.IncrementNotificationIndices
-func (c *repo) IncrementNotificationIndices(ctx context.Context, subscriptionIds []dssmodels.ID) ([]int, error) {
-	var updateQuery = `
-			UPDATE scd_subscriptions
-			SET notification_index = notification_index + 1
-			WHERE id = ANY($1)
-			RETURNING id, notification_index`
+// IncrementNotificationIndicesForOperationalIntents finds the Subscriptions in v4d that
+// want operational intent notifications, increments their notification index and returns
+// them with the new index..
+func (c *repo) IncrementNotificationIndicesForOperationalIntents(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
+	var query = fmt.Sprintf(`
+		UPDATE
+			scd_subscriptions
+		SET
+			notification_index = notification_index + 1
+		WHERE
+			cells && $1
+		AND
+			COALESCE(starts_at <= $3, true)
+		AND
+			COALESCE(ends_at >= $2, true)
+		AND
+			notify_for_operations
+		RETURNING
+			%s`, subscriptionFieldsWithoutPrefix)
 
-	ids := make([]string, len(subscriptionIds))
-	for i, id := range subscriptionIds {
-		ids[i] = id.String()
-	}
-
-	rows, err := c.q.Query(ctx, updateQuery, ids)
+	cells, err := v4d.CalculateSpatialCovering()
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "Error in query: %s", updateQuery)
+		return nil, stacktrace.Propagate(err, "Could not calculate spatial covering")
 	}
-	defer rows.Close()
+	if len(cells) == 0 {
+		return nil, nil
+	}
+	return c.fetchSubscriptions(ctx, c.q, query, dsssql.CellUnionToCellIds(cells), v4d.StartTime, v4d.EndTime)
 
-	indices := make(map[dssmodels.ID]int)
-	for rows.Next() {
-		var id string
-		var notificationIndex int
-		err := rows.Scan(&id, &notificationIndex)
-		if err != nil {
-			return nil, stacktrace.Propagate(err, "Error scanning notification index row")
-		}
-		indices[dssmodels.ID(id)] = notificationIndex
+}
+
+// IncrementNotificationIndicesForConstraints finds the Subscriptions in v4d that want
+// constraint notifications, increments their notification index and returns them with the
+// new index.
+func (c *repo) IncrementNotificationIndicesForConstraints(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
+	var query = fmt.Sprintf(`
+		UPDATE
+			scd_subscriptions
+		SET
+			notification_index = notification_index + 1
+		WHERE
+			cells && $1
+		AND
+			COALESCE(starts_at <= $3, true)
+		AND
+			COALESCE(ends_at >= $2, true)
+		AND
+			notify_for_constraints
+		RETURNING
+			%s`, subscriptionFieldsWithoutPrefix)
+
+	cells, err := v4d.CalculateSpatialCovering()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "Could not calculate spatial covering")
 	}
-	if err := rows.Err(); err != nil {
-		return nil, stacktrace.Propagate(err, "Error in rows query result")
+	if len(cells) == 0 {
+		return nil, nil
 	}
 
-	if len(indices) != len(subscriptionIds) {
-		return nil, stacktrace.NewError(
-			"Expected %d notification_index results when incrementing but got %d instead",
-			len(subscriptionIds), len(indices))
-	}
-
-	orderedIndices := make([]int, 0, len(indices))
-	for _, id := range subscriptionIds {
-		orderedIndices = append(orderedIndices, indices[id])
-	}
-	return orderedIndices, nil
+	return c.fetchSubscriptions(
+		ctx, c.q, query, dsssql.CellUnionToCellIds(cells), v4d.StartTime, v4d.EndTime)
 }
 
 func (c *repo) LockSubscriptionsOnCells(ctx context.Context, cells s2.CellUnion, subscriptionIds []dssmodels.ID, startTime *time.Time, endTime *time.Time) error {


### PR DESCRIPTION
This PR do a small optimization in SCD when incrementing notification index, by querying and updating them in one query instead of doing that with two.

It also do filtering on sql side instead of manual filtering on go side.

`FlightsInSub.py`, ran locally in a single node crdb show a small improvement:

<img width="1948" height="1130" alt="image" src="https://github.com/user-attachments/assets/e5f6b185-0a0c-4ccc-9e38-4c271885cd91" />

Worst cases where round-trip is higher should probably show better improvement.

Small behavior change: number of updated subcriptions / returned is not limited anymore. We can add that back but it feels wrong.
