### PR TITLE
[doc] Add documentation about migrations, moved from a too specifc place

### DIFF
--- a/docs/infrastructure/google-manual.md
+++ b/docs/infrastructure/google-manual.md
@@ -479,34 +479,6 @@ See [operations monitoring documentation](../operations/monitoring.md).
 
 See [Troubleshooting in `deploy/operations`](../operations/troubleshooting.md).
 
-## Upgrading Database Schemas
-
-All schemas-related files are in `db_schemas` directory.  Any changes you
-wish to make to the database schema should be done in their respective database
-folders.  The files are applied in sequential numeric steps from the current
-version M to the desired version N.
-
-For the first-ever run during the CRDB cluster initialization, the db-manager
-will run once to bootstrap and bring the database up to date.  To upgrade
-existing clusters you will need to:
-
-### If performing this operation on the original cluster
-1. Update the `desired_xyz_db_version` field in `main.jsonnet`
-2. Delete the existing db-manager job in your k8s cluster
-3. Redeploy the newly configured db-manager with `tk apply -t job/<xyz-schema-manager>`. It should automatically up/down grade your database schema to your desired version.
-
-### If performing this operation on any other cluster
-
-1. Create `workspace/$CLUSTER_CONTEXT_schema_manager` in this (build) directory.
-
-1.  From this (build) working directory,
-    `cp -r ../deploy/services/tanka/examples/schema_manager/* workspace/$CLUSTER_CONTEXT_schema_manager`.
-
-1.  Edit `workspace/$CLUSTER_CONTEXT_schema_manager/main.jsonnet` and replace all `VAR_*`
-    instances with appropriate values where applicable as explained in the above section.
-
-1.  Run `tk apply workspace/$CLUSTER_CONTEXT_schema_manager`
-
 ### Garbage collector job
 Only since commit [c789b2b](https://github.com/interuss/dss/commit/c789b2b4a9fa5fb651d202da0a3abc02a03c15d2) on Aug 25, 2020 will the DSS enable automatic garbage collection of records by tracking which DSS instance is responsible for garbage collection of the record. Expired records added with a DSS deployment running code earlier than this must be manually removed.
 

--- a/docs/operations/.nav.yml
+++ b/docs/operations/.nav.yml
@@ -6,6 +6,7 @@ nav:
   - "Monitoring": monitoring.md
   - "Health checks": healthchecks.md
   - "Migrations": migrations.md
+  - "Database migrations": database-migrations.md
   - "Performances": performances.md
   - "Cleanup": cleanup.md
   - "Troubleshooting": troubleshooting.md

--- a/docs/operations/database-migrations.md
+++ b/docs/operations/database-migrations.md
@@ -1,0 +1,41 @@
+# Database Migrations
+
+## Upgrading Database Schemas
+
+All schema-related files are located in the `db_schemas` directory. Any changes you wish to make to the database schema must be done within their respective database folders. The migration files are applied in sequential numeric steps from the current version to the desired version.
+
+By default, deployment tools target the `latest` tag and will automatically perform upgrades to the most recent version.
+
+### Target a Specific Version
+
+To pin your database to a specific schema version, update the corresponding deployment variables and apply the changes as you would during a standard deployment.
+
+!!! info
+    The migration tools also fully support downgrades, should the targeted version be lower than the current one.
+
+### Manual Migrations
+
+When operating outside of the automated deployment tools, you can use the `db-manager migrate` CLI command to apply migrations directly. Refer to the tool's built-in help (`--help`) for specific command arguments and flags.
+
+---
+
+!!! warning "Helm Restrictions"
+    When using Helm (either directly or via Terraform), only the `latest` version will be installed for now.
+
+=== "Terraform"
+    Controlled by the following variables:
+
+    * `desired_rid_db_version`
+    * `desired_scd_db_version`
+    * `desired_aux_db_version`
+
+=== "Tanka"
+    Controlled by the following variables:
+
+    * `desired_rid_db_version`
+    * `desired_scd_db_version`
+    * `desired_aux_db_version`
+
+
+=== "Helm"
+    Manual version targeting is not available for now.

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -24,9 +24,14 @@ See [Leaving a pool](pooling.md#leaving-a-pool)
 
 See [Monitoring](monitoring.md)
 
+
 ## Health checks
 
 See [Health checks](healthchecks.md)
+
+## Database migrations
+
+See [Database migrations](database-migrations.md)
 
 ## Performances
 


### PR DESCRIPTION
Move documentation about migration from google-manual doc (where its apply everywhere) to a more centralized, operational location.

'Quick' fix outside current documentation effort to make it available for #1517 release notes.