### PR TITLE
[terraform] Increase GKE disk size

### DIFF
--- a/NEXT_RELEASE_NOTES.md
+++ b/NEXT_RELEASE_NOTES.md
@@ -62,6 +62,11 @@ The release notes should contain at least the following sections:
 * Server timeout flag has been renamed from `server timeout` to `server_timeout`.
 * The `duration` field, previously recorded as a string containing the unit, has been changed to `duration_ms`, a float representing the duration in milliseconds, rounded to 0.01.
 * Grafana version deployed by Helm charts or Tanka files have been upgraded to 13.0. Ensure to read grafana changelog based on your current version.
+* The Google Kubernetes Engine (GKE) node disk size has been increased from 15GB to 25GB to prevent issues with saturated system disks.
+
+  * You will need to apply the Terraform state once to recreate the node pool.
+  * This process will take some time because it is performed in a non-disruptive rolling update, draining and moving pods across nodes during the upgrade.
+  * Please plan accordingly and test the rollout on a non-production cluster first.
 
 ## Minimal database schema version
 

--- a/deploy/infrastructure/dependencies/terraform-google-kubernetes/cluster.tf
+++ b/deploy/infrastructure/dependencies/terraform-google-kubernetes/cluster.tf
@@ -26,7 +26,7 @@ resource "google_container_node_pool" "dss_pool" {
 
   node_config {
     machine_type = var.google_machine_type
-    disk_size_gb = 15 # Kubernetes PVC will create distinct disks.
+    disk_size_gb = 25 # Kubernetes PVC will create distinct disks.
 
     # TODO: Use non-default service account with IAM roles
     oauth_scopes = [


### PR DESCRIPTION
The base disk image of google kubernetes is too small, leading to random DiskPresureError and make it hard to deploy service.

This bump it by 10G to ensure some margin (only 2.5G with current version of OS/k8s is left.)