### PR TITLE
[yugabyte] Implement Transact retries

### DIFF
--- a/pkg/sqlstore/store.go
+++ b/pkg/sqlstore/store.go
@@ -2,7 +2,9 @@ package sqlstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 	"github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jonboulle/clockwork"
 	"github.com/robfig/cron/v3"
@@ -174,10 +177,41 @@ func (s *Store[R]) Interact(_ context.Context) (R, error) {
 }
 
 func (s *Store[R]) Transact(ctx context.Context, f func(context.Context, R) error) error {
+	if s.Version.Type == Yugabyte {
+		return s.transactYugabyte(ctx, f)
+	}
+
 	ctx = crdb.WithMaxRetries(ctx, s.maxRetries)
 	return crdbpgx.ExecuteTx(ctx, s.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
 		return f(ctx, s.newRepo(tx))
 	})
+}
+
+func (s *Store[R]) transactYugabyte(ctx context.Context, f func(context.Context, R) error) error {
+	var err error
+	for attempt := 0; attempt <= s.maxRetries; attempt++ {
+		err = pgx.BeginTxFunc(ctx, s.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
+			return f(ctx, s.newRepo(tx))
+		})
+		if err == nil || !isYugabyteRetryable(err) {
+			return err
+		}
+		backoff := time.Duration(1<<min(attempt, 6)) * time.Millisecond
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(backoff + time.Duration(rand.Int64N(int64(backoff)+1))):
+		}
+	}
+	return err
+}
+
+func isYugabyteRetryable(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "40001" || pgErr.Code == "40P01"
+	}
+	return false
 }
 
 func (s *Store[R]) Close() error {

--- a/pkg/sqlstore/store.go
+++ b/pkg/sqlstore/store.go
@@ -196,6 +196,9 @@ func (s *Store[R]) transactYugabyte(ctx context.Context, f func(context.Context,
 		if err == nil || !isYugabyteRetryable(err) {
 			return err
 		}
+		if attempt == s.maxRetries {
+			break
+		}
 		backoff := time.Duration(1<<min(attempt, 6)) * time.Millisecond
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
When trying to use the latest monitoring image version - which includes a tougher test on RID - Yugabyte is unable to pass the test.

This PR implements an initial fix by adding correct retry logic within Transact(). We cannot rely on the standard crdb utility functions here, as the error codes returned by Yugabyte differ from those of CockroachDB.

At some point, we should probably replace the library entirely and implement our own custom retry mechanism for everything. However, this PR intentionally limits the scope to avoid making any structural changes on the CockroachDB side.

See #1571 as well.