### PR TITLE
 [scd] Add hash lock option 

### DIFF
--- a/NEXT_RELEASE_NOTES.md
+++ b/NEXT_RELEASE_NOTES.md
@@ -53,6 +53,8 @@ The release notes should contain at least the following sections:
   * This migration will improve performance. If that is not the case for a specific scenario that was missed, please downgrade to the previous version and open an issue.
   * These indexes are still useful for Yugabyte, so no such migration exists for it.
   * Details about migrations are available [there](https://interuss.github.io/dss/latest/operations/database-migrations/)
+* The 3.4.1 (or 1.1.1 for Yugabyte) migration for SCD is mandatory if you plan to use the new SCD hash lock option.
+  * This migration can be applied without any impact if you do not plan to use it.
 
 ## Important information
 

--- a/build/db_schemas/scd.libsonnet
+++ b/build/db_schemas/scd.libsonnet
@@ -7,6 +7,7 @@
     "downfrom-v3.2.0-remove_ovn_columns.sql": importstr "scd/downfrom-v3.2.0-remove_ovn_columns.sql",
     "downfrom-v3.3.0-remove_locks.sql": importstr "scd/downfrom-v3.3.0-remove_locks.sql",
     "downfrom-v3.4.0-drop_unused_indexes.sql": importstr "scd/downfrom-v3.4.0-drop_unused_indexes.sql",
+    "downfrom-v3.4.1-remove_locks_entries.sql": importstr "scd/downfrom-v3.4.1-remove_locks_entries.sql",
     "upto-v1.0.0-create_initial_version.sql": importstr "scd/upto-v1.0.0-create_initial_version.sql",
     "upto-v2.0.0-support_api_1_0_0.sql": importstr "scd/upto-v2.0.0-support_api_1_0_0.sql",
     "upto-v3.0.0-add_inverted_indices.sql": importstr "scd/upto-v3.0.0-add_inverted_indices.sql",
@@ -14,5 +15,6 @@
     "upto-v3.2.0-add_ovn_columns.sql": importstr "scd/upto-v3.2.0-add_ovn_columns.sql",
     "upto-v3.3.0-add_locks.sql": importstr "scd/upto-v3.3.0-add_locks.sql",
     "upto-v3.4.0-drop_unused_indexes.sql": importstr "scd/upto-v3.4.0-drop_unused_indexes.sql",
+    "upto-v3.4.1-add_locks_entries.sql": importstr "scd/upto-v3.4.1-add_locks_entries.sql",
   },
 }

--- a/build/db_schemas/scd/downfrom-v3.4.1-remove_locks_entries.sql
+++ b/build/db_schemas/scd/downfrom-v3.4.1-remove_locks_entries.sql
@@ -1,0 +1,5 @@
+DELETE FROM scd_locks WHERE key BETWEEN 1 AND 65535;
+
+UPDATE schema_versions
+SET schema_version = 'v3.4.0'
+WHERE onerow_enforcer = TRUE;

--- a/build/db_schemas/scd/upto-v3.4.1-add_locks_entries.sql
+++ b/build/db_schemas/scd/upto-v3.4.1-add_locks_entries.sql
@@ -1,0 +1,6 @@
+INSERT INTO scd_locks (key)
+SELECT generate_series(1, 65535);
+
+UPDATE schema_versions
+SET schema_version = 'v3.4.1'
+WHERE onerow_enforcer = TRUE;

--- a/build/db_schemas/yugabyte/scd/downfrom-v1.1.1-remove_locks_entries.sql
+++ b/build/db_schemas/yugabyte/scd/downfrom-v1.1.1-remove_locks_entries.sql
@@ -1,0 +1,3 @@
+DELETE FROM scd_locks WHERE key BETWEEN 1 AND 65535;
+
+UPDATE schema_versions set schema_version = 'v1.1.0' WHERE onerow_enforcer = TRUE;

--- a/build/db_schemas/yugabyte/scd/upto-v1.1.1-add_locks_entries.sql
+++ b/build/db_schemas/yugabyte/scd/upto-v1.1.1-add_locks_entries.sql
@@ -1,0 +1,4 @@
+INSERT INTO scd_locks (key)
+SELECT generate_series(1, 65535);
+
+UPDATE schema_versions set schema_version = 'v1.1.1' WHERE onerow_enforcer = TRUE;

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -257,7 +257,19 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 	logger.Info("config", zap.Bool("scd", *enableSCD))
 	storeOptions := params.GetStoreOptions()
 	logger.Info("config", zap.Bool("scdGlobalLock", storeOptions.GlobalLock))
+	logger.Info("config", zap.Bool("scdHashLock", storeOptions.HashLock))
 	logger.Info("config", zap.Bool("timeBasedNotificationIndex", storeOptions.TimeBasedNotificationIndex))
+
+	enabledOptions := 0
+	for _, enabled := range []bool{storeOptions.GlobalLock, storeOptions.HashLock, storeOptions.TimeBasedNotificationIndex} {
+		if enabled {
+			enabledOptions++
+		}
+	}
+	if enabledOptions > 1 {
+		return stacktrace.NewError("At most one of --enable_scd_global_lock, --enable_scd_hash_lock and --enable_time_based_notification_index may be enabled")
+	}
+
 	// params.StoreParameters should not be used directly in this file but this log warning is temporarily helpful and will be removed in the future.
 	if params.GetStoreParameters().StoreType == params.RaftStoreType {
 		logger.Warn("The raft datastore is experimental and its implementation is in progress. See issue for more details: https://github.com/interuss/dss/issues/1463")

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/default_latest.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/default_latest.tf
@@ -1,5 +1,5 @@
 locals {
   rid_db_schema = var.desired_rid_db_version == "latest" ? (var.datastore_type == "cockroachdb" ? "4.1.0" : "1.0.1") : var.desired_rid_db_version
-  scd_db_schema = var.desired_scd_db_version == "latest" ? (var.datastore_type == "cockroachdb" ? "3.4.0" : "1.1.0") : var.desired_scd_db_version
+  scd_db_schema = var.desired_scd_db_version == "latest" ? (var.datastore_type == "cockroachdb" ? "3.4.1" : "1.1.1") : var.desired_scd_db_version
   aux_db_schema = var.desired_aux_db_version == "latest" ? "1.1.0" : var.desired_aux_db_version
 }

--- a/deploy/services/helm-charts/dss/templates/schema-manager.yaml
+++ b/deploy/services/helm-charts/dss/templates/schema-manager.yaml
@@ -5,11 +5,11 @@
 {{- $jobVersion := .Release.Revision -}} {{/* Jobs template definition is immutable, using the revision in the name forces the job to be recreated at each helm upgrade. */}}
 
 {{- $waitForDatastore := include "init-container-wait-for-http" (dict "serviceName" "cockroachdb" "url" (printf "http://%s:8080/health" $datastoreHost)) -}}
-{{- $schemas := dict "rid" "4.1.0" "scd" "3.4.0" "aux_" "1.1.0" }}
+{{- $schemas := dict "rid" "4.1.0" "scd" "3.4.1" "aux_" "1.1.0" }}
 
 {{- if .Values.yugabyte.enabled }}
 {{- $waitForDatastore = include "init-container-wait-for-http" (dict "serviceName" "yb-tserver" "url" (printf "http://%s:9000/status" $datastoreHost)) -}}
-{{- $schemas = dict "rid" "1.0.1" "scd" "1.1.0" "aux_" "1.1.0" }}
+{{- $schemas = dict "rid" "1.0.1" "scd" "1.1.1" "aux_" "1.1.0" }}
 {{- end -}}
 
 {{- range $service, $schemaVersion := $schemas }}

--- a/deploy/services/tanka/examples/minikube/main.jsonnet
+++ b/deploy/services/tanka/examples/minikube/main.jsonnet
@@ -42,7 +42,7 @@ local metadata = metadataBase {
     enable: true,
     image: 'docker.io/interuss-local/dss:latest',
     desired_rid_db_version: '1.0.1',
-    desired_scd_db_version: '1.1.0',
+    desired_scd_db_version: '1.1.1',
     desired_aux_db_version: '1.1.0',
   },
   evict+: {

--- a/deploy/services/tanka/examples/minimum/main.jsonnet
+++ b/deploy/services/tanka/examples/minimum/main.jsonnet
@@ -62,7 +62,7 @@ local metadata = metadataBase {
     enable: false, // <-- this boolean value is VAR_ENABLE_SCHEMA_MANAGER
     image: 'VAR_DOCKER_IMAGE_NAME',
     desired_rid_db_version: '4.1.0',
-    desired_scd_db_version: '3.4.0',
+    desired_scd_db_version: '3.4.1',
     desired_aux_db_version: '1.1.0',
   },
   prometheus+: {

--- a/deploy/services/tanka/examples/schema_manager/main.jsonnet
+++ b/deploy/services/tanka/examples/schema_manager/main.jsonnet
@@ -18,7 +18,7 @@ local metadata = metadataBase {
     enable: true, // <-- this boolean value is VAR_ENABLE_SCHEMA_MANAGER
     image: 'VAR_DOCKER_IMAGE_NAME',
     desired_rid_db_version: '4.1.0',
-    desired_scd_db_version: '3.4.0',
+    desired_scd_db_version: '3.4.1',
     desired_aux_db_version: '1.1.0',
   },
 };

--- a/deploy/services/tanka/metadata_base.libsonnet
+++ b/deploy/services/tanka/metadata_base.libsonnet
@@ -91,7 +91,7 @@
     enable: false, // NB: Automatically enabled if should_init is set to true.
     image: error 'must specify image',
     desired_rid_db_version: '4.1.0',
-    desired_scd_db_version: '3.4.0',
+    desired_scd_db_version: '3.4.1',
     desired_aux_db_version: '1.1.0',
   },
   evict: {

--- a/docs/operations/performances.md
+++ b/docs/operations/performances.md
@@ -11,7 +11,7 @@ See the detailed [section about cleanup](cleanup.md).
 !!! danger
      All DSS instances in a DSS pool must use the same value for this option. Mixing will result in dramatically lower performance.
 
-     You can use the `/aux/v1/configuration/global_options` endpoint to retrive the current value for a specifc DSS instance.
+     You can use the `/aux/v1/configuration/global_options` endpoint to retrieve the current value for a specifc DSS instance.
 
 It has been reported in issue [#1311](https://github.com/interuss/dss/issues/1311) that creating a lot of overlapping operational intents may increase the datastore load in a way that creates timeouts.
 
@@ -35,15 +35,37 @@ All graphs have been generated with the [loadtest present in the monitoring repo
 ![](../assets/perfs_scd_lock_notoverlapping.png)
 *Non-overlapping requests. Notice the reduction of performance on the right, with a single lock.*
 
+## The SCD hash lock option
+
+!!! danger
+     All DSS instances in a DSS pool must use the same value for this option. Mixing will result in dramatically lower performance.
+
+     You can use the `/aux/v1/configuration/global_options` endpoint to retrieve the current value for a specifc DSS instance.
+
+!!! danger
+    This option requires migration 3.4.1 for CockroachDB and 1.1.1 for Yugabyte to be effective
+
+Similar to the SCD global lock option, but use lock based on hashed cells (with 65k locks).
+
+This should be better than global lock, as long as cells used don't collide and limit number of entries in the database.
+
+The number of locks (65535) is a compromise between lock contention (the more locks, the less unrelated cells share the same one) and the size of the `scd_locks` table. It is fixed and cannot be changed.
+
 ## The time-based notification index option
 
 !!! danger
     All DSS instances in a DSS pool must use the same value for this option. Mixing them will result in undetermined behavior.
 
-     You can use the `/aux/v1/configuration/global_options` endpoint to retrive the current value for a specifc DSS instance.
+     You can use the `/aux/v1/configuration/global_options` endpoint to retrieve the current value for a specifc DSS instance.
 
 Following the rationale described in issue [#1541](https://github.com/interuss/dss/issues/1541), this flag use a time-based system for notification indexes in SCD and RID.
 Please check the details in the linked issue above and ensure you understand the consequences of enabling this flag, including the specific requirements you want or need to comply with.
+
+## Combining the options
+
+!!! danger
+    The SCD global lock, SCD hash lock and time-based notification index options are mutually exclusive: at most one of them may be enabled.
+
 
 ## SCD lock diagnostics logs
 

--- a/interfaces/aux_/aux_.yaml
+++ b/interfaces/aux_/aux_.yaml
@@ -101,10 +101,12 @@ components:
         scd_global_lock:
           description: The value of the 'enable_scd_global_lock' option for this DSS instance
           type: boolean
+        scd_hash_lock:
+          description: The value of the 'enable_scd_hash_lock' option for this DSS instance
+          type: boolean
         time_based_notification_index:
           description: The value of the 'enable_time_based_notification_index' option for this DSS instance
           type: boolean
-
 paths:
   /aux/v1/version:
     get:

--- a/pkg/api/auxv1/types.gen.go
+++ b/pkg/api/auxv1/types.gen.go
@@ -57,6 +57,9 @@ type GlobalOptionsResponse struct {
 	// The value of the 'enable_scd_global_lock' option for this DSS instance
 	ScdGlobalLock *bool `json:"scd_global_lock,omitempty"`
 
+	// The value of the 'enable_scd_hash_lock' option for this DSS instance
+	ScdHashLock *bool `json:"scd_hash_lock,omitempty"`
+
 	// The value of the 'enable_time_based_notification_index' option for this DSS instance
 	TimeBasedNotificationIndex *bool `json:"time_based_notification_index,omitempty"`
 }

--- a/pkg/aux_/global_options.go
+++ b/pkg/aux_/global_options.go
@@ -8,5 +8,5 @@ import (
 
 func (a *Server) GetGlobalOptions(ctx context.Context, req *restapi.GetGlobalOptionsRequest) restapi.GetGlobalOptionsResponseSet {
 
-	return restapi.GetGlobalOptionsResponseSet{Response200: &restapi.GlobalOptionsResponse{ScdGlobalLock: &a.Options.GlobalLock, TimeBasedNotificationIndex: &a.Options.TimeBasedNotificationIndex}}
+	return restapi.GetGlobalOptionsResponseSet{Response200: &restapi.GlobalOptionsResponse{ScdGlobalLock: &a.Options.GlobalLock, ScdHashLock: &a.Options.HashLock, TimeBasedNotificationIndex: &a.Options.TimeBasedNotificationIndex}}
 }

--- a/pkg/scd/store/sqlstore/store.go
+++ b/pkg/scd/store/sqlstore/store.go
@@ -27,6 +27,7 @@ type repo struct {
 	clock                      clockwork.Clock
 	logger                     *zap.Logger
 	globalLock                 bool
+	hashLock                   bool
 	timeBasedNotificationIndex bool
 }
 
@@ -44,6 +45,7 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*sqlstor
 				clock:                      clock,
 				logger:                     logging.WithValuesFromContext(ctx, logger),
 				globalLock:                 opts.GlobalLock,
+				hashLock:                   opts.HashLock,
 				timeBasedNotificationIndex: opts.TimeBasedNotificationIndex,
 			}
 		},

--- a/pkg/scd/store/sqlstore/subscriptions.go
+++ b/pkg/scd/store/sqlstore/subscriptions.go
@@ -3,6 +3,8 @@ package sqlstore
 import (
 	"context"
 	"fmt"
+	"math/bits"
+	"slices"
 	"strings"
 	"time"
 
@@ -409,6 +411,37 @@ func (c *repo) IncrementNotificationIndicesForConstraints(ctx context.Context, v
 		ctx, c.q, query, dsssql.CellUnionToCellIds(cells), v4d.StartTime, v4d.EndTime)
 }
 
+// lockStripes is the number of rows of the scd_locks table used by the hash lock option, cells
+// being mapped to one of those rows. Its value is a compromise between lock contention
+// (the more stripes, the less unrelated cells share the same one) and the size of the scd_locks
+// table. It is fixed by the migrations creating those rows and cannot be changed without a matching migration.
+const lockStripes = 65536
+
+var lockStripeShift = 64 - bits.Len64(lockStripes-1)
+
+// FibonacciHashMultiplier is 2^64/φ, φ being the golden ratio, as used by Fibonacci hashing:
+// https://en.wikipedia.org/wiki/Fibonacci_hashing
+// This multiplier uniformly distributes over the table space blocks of consecutive keys with
+// respect to any block of bits of the key, including the high bits to speads cells evenly.
+const FibonacciHashMultiplier = 0x9e3779b97f4a7c15
+
+// cellLockKeys maps a cell union to the deduplicated scd_locks keys covering it. The returned keys
+// are sorted so that all transactions acquire the locks in the same order, preventing deadlocks.
+func cellLockKeys(cells s2.CellUnion) []int64 {
+	seen := make(map[int64]struct{}, len(cells))
+	keys := make([]int64, 0, len(cells))
+	for _, cell := range cells {
+		k := int64((uint64(cell) * FibonacciHashMultiplier) >> lockStripeShift) // Use high bits since entropy is higher on thoses
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
 func (c *repo) LockSubscriptionsOnCells(ctx context.Context, cells s2.CellUnion, subscriptionIds []dssmodels.ID, startTime *time.Time, endTime *time.Time) error {
 
 	if c.timeBasedNotificationIndex { // No lock when working with timeBasedNotificationIndex
@@ -444,6 +477,53 @@ func (c *repo) LockSubscriptionsOnCells(ctx context.Context, cells s2.CellUnion,
 				zap.Bool("global_lock", true),
 				zap.Duration("duration", duration),
 				zap.Int("cell_count", len(cells)),
+				zap.Int("explicit_subscription_id_count", len(subscriptionIds)),
+			)
+		}
+
+		return nil
+
+	}
+
+	if c.hashLock {
+
+		const query = `
+		SELECT key FROM scd_locks WHERE key = ANY($1) FOR UPDATE`
+		const idQuery = `
+		SELECT id FROM scd_subscriptions WHERE id = ANY($1) FOR UPDATE`
+
+		ids := make([]string, len(subscriptionIds))
+		for i, id := range subscriptionIds {
+			ids[i] = id.String()
+		}
+
+		slices.Sort(ids)
+		start := time.Now()
+
+		keys := cellLockKeys(cells)
+
+		_, err := c.q.Exec(ctx, query, keys)
+		if err == nil && len(ids) > 0 {
+			_, err = c.q.Exec(ctx, idQuery, ids)
+		}
+		duration := time.Since(start)
+		if err != nil {
+			logger.Warn("SCD subscription lock query failed",
+				zap.Duration("duration", duration),
+				zap.Int("cell_count", len(cells)),
+				zap.Int("hashed_cell_count", len(keys)),
+				zap.Int("explicit_subscription_id_count", len(subscriptionIds)),
+				zap.Error(err),
+			)
+			return stacktrace.Propagate(err, "Error in query: %s", query)
+		}
+
+		if duration >= lockQuerySlowThreshold {
+			logger.Warn("Expensive SCD lock detected",
+				zap.Bool("global_lock", false),
+				zap.Duration("duration", duration),
+				zap.Int("cell_count", len(cells)),
+				zap.Int("hashed_cell_count", len(keys)),
 				zap.Int("explicit_subscription_id_count", len(subscriptionIds)),
 			)
 		}

--- a/pkg/scd/store/sqlstore/subscriptions_test.go
+++ b/pkg/scd/store/sqlstore/subscriptions_test.go
@@ -2,9 +2,11 @@ package sqlstore
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
+	"github.com/golang/geo/s2"
 	"github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	"github.com/stretchr/testify/require"
@@ -114,4 +116,40 @@ func TestListExpiredSubscriptions(t *testing.T) {
 			require.ElementsMatch(t, expiredIDs, testCase.expired)
 		})
 	}
+}
+
+func TestCellLockKeys(t *testing.T) {
+
+	// No cells -> no hash
+	require.Empty(t, cellLockKeys(s2.CellUnion{}))
+
+	adjacent := s2.CellUnion{}
+	cell := cells[0]
+	for i := 0; i < 16; i++ {
+		adjacent = append(adjacent, cell)
+		cell = cell.Next()
+	}
+
+	keys := cellLockKeys(adjacent)
+	// Adjacent cells -> spread
+	require.Len(t, keys, 16)
+	// Key are sorted
+	require.True(t, slices.IsSorted(keys))
+	// Hash is predicatable
+	require.Equal(t, keys, cellLockKeys(adjacent))
+
+	// Hash stay in range
+	for _, key := range keys {
+		require.GreaterOrEqual(t, key, int64(0))
+		require.Less(t, key, int64(lockStripes))
+	}
+
+	// Identical cells -> identical hash
+	require.Equal(t,
+		cellLockKeys(s2.CellUnion{cells[0], cells[1]}),
+		cellLockKeys(s2.CellUnion{cells[1], cells[0], cells[0]}))
+
+	// Test expected value as well
+	require.Equal(t, []int64{42925, 44377, 45830, 47282, 48734, 50186, 51638, 53090, 54542, 55994, 57446, 58899, 60351, 61803, 63255, 64707}, keys)
+
 }

--- a/pkg/store/params/params.go
+++ b/pkg/store/params/params.go
@@ -20,6 +20,7 @@ type (
 	// Options carries the configuration flags shared by all datastore backends.
 	Options struct {
 		GlobalLock                 bool
+		HashLock                   bool
 		TimeBasedNotificationIndex bool
 	}
 )
@@ -33,6 +34,7 @@ func init() {
 	// NB: Memstore is not available here on purpose, as it is only to be used internally.
 	flag.StringVar(&storeParameters.StoreType, "store_type", SQLStoreType, fmt.Sprintf("Store type. Use '%s' for CockroachDB/YugabyteDB and '%s' for Raft-based store.", SQLStoreType, RaftStoreType))
 	flag.BoolVar(&storeOptions.GlobalLock, "enable_scd_global_lock", false, "Experimental: Use a global lock when working with SCD subscriptions. Reduce global throughput but improve throughput with lot of subscriptions in the same areas.")
+	flag.BoolVar(&storeOptions.HashLock, "enable_scd_hash_lock", false, "Experimental: Lock based on hashed cells id when working with SCD subscriptions. Better performances than global lock.")
 	flag.BoolVar(&storeOptions.TimeBasedNotificationIndex, "enable_time_based_notification_index", false, "Use a time-based notification index when working with RID and SCD subscriptions.")
 }
 


### PR DESCRIPTION
This PR follows #1518 as it increases the performance of that PR.

Adds a new option to lock cells using a hash, as an intermediate between the global lock option and the subscriptions lock.

Using the `FlightsInSubs` test with 8 clusters on a single-local CRDB node, we can see an improvement over other lock methods.

<img width="2004" height="1399" alt="image" src="https://github.com/user-attachments/assets/8dab9987-9901-4c3f-892f-46acdfa51a31" />

(Doesn't include option in terraform/helm/tanka yet)