### PR TITLE
[store] Move behaviour flags to a dedicated config object

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -65,9 +65,6 @@ var (
 	jwksKeyIDs        = flag.String("jwks_key_ids", "", "IDs of a set of key in a JWKS, separated by commas")
 	keyRefreshTimeout = flag.Duration("key_refresh_timeout", 1*time.Minute, "Timeout for refreshing keys for JWT verification")
 	jwtAudiences      = flag.String("accepted_jwt_audiences", "", "comma-separated acceptable JWT `aud` claims")
-
-	scdGlobalLock              = flag.Bool("enable_scd_global_lock", false, "Experimental: Use a global lock when working with SCD subscriptions. Reduce global throughput but improve throughput with lot of subscriptions in the same areas.")
-	timeBasedNotificationIndex = flag.Bool("enable_time_based_notification_index", false, "Use a time-based notification index when working with RID and SCD subscriptions.")
 )
 
 func createKeyResolver() (auth.KeyResolver, error) {
@@ -91,7 +88,7 @@ func createKeyResolver() (auth.KeyResolver, error) {
 	}
 }
 
-func createAuxServer(ctx context.Context, locality string, publicEndpoint string, scdGlobalLock bool, logger *zap.Logger) (*aux.Server, error) {
+func createAuxServer(ctx context.Context, locality string, publicEndpoint string, opts params.Options, logger *zap.Logger) (*aux.Server, error) {
 	auxStore, err := auxs.Init(ctx, logger, true)
 	if err != nil {
 		return nil, err
@@ -108,12 +105,12 @@ func createAuxServer(ctx context.Context, locality string, publicEndpoint string
 		return nil, stacktrace.Propagate(err, "Unable to store current metadata")
 	}
 
-	return &aux.Server{Store: auxStore, Locality: locality, ScdGlobalLock: scdGlobalLock}, nil
+	return &aux.Server{Store: auxStore, Locality: locality, Options: opts}, nil
 }
 
 func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) (*rid_v1.Server, *rid_v2.Server, error) {
 
-	ridStore, err := rids.Init(ctx, logger, true, *timeBasedNotificationIndex)
+	ridStore, err := rids.Init(ctx, logger, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -145,7 +142,7 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 
 func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, error) {
 
-	scdStore, err := scds.Init(ctx, logger, true, *scdGlobalLock, *timeBasedNotificationIndex)
+	scdStore, err := scds.Init(ctx, logger, true)
 	if err != nil {
 		return nil, err
 	}
@@ -159,10 +156,9 @@ func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, erro
 	}
 
 	return &scd.Server{
-		Store:                      scdStore,
-		DSSReportHandler:           &scd.JSONLoggingReceivedReportHandler{ReportLogger: logger},
-		AllowHTTPBaseUrls:          *allowHTTPBaseUrls,
-		TimeBasedNotificationIndex: *timeBasedNotificationIndex,
+		Store:             scdStore,
+		DSSReportHandler:  &scd.JSONLoggingReceivedReportHandler{ReportLogger: logger},
+		AllowHTTPBaseUrls: *allowHTTPBaseUrls,
 	}, nil
 }
 
@@ -258,8 +254,9 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 	logger.Info("version", zap.Any("version", version.Current()))
 	logger.Info("build", zap.Any("description", build.Describe()))
 	logger.Info("config", zap.Bool("scd", *enableSCD))
-	logger.Info("config", zap.Bool("scdGlobalLock", *scdGlobalLock))
-	logger.Info("config", zap.Bool("timeBasedNotificationIndex", *timeBasedNotificationIndex))
+	storeOptions := params.GetStoreOptions()
+	logger.Info("config", zap.Bool("scdGlobalLock", storeOptions.GlobalLock))
+	logger.Info("config", zap.Bool("timeBasedNotificationIndex", storeOptions.TimeBasedNotificationIndex))
 	// params.StoreParameters should not be used directly in this file but this log warning is temporarily helpful and will be removed in the future.
 	if params.GetStoreParameters().StoreType == params.RaftStoreType {
 		logger.Warn("The raft datastore is experimental and its implementation is in progress. See issue for more details: https://github.com/interuss/dss/issues/1463")
@@ -284,7 +281,7 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 	defer ctxCancel()
 
 	// Initialize aux
-	auxV1Server, err = createAuxServer(ctx, locality, *publicEndpoint, *scdGlobalLock, logger)
+	auxV1Server, err = createAuxServer(ctx, locality, *publicEndpoint, storeOptions, logger)
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to create aux server")
 	}

--- a/cmds/db-manager/cleanup/evict.go
+++ b/cmds/db-manager/cleanup/evict.go
@@ -54,12 +54,12 @@ func evict(cmd *cobra.Command, _ []string) error {
 
 	logger := logging.WithValuesFromContext(ctx, logging.Logger)
 
-	scdStore, err := scds.Init(ctx, logger, false, false, false)
+	scdStore, err := scds.Init(ctx, logger, false)
 	if err != nil {
 		return err
 	}
 
-	ridStore, err := rids.Init(ctx, logger, false, false)
+	ridStore, err := rids.Init(ctx, logger, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/aux_/scd_lock_mode.go
+++ b/pkg/aux_/scd_lock_mode.go
@@ -8,5 +8,5 @@ import (
 
 func (a *Server) GetScdLockMode(ctx context.Context, req *restapi.GetScdLockModeRequest) restapi.GetScdLockModeResponseSet {
 
-	return restapi.GetScdLockModeResponseSet{Response200: &restapi.SCDLockModeResponse{GlobalLock: &a.ScdGlobalLock}}
+	return restapi.GetScdLockModeResponseSet{Response200: &restapi.SCDLockModeResponse{GlobalLock: &a.Options.GlobalLock}}
 }

--- a/pkg/aux_/server.go
+++ b/pkg/aux_/server.go
@@ -7,6 +7,7 @@ import (
 	restapi "github.com/interuss/dss/pkg/api/auxv1"
 	auxstore "github.com/interuss/dss/pkg/aux_/store"
 	dsserr "github.com/interuss/dss/pkg/errors"
+	storeparams "github.com/interuss/dss/pkg/store/params"
 
 	"github.com/interuss/dss/pkg/version"
 	"github.com/interuss/stacktrace"
@@ -14,9 +15,9 @@ import (
 
 // Server implements auxv1.Implementation.
 type Server struct {
-	Store         auxstore.Store
-	Locality      string
-	ScdGlobalLock bool
+	Store    auxstore.Store
+	Locality string
+	Options  storeparams.Options
 }
 
 // GetVersion returns information about the version of the server.

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -61,7 +61,7 @@ func setUpStore(ctx context.Context, t *testing.T, logger *zap.Logger) (store.St
 
 	connectParameters.DBName = "rid"
 
-	store, err := ridc.Init(ctx, logger, false, false)
+	store, err := ridc.Init(ctx, logger, false)
 	require.NoError(t, err)
 	logger.Info("using sqlstore.")
 

--- a/pkg/rid/store/sqlstore/store.go
+++ b/pkg/rid/store/sqlstore/store.go
@@ -8,6 +8,7 @@ import (
 	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/rid/repos"
 	"github.com/interuss/dss/pkg/sqlstore"
+	"github.com/interuss/dss/pkg/store/params"
 	"github.com/jonboulle/clockwork"
 	"go.uber.org/zap"
 )
@@ -29,7 +30,8 @@ type repo struct {
 
 // Init initializes the SQL-backed rid store. It return a concrete sqlstore.Store[rid.repos.Repository] providing the
 // ability to interact with a database-backed store of rid information.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, timeBasedNotificationIndex bool) (*sqlstore.Store[repos.Repository], error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*sqlstore.Store[repos.Repository], error) {
+	opts := params.GetStoreOptions()
 	return sqlstore.Init(ctx, sqlstore.Config[repos.Repository]{
 		DBName:                 "rid",
 		CrdbMajorSchemaVersion: currentCrdbMajorSchemaVersion,
@@ -39,7 +41,7 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, timeBased
 				Queryable:                  q,
 				clock:                      clock,
 				logger:                     logging.WithValuesFromContext(ctx, logger),
-				timeBasedNotificationIndex: timeBasedNotificationIndex,
+				timeBasedNotificationIndex: opts.TimeBasedNotificationIndex,
 			}
 		},
 	}, withCheckCron)

--- a/pkg/rid/store/sqlstore/store_test.go
+++ b/pkg/rid/store/sqlstore/store_test.go
@@ -43,7 +43,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*sqlstore.Store[repos.Reposi
 }
 
 func newTestStore(ctx context.Context, t *testing.T, connectParameters params.ConnectParameters) (*sqlstore.Store[repos.Repository], error) {
-	s, err := Init(ctx, logging.Logger, false, false)
+	s, err := Init(ctx, logging.Logger, false)
 
 	if err != nil {
 		return nil, err

--- a/pkg/rid/store/store.go
+++ b/pkg/rid/store/store.go
@@ -17,11 +17,11 @@ import (
 type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the rid store backend.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, timeBasedNotificationIndex bool) (Store, error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
 	storeType := params.GetStoreParameters().StoreType
 	switch storeType {
 	case params.SQLStoreType:
-		return ridsqlstore.Init(ctx, logger, withCheckCron, timeBasedNotificationIndex)
+		return ridsqlstore.Init(ctx, logger, withCheckCron)
 	case params.RaftStoreType:
 		return ridraftstore.Init(ctx, logger)
 	default:

--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -103,11 +103,9 @@ func (a *Server) DeleteOperationalIntentReference(ctx context.Context, req *rest
 			subscriptionIds = append(subscriptionIds, *old.SubscriptionID)
 		}
 
-		if !a.TimeBasedNotificationIndex {
-			err = r.LockSubscriptionsOnCells(ctx, old.Cells, subscriptionIds, old.StartTime, old.EndTime)
-			if err != nil {
-				return stacktrace.Propagate(err, "Unable to acquire lock")
-			}
+		err = r.LockSubscriptionsOnCells(ctx, old.Cells, subscriptionIds, old.StartTime, old.EndTime)
+		if err != nil {
+			return stacktrace.Propagate(err, "Unable to acquire lock")
 		}
 
 		// Get the Subscription supporting the OperationalIntent, if one is defined
@@ -799,11 +797,9 @@ func (a *Server) upsertOperationalIntentReference(ctx context.Context, now time.
 			subscriptionIds = append(subscriptionIds, validParams.subscriptionID)
 		}
 
-		if !a.TimeBasedNotificationIndex {
-			err = r.LockSubscriptionsOnCells(ctx, validParams.cells, subscriptionIds, validParams.uExtent.StartTime, validParams.uExtent.EndTime)
-			if err != nil {
-				return stacktrace.Propagate(err, "Unable to acquire lock")
-			}
+		err = r.LockSubscriptionsOnCells(ctx, validParams.cells, subscriptionIds, validParams.uExtent.StartTime, validParams.uExtent.EndTime)
+		if err != nil {
+			return stacktrace.Propagate(err, "Unable to acquire lock")
 		}
 
 		// Validate the request against the previous OIR

--- a/pkg/scd/server.go
+++ b/pkg/scd/server.go
@@ -29,8 +29,7 @@ func makeSubscribersToNotify(subscriptions []*scdmodels.Subscription) []restapi.
 
 // Server implements scdv1.Implementation.
 type Server struct {
-	Store                      scdstore.Store
-	DSSReportHandler           ReceivedReportHandler
-	AllowHTTPBaseUrls          bool
-	TimeBasedNotificationIndex bool
+	Store             scdstore.Store
+	DSSReportHandler  ReceivedReportHandler
+	AllowHTTPBaseUrls bool
 }

--- a/pkg/scd/store/sqlstore/store.go
+++ b/pkg/scd/store/sqlstore/store.go
@@ -8,6 +8,7 @@ import (
 	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/scd/repos"
 	"github.com/interuss/dss/pkg/sqlstore"
+	"github.com/interuss/dss/pkg/store/params"
 	"github.com/jonboulle/clockwork"
 	"go.uber.org/zap"
 )
@@ -30,7 +31,8 @@ type repo struct {
 
 // Init initializes the SQL-backed sid store. It return a concrete sqlstore.Store[sid.repos.Repository] providing the
 // ability to interact with a database-backed store of sid information.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool, timeBasedNotificationIndex bool) (*sqlstore.Store[repos.Repository], error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*sqlstore.Store[repos.Repository], error) {
+	opts := params.GetStoreOptions()
 	return sqlstore.Init(ctx, sqlstore.Config[repos.Repository]{
 		DBName:                 "scd",
 		CrdbMajorSchemaVersion: currentCrdbMajorSchemaVersion,
@@ -40,8 +42,8 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLoc
 				q:                          q,
 				clock:                      clock,
 				logger:                     logging.WithValuesFromContext(ctx, logger),
-				globalLock:                 globalLock,
-				timeBasedNotificationIndex: timeBasedNotificationIndex,
+				globalLock:                 opts.GlobalLock,
+				timeBasedNotificationIndex: opts.TimeBasedNotificationIndex,
 			}
 		},
 	}, withCheckCron)

--- a/pkg/scd/store/sqlstore/store_test.go
+++ b/pkg/scd/store/sqlstore/store_test.go
@@ -34,7 +34,7 @@ func setUpStore(ctx context.Context, t *testing.T) (*sqlstore.Store[repos.Reposi
 }
 
 func newTestStore(ctx context.Context, t *testing.T, connectParameters params.ConnectParameters) (*sqlstore.Store[repos.Repository], error) {
-	s, err := Init(ctx, logging.Logger, false, false, false)
+	s, err := Init(ctx, logging.Logger, false)
 
 	if err != nil {
 		return nil, err

--- a/pkg/scd/store/sqlstore/subscriptions.go
+++ b/pkg/scd/store/sqlstore/subscriptions.go
@@ -410,6 +410,11 @@ func (c *repo) IncrementNotificationIndicesForConstraints(ctx context.Context, v
 }
 
 func (c *repo) LockSubscriptionsOnCells(ctx context.Context, cells s2.CellUnion, subscriptionIds []dssmodels.ID, startTime *time.Time, endTime *time.Time) error {
+
+	if c.timeBasedNotificationIndex { // No lock when working with timeBasedNotificationIndex
+		return nil
+	}
+
 	logger := logging.WithValuesFromContext(ctx, logging.Logger)
 
 	if c.globalLock {

--- a/pkg/scd/store/store.go
+++ b/pkg/scd/store/store.go
@@ -17,11 +17,11 @@ import (
 type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the scd store backend.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, globalLock bool, timeBasedNotificationIndex bool) (Store, error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
 	storeType := params.GetStoreParameters().StoreType
 	switch storeType {
 	case params.SQLStoreType:
-		return scdsqlstore.Init(ctx, logger, withCheckCron, globalLock, timeBasedNotificationIndex)
+		return scdsqlstore.Init(ctx, logger, withCheckCron)
 	case params.RaftStoreType:
 		return scdraftstore.Init(ctx, logger)
 	default:

--- a/pkg/store/params/params.go
+++ b/pkg/store/params/params.go
@@ -15,17 +15,31 @@ type (
 	StoreParameters struct {
 		StoreType string
 	}
+
+	// Options carries the configuration flags shared by all datastore backends.
+	Options struct {
+		GlobalLock                 bool
+		TimeBasedNotificationIndex bool
+	}
 )
 
 var (
 	storeParameters StoreParameters
+	storeOptions    Options
 )
 
 func init() {
 	flag.StringVar(&storeParameters.StoreType, "store_type", SQLStoreType, fmt.Sprintf("Store type. Use '%s' for CockroachDB/YugabyteDB and '%s' for Raft-based store.", SQLStoreType, RaftStoreType))
+	flag.BoolVar(&storeOptions.GlobalLock, "enable_scd_global_lock", false, "Experimental: Use a global lock when working with SCD subscriptions. Reduce global throughput but improve throughput with lot of subscriptions in the same areas.")
+	flag.BoolVar(&storeOptions.TimeBasedNotificationIndex, "enable_time_based_notification_index", false, "Use a time-based notification index when working with RID and SCD subscriptions.")
 }
 
 // GetStoreParameters returns a StoreParameters instance that gets populated from well-known CLI flags.
 func GetStoreParameters() StoreParameters {
 	return storeParameters
+}
+
+// GetStoreOptions returns the datastore Options populated from well-known CLI flags.
+func GetStoreOptions() Options {
+	return storeOptions
 }


### PR DESCRIPTION
This MR move behavior changes like global lock to a dedicated, shared config object, now in the store package.

Passage of all option is now automatically done and will improve readability, especially since more flags are coming.

`TimeBasedNotificationIndex` has been removed from SCD store and behavior change has been moved in the store itself.

No practical / behavioral change, just refactoring.

