### PR TITLE
 [raft/memstore] Use now from context 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,26 @@ linters:
     - predeclared
     - nolintlint
     - unparam
+    - forbidigo
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: '^time\.Now$'
+          msg: use timestamp.RequestTimestampFromContext(ctx)
+        - pattern: '^time\.(Since|Until)$'
+          msg: use timestamp.RequestTimestampFromContext(ctx)
+        - pattern: '^time\.(Tick|After|AfterFunc|NewTimer|NewTicker)$'
+          msg: no real clock in memstore
+        - pattern: 'clock\.Now$'
+          msg: use timestamp.RequestTimestampFromContext(ctx)
   exclusions:
       paths:
           - build/workspace
           - '.*\.gen\.go'
+      rules:
+          - linters:
+                - forbidigo
+            path-except: 'pkg/(aux_|rid|scd)/store/memstore/'
+          - linters:
+                - forbidigo
+            path: '_test\.go'

--- a/pkg/aux_/store/memstore/dss.go
+++ b/pkg/aux_/store/memstore/dss.go
@@ -3,14 +3,14 @@ package memstore
 import (
 	"context"
 	"database/sql"
-	"time"
 
 	auxmodels "github.com/interuss/dss/pkg/aux_/models"
 	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/interuss/stacktrace"
 )
 
-func (r *repo) SaveOwnMetadata(_ context.Context, loc string, publicEndpoint string) error {
+func (r *repo) SaveOwnMetadata(ctx context.Context, loc string, publicEndpoint string) error {
 	if loc == "" {
 		return stacktrace.NewErrorWithCode(dsserr.BadRequest, "Locality not set")
 	}
@@ -18,9 +18,11 @@ func (r *repo) SaveOwnMetadata(_ context.Context, loc string, publicEndpoint str
 		return stacktrace.NewErrorWithCode(dsserr.BadRequest, "Public endpoint not set")
 	}
 
+	now := timestamp.MustGetRequestTimestamp(ctx)
+
 	r.state.Participants[locality(loc)] = &participant{
 		PublicEndpoint: publicEndpoint,
-		UpdatedAt:      time.Now().UTC(),
+		UpdatedAt:      now.UTC(),
 	}
 	return nil
 }
@@ -60,7 +62,7 @@ func (r *repo) GetDSSMetadata(_ context.Context) ([]*auxmodels.DSSMetadata, erro
 	return metadata, nil
 }
 
-func (r *repo) RecordHeartbeat(_ context.Context, heartbeat auxmodels.Heartbeat) error {
+func (r *repo) RecordHeartbeat(ctx context.Context, heartbeat auxmodels.Heartbeat) error {
 	if heartbeat.Locality == "" {
 		return stacktrace.NewErrorWithCode(dsserr.BadRequest, "Locality not set")
 	}
@@ -69,7 +71,7 @@ func (r *repo) RecordHeartbeat(_ context.Context, heartbeat auxmodels.Heartbeat)
 	}
 
 	if heartbeat.Timestamp == nil {
-		now := time.Now().UTC()
+		now := timestamp.MustGetRequestTimestamp(ctx).UTC()
 		heartbeat.Timestamp = &now
 	}
 

--- a/pkg/aux_/store/memstore/dss_test.go
+++ b/pkg/aux_/store/memstore/dss_test.go
@@ -7,12 +7,17 @@ import (
 
 	auxmodels "github.com/interuss/dss/pkg/aux_/models"
 	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/interuss/stacktrace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 )
 
+var fakeClock = clockwork.NewFakeClock()
+
 func TestSaveOwnMetadataValidation(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	r := newRepo()
 
 	require.Equal(t, dsserr.BadRequest, stacktrace.GetCode(r.SaveOwnMetadata(ctx, "", "https://example.com")))
@@ -21,6 +26,7 @@ func TestSaveOwnMetadataValidation(t *testing.T) {
 
 func TestSaveOwnMetadataRoundTrip(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	r := newRepo()
 
 	require.NoError(t, r.SaveOwnMetadata(ctx, "dss-1", "https://example.com"))
@@ -40,6 +46,7 @@ func TestSaveOwnMetadataRoundTrip(t *testing.T) {
 
 func TestSaveOwnMetadataUpsert(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	r := newRepo()
 
 	require.NoError(t, r.SaveOwnMetadata(ctx, "dss-1", "https://old.example.com"))
@@ -54,6 +61,7 @@ func TestSaveOwnMetadataUpsert(t *testing.T) {
 
 func TestRecordHeartbeatValidation(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	r := newRepo()
 
 	require.Equal(t, dsserr.BadRequest, stacktrace.GetCode(r.RecordHeartbeat(ctx, auxmodels.Heartbeat{Source: "source1"})))
@@ -73,6 +81,7 @@ func TestRecordHeartbeatValidation(t *testing.T) {
 
 func TestRecordHeartbeatDefaultsTimestamp(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	r := newRepo()
 
 	require.NoError(t, r.SaveOwnMetadata(ctx, "dss-1", "https://example.com"))
@@ -88,6 +97,7 @@ func TestRecordHeartbeatDefaultsTimestamp(t *testing.T) {
 
 func TestGetDSSMetadataPicksLatestHeartbeat(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	r := newRepo()
 
 	require.NoError(t, r.SaveOwnMetadata(ctx, "dss-1", "https://example.com"))
@@ -108,6 +118,7 @@ func TestGetDSSMetadataPicksLatestHeartbeat(t *testing.T) {
 
 func TestGetDSSMetadataUpdatesHeartbeatPerSource(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	r := newRepo()
 
 	require.NoError(t, r.SaveOwnMetadata(ctx, "dss-1", "https://example.com"))

--- a/pkg/aux_/store/memstore/snapshot_test.go
+++ b/pkg/aux_/store/memstore/snapshot_test.go
@@ -7,12 +7,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	auxmodels "github.com/interuss/dss/pkg/aux_/models"
+	"github.com/interuss/dss/pkg/models"
+	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSnapshotRoundTrip(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	src := newRepo()
 	require.NoError(t, src.SaveOwnMetadata(ctx, "dss-1", "https://example.com"))
 	ts := time.Now().UTC()
@@ -28,11 +33,14 @@ func TestSnapshotRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	got, err := dst.GetDSSMetadata(ctx)
 	require.NoError(t, err)
-	require.Equal(t, want, got)
+	if diff := cmp.Diff(want, got, cmpopts.EquateApproxTime(0), cmp.AllowUnexported(models.Version{})); diff != "" {
+		t.Errorf("Store mismatch (-want +got):\n%s", diff)
+	}
 }
 
 func TestRestoreFromSnapshotReplacesState(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	src := newRepo()
 	require.NoError(t, src.SaveOwnMetadata(ctx, "dss-1", "https://example.com"))
 	data, err := src.GetSnapshot()

--- a/pkg/rid/store/memstore/identification_service_area.go
+++ b/pkg/rid/store/memstore/identification_service_area.go
@@ -9,6 +9,7 @@ import (
 	dsserr "github.com/interuss/dss/pkg/errors"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
+	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/interuss/stacktrace"
 )
 
@@ -51,19 +52,22 @@ func (r *repo) GetISA(_ context.Context, id dssmodels.ID, _ bool) (*ridmodels.Id
 	return rec.toModel(), nil
 }
 
-func (r *repo) InsertISA(_ context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error) {
+func (r *repo) InsertISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error) {
 	if err := validateWriteData(isa.Cells, isa.StartTime, isa.EndTime); err != nil {
 		return nil, err
 	}
 	if _, ok := r.state.ISAs[isa.ID]; ok {
 		return nil, stacktrace.NewError("ISA with id %s already exists", isa.ID)
 	}
-	rec := isaRecordFromModel(isa, r.clock.Now())
+
+	now := timestamp.MustGetRequestTimestamp(ctx)
+
+	rec := isaRecordFromModel(isa, now)
 	r.state.ISAs[isa.ID] = rec
 	return rec.toModel(), nil
 }
 
-func (r *repo) UpdateISA(_ context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error) {
+func (r *repo) UpdateISA(ctx context.Context, isa *ridmodels.IdentificationServiceArea) (*ridmodels.IdentificationServiceArea, error) {
 	if err := validateWriteData(isa.Cells, isa.StartTime, isa.EndTime); err != nil {
 		return nil, err
 	}
@@ -71,8 +75,12 @@ func (r *repo) UpdateISA(_ context.Context, isa *ridmodels.IdentificationService
 	if !ok {
 		return nil, nil
 	}
-	rec := isaRecordFromModel(isa, r.clock.Now())
+
+	now := timestamp.MustGetRequestTimestamp(ctx)
+
+	rec := isaRecordFromModel(isa, now)
 	rec.Owner = prev.Owner // It's not possible to update the owner of an ISA, this ensure it's to changed to a new value.
+
 	r.state.ISAs[isa.ID] = rec
 	return rec.toModel(), nil
 }

--- a/pkg/rid/store/memstore/identification_service_area_test.go
+++ b/pkg/rid/store/memstore/identification_service_area_test.go
@@ -10,7 +10,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
 	"github.com/interuss/dss/pkg/rid/repos"
-	"github.com/jonboulle/clockwork"
+	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,6 +34,7 @@ var (
 
 func TestStoreSearchISAs(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	cells := s2.CellUnion{
 		s2.CellID(17106221850767130624),
 		s2.CellID(17106221885126868992),
@@ -136,6 +137,7 @@ func TestStoreSearchISAs(t *testing.T) {
 
 func TestBadVersion(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	saOut1, err := repo.InsertISA(ctx, serviceArea)
@@ -157,6 +159,7 @@ func TestBadVersion(t *testing.T) {
 
 func TestStoreExpiredISA(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	saOut, err := repo.InsertISA(ctx, serviceArea)
@@ -164,10 +167,10 @@ func TestStoreExpiredISA(t *testing.T) {
 	require.NotNil(t, saOut)
 
 	// The ISA's endTime is one hour from now.
-	fakeClock.Advance(59 * time.Minute)
+	now := fakeClock.Now()
+	now = now.Add(59 * time.Minute)
 
 	// We should still be able to find the ISA by searching and by ID.
-	now := fakeClock.Now()
 	serviceAreas, err := repo.SearchISAs(ctx, serviceArea.Cells, &now, nil)
 	require.NoError(t, err)
 	require.Len(t, serviceAreas, 1)
@@ -177,8 +180,7 @@ func TestStoreExpiredISA(t *testing.T) {
 	require.NotNil(t, ret)
 
 	// But now the ISA has expired.
-	fakeClock.Advance(2 * time.Minute)
-	now = fakeClock.Now()
+	now = now.Add(2 * time.Minute)
 
 	serviceAreas, err = repo.SearchISAs(ctx, serviceArea.Cells, &now, nil)
 	require.NoError(t, err)
@@ -192,6 +194,7 @@ func TestStoreExpiredISA(t *testing.T) {
 
 func TestStoreDeleteISAs(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	// Insert the ISA.
@@ -212,6 +215,7 @@ func TestStoreDeleteISAs(t *testing.T) {
 
 func TestStoreISAWithNoGeoData(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	endTime := fakeClock.Now().Add(24 * time.Hour)
@@ -226,9 +230,8 @@ func TestStoreISAWithNoGeoData(t *testing.T) {
 
 func TestListExpiredISAs(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
-
-	fakeClock := clockwork.NewFakeClockAt(time.Now())
 
 	// Insert ISA with endtime 1 day from now
 	isa1 := *serviceArea
@@ -258,9 +261,8 @@ func TestListExpiredISAs(t *testing.T) {
 
 func TestListExpiredISAsWithEmptyWriter(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
-
-	fakeClock := clockwork.NewFakeClockAt(time.Now())
 
 	// Insert ISA with endtime 1 day from now
 	isa1 := *serviceArea
@@ -292,6 +294,7 @@ func TestListExpiredISAsWithEmptyWriter(t *testing.T) {
 
 func TestStoreCountISAs(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	// Insert the ISA.

--- a/pkg/rid/store/memstore/snapshot_test.go
+++ b/pkg/rid/store/memstore/snapshot_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/interuss/dss/pkg/models"
+	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSnapshotRoundTrip(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	src := setUpStore(t)
 	_, err := src.InsertISA(ctx, serviceArea)
 	require.NoError(t, err)
@@ -47,6 +49,7 @@ func TestSnapshotRoundTrip(t *testing.T) {
 
 func TestRestoreFromSnapshotReplacesState(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	src := setUpStore(t)
 	_, err := src.InsertISA(ctx, serviceArea)
 	require.NoError(t, err)

--- a/pkg/rid/store/memstore/store.go
+++ b/pkg/rid/store/memstore/store.go
@@ -10,14 +10,12 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	"github.com/interuss/dss/pkg/rid/repos"
 	"github.com/interuss/stacktrace"
-	"github.com/jonboulle/clockwork"
 	"go.uber.org/zap"
 )
 
 // repo is a full implementation of rid.repos.Repository for memory-based storage.
 type repo struct {
 	state state
-	clock clockwork.Clock
 }
 
 // state is the serializable in-memory state.
@@ -60,7 +58,7 @@ type subscriptionRecord struct {
 }
 
 func newRepo() *repo {
-	r := &repo{clock: clockwork.NewRealClock()}
+	r := &repo{}
 	r.resetState()
 	return r
 }

--- a/pkg/rid/store/memstore/store_test.go
+++ b/pkg/rid/store/memstore/store_test.go
@@ -23,9 +23,7 @@ var (
 // fakeClock, so tests can advance time deterministically.
 func setUpStore(t *testing.T) *repo {
 	t.Helper()
-	fakeClock = clockwork.NewFakeClock()
 	r := newRepo()
-	r.clock = fakeClock
 	return r
 }
 

--- a/pkg/rid/store/memstore/subscriptions.go
+++ b/pkg/rid/store/memstore/subscriptions.go
@@ -11,6 +11,7 @@ import (
 	dsserr "github.com/interuss/dss/pkg/errors"
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
+	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/interuss/stacktrace"
 )
 
@@ -54,19 +55,22 @@ func (r *repo) GetSubscription(_ context.Context, id dssmodels.ID) (*ridmodels.S
 	return rec.toModel(), nil
 }
 
-func (r *repo) InsertSubscription(_ context.Context, s *ridmodels.Subscription) (*ridmodels.Subscription, error) {
+func (r *repo) InsertSubscription(ctx context.Context, s *ridmodels.Subscription) (*ridmodels.Subscription, error) {
 	if err := validateWriteData(s.Cells, s.StartTime, s.EndTime); err != nil {
 		return nil, err
 	}
 	if _, ok := r.state.Subscriptions[s.ID]; ok {
 		return nil, stacktrace.NewError("Subscription with id %s already exists", s.ID)
 	}
-	rec := subRecordFromModel(s, r.clock.Now())
+
+	now := timestamp.MustGetRequestTimestamp(ctx)
+
+	rec := subRecordFromModel(s, now)
 	r.state.Subscriptions[s.ID] = rec
 	return rec.toModel(), nil
 }
 
-func (r *repo) UpdateSubscription(_ context.Context, s *ridmodels.Subscription) (*ridmodels.Subscription, error) {
+func (r *repo) UpdateSubscription(ctx context.Context, s *ridmodels.Subscription) (*ridmodels.Subscription, error) {
 	if err := validateWriteData(s.Cells, s.StartTime, s.EndTime); err != nil {
 		return nil, err
 	}
@@ -74,7 +78,10 @@ func (r *repo) UpdateSubscription(_ context.Context, s *ridmodels.Subscription) 
 	if !ok {
 		return nil, nil
 	}
-	rec := subRecordFromModel(s, r.clock.Now())
+
+	now := timestamp.MustGetRequestTimestamp(ctx)
+
+	rec := subRecordFromModel(s, now)
 	rec.Owner = prev.Owner // It's not possible to update the owner of a subscription, this ensure it's to changed to a new value.
 	r.state.Subscriptions[s.ID] = rec
 	return rec.toModel(), nil
@@ -92,9 +99,9 @@ func (r *repo) DeleteSubscription(_ context.Context, s *ridmodels.Subscription) 
 
 // liveSubscriptionsInCells yields the non-expired subscriptions touching cells,
 // optionally restricted to a single owner.
-func (r *repo) liveSubscriptionsInCells(cells s2.CellUnion, owner *dssmodels.Owner) iter.Seq[*subscriptionRecord] {
+func (r *repo) liveSubscriptionsInCells(now time.Time, cells s2.CellUnion, owner *dssmodels.Owner) iter.Seq[*subscriptionRecord] {
 	return func(yield func(*subscriptionRecord) bool) {
-		now := r.clock.Now()
+
 		want := cellSet(cells)
 		for _, rec := range r.state.Subscriptions {
 			if owner != nil && rec.Owner != *owner {
@@ -113,20 +120,23 @@ func (r *repo) liveSubscriptionsInCells(cells s2.CellUnion, owner *dssmodels.Own
 	}
 }
 
-func (r *repo) SearchSubscriptions(_ context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
-	return r.searchSubscriptions(cells, nil)
+func (r *repo) SearchSubscriptions(ctx context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
+	return r.searchSubscriptions(ctx, cells, nil)
 }
 
-func (r *repo) SearchSubscriptionsByOwner(_ context.Context, cells s2.CellUnion, owner dssmodels.Owner) ([]*ridmodels.Subscription, error) {
-	return r.searchSubscriptions(cells, &owner)
+func (r *repo) SearchSubscriptionsByOwner(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) ([]*ridmodels.Subscription, error) {
+	return r.searchSubscriptions(ctx, cells, &owner)
 }
 
-func (r *repo) searchSubscriptions(cells s2.CellUnion, owner *dssmodels.Owner) ([]*ridmodels.Subscription, error) {
+func (r *repo) searchSubscriptions(ctx context.Context, cells s2.CellUnion, owner *dssmodels.Owner) ([]*ridmodels.Subscription, error) {
 	if len(cells) == 0 {
 		return nil, stacktrace.NewErrorWithCode(dsserr.BadRequest, "no location provided")
 	}
+
+	now := timestamp.MustGetRequestTimestamp(ctx)
+
 	var out []*ridmodels.Subscription
-	for rec := range r.liveSubscriptionsInCells(cells, owner) {
+	for rec := range r.liveSubscriptionsInCells(now, cells, owner) {
 		out = append(out, rec.toModel())
 
 		if len(out) > dssmodels.MaxResultLimit { // This mimics sqlstore behaviour, but it's not very good.
@@ -138,19 +148,25 @@ func (r *repo) searchSubscriptions(cells s2.CellUnion, owner *dssmodels.Owner) (
 
 // UpdateNotificationIdxsInCells increments the notification index for each
 // subscription in the given cells.
-func (r *repo) UpdateNotificationIdxsInCells(_ context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
+func (r *repo) UpdateNotificationIdxsInCells(ctx context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
+
+	now := timestamp.MustGetRequestTimestamp(ctx)
+
 	var out []*ridmodels.Subscription
-	for rec := range r.liveSubscriptionsInCells(cells, nil) {
+	for rec := range r.liveSubscriptionsInCells(now, cells, nil) {
 		rec.NotificationIndex++
 		out = append(out, rec.toModel())
 	}
 	return out, nil
 }
 
-func (r *repo) MaxSubscriptionCountInCellsByOwner(_ context.Context, cells s2.CellUnion, owner dssmodels.Owner) (int, error) {
+func (r *repo) MaxSubscriptionCountInCellsByOwner(ctx context.Context, cells s2.CellUnion, owner dssmodels.Owner) (int, error) {
+
+	now := timestamp.MustGetRequestTimestamp(ctx)
+
 	want := cellSet(cells)
 	counts := make(map[s2.CellID]int, len(cells))
-	for rec := range r.liveSubscriptionsInCells(cells, &owner) {
+	for rec := range r.liveSubscriptionsInCells(now, cells, &owner) {
 		for _, c := range rec.Cells {
 			if _, ok := want[c]; ok {
 				counts[c]++

--- a/pkg/rid/store/memstore/subscriptions_test.go
+++ b/pkg/rid/store/memstore/subscriptions_test.go
@@ -10,6 +10,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
 	"github.com/interuss/dss/pkg/rid/repos"
+	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 )
@@ -69,6 +70,7 @@ var (
 
 func TestStoreGetSubscription(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	for _, r := range subscriptionsPool {
@@ -88,6 +90,7 @@ func TestStoreGetSubscription(t *testing.T) {
 
 func TestStoreInsertSubscription(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	for _, r := range subscriptionsPool {
@@ -131,6 +134,7 @@ func TestStoreInsertSubscription(t *testing.T) {
 
 func TestStoreDeleteSubscription(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	for _, r := range subscriptionsPool {
@@ -158,6 +162,7 @@ func TestStoreDeleteSubscription(t *testing.T) {
 
 func TestStoreSearchSubscription(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now().UTC())
 	repo := setUpStore(t)
 
 	var (
@@ -202,6 +207,7 @@ func TestStoreSearchSubscription(t *testing.T) {
 
 func TestStoreExpiredSubscription(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	endTime := fakeClock.Now().Add(24 * time.Hour)
@@ -215,7 +221,7 @@ func TestStoreExpiredSubscription(t *testing.T) {
 	require.NoError(t, err)
 
 	// The subscription's endTime is 24 hours from now.
-	fakeClock.Advance(23 * time.Hour)
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now().Add(23*time.Hour))
 
 	// We should still be able to find the subscription by searching and by ID.
 	subs, err := repo.SearchSubscriptionsByOwner(ctx, sub.Cells, "original owner")
@@ -227,7 +233,7 @@ func TestStoreExpiredSubscription(t *testing.T) {
 	require.NotNil(t, &ret)
 
 	// But now the subscription has expired.
-	fakeClock.Advance(2 * time.Hour)
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now().Add(25*time.Hour))
 
 	subs, err = repo.SearchSubscriptionsByOwner(ctx, sub.Cells, "original owner")
 	require.NoError(t, err)
@@ -240,6 +246,7 @@ func TestStoreExpiredSubscription(t *testing.T) {
 
 func TestStoreSubscriptionWithNoGeoData(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	endTime := fakeClock.Now().Add(24 * time.Hour)
@@ -254,6 +261,7 @@ func TestStoreSubscriptionWithNoGeoData(t *testing.T) {
 
 func TestMaxSubscriptionCountInCellsByOwner(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	for _, s := range subscriptionsPool {
@@ -268,6 +276,7 @@ func TestMaxSubscriptionCountInCellsByOwner(t *testing.T) {
 
 func TestListExpiredSubscriptions(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	fakeClock := clockwork.NewFakeClockAt(time.Now())
@@ -300,9 +309,8 @@ func TestListExpiredSubscriptions(t *testing.T) {
 
 func TestListExpiredSubscriptionsWithEmptyWriter(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
-
-	fakeClock := clockwork.NewFakeClockAt(time.Now())
 
 	// Insert Subscription with endtime 1 day from now
 	subscripiton1 := *subscriptionsPool[0].input
@@ -334,6 +342,7 @@ func TestListExpiredSubscriptionsWithEmptyWriter(t *testing.T) {
 
 func TestStoreCountSubscription(t *testing.T) {
 	ctx := context.Background()
+	ctx = timestamp.WithRequestTimestamp(ctx, fakeClock.Now())
 	repo := setUpStore(t)
 
 	for _, r := range subscriptionsPool {

--- a/pkg/timestamp/timestamp.go
+++ b/pkg/timestamp/timestamp.go
@@ -26,6 +26,17 @@ func RequestTimestampFromContext(ctx context.Context) (time.Time, error) {
 	return timestamp, nil
 }
 
+// MustGetRequestTimestamp returns the request timestamp from the context and panics if it is not
+// present or invalid, which is a programming error.
+func MustGetRequestTimestamp(ctx context.Context) time.Time {
+	timestamp, err := RequestTimestampFromContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	return timestamp
+}
+
 // WithRequestTimestamp returns a new context with the given timestamp.
 func WithRequestTimestamp(ctx context.Context, timestamp time.Time) context.Context {
 	return context.WithValue(ctx, timestampKey{}, timestamp)


### PR DESCRIPTION
This PR is part of a new chain, implementing memstore.

#1525 (Generic raftstore) -> #1527 (Base memstore) -> #1529 (Aux memstore) -> #1530 (Snapshots) -> #1534 (Rid memstore) -> #1535 (Correct use of now) -> #1539 (Checkpoint) -> #1542 (Scd memstore) -> #1528 (First PR with raft using memstore)

---

It uses the helper from timestamp to use now from context, if available, to ensure consistent time in the raft context.