### PR TITLE
 [raft] Add base memstore 

### DIFF
--- a/pkg/aux_/store/memstore/doc.go
+++ b/pkg/aux_/store/memstore/doc.go
@@ -1,0 +1,3 @@
+// Package aux_.store.memstore provides a full implementation of store.Store[aux_.repos.Repository]
+// storing data in memory. It is meant to be used by raftstore.
+package memstore

--- a/pkg/aux_/store/memstore/dss.go
+++ b/pkg/aux_/store/memstore/dss.go
@@ -1,0 +1,25 @@
+package memstore
+
+import (
+	"context"
+
+	auxmodels "github.com/interuss/dss/pkg/aux_/models"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/stacktrace"
+)
+
+func (r *repo) SaveOwnMetadata(_ context.Context, locality string, publicEndpoint string) error {
+	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "SaveOwnMetadata not implemented for memstore")
+}
+
+func (r *repo) GetDSSMetadata(_ context.Context) ([]*auxmodels.DSSMetadata, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetDSSMetadata not implemented for memstore")
+}
+
+func (r *repo) RecordHeartbeat(_ context.Context, heartbeat auxmodels.Heartbeat) error {
+	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "RecordHeartbeat not implemented for memstore")
+}
+
+func (r *repo) GetDSSAirspaceRepresentationID(_ context.Context) (string, error) {
+	return "", stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetDSSAirspaceRepresentationID not implemented for memstore")
+}

--- a/pkg/aux_/store/memstore/store.go
+++ b/pkg/aux_/store/memstore/store.go
@@ -1,0 +1,18 @@
+package memstore
+
+import (
+	"context"
+
+	"github.com/interuss/dss/pkg/aux_/repos"
+	"github.com/interuss/dss/pkg/memstore"
+	"go.uber.org/zap"
+)
+
+// repo is a full implementation of aux_.repos.Repository for memory-based storage.
+type repo struct{}
+
+func Init(ctx context.Context, logger *zap.Logger) (*memstore.Store[repos.Repository], error) {
+	return memstore.Init(ctx, logger, "aux_", &repo{})
+}
+
+func (r *repo) GetRepo() repos.Repository { return r }

--- a/pkg/aux_/store/store.go
+++ b/pkg/aux_/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/interuss/dss/pkg/aux_/repos"
+	auxmemstore "github.com/interuss/dss/pkg/aux_/store/memstore"
 	auxraftstore "github.com/interuss/dss/pkg/aux_/store/raftstore"
 	auxsqlstore "github.com/interuss/dss/pkg/aux_/store/sqlstore"
 	dssstore "github.com/interuss/dss/pkg/store"
@@ -24,6 +25,8 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, e
 		return auxsqlstore.Init(ctx, logger, withCheckCron)
 	case params.RaftStoreType:
 		return auxraftstore.Init(ctx, logger)
+	case params.MemStoreType:
+		return auxmemstore.Init(ctx, logger)
 	default:
 		return nil, stacktrace.NewError("Unsupported store type %q for aux", storeType)
 	}

--- a/pkg/memstore/store.go
+++ b/pkg/memstore/store.go
@@ -1,0 +1,63 @@
+package memstore
+
+// Memstore is a special kind of store:
+// Store instances store data in memory. There is no persistent storage.
+// Store instances are a singleton.
+// Repository usage is not thread-safe.
+// It's used by raftstore for projected storage.
+
+import (
+	"context"
+	"sync"
+
+	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/dss/pkg/logging"
+	"github.com/interuss/stacktrace"
+	"go.uber.org/zap"
+)
+
+type MemRepo[R any] interface {
+	GetRepo() R
+}
+
+type Store[R any] struct {
+	logger *zap.Logger
+
+	name    string
+	memRepo MemRepo[R]
+}
+
+var (
+	stores   = map[string]any{}
+	storesMu sync.Mutex
+)
+
+func Init[R any](ctx context.Context, logger *zap.Logger, name string, r MemRepo[R]) (*Store[R], error) {
+
+	storesMu.Lock()
+	defer storesMu.Unlock()
+	if s, ok := stores[name]; ok {
+		return s.(*Store[R]), nil
+	}
+
+	store := &Store[R]{
+		name:    name,
+		logger:  logging.WithValuesFromContext(ctx, logger),
+		memRepo: r,
+	}
+
+	stores[name] = store
+	return store, nil
+}
+
+func (s *Store[R]) Transact(ctx context.Context, _ func(context.Context, R) error) error {
+	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "Transact not implemented for memstore")
+}
+
+func (s *Store[R]) Interact(_ context.Context) (R, error) {
+	return s.memRepo.GetRepo(), nil
+}
+
+func (s *Store[R]) Close() error {
+	return nil
+}

--- a/pkg/rid/store/memstore/doc.go
+++ b/pkg/rid/store/memstore/doc.go
@@ -1,0 +1,3 @@
+// Package rid.store.memstore provides a full implementation of store.Store[rid.repos.Repository]
+// storing data in memory. It as meant to be used by raftstore.
+package memstore

--- a/pkg/rid/store/memstore/identification_service_area.go
+++ b/pkg/rid/store/memstore/identification_service_area.go
@@ -1,0 +1,40 @@
+package memstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang/geo/s2"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	dssmodels "github.com/interuss/dss/pkg/models"
+	ridmodels "github.com/interuss/dss/pkg/rid/models"
+	"github.com/interuss/stacktrace"
+)
+
+func (r *repo) GetISA(_ context.Context, id dssmodels.ID, forUpdate bool) (*ridmodels.IdentificationServiceArea, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetISA not implemented for memstore")
+}
+
+func (r *repo) DeleteISA(_ context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "DeleteISA not implemented for memstore")
+}
+
+func (r *repo) InsertISA(_ context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "InsertISA not implemented for memstore")
+}
+
+func (r *repo) UpdateISA(_ context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "UpdateISA not implemented for memstore")
+}
+
+func (r *repo) SearchISAs(_ context.Context, cells s2.CellUnion, earliest *time.Time, latest *time.Time) ([]*ridmodels.IdentificationServiceArea, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "SearchISAs not implemented for memstore")
+}
+
+func (r *repo) ListExpiredISAs(_ context.Context, writer string, threshold time.Time) ([]*ridmodels.IdentificationServiceArea, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "ListExpiredISAs not implemented for memstore")
+}
+
+func (r *repo) CountISAs(_ context.Context) (int64, error) {
+	return 0, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "CountISAs not implemented for memstore")
+}

--- a/pkg/rid/store/memstore/store.go
+++ b/pkg/rid/store/memstore/store.go
@@ -1,0 +1,18 @@
+package memstore
+
+import (
+	"context"
+
+	"github.com/interuss/dss/pkg/memstore"
+	"github.com/interuss/dss/pkg/rid/repos"
+	"go.uber.org/zap"
+)
+
+// repo is a full implementation of rid.repos.Repository for memory-based storage.
+type repo struct{}
+
+func Init(ctx context.Context, logger *zap.Logger) (*memstore.Store[repos.Repository], error) {
+	return memstore.Init(ctx, logger, "rid", &repo{})
+}
+
+func (r *repo) GetRepo() repos.Repository { return r }

--- a/pkg/rid/store/memstore/subscriptions.go
+++ b/pkg/rid/store/memstore/subscriptions.go
@@ -1,0 +1,52 @@
+package memstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang/geo/s2"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	dssmodels "github.com/interuss/dss/pkg/models"
+	ridmodels "github.com/interuss/dss/pkg/rid/models"
+	"github.com/interuss/stacktrace"
+)
+
+func (r *repo) GetSubscription(_ context.Context, id dssmodels.ID) (*ridmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetSubscription not implemented for memstore")
+}
+
+func (r *repo) DeleteSubscription(_ context.Context, sub *ridmodels.Subscription) (*ridmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "DeleteSubscription not implemented for memstore")
+}
+
+func (r *repo) InsertSubscription(_ context.Context, sub *ridmodels.Subscription) (*ridmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "InsertSubscription not implemented for memstore")
+}
+
+func (r *repo) UpdateSubscription(_ context.Context, sub *ridmodels.Subscription) (*ridmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "UpdateSubscription not implemented for memstore")
+}
+
+func (r *repo) SearchSubscriptions(_ context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "SearchSubscriptions not implemented for memstore")
+}
+
+func (r *repo) SearchSubscriptionsByOwner(_ context.Context, cells s2.CellUnion, owner dssmodels.Owner) ([]*ridmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "SearchSubscriptionsByOwner not implemented for memstore")
+}
+
+func (r *repo) UpdateNotificationIdxsInCells(_ context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "UpdateNotificationIdxsInCells not implemented for memstore")
+}
+
+func (r *repo) MaxSubscriptionCountInCellsByOwner(_ context.Context, cells s2.CellUnion, owner dssmodels.Owner) (int, error) {
+	return 0, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "MaxSubscriptionCountInCellsByOwner not implemented for memstore")
+}
+
+func (r *repo) ListExpiredSubscriptions(_ context.Context, writer string, threshold time.Time) ([]*ridmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "ListExpiredSubscriptions not implemented for memstore")
+}
+
+func (r *repo) CountSubscriptions(_ context.Context) (int64, error) {
+	return 0, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "CountSubscriptions not implemented for memstore")
+}

--- a/pkg/rid/store/store.go
+++ b/pkg/rid/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/interuss/dss/pkg/rid/repos"
+	ridmemstore "github.com/interuss/dss/pkg/rid/store/memstore"
 	ridraftstore "github.com/interuss/dss/pkg/rid/store/raftstore"
 	ridsqlstore "github.com/interuss/dss/pkg/rid/store/sqlstore"
 	dssstore "github.com/interuss/dss/pkg/store"
@@ -24,6 +25,8 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, e
 		return ridsqlstore.Init(ctx, logger, withCheckCron)
 	case params.RaftStoreType:
 		return ridraftstore.Init(ctx, logger)
+	case params.MemStoreType:
+		return ridmemstore.Init(ctx, logger)
 	default:
 		return nil, stacktrace.NewError("Unsupported store type %q for rid", storeType)
 	}

--- a/pkg/scd/store/memstore/availability.go
+++ b/pkg/scd/store/memstore/availability.go
@@ -1,0 +1,18 @@
+package memstore
+
+import (
+	"context"
+
+	dsserr "github.com/interuss/dss/pkg/errors"
+	dssmodels "github.com/interuss/dss/pkg/models"
+	scdmodels "github.com/interuss/dss/pkg/scd/models"
+	"github.com/interuss/stacktrace"
+)
+
+func (r *repo) GetUssAvailability(_ context.Context, id dssmodels.Manager) (*scdmodels.UssAvailabilityStatus, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetUssAvailability not implemented for memstore")
+}
+
+func (r *repo) UpsertUssAvailability(_ context.Context, ussa *scdmodels.UssAvailabilityStatus) (*scdmodels.UssAvailabilityStatus, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "UpsertUssAvailability not implemented for memstore")
+}

--- a/pkg/scd/store/memstore/constraints.go
+++ b/pkg/scd/store/memstore/constraints.go
@@ -1,0 +1,30 @@
+package memstore
+
+import (
+	"context"
+
+	dsserr "github.com/interuss/dss/pkg/errors"
+	dssmodels "github.com/interuss/dss/pkg/models"
+	scdmodels "github.com/interuss/dss/pkg/scd/models"
+	"github.com/interuss/stacktrace"
+)
+
+func (r *repo) SearchConstraints(_ context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Constraint, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "SearchConstraints not implemented for memstore")
+}
+
+func (r *repo) GetConstraint(_ context.Context, id dssmodels.ID) (*scdmodels.Constraint, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetConstraint not implemented for memstore")
+}
+
+func (r *repo) UpsertConstraint(_ context.Context, constraint *scdmodels.Constraint) (*scdmodels.Constraint, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "UpsertConstraint not implemented for memstore")
+}
+
+func (r *repo) DeleteConstraint(_ context.Context, id dssmodels.ID) error {
+	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "DeleteConstraint not implemented for memstore")
+}
+
+func (r *repo) CountConstraints(_ context.Context) (int64, error) {
+	return 0, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "CountConstraint not implemented for memstore")
+}

--- a/pkg/scd/store/memstore/doc.go
+++ b/pkg/scd/store/memstore/doc.go
@@ -1,0 +1,3 @@
+// Package scd.store.memstore provides a full implementation of store.Store[scd.repos.Repository]
+// storing data in memory. It is meant to be used by raftstore.
+package memstore

--- a/pkg/scd/store/memstore/operational_intents.go
+++ b/pkg/scd/store/memstore/operational_intents.go
@@ -1,0 +1,39 @@
+package memstore
+
+import (
+	"context"
+	"time"
+
+	dsserr "github.com/interuss/dss/pkg/errors"
+	dssmodels "github.com/interuss/dss/pkg/models"
+	scdmodels "github.com/interuss/dss/pkg/scd/models"
+	"github.com/interuss/stacktrace"
+)
+
+func (r *repo) GetOperationalIntent(_ context.Context, id dssmodels.ID) (*scdmodels.OperationalIntent, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetOperationalIntent not implemented for memstore")
+}
+
+func (r *repo) DeleteOperationalIntent(_ context.Context, id dssmodels.ID) error {
+	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "DeleteOperationalIntent not implemented for memstore")
+}
+
+func (r *repo) UpsertOperationalIntent(_ context.Context, operation *scdmodels.OperationalIntent) (*scdmodels.OperationalIntent, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "UpsertOperationalIntent not implemented for memstore")
+}
+
+func (r *repo) SearchOperationalIntents(_ context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.OperationalIntent, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "SearchOperationalIntents not implemented for memstore")
+}
+
+func (r *repo) GetDependentOperationalIntents(_ context.Context, subscriptionID dssmodels.ID) ([]dssmodels.ID, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetDependentOperationalIntents not implemented for memstore")
+}
+
+func (r *repo) ListExpiredOperationalIntents(_ context.Context, threshold time.Time) ([]*scdmodels.OperationalIntent, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "ListExpiredOperationalIntents not implemented for memstore")
+}
+
+func (r *repo) CountOperationalIntents(_ context.Context) (int64, error) {
+	return 0, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "CountOperationalIntents not implemented for memstore")
+}

--- a/pkg/scd/store/memstore/store.go
+++ b/pkg/scd/store/memstore/store.go
@@ -1,0 +1,18 @@
+package memstore
+
+import (
+	"context"
+
+	"github.com/interuss/dss/pkg/memstore"
+	"github.com/interuss/dss/pkg/scd/repos"
+	"go.uber.org/zap"
+)
+
+// repo is a full implementation of scd.repos.Repository for memory-based storage.
+type repo struct{}
+
+func Init(ctx context.Context, logger *zap.Logger) (*memstore.Store[repos.Repository], error) {
+	return memstore.Init(ctx, logger, "scd", &repo{})
+}
+
+func (r *repo) GetRepo() repos.Repository { return r }

--- a/pkg/scd/store/memstore/subscriptions.go
+++ b/pkg/scd/store/memstore/subscriptions.go
@@ -1,0 +1,48 @@
+package memstore
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang/geo/s2"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	dssmodels "github.com/interuss/dss/pkg/models"
+	scdmodels "github.com/interuss/dss/pkg/scd/models"
+	"github.com/interuss/stacktrace"
+)
+
+func (r *repo) SearchSubscriptions(_ context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "SearchSubscriptions not implemented for memstore")
+}
+
+func (r *repo) GetSubscription(_ context.Context, id dssmodels.ID) (*scdmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "GetSubscription not implemented for memstore")
+}
+
+func (r *repo) UpsertSubscription(_ context.Context, sub *scdmodels.Subscription) (*scdmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "UpsertSubscription not implemented for memstore")
+}
+
+func (r *repo) DeleteSubscription(_ context.Context, id dssmodels.ID) error {
+	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "DeleteSubscription not implemented for memstore")
+}
+
+func (r *repo) IncrementNotificationIndicesForOperationalIntents(_ context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "IncrementNotificationIndicesForOperationalIntents not implemented for memstore")
+}
+
+func (r *repo) IncrementNotificationIndicesForConstraints(_ context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "IncrementNotificationIndicesForConstraints not implemented for memstore")
+}
+
+func (r *repo) LockSubscriptionsOnCells(_ context.Context, cells s2.CellUnion, subscriptionIds []dssmodels.ID, startTime *time.Time, endTime *time.Time) error {
+	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "LockSubscriptionsOnCells not implemented for memstore")
+}
+
+func (r *repo) ListExpiredSubscriptions(_ context.Context, threshold time.Time) ([]*scdmodels.Subscription, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "ListExpiredSubscriptions not implemented for memstore")
+}
+
+func (r *repo) CountSubscriptions(_ context.Context) (int64, error) {
+	return 0, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "CountSubscriptions not implemented for memstore")
+}

--- a/pkg/scd/store/store.go
+++ b/pkg/scd/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/interuss/dss/pkg/scd/repos"
+	scdmemstore "github.com/interuss/dss/pkg/scd/store/memstore"
 	scdraftstore "github.com/interuss/dss/pkg/scd/store/raftstore"
 	scdsqlstore "github.com/interuss/dss/pkg/scd/store/sqlstore"
 	dssstore "github.com/interuss/dss/pkg/store"
@@ -24,6 +25,8 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, e
 		return scdsqlstore.Init(ctx, logger, withCheckCron)
 	case params.RaftStoreType:
 		return scdraftstore.Init(ctx, logger)
+	case params.MemStoreType:
+		return scdmemstore.Init(ctx, logger)
 	default:
 		return nil, stacktrace.NewError("Unsupported store type %q for scd", storeType)
 	}

--- a/pkg/store/params/params.go
+++ b/pkg/store/params/params.go
@@ -8,6 +8,7 @@ import (
 const (
 	RaftStoreType = "raft"
 	SQLStoreType  = "sql"
+	MemStoreType  = "mem"
 )
 
 type (
@@ -29,6 +30,7 @@ var (
 )
 
 func init() {
+	// NB: Memstore is not available here on purpose, as it is only to be used internally.
 	flag.StringVar(&storeParameters.StoreType, "store_type", SQLStoreType, fmt.Sprintf("Store type. Use '%s' for CockroachDB/YugabyteDB and '%s' for Raft-based store.", SQLStoreType, RaftStoreType))
 	flag.BoolVar(&storeOptions.GlobalLock, "enable_scd_global_lock", false, "Experimental: Use a global lock when working with SCD subscriptions. Reduce global throughput but improve throughput with lot of subscriptions in the same areas.")
 	flag.BoolVar(&storeOptions.TimeBasedNotificationIndex, "enable_time_based_notification_index", false, "Use a time-based notification index when working with RID and SCD subscriptions.")


### PR DESCRIPTION
This PR is part of a new chain, implementing memstore.

#1525 (Generic raftstore) -> #1527 (Base memstore) -> #1529 (Aux memstore) -> #1530 (Snapshots) -> #1534 (Rid memstore) -> #1535 (Correct use of now) -> #1539 (Checkpoint) -> #1542 (Scd memstore) -> #1528 (First PR with raft using memstore)

It does add the base for the 'in memory' store to be used by raft as underlying storage.

Rationale for direct, in memory structure is in #1526 

In theory, this store could be used e.g. for testing as 'regular' storage with small tweaks (like implementation of transact and being thread-safe), but for now it's goal is only to be used by raft.

Follow-up PRs will come with actual implementation.