### PR TITLE
[db-manager] Add explicit error on unknown migrations

### DIFF
--- a/cmds/db-manager/migration/migrate.go
+++ b/cmds/db-manager/migration/migrate.go
@@ -152,6 +152,10 @@ func migrate(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	if currentStepIndex == -1 {
+		return fmt.Errorf("unexpected migration, this migration is not present locally: %s\nPlease downgrade the database using the version that contains this migration first", *currentVersion)
+	}
+
 	// Perform migration steps until current version matches target version
 	for !currentVersion.Equal(*targetVersion) {
 		// Compute which migration step to run next and how it will change the schema version


### PR DESCRIPTION
When the database contains a migration "in the future", e.g. because future code or in a parallel branch was tested, db-manger crash with a nil pointer.

```
local-dss-scd-bootstrapper-1  | panic: runtime error: index out of range [-1]
local-dss-scd-bootstrapper-1  | 
local-dss-scd-bootstrapper-1  | goroutine 1 [running]:
local-dss-scd-bootstrapper-1  | github.com/interuss/dss/cmds/db-manager/migration.migrate(0x3d1a46a5c100?, {0x107c12d?, 0x4?, 0x107c131?})
local-dss-scd-bootstrapper-1  |         /app/cmds/db-manager/migration/migrate.go:168 +0x205b
local-dss-scd-bootstrapper-1  | github.com/spf13/cobra.(*Command).execute(0x1a88560, {0x3d1a4692a0f0, 0x5, 0x5})
local-dss-scd-bootstrapper-1  |         /go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015 +0xb14
local-dss-scd-bootstrapper-1  | github.com/spf13/cobra.(*Command).ExecuteC(0x1a87fa0)
local-dss-scd-bootstrapper-1  |         /go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148 +0x465
local-dss-scd-bootstrapper-1  | github.com/spf13/cobra.(*Command).Execute(...)
local-dss-scd-bootstrapper-1  |         /go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
local-dss-scd-bootstrapper-1  | main.main()
local-dss-scd-bootstrapper-1  |         /app/cmds/db-manager/main.go:27 +0x1e
```

This make it nicer with a proper message and next steps.

```
local-dss-scd-bootstrapper-1  | 2026/06/16 07:38:10 failed to execute db-manager: Unexpected migration. This migration is not present locally: 3.3.1.
local-dss-scd-bootstrapper-1  | Please downgrade the database using the version that contains this migration first.

```