### PR TITLE
[deploy] Add datastore_max_open_conns flags to available options

### DIFF
--- a/deploy/infrastructure/dependencies/terraform-commons-dss/helm.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/helm.tf
@@ -71,6 +71,7 @@ resource "local_file" "helm_chart_values" {
         enableTimeBasedNotificationIndex = var.enable_time_based_notification_index
         enableDssMetrics                 = var.enable_dss_metrics
         locality                         = "zone=${var.locality}"
+        datastoreMaxOpenConns            = var.datastore_max_open_conns
 
         evict = {
           scd = {
@@ -279,6 +280,7 @@ resource "local_file" "helm_chart_values" {
         enableTimeBasedNotificationIndex = var.enable_time_based_notification_index
         enableDssMetrics                 = var.enable_dss_metrics
         locality                         = "zone=${var.locality}"
+        datastoreMaxOpenConns            = var.datastore_max_open_conns
 
         evict = {
           scd = {

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/tanka.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/tanka.tf
@@ -14,6 +14,7 @@ resource "local_file" "tanka_config_main" {
     VAR_DB_HOSTNAME_SUFFIX                   = var.db_hostname_suffix
     VAR_LOCALITY                             = var.locality
     VAR_DATASTORE                            = var.datastore_type
+    VAR_DATASTORE_MAX_OPEN_CONNS             = var.datastore_max_open_conns
     VAR_CRDB_NODE_IPS                        = join(",", [for i in var.crdb_internal_nodes[*].ip : "'${i}'"])
     VAR_INGRESS_NAME                         = var.ip_gateway
     VAR_CRDB_EXTERNAL_NODES                  = join(",", [for a in var.crdb_external_nodes : "'${a}'"])

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/templates/main.jsonnet.tmp
@@ -15,6 +15,7 @@ local metadata = metadataBase {
   enableTimeBasedNotificationIndex: ${VAR_ENABLE_TIME_BASED_NOTIFICATION_INDEX}, // <-- This boolean value is VAR_ENABLE_TIME_BASED_NOTIFICATION_INDEX
   enableDssMetrics: ${VAR_ENABLE_DSS_METRICS}, // <-- This boolean value is VAR_ENABLE_DSS_METRICS
   datastore: '${VAR_DATASTORE}',
+  datastoreMaxOpenConns: ${VAR_DATASTORE_MAX_OPEN_CONNS},
   locality: '${VAR_LOCALITY}',
   cockroach+: {
     image: '${VAR_CRDB_DOCKER_IMAGE_NAME}',

--- a/deploy/infrastructure/dependencies/terraform-commons-dss/variables.gen.tf
+++ b/deploy/infrastructure/dependencies/terraform-commons-dss/variables.gen.tf
@@ -289,6 +289,13 @@ variable "locality" {
 }
 
 
+variable "datastore_max_open_conns" {
+  type        = number
+  description = "Maximum number of open connections to the datastore."
+  default     = 4
+}
+
+
 variable "crdb_external_nodes" {
   type        = list(string)
   description = <<-EOT

--- a/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
@@ -135,6 +135,10 @@ From v.17, the recommended CockroachDB version is v24.1.3.</p>
                 <td><p>This variable has been renamed to locality and is left to warn users about migration.</p>
 <br/>Default value: <code>""</code></td>
             </tr><tr>
+                <td>datastore_max_open_conns (<code>number</code>)</td>
+                <td><p>Maximum number of open connections to the datastore.</p>
+<br/>Default value: <code>4</code></td>
+            </tr><tr>
                 <td>datastore_type (<code>string</code>)</td>
                 <td><p>Type of datastore used</p>
 <p>Supported technologies: cockroachdb, yugabyte</p>

--- a/deploy/infrastructure/modules/terraform-aws-dss/main.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/main.tf
@@ -27,6 +27,7 @@ module "terraform-commons-dss" {
   crdb_cluster_name                    = var.crdb_cluster_name
   db_hostname_suffix                   = var.db_hostname_suffix
   datastore_type                       = var.datastore_type
+  datastore_max_open_conns             = var.datastore_max_open_conns
   should_init                          = var.should_init
   authorization                        = var.authorization
   locality                             = var.locality

--- a/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
@@ -403,6 +403,13 @@ variable "locality" {
 }
 
 
+variable "datastore_max_open_conns" {
+  type        = number
+  description = "Maximum number of open connections to the datastore."
+  default     = 4
+}
+
+
 variable "crdb_external_nodes" {
   type        = list(string)
   description = <<-EOT

--- a/deploy/infrastructure/modules/terraform-google-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-google-dss/TFVARS.gen.md
@@ -97,6 +97,10 @@ From v.17, the recommended CockroachDB version is v24.1.3.</p>
                 <td><p>This variable has been renamed to locality and is left to warn users about migration.</p>
 <br/>Default value: <code>""</code></td>
             </tr><tr>
+                <td>datastore_max_open_conns (<code>number</code>)</td>
+                <td><p>Maximum number of open connections to the datastore.</p>
+<br/>Default value: <code>4</code></td>
+            </tr><tr>
                 <td>datastore_type (<code>string</code>)</td>
                 <td><p>Type of datastore used</p>
 <p>Supported technologies: cockroachdb, yugabyte</p>

--- a/deploy/infrastructure/modules/terraform-google-dss/main.tf
+++ b/deploy/infrastructure/modules/terraform-google-dss/main.tf
@@ -27,6 +27,7 @@ module "terraform-commons-dss" {
   crdb_cluster_name                    = var.crdb_cluster_name
   db_hostname_suffix                   = var.db_hostname_suffix
   datastore_type                       = var.datastore_type
+  datastore_max_open_conns             = var.datastore_max_open_conns
   should_init                          = var.should_init
   authorization                        = var.authorization
   locality                             = var.locality

--- a/deploy/infrastructure/modules/terraform-google-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-google-dss/variables.gen.tf
@@ -405,6 +405,13 @@ variable "locality" {
 }
 
 
+variable "datastore_max_open_conns" {
+  type        = number
+  description = "Maximum number of open connections to the datastore."
+  default     = 4
+}
+
+
 variable "crdb_external_nodes" {
   type        = list(string)
   description = <<-EOT

--- a/deploy/infrastructure/utils/definitions/datastore_max_open_conns.tf
+++ b/deploy/infrastructure/utils/definitions/datastore_max_open_conns.tf
@@ -1,0 +1,5 @@
+variable "datastore_max_open_conns" {
+  type        = number
+  description = "Maximum number of open connections to the datastore."
+  default     = 4
+}

--- a/deploy/infrastructure/utils/variables.py
+++ b/deploy/infrastructure/utils/variables.py
@@ -47,6 +47,7 @@ COMMONS_DSS_VARIABLES = GLOBAL_VARIABLES + [
     "crdb_image_tag",
     "crdb_cluster_name",
     "locality",
+    "datastore_max_open_conns",
     "crdb_external_nodes",
     "kubernetes_namespace",
     "yugabyte_cloud",

--- a/deploy/operations/ci/aws-1/variables.gen.tf
+++ b/deploy/operations/ci/aws-1/variables.gen.tf
@@ -403,6 +403,13 @@ variable "locality" {
 }
 
 
+variable "datastore_max_open_conns" {
+  type        = number
+  description = "Maximum number of open connections to the datastore."
+  default     = 4
+}
+
+
 variable "crdb_external_nodes" {
   type        = list(string)
   description = <<-EOT

--- a/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
+++ b/deploy/services/helm-charts/dss/templates/dss-core-service.yaml
@@ -57,6 +57,7 @@ spec:
             - --datastore_host={{ $datastoreHost }}
             - --datastore_port={{ $datastorePort }}
             - --datastore_user={{ $datastoreUser }}
+            - --datastore_max_open_conns={{$dss.conf.datastoreMaxOpenConns | default 4}}
 {{ if $.Values.cockroachdb.enabled }}
             - --datastore_ssl_dir=/cockroach/cockroach-certs
             - --datastore_ssl_mode=verify-full

--- a/deploy/services/helm-charts/dss/values.example.yaml
+++ b/deploy/services/helm-charts/dss/values.example.yaml
@@ -16,6 +16,7 @@ dss:
     enableTimeBasedNotificationIndex: false
     enableDssMetrics: false
     locality: zone=interuss-example-google-ew1
+    datastoreMaxOpenConns: 4
 
 cockroachdb:
   enabled: true

--- a/deploy/services/helm-charts/dss/values.schema.json
+++ b/deploy/services/helm-charts/dss/values.schema.json
@@ -284,6 +284,9 @@
               "description": "Locality attribute for this deployment. Example: zone=example",
               "type": "string"
             },
+            "datastoreMaxOpenConns": {
+              "type": "integer"
+            },
             "evict": {
               "description": "Evict jobs configuration",
               "type": "object",

--- a/deploy/services/tanka/datastoreparameters.libsonnet
+++ b/deploy/services/tanka/datastoreparameters.libsonnet
@@ -6,11 +6,13 @@
       datastore_ssl_mode: 'verify-full',
       datastore_user: 'root',
       datastore_ssl_dir: '/cockroach/cockroach-certs',
+      datastore_max_open_conns: metadata.datastoreMaxOpenConns,
     } else {
       datastore_host: 'yb-tservers.' + metadata.namespace,
       datastore_port: 5433,
       datastore_ssl_mode: 'verify-full',
       datastore_user: 'yugabyte',
       datastore_ssl_dir: '/opt/yugabyte-certs/',
+      datastore_max_open_conns: metadata.datastoreMaxOpenConns,
     }
 }

--- a/deploy/services/tanka/examples/minikube/main.jsonnet
+++ b/deploy/services/tanka/examples/minikube/main.jsonnet
@@ -13,6 +13,7 @@ local metadata = metadataBase {
   enableTimeBasedNotificationIndex: false,
   enableDssMetrics: false,
   datastore: 'yugabyte',
+  datastoreMaxOpenConns: 4,
   locality: 'minikube',
   cockroach+: {
     image: 'cockroachdb/cockroach:v24.1.3',

--- a/deploy/services/tanka/examples/minimum/main.jsonnet
+++ b/deploy/services/tanka/examples/minimum/main.jsonnet
@@ -15,6 +15,7 @@ local metadata = metadataBase {
   enableTimeBasedNotificationIndex: false, // <-- This boolean value is VAR_ENABLE_TIME_BASED_NOTIFICATION_INDEX
   enableDssMetrics: false, // <-- This boolean value is VAR_ENABLE_DSS_METRICS
   datastore: 'VAR_DATASTORE',
+  datastoreMaxOpenConns: 4, // <-- This integer value is VAR_DATASTORE_MAX_OPEN_CONNS
   locality: 'VAR_LOCALITY',
   cockroach+: {
     image: 'VAR_CRDB_DOCKER_IMAGE_NAME',

--- a/deploy/services/tanka/metadata_base.libsonnet
+++ b/deploy/services/tanka/metadata_base.libsonnet
@@ -12,6 +12,7 @@
   enableTimeBasedNotificationIndex: false,
   enableDssMetrics: false,
   datastore: 'cockroachdb',
+  datastoreMaxOpenConns: 4,
   locality: error 'must supply locality',
   cockroach: {
     locality: '',

--- a/docs/infrastructure/google-manual.md
+++ b/docs/infrastructure/google-manual.md
@@ -232,6 +232,8 @@ your chosen provider.
 
     1.  `VAR_DATASTORE`: Datastore to use. Can be set to 'cockroachdb' or 'yugabyte'.
 
+    1.  `VAR_DATASTORE_MAX_OPEN_CONNS`: Maximum number of open connections to the database, default is 4.
+
     1.  `VAR_CRDB_DOCKER_IMAGE_NAME`: Docker image of cockroach db pods. Until
         DSS v0.16, the recommended CockroachDB image name is `cockroachdb/cockroach:v21.2.7`.
         From DSS v0.17, the recommended CockroachDB version is `cockroachdb/cockroach:v24.1.3`.


### PR DESCRIPTION
This PR follow #1562 

It does add datastore_max_open_conns flag as an option for the deploy tools. Default to the DSS current default.