### PR TITLE
[dss] Add flag to enable time-based notification index

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -66,7 +66,8 @@ var (
 	keyRefreshTimeout = flag.Duration("key_refresh_timeout", 1*time.Minute, "Timeout for refreshing keys for JWT verification")
 	jwtAudiences      = flag.String("accepted_jwt_audiences", "", "comma-separated acceptable JWT `aud` claims")
 
-	scdGlobalLock = flag.Bool("enable_scd_global_lock", false, "Experimental: Use a global lock when working with SCD subscriptions. Reduce global throughput but improve throughput with lot of subscriptions in the same areas.")
+	scdGlobalLock                     = flag.Bool("enable_scd_global_lock", false, "Experimental: Use a global lock when working with SCD subscriptions. Reduce global throughput but improve throughput with lot of subscriptions in the same areas.")
+	timeBasedNotificationIndexEnabled = flag.Bool("enable_time_based_notification_index", false, "Use a time based notification index when working with RID and SCD subscriptions.")
 )
 
 func createKeyResolver() (auth.KeyResolver, error) {
@@ -112,7 +113,7 @@ func createAuxServer(ctx context.Context, locality string, publicEndpoint string
 
 func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) (*rid_v1.Server, *rid_v2.Server, error) {
 
-	ridStore, err := rids.Init(ctx, logger, true)
+	ridStore, err := rids.Init(ctx, logger, true, *timeBasedNotificationIndexEnabled)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -144,7 +145,9 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 
 func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, error) {
 
-	scdStore, err := scds.Init(ctx, logger, true, *scdGlobalLock)
+	logger.Info(fmt.Sprintf("Time-based notification index enabled: %t", *timeBasedNotificationIndexEnabled))
+
+	scdStore, err := scds.Init(ctx, logger, true, *scdGlobalLock, *timeBasedNotificationIndexEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -158,9 +161,10 @@ func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, erro
 	}
 
 	return &scd.Server{
-		Store:             scdStore,
-		DSSReportHandler:  &scd.JSONLoggingReceivedReportHandler{ReportLogger: logger},
-		AllowHTTPBaseUrls: *allowHTTPBaseUrls,
+		Store:                             scdStore,
+		DSSReportHandler:                  &scd.JSONLoggingReceivedReportHandler{ReportLogger: logger},
+		AllowHTTPBaseUrls:                 *allowHTTPBaseUrls,
+		TimeBasedNotificationIndexEnabled: *timeBasedNotificationIndexEnabled,
 	}, nil
 }
 

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -66,8 +66,8 @@ var (
 	keyRefreshTimeout = flag.Duration("key_refresh_timeout", 1*time.Minute, "Timeout for refreshing keys for JWT verification")
 	jwtAudiences      = flag.String("accepted_jwt_audiences", "", "comma-separated acceptable JWT `aud` claims")
 
-	scdGlobalLock                     = flag.Bool("enable_scd_global_lock", false, "Experimental: Use a global lock when working with SCD subscriptions. Reduce global throughput but improve throughput with lot of subscriptions in the same areas.")
-	timeBasedNotificationIndexEnabled = flag.Bool("enable_time_based_notification_index", false, "Use a time based notification index when working with RID and SCD subscriptions.")
+	scdGlobalLock              = flag.Bool("enable_scd_global_lock", false, "Experimental: Use a global lock when working with SCD subscriptions. Reduce global throughput but improve throughput with lot of subscriptions in the same areas.")
+	timeBasedNotificationIndex = flag.Bool("enable_time_based_notification_index", false, "Use a time-based notification index when working with RID and SCD subscriptions.")
 )
 
 func createKeyResolver() (auth.KeyResolver, error) {
@@ -113,7 +113,7 @@ func createAuxServer(ctx context.Context, locality string, publicEndpoint string
 
 func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) (*rid_v1.Server, *rid_v2.Server, error) {
 
-	ridStore, err := rids.Init(ctx, logger, true, *timeBasedNotificationIndexEnabled)
+	ridStore, err := rids.Init(ctx, logger, true, *timeBasedNotificationIndex)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -145,9 +145,7 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 
 func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, error) {
 
-	logger.Info(fmt.Sprintf("Time-based notification index enabled: %t", *timeBasedNotificationIndexEnabled))
-
-	scdStore, err := scds.Init(ctx, logger, true, *scdGlobalLock, *timeBasedNotificationIndexEnabled)
+	scdStore, err := scds.Init(ctx, logger, true, *scdGlobalLock, *timeBasedNotificationIndex)
 	if err != nil {
 		return nil, err
 	}
@@ -161,10 +159,10 @@ func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, erro
 	}
 
 	return &scd.Server{
-		Store:                             scdStore,
-		DSSReportHandler:                  &scd.JSONLoggingReceivedReportHandler{ReportLogger: logger},
-		AllowHTTPBaseUrls:                 *allowHTTPBaseUrls,
-		TimeBasedNotificationIndexEnabled: *timeBasedNotificationIndexEnabled,
+		Store:                      scdStore,
+		DSSReportHandler:           &scd.JSONLoggingReceivedReportHandler{ReportLogger: logger},
+		AllowHTTPBaseUrls:          *allowHTTPBaseUrls,
+		TimeBasedNotificationIndex: *timeBasedNotificationIndex,
 	}, nil
 }
 
@@ -261,6 +259,7 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 	logger.Info("build", zap.Any("description", build.Describe()))
 	logger.Info("config", zap.Bool("scd", *enableSCD))
 	logger.Info("config", zap.Bool("scdGlobalLock", *scdGlobalLock))
+	logger.Info("config", zap.Bool("timeBasedNotificationIndex", *timeBasedNotificationIndex))
 	// params.StoreParameters should not be used directly in this file but this log warning is temporarily helpful and will be removed in the future.
 	if params.GetStoreParameters().StoreType == params.RaftStoreType {
 		logger.Warn("The raft datastore is experimental and its implementation is in progress. See issue for more details: https://github.com/interuss/dss/issues/1463")

--- a/cmds/db-manager/cleanup/evict.go
+++ b/cmds/db-manager/cleanup/evict.go
@@ -54,12 +54,12 @@ func evict(cmd *cobra.Command, _ []string) error {
 
 	logger := logging.WithValuesFromContext(ctx, logging.Logger)
 
-	scdStore, err := scds.Init(ctx, logger, false, false)
+	scdStore, err := scds.Init(ctx, logger, false, false, false)
 	if err != nil {
 		return err
 	}
 
-	ridStore, err := rids.Init(ctx, logger, false)
+	ridStore, err := rids.Init(ctx, logger, false, false)
 	if err != nil {
 		return err
 	}

--- a/docs/operations/performances.md
+++ b/docs/operations/performances.md
@@ -35,6 +35,14 @@ All graphs have been generated with the [loadtest present in the monitoring repo
 ![](../assets/perfs_scd_lock_notoverlapping.png)
 *Non-overlapping requests. Notice the reduction of performance on the right, with a single lock.*
 
+## The time-based notification index option
+
+!!! danger
+    All DSS instances in a DSS pool must use the same value for this option. Mixing them will result in undetermined behavior.
+
+Following the rationale described in issue [#1541](https://github.com/interuss/dss/issues/1541), this flag use a time-based system for notification indexes in SCD and RID.
+Please check the details in the linked issue above and ensure you understand the consequences of enabling this flag, including the specific requirements you want or need to comply with.
+
 ## SCD lock diagnostics logs
 
 To help diagnose latency spikes (for example as discussed in [#1311](https://github.com/interuss/dss/issues/1311)), the SCD subscription lock path emits targeted warning logs when a lock query looks expensive.

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -61,7 +61,7 @@ func setUpStore(ctx context.Context, t *testing.T, logger *zap.Logger) (store.St
 
 	connectParameters.DBName = "rid"
 
-	store, err := ridc.Init(ctx, logger, false)
+	store, err := ridc.Init(ctx, logger, false, false)
 	require.NoError(t, err)
 	logger.Info("using sqlstore.")
 

--- a/pkg/rid/store/sqlstore/store.go
+++ b/pkg/rid/store/sqlstore/store.go
@@ -22,22 +22,24 @@ const (
 // use a database such as CockroachDB or YugabyteDB.
 type repo struct {
 	dssql.Queryable
-	clock  clockwork.Clock
-	logger *zap.Logger
+	clock                      clockwork.Clock
+	logger                     *zap.Logger
+	timeBasedNotificationIndex bool
 }
 
 // Init initializes the SQL-backed rid store. It return a concrete sqlstore.Store[rid.repos.Repository] providing the
 // ability to interact with a database-backed store of rid information.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*sqlstore.Store[repos.Repository], error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, timeBasedNotificationIndex bool) (*sqlstore.Store[repos.Repository], error) {
 	return sqlstore.Init(ctx, sqlstore.Config[repos.Repository]{
 		DBName:                 "rid",
 		CrdbMajorSchemaVersion: currentCrdbMajorSchemaVersion,
 		YbMajorSchemaVersion:   currentYugabyteMajorSchemaVersion,
 		NewRepo: func(q dssql.Queryable, clock clockwork.Clock, _ *sqlstore.Version) repos.Repository {
 			return &repo{
-				Queryable: q,
-				clock:     clock,
-				logger:    logging.WithValuesFromContext(ctx, logger),
+				Queryable:                  q,
+				clock:                      clock,
+				logger:                     logging.WithValuesFromContext(ctx, logger),
+				timeBasedNotificationIndex: timeBasedNotificationIndex,
 			}
 		},
 	}, withCheckCron)

--- a/pkg/rid/store/sqlstore/store_test.go
+++ b/pkg/rid/store/sqlstore/store_test.go
@@ -43,7 +43,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*sqlstore.Store[repos.Reposi
 }
 
 func newTestStore(ctx context.Context, t *testing.T, connectParameters params.ConnectParameters) (*sqlstore.Store[repos.Repository], error) {
-	s, err := Init(ctx, logging.Logger, false)
+	s, err := Init(ctx, logging.Logger, false, false)
 
 	if err != nil {
 		return nil, err

--- a/pkg/rid/store/sqlstore/subscriptions.go
+++ b/pkg/rid/store/sqlstore/subscriptions.go
@@ -55,6 +55,11 @@ func (r *repo) process(ctx context.Context, query string, args ...interface{}) (
 
 		s.SetCells(cids)
 		s.Version = dssmodels.VersionFromTime(updateTime)
+
+		if r.timeBasedNotificationIndex {
+			s.NotificationIndex = dssql.MillisSinceMidnight()
+		}
+
 		payload = append(payload, s)
 	}
 	if err := rows.Err(); err != nil {
@@ -214,19 +219,26 @@ func (r *repo) DeleteSubscription(ctx context.Context, s *ridmodels.Subscription
 // UpdateNotificationIdxsInCells incremement the notification for each sub in the given cells.
 func (r *repo) UpdateNotificationIdxsInCells(ctx context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
 
-	var notificationIndexIncrement = `notification_index = notification_index + 1`
-	if r.timeBasedNotificationIndex {
-		notificationIndexIncrement = `notification_index = floor(extract(epoch from now() - date_trunc('day', now())) * 1000)`
-	}
+	var updateQuery string
 
-	var updateQuery = fmt.Sprintf(`
+	if r.timeBasedNotificationIndex {
+		updateQuery = fmt.Sprintf(`
+			SELECT
+                %s
+            subscriptions
+			WHERE
+				cells && $1
+				AND ends_at >= $2`, subscriptionFields)
+	} else {
+		updateQuery = fmt.Sprintf(`
 			UPDATE subscriptions
 			SET
-				%s
+                notification_index = notification_index + 1
 			WHERE
 				cells && $1
 				AND ends_at >= $2
-			RETURNING %s`, notificationIndexIncrement, subscriptionFields)
+			RETURNING %s`, subscriptionFields)
+	}
 
 	return r.process(
 		ctx, updateQuery, dssql.CellUnionToCellIds(cells), r.clock.Now())

--- a/pkg/rid/store/sqlstore/subscriptions.go
+++ b/pkg/rid/store/sqlstore/subscriptions.go
@@ -213,13 +213,20 @@ func (r *repo) DeleteSubscription(ctx context.Context, s *ridmodels.Subscription
 
 // UpdateNotificationIdxsInCells incremement the notification for each sub in the given cells.
 func (r *repo) UpdateNotificationIdxsInCells(ctx context.Context, cells s2.CellUnion) ([]*ridmodels.Subscription, error) {
+
+	var notificationIndexIncrement = `notification_index = notification_index + 1`
+	if r.timeBasedNotificationIndex {
+		notificationIndexIncrement = `notification_index = floor(extract(epoch from now() - date_trunc('day', now())) * 1000)`
+	}
+
 	var updateQuery = fmt.Sprintf(`
 			UPDATE subscriptions
-			SET notification_index = notification_index + 1
+			SET
+				%s
 			WHERE
 				cells && $1
 				AND ends_at >= $2
-			RETURNING %s`, subscriptionFields)
+			RETURNING %s`, notificationIndexIncrement, subscriptionFields)
 
 	return r.process(
 		ctx, updateQuery, dssql.CellUnionToCellIds(cells), r.clock.Now())

--- a/pkg/rid/store/store.go
+++ b/pkg/rid/store/store.go
@@ -17,11 +17,11 @@ import (
 type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the rid store backend.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, timeBasedNotificationIndex bool) (Store, error) {
 	storeType := params.GetStoreParameters().StoreType
 	switch storeType {
 	case params.SQLStoreType:
-		return ridsqlstore.Init(ctx, logger, withCheckCron)
+		return ridsqlstore.Init(ctx, logger, withCheckCron, timeBasedNotificationIndex)
 	case params.RaftStoreType:
 		return ridraftstore.Init(ctx, logger)
 	default:

--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -103,7 +103,7 @@ func (a *Server) DeleteOperationalIntentReference(ctx context.Context, req *rest
 			subscriptionIds = append(subscriptionIds, *old.SubscriptionID)
 		}
 
-		if !a.TimeBasedNotificationIndexEnabled {
+		if !a.TimeBasedNotificationIndex {
 			err = r.LockSubscriptionsOnCells(ctx, old.Cells, subscriptionIds, old.StartTime, old.EndTime)
 			if err != nil {
 				return stacktrace.Propagate(err, "Unable to acquire lock")
@@ -799,7 +799,7 @@ func (a *Server) upsertOperationalIntentReference(ctx context.Context, now time.
 			subscriptionIds = append(subscriptionIds, validParams.subscriptionID)
 		}
 
-		if !a.TimeBasedNotificationIndexEnabled {
+		if !a.TimeBasedNotificationIndex {
 			err = r.LockSubscriptionsOnCells(ctx, validParams.cells, subscriptionIds, validParams.uExtent.StartTime, validParams.uExtent.EndTime)
 			if err != nil {
 				return stacktrace.Propagate(err, "Unable to acquire lock")

--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -103,9 +103,11 @@ func (a *Server) DeleteOperationalIntentReference(ctx context.Context, req *rest
 			subscriptionIds = append(subscriptionIds, *old.SubscriptionID)
 		}
 
-		err = r.LockSubscriptionsOnCells(ctx, old.Cells, subscriptionIds, old.StartTime, old.EndTime)
-		if err != nil {
-			return stacktrace.Propagate(err, "Unable to acquire lock")
+		if !a.TimeBasedNotificationIndexEnabled {
+			err = r.LockSubscriptionsOnCells(ctx, old.Cells, subscriptionIds, old.StartTime, old.EndTime)
+			if err != nil {
+				return stacktrace.Propagate(err, "Unable to acquire lock")
+			}
 		}
 
 		// Get the Subscription supporting the OperationalIntent, if one is defined
@@ -797,9 +799,11 @@ func (a *Server) upsertOperationalIntentReference(ctx context.Context, now time.
 			subscriptionIds = append(subscriptionIds, validParams.subscriptionID)
 		}
 
-		err = r.LockSubscriptionsOnCells(ctx, validParams.cells, subscriptionIds, validParams.uExtent.StartTime, validParams.uExtent.EndTime)
-		if err != nil {
-			return stacktrace.Propagate(err, "Unable to acquire lock")
+		if !a.TimeBasedNotificationIndexEnabled {
+			err = r.LockSubscriptionsOnCells(ctx, validParams.cells, subscriptionIds, validParams.uExtent.StartTime, validParams.uExtent.EndTime)
+			if err != nil {
+				return stacktrace.Propagate(err, "Unable to acquire lock")
+			}
 		}
 
 		// Validate the request against the previous OIR

--- a/pkg/scd/server.go
+++ b/pkg/scd/server.go
@@ -29,8 +29,8 @@ func makeSubscribersToNotify(subscriptions []*scdmodels.Subscription) []restapi.
 
 // Server implements scdv1.Implementation.
 type Server struct {
-	Store                             scdstore.Store
-	DSSReportHandler                  ReceivedReportHandler
-	AllowHTTPBaseUrls                 bool
-	TimeBasedNotificationIndexEnabled bool
+	Store                      scdstore.Store
+	DSSReportHandler           ReceivedReportHandler
+	AllowHTTPBaseUrls          bool
+	TimeBasedNotificationIndex bool
 }

--- a/pkg/scd/server.go
+++ b/pkg/scd/server.go
@@ -29,7 +29,8 @@ func makeSubscribersToNotify(subscriptions []*scdmodels.Subscription) []restapi.
 
 // Server implements scdv1.Implementation.
 type Server struct {
-	Store             scdstore.Store
-	DSSReportHandler  ReceivedReportHandler
-	AllowHTTPBaseUrls bool
+	Store                             scdstore.Store
+	DSSReportHandler                  ReceivedReportHandler
+	AllowHTTPBaseUrls                 bool
+	TimeBasedNotificationIndexEnabled bool
 }

--- a/pkg/scd/store/sqlstore/store.go
+++ b/pkg/scd/store/sqlstore/store.go
@@ -25,12 +25,12 @@ type repo struct {
 	clock                      clockwork.Clock
 	logger                     *zap.Logger
 	globalLock                 bool
-	timebasedNotificationIndex bool
+	timeBasedNotificationIndex bool
 }
 
 // Init initializes the SQL-backed sid store. It return a concrete sqlstore.Store[sid.repos.Repository] providing the
 // ability to interact with a database-backed store of sid information.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool, timebasedNotificationIndex bool) (*sqlstore.Store[repos.Repository], error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool, timeBasedNotificationIndex bool) (*sqlstore.Store[repos.Repository], error) {
 	return sqlstore.Init(ctx, sqlstore.Config[repos.Repository]{
 		DBName:                 "scd",
 		CrdbMajorSchemaVersion: currentCrdbMajorSchemaVersion,
@@ -41,7 +41,7 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLoc
 				clock:                      clock,
 				logger:                     logging.WithValuesFromContext(ctx, logger),
 				globalLock:                 globalLock,
-				timebasedNotificationIndex: timebasedNotificationIndex,
+				timeBasedNotificationIndex: timeBasedNotificationIndex,
 			}
 		},
 	}, withCheckCron)

--- a/pkg/scd/store/sqlstore/store.go
+++ b/pkg/scd/store/sqlstore/store.go
@@ -21,25 +21,27 @@ const (
 // scd.store.sqlstore.repo is a full implementation of scd.repos.Repository for data backings that
 // use a database such as CockroachDB or YugabyteDB.
 type repo struct {
-	q          dssql.Queryable
-	clock      clockwork.Clock
-	logger     *zap.Logger
-	globalLock bool
+	q                          dssql.Queryable
+	clock                      clockwork.Clock
+	logger                     *zap.Logger
+	globalLock                 bool
+	timebasedNotificationIndex bool
 }
 
 // Init initializes the SQL-backed sid store. It return a concrete sqlstore.Store[sid.repos.Repository] providing the
 // ability to interact with a database-backed store of sid information.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool) (*sqlstore.Store[repos.Repository], error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool, timebasedNotificationIndex bool) (*sqlstore.Store[repos.Repository], error) {
 	return sqlstore.Init(ctx, sqlstore.Config[repos.Repository]{
 		DBName:                 "scd",
 		CrdbMajorSchemaVersion: currentCrdbMajorSchemaVersion,
 		YbMajorSchemaVersion:   currentYugabyteMajorSchemaVersion,
 		NewRepo: func(q dssql.Queryable, clock clockwork.Clock, _ *sqlstore.Version) repos.Repository {
 			return &repo{
-				q:          q,
-				clock:      clock,
-				logger:     logging.WithValuesFromContext(ctx, logger),
-				globalLock: globalLock,
+				q:                          q,
+				clock:                      clock,
+				logger:                     logging.WithValuesFromContext(ctx, logger),
+				globalLock:                 globalLock,
+				timebasedNotificationIndex: timebasedNotificationIndex,
 			}
 		},
 	}, withCheckCron)

--- a/pkg/scd/store/sqlstore/store_test.go
+++ b/pkg/scd/store/sqlstore/store_test.go
@@ -34,7 +34,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*sqlstore.Store[repos.Reposi
 }
 
 func newTestStore(ctx context.Context, t *testing.T, connectParameters params.ConnectParameters) (*sqlstore.Store[repos.Repository], error) {
-	s, err := Init(ctx, logging.Logger, false, false)
+	s, err := Init(ctx, logging.Logger, false, false, false)
 
 	if err != nil {
 		return nil, err

--- a/pkg/scd/store/sqlstore/subscriptions.go
+++ b/pkg/scd/store/sqlstore/subscriptions.go
@@ -93,6 +93,10 @@ func (c *repo) fetchSubscriptions(ctx context.Context, q dsssql.Queryable, query
 			return nil, stacktrace.Propagate(err, "Error generating Subscription version")
 		}
 		s.SetCells(cids)
+
+		if c.timeBasedNotificationIndex {
+			s.NotificationIndex = dsssql.MillisSinceMidnight()
+		}
 		payload = append(payload, s)
 	}
 	if err = rows.Err(); err != nil {
@@ -198,6 +202,11 @@ func (c *repo) pushSubscription(ctx context.Context, q dsssql.Queryable, s *scdm
 		s.StartTime,
 		s.EndTime,
 		cids)
+
+	if c.timeBasedNotificationIndex {
+		s.NotificationIndex = dsssql.MillisSinceMidnight()
+	}
+
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "Error fetching Subscription from upsert query")
 	}
@@ -298,16 +307,30 @@ func (c *repo) SearchSubscriptions(ctx context.Context, v4d *dssmodels.Volume4D)
 // them with the new index..
 func (c *repo) IncrementNotificationIndicesForOperationalIntents(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
 
-	var notificationIndexIncrement = `notification_index = notification_index + 1`
-	if c.timebasedNotificationIndex {
-		notificationIndexIncrement = `notification_index = floor(extract(epoch from now() - date_trunc('day', now())) * 1000)`
-	}
+	var query string
 
-	var query = fmt.Sprintf(`
+	if c.timeBasedNotificationIndex {
+		query = fmt.Sprintf(`
+                SELECT
+                    %s
+                FROM
+                    scd_subscriptions
+                    WHERE
+                        cells && $1
+                    AND
+                        COALESCE(starts_at <= $3, true)
+                    AND
+                        COALESCE(ends_at >= $2, true)
+                    AND
+                        notify_for_operations
+                    `, subscriptionFieldsWithPrefix)
+	} else {
+
+		query = fmt.Sprintf(`
 		UPDATE
 			scd_subscriptions
 		SET
-			%s
+			notification_index = notification_index + 1
 		WHERE
 			cells && $1
 		AND
@@ -317,7 +340,9 @@ func (c *repo) IncrementNotificationIndicesForOperationalIntents(ctx context.Con
 		AND
 			notify_for_operations
 		RETURNING
-			%s`, notificationIndexIncrement, subscriptionFieldsWithoutPrefix)
+			%s`, subscriptionFieldsWithoutPrefix)
+
+	}
 
 	cells, err := v4d.CalculateSpatialCovering()
 	if err != nil {
@@ -334,16 +359,31 @@ func (c *repo) IncrementNotificationIndicesForOperationalIntents(ctx context.Con
 // constraint notifications, increments their notification index and returns them with the
 // new index.
 func (c *repo) IncrementNotificationIndicesForConstraints(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
-	var notificationIndexIncrement = `notification_index = notification_index + 1`
-	if c.timebasedNotificationIndex {
-		notificationIndexIncrement = `notification_index = floor(extract(epoch from now() - date_trunc('day', now())) * 1000)`
-	}
 
-	var query = fmt.Sprintf(`
+	var query string
+
+	if c.timeBasedNotificationIndex {
+		query = fmt.Sprintf(`
+                SELECT
+                    %s
+                FROM
+                    scd_subscriptions
+                    WHERE
+                        cells && $1
+                    AND
+                        COALESCE(starts_at <= $3, true)
+                    AND
+                        COALESCE(ends_at >= $2, true)
+                    AND
+                        notify_for_constraints
+                    `, subscriptionFieldsWithPrefix)
+	} else {
+
+		query = fmt.Sprintf(`
 		UPDATE
 			scd_subscriptions
 		SET
-			%s
+			notification_index = notification_index + 1
 		WHERE
 			cells && $1
 		AND
@@ -353,7 +393,9 @@ func (c *repo) IncrementNotificationIndicesForConstraints(ctx context.Context, v
 		AND
 			notify_for_constraints
 		RETURNING
-			%s`, notificationIndexIncrement, subscriptionFieldsWithoutPrefix)
+			%s`, subscriptionFieldsWithoutPrefix)
+
+	}
 
 	cells, err := v4d.CalculateSpatialCovering()
 	if err != nil {

--- a/pkg/scd/store/sqlstore/subscriptions.go
+++ b/pkg/scd/store/sqlstore/subscriptions.go
@@ -297,11 +297,17 @@ func (c *repo) SearchSubscriptions(ctx context.Context, v4d *dssmodels.Volume4D)
 // want operational intent notifications, increments their notification index and returns
 // them with the new index..
 func (c *repo) IncrementNotificationIndicesForOperationalIntents(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
+
+	var notificationIndexIncrement = `notification_index = notification_index + 1`
+	if c.timebasedNotificationIndex {
+		notificationIndexIncrement = `notification_index = floor(extract(epoch from now() - date_trunc('day', now())) * 1000)`
+	}
+
 	var query = fmt.Sprintf(`
 		UPDATE
 			scd_subscriptions
 		SET
-			notification_index = notification_index + 1
+			%s
 		WHERE
 			cells && $1
 		AND
@@ -311,7 +317,7 @@ func (c *repo) IncrementNotificationIndicesForOperationalIntents(ctx context.Con
 		AND
 			notify_for_operations
 		RETURNING
-			%s`, subscriptionFieldsWithoutPrefix)
+			%s`, notificationIndexIncrement, subscriptionFieldsWithoutPrefix)
 
 	cells, err := v4d.CalculateSpatialCovering()
 	if err != nil {
@@ -328,11 +334,16 @@ func (c *repo) IncrementNotificationIndicesForOperationalIntents(ctx context.Con
 // constraint notifications, increments their notification index and returns them with the
 // new index.
 func (c *repo) IncrementNotificationIndicesForConstraints(ctx context.Context, v4d *dssmodels.Volume4D) ([]*scdmodels.Subscription, error) {
+	var notificationIndexIncrement = `notification_index = notification_index + 1`
+	if c.timebasedNotificationIndex {
+		notificationIndexIncrement = `notification_index = floor(extract(epoch from now() - date_trunc('day', now())) * 1000)`
+	}
+
 	var query = fmt.Sprintf(`
 		UPDATE
 			scd_subscriptions
 		SET
-			notification_index = notification_index + 1
+			%s
 		WHERE
 			cells && $1
 		AND
@@ -342,7 +353,7 @@ func (c *repo) IncrementNotificationIndicesForConstraints(ctx context.Context, v
 		AND
 			notify_for_constraints
 		RETURNING
-			%s`, subscriptionFieldsWithoutPrefix)
+			%s`, notificationIndexIncrement, subscriptionFieldsWithoutPrefix)
 
 	cells, err := v4d.CalculateSpatialCovering()
 	if err != nil {

--- a/pkg/scd/store/store.go
+++ b/pkg/scd/store/store.go
@@ -17,11 +17,11 @@ import (
 type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the scd store backend.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool) (Store, error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool, timeBasedNotificationIndex bool) (Store, error) {
 	storeType := params.GetStoreParameters().StoreType
 	switch storeType {
 	case params.SQLStoreType:
-		return scdsqlstore.Init(ctx, logger, withCheckCron, globalLock)
+		return scdsqlstore.Init(ctx, logger, withCheckCron, globalLock, timeBasedNotificationIndex)
 	case params.RaftStoreType:
 		return scdraftstore.Init(ctx, logger)
 	default:

--- a/pkg/sql/utils.go
+++ b/pkg/sql/utils.go
@@ -1,10 +1,12 @@
 package sql
 
 import (
+	"slices"
+	"time"
+
 	"github.com/golang/geo/s2"
 	"github.com/interuss/dss/pkg/geo"
 	"github.com/interuss/stacktrace"
-	"slices"
 )
 
 func CellUnionToCellIds(cu s2.CellUnion) []int64 {
@@ -32,4 +34,10 @@ func ForUpdate(forUpdate bool) string {
 		return "FOR UPDATE"
 	}
 	return ""
+}
+
+func MillisSinceMidnight() int {
+	now := time.Now().UTC()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	return int(now.Sub(midnight).Milliseconds())
 }


### PR DESCRIPTION
This PR contribute to #1541 by adding a flag to use current time for notification indexes.

When active, this will also remove the explicit lock on subscriptions.

A few remarks:

- The field in the table is not removed and still fetched / inserted, it's just left to default value. This shouldn't have a meaningful impact on performance and avoid maintaining a double query system / schema for all queries.
- Subscription table still need to be read to fetch and return the list of endpoint to notify. This mean the potential for contention still exists, as in CRDB serializable mode, inserting a new subscription in a parallel query should make the transaction to be restarted.
- Please assess performance before using the flag for your use case
- Doesn't include changes on infrastructure, that will come in a follow-up PR.
- Passage of flag like that starts to be tedious (especially as there are others PR that also add more flags). I will propose in a follow up PR a shared object and update of the aux endpoint to be normalized. For now the option is not exposed.