### PR TITLE
[rid] Improve UpdateNotificationIdxsInCells by locking row in order

### DIFF
--- a/pkg/rid/store/sqlstore/subscriptions.go
+++ b/pkg/rid/store/sqlstore/subscriptions.go
@@ -231,13 +231,16 @@ func (r *repo) UpdateNotificationIdxsInCells(ctx context.Context, cells s2.CellU
 				AND ends_at >= $2`, subscriptionFields)
 	} else {
 		updateQuery = fmt.Sprintf(`
-			UPDATE subscriptions
-			SET
-                notification_index = notification_index + 1
-			WHERE
-				cells && $1
-				AND ends_at >= $2
-			RETURNING %s`, subscriptionFields)
+			WITH affected AS (
+                SELECT id FROM subscriptions
+                WHERE cells && $1 AND ends_at >= $2
+                ORDER BY id
+                FOR UPDATE
+            )
+            UPDATE subscriptions
+            SET notification_index = notification_index + 1
+            WHERE id IN (SELECT id FROM affected)
+            RETURNING %s`, subscriptionFields)
 	}
 
 	return r.process(


### PR DESCRIPTION
When trying to use the latest monitoring image version - which includes a tougher test on RID - Yugabyte is unable to pass the test.

This PR implements improve the UpdateNotificationIdxsInCells by first locking row ordered by PK, limiting deadlock. This improve performance and, combined with others fixes make it passing.

See #1570 as well.

Performance on Cockroach is hard to determine since we don't have load test on RID.

Using a modified version of RID that insert a subscription show no changes (single node, no latency):

<img width="1892" height="1498" alt="image" src="https://github.com/user-attachments/assets/6f273b8b-69c1-476e-aa09-cabd4d375177" />


