### PR TITLE
[raft/store] Update Transact signature

### DIFF
--- a/cmds/db-manager/cleanup/evict.go
+++ b/cmds/db-manager/cleanup/evict.go
@@ -14,6 +14,7 @@ import (
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	scdrepos "github.com/interuss/dss/pkg/scd/repos"
 	scds "github.com/interuss/dss/pkg/scd/store"
+	dssstore "github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -100,7 +101,7 @@ func evict(cmd *cobra.Command, _ []string) error {
 		}
 		return nil
 	}
-	if err = scdStore.Transact(ctx, scdAction); err != nil {
+	if _, err = scdStore.Transact(ctx, dssstore.NewFuncOperation(scdAction)); err != nil {
 		return fmt.Errorf("failed to execute SCD transaction: %w", err)
 	}
 
@@ -145,7 +146,7 @@ func evict(cmd *cobra.Command, _ []string) error {
 
 		return nil
 	}
-	if err = ridStore.Transact(ctx, ridAction); err != nil {
+	if _, err = ridStore.Transact(ctx, dssstore.NewFuncOperation(ridAction)); err != nil {
 		return fmt.Errorf("failed to execute RID transaction: %w", err)
 	}
 

--- a/pkg/aux_/actions/registry.go
+++ b/pkg/aux_/actions/registry.go
@@ -1,0 +1,10 @@
+package actions
+
+import (
+	"github.com/interuss/dss/pkg/aux_/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
+)
+
+// Registry maps operation IDs to their handlers.
+// TODO: implement
+var Registry = map[string]dssstore.OperationHandler[repos.Repository]{}

--- a/pkg/aux_/store/sqlstore/store.go
+++ b/pkg/aux_/store/sqlstore/store.go
@@ -3,6 +3,7 @@ package sqlstore
 import (
 	"context"
 
+	"github.com/interuss/dss/pkg/aux_/actions"
 	"github.com/interuss/dss/pkg/aux_/repos"
 	"github.com/interuss/dss/pkg/logging"
 	dssql "github.com/interuss/dss/pkg/sql"
@@ -39,5 +40,6 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*sqlstor
 				version:   version,
 			}
 		},
+		Registry: actions.Registry,
 	}, withCheckCron)
 }

--- a/pkg/memstore/store.go
+++ b/pkg/memstore/store.go
@@ -12,6 +12,7 @@ import (
 
 	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/logging"
+	"github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 	"go.uber.org/zap"
 )
@@ -50,8 +51,8 @@ func Init[R any](ctx context.Context, logger *zap.Logger, name string, r MemRepo
 	return store, nil
 }
 
-func (s *Store[R]) Transact(ctx context.Context, _ func(context.Context, R) error) error {
-	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "Transact not implemented for memstore")
+func (s *Store[R]) Transact(ctx context.Context, _ store.OperationRequest) (any, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "Transact not implemented for memstore")
 }
 
 func (s *Store[R]) Interact(_ context.Context) (R, error) {

--- a/pkg/raftstore/store.go
+++ b/pkg/raftstore/store.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/interuss/dss/pkg/raftstore/consensus"
 	raftparams "github.com/interuss/dss/pkg/raftstore/params"
+	"github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 	"go.uber.org/zap"
 )
@@ -29,9 +30,9 @@ func Init[R any](ctx context.Context, logger *zap.Logger, params raftparams.Conn
 }
 
 // Transact proposes the entry to Raft and blocks until it is committed and applied.
-func (s *Store[R]) Transact(ctx context.Context, f func(context.Context, R) error) error {
+func (s *Store[R]) Transact(_ context.Context, _ store.OperationRequest) (any, error) {
 	// TODO: implement
-	return nil
+	return nil, nil
 }
 
 // Interact returns a repository that can be used to query the store without proposing a Raft entry.

--- a/pkg/rid/actions/registry.go
+++ b/pkg/rid/actions/registry.go
@@ -1,0 +1,10 @@
+package actions
+
+import (
+	"github.com/interuss/dss/pkg/rid/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
+)
+
+// Registry maps operation IDs to their handlers.
+// TODO: implement
+var Registry = map[string]dssstore.OperationHandler[repos.Repository]{}

--- a/pkg/rid/application/application_test.go
+++ b/pkg/rid/application/application_test.go
@@ -13,6 +13,8 @@ import (
 	dssql "github.com/interuss/dss/pkg/sql"
 	"github.com/interuss/dss/pkg/sqlstore"
 	"github.com/interuss/dss/pkg/sqlstore/params"
+	dssstore "github.com/interuss/dss/pkg/store"
+	"github.com/interuss/stacktrace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
@@ -35,8 +37,11 @@ func (s *mockRepo) Interact(ctx context.Context) (repos.Repository, error) {
 	return s, nil
 }
 
-func (s *mockRepo) Transact(ctx context.Context, f func(ctx context.Context, repo repos.Repository) error) error {
-	return f(ctx, s)
+func (s *mockRepo) Transact(ctx context.Context, request dssstore.OperationRequest) (any, error) {
+	if fn, ok := request.(*dssstore.FuncOperation[repos.Repository]); ok {
+		return nil, fn.Execute(ctx, s)
+	}
+	return nil, stacktrace.NewError("unsupported operation type %T", request)
 }
 
 func (s *mockRepo) Close() error {

--- a/pkg/rid/application/isa.go
+++ b/pkg/rid/application/isa.go
@@ -10,6 +10,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
 	"github.com/interuss/dss/pkg/rid/repos"
+	"github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 )
 
@@ -63,7 +64,7 @@ func (a *app) DeleteISA(ctx context.Context, id dssmodels.ID, owner dssmodels.Ow
 		subs []*ridmodels.Subscription
 	)
 	// The following will automatically retry TXN retry errors.
-	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
+	_, err := a.store.Transact(ctx, store.NewFuncOperation(func(ctx context.Context, repo repos.Repository) error {
 		old, err := repo.GetISA(ctx, id, true)
 		switch {
 		case err != nil:
@@ -88,7 +89,7 @@ func (a *app) DeleteISA(ctx context.Context, id dssmodels.ID, owner dssmodels.Ow
 			return stacktrace.Propagate(err, "Error updating notification indices")
 		}
 		return nil
-	})
+	}))
 	return ret, subs, err // No need to Propagate this error as this stack layer does not add useful information
 }
 
@@ -104,7 +105,7 @@ func (a *app) InsertISA(ctx context.Context, isa *ridmodels.IdentificationServic
 		subs []*ridmodels.Subscription
 	)
 	// The following will automatically retry TXN retry errors.
-	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
+	_, err := a.store.Transact(ctx, store.NewFuncOperation(func(ctx context.Context, repo repos.Repository) error {
 		// ensure it doesn't exist yet
 		old, err := repo.GetISA(ctx, isa.ID, false)
 		if err != nil {
@@ -126,7 +127,7 @@ func (a *app) InsertISA(ctx context.Context, isa *ridmodels.IdentificationServic
 			return stacktrace.Propagate(err, "Error inserting ISA")
 		}
 		return nil
-	})
+	}))
 	return ret, subs, err // No need to Propagate this error as this stack layer does not add useful information
 }
 
@@ -138,7 +139,7 @@ func (a *app) UpdateISA(ctx context.Context, isa *ridmodels.IdentificationServic
 		subs []*ridmodels.Subscription
 	)
 	// The following will automatically retry TXN retry errors.
-	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
+	_, err := a.store.Transact(ctx, store.NewFuncOperation(func(ctx context.Context, repo repos.Repository) error {
 		var err error
 
 		old, err := repo.GetISA(ctx, isa.ID, true)
@@ -176,7 +177,7 @@ func (a *app) UpdateISA(ctx context.Context, isa *ridmodels.IdentificationServic
 			return stacktrace.Propagate(err, "Error updating notification indices")
 		}
 		return nil
-	})
+	}))
 
 	return ret, subs, err // No need to Propagate this error as this stack layer does not add useful information
 }

--- a/pkg/rid/application/subscription.go
+++ b/pkg/rid/application/subscription.go
@@ -8,6 +8,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	ridmodels "github.com/interuss/dss/pkg/rid/models"
 	"github.com/interuss/dss/pkg/rid/repos"
+	"github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 	"go.uber.org/zap"
 )
@@ -60,7 +61,7 @@ func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription)
 		return nil, stacktrace.Propagate(err, "Unable to adjust time range")
 	}
 	var sub *ridmodels.Subscription
-	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
+	_, err := a.store.Transact(ctx, store.NewFuncOperation(func(ctx context.Context, repo repos.Repository) error {
 
 		// ensure it doesn't exist yet
 		old, err := repo.GetSubscription(ctx, s.ID)
@@ -90,7 +91,7 @@ func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription)
 		}
 
 		return nil
-	})
+	}))
 	return sub, err
 }
 
@@ -98,7 +99,7 @@ func (a *app) InsertSubscription(ctx context.Context, s *ridmodels.Subscription)
 func (a *app) UpdateSubscription(ctx context.Context, s *ridmodels.Subscription) (*ridmodels.Subscription, error) {
 	var sub *ridmodels.Subscription
 
-	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
+	_, err := a.store.Transact(ctx, store.NewFuncOperation(func(ctx context.Context, repo repos.Repository) error {
 		old, err := repo.GetSubscription(ctx, s.ID)
 		switch {
 		case err != nil:
@@ -138,14 +139,14 @@ func (a *app) UpdateSubscription(ctx context.Context, s *ridmodels.Subscription)
 			return stacktrace.Propagate(err, "Error updating Subscription in repo")
 		}
 		return nil
-	})
+	}))
 	return sub, err
 }
 
 // DeleteSubscription deletes the Subscription identified by "id" and owned by "owner".
 func (a *app) DeleteSubscription(ctx context.Context, id dssmodels.ID, owner dssmodels.Owner, version *dssmodels.Version) (*ridmodels.Subscription, error) {
 	var ret *ridmodels.Subscription
-	err := a.store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
+	_, err := a.store.Transact(ctx, store.NewFuncOperation(func(ctx context.Context, repo repos.Repository) error {
 		var err error
 		old, err := repo.GetSubscription(ctx, id)
 		switch {
@@ -168,6 +169,6 @@ func (a *app) DeleteSubscription(ctx context.Context, id dssmodels.ID, owner dss
 			return stacktrace.Propagate(err, "Error deleting Subscription from repo")
 		}
 		return nil
-	})
+	}))
 	return ret, err
 }

--- a/pkg/rid/store/sqlstore/store.go
+++ b/pkg/rid/store/sqlstore/store.go
@@ -6,6 +6,7 @@ import (
 	dssql "github.com/interuss/dss/pkg/sql"
 
 	"github.com/interuss/dss/pkg/logging"
+	"github.com/interuss/dss/pkg/rid/actions"
 	"github.com/interuss/dss/pkg/rid/repos"
 	"github.com/interuss/dss/pkg/sqlstore"
 	"github.com/interuss/dss/pkg/store/params"
@@ -44,5 +45,6 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*sqlstor
 				timeBasedNotificationIndex: opts.TimeBasedNotificationIndex,
 			}
 		},
+		Registry: actions.Registry,
 	}, withCheckCron)
 }

--- a/pkg/rid/store/sqlstore/store_test.go
+++ b/pkg/rid/store/sqlstore/store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/interuss/dss/pkg/rid/repos"
 	"github.com/interuss/dss/pkg/sqlstore"
 	"github.com/interuss/dss/pkg/sqlstore/params"
+	dssstore "github.com/interuss/dss/pkg/store"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
@@ -97,12 +98,12 @@ func TestTxnRetrier(t *testing.T) {
 	require.NotNil(t, store)
 	defer tearDownStore()
 
-	err := store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
+	_, err := store.Transact(ctx, dssstore.NewFuncOperation(func(ctx context.Context, repo repos.Repository) error {
 		// can query within this
 		isa, err := repo.InsertISA(ctx, serviceArea)
 		require.NotNil(t, isa)
 		return err
-	})
+	}))
 	require.NoError(t, err)
 	// can query afterwads
 	repo, err := store.Interact(ctx)
@@ -118,12 +119,12 @@ func TestTxnRetrier(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
 	defer cancel()
 	count := 0
-	err = store.Transact(ctx, func(ctx context.Context, repo repos.Repository) error {
+	_, err = store.Transact(ctx, dssstore.NewFuncOperation(func(ctx context.Context, repo repos.Repository) error {
 		// can query within this
 		count++
 		// Postgre retryable error
 		return &pgconn.PgError{Code: "40001"}
-	})
+	}))
 	require.Error(t, err)
 	// Ensure it was retried.
 	require.Greater(t, count, 1)
@@ -141,13 +142,13 @@ func TestTransactor(t *testing.T) {
 	subscription2 := subscriptionsPool[1].input
 
 	txnCount := 0
-	err := store.Transact(ctx, func(ctx context.Context, s1 repos.Repository) error {
+	_, err := store.Transact(ctx, dssstore.NewFuncOperation(func(ctx context.Context, s1 repos.Repository) error {
 		// We should get to this retry, then return nothing.
 		if txnCount > 0 {
 			return errors.New("already failed")
 		}
 		txnCount++
-		err := store.Transact(ctx, func(ctx context.Context, s2 repos.Repository) error {
+		_, err := store.Transact(ctx, dssstore.NewFuncOperation(func(ctx context.Context, s2 repos.Repository) error {
 			subs, err := s1.SearchSubscriptions(ctx, subscription1.Cells)
 			require.NoError(t, err)
 			require.Len(t, subs, 0)
@@ -164,9 +165,9 @@ func TestTransactor(t *testing.T) {
 			require.NoError(t, err)
 
 			return nil
-		})
+		}))
 		return err
-	})
+	}))
 	require.Error(t, err)
 
 	repo, err := store.Interact(ctx)

--- a/pkg/scd/actions/registry.go
+++ b/pkg/scd/actions/registry.go
@@ -1,0 +1,10 @@
+package actions
+
+import (
+	"github.com/interuss/dss/pkg/scd/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
+)
+
+// Registry maps operation IDs to their handlers
+// TODO: implement
+var Registry = map[string]dssstore.OperationHandler[repos.Repository]{}

--- a/pkg/scd/constraints_handler.go
+++ b/pkg/scd/constraints_handler.go
@@ -11,6 +11,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	"github.com/interuss/dss/pkg/scd/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 	"github.com/jackc/pgx/v5"
 )
@@ -88,7 +89,7 @@ func (a *Server) DeleteConstraintReference(ctx context.Context, req *restapi.Del
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		err = stacktrace.Propagate(err, "Could not delete constraint")
 		errResp := &restapi.ErrorResponse{Message: dsserr.Handle(ctx, err)}
@@ -147,7 +148,7 @@ func (a *Server) GetConstraintReference(ctx context.Context, req *restapi.GetCon
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		err = stacktrace.Propagate(err, "Could not get constraint")
 		if stacktrace.GetCode(err) == dsserr.NotFound {
@@ -306,7 +307,7 @@ func (a *Server) PutConstraintReference(ctx context.Context, manager string, ent
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		return nil, err // No need to Propagate this error as this is not a useful stacktrace line
 	}
@@ -434,7 +435,7 @@ func (a *Server) QueryConstraintReferences(ctx context.Context, req *restapi.Que
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		return restapi.QueryConstraintReferencesResponseSet{Response500: &api.InternalServerErrorBody{
 			ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(err, "Got an unexpected error"))}}

--- a/pkg/scd/operational_intents_handler.go
+++ b/pkg/scd/operational_intents_handler.go
@@ -13,6 +13,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	"github.com/interuss/dss/pkg/scd/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 )
 
@@ -165,7 +166,7 @@ func (a *Server) DeleteOperationalIntentReference(ctx context.Context, req *rest
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		err = stacktrace.Propagate(err, "Could not delete operational intent")
 		errResp := &restapi.ErrorResponse{Message: dsserr.Handle(ctx, err)}
@@ -221,7 +222,7 @@ func (a *Server) GetOperationalIntentReference(ctx context.Context, req *restapi
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		err = stacktrace.Propagate(err, "Could not get operational intent")
 		if stacktrace.GetCode(err) == dsserr.NotFound {
@@ -288,7 +289,7 @@ func (a *Server) QueryOperationalIntentReferences(ctx context.Context, req *rest
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		err = stacktrace.Propagate(err, "Could not query operational intent")
 		if stacktrace.GetCode(err) == dsserr.BadRequest {
@@ -934,7 +935,7 @@ func (a *Server) upsertOperationalIntentReference(ctx context.Context, now time.
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		return nil, responseConflict, err // No need to Propagate this error as this is not a useful stacktrace line
 	}

--- a/pkg/scd/store/sqlstore/store.go
+++ b/pkg/scd/store/sqlstore/store.go
@@ -6,6 +6,7 @@ import (
 	dssql "github.com/interuss/dss/pkg/sql"
 
 	"github.com/interuss/dss/pkg/logging"
+	"github.com/interuss/dss/pkg/scd/actions"
 	"github.com/interuss/dss/pkg/scd/repos"
 	"github.com/interuss/dss/pkg/sqlstore"
 	"github.com/interuss/dss/pkg/store/params"
@@ -46,5 +47,6 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*sqlstor
 				timeBasedNotificationIndex: opts.TimeBasedNotificationIndex,
 			}
 		},
+		Registry: actions.Registry,
 	}, withCheckCron)
 }

--- a/pkg/scd/subscriptions_handler.go
+++ b/pkg/scd/subscriptions_handler.go
@@ -12,6 +12,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	"github.com/interuss/dss/pkg/scd/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 	"github.com/jonboulle/clockwork"
 )
@@ -276,7 +277,7 @@ func (a *Server) PutSubscription(ctx context.Context, manager string, subscripti
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		return nil, err // No need to Propagate this error as this is not a useful stacktrace line
 	}
@@ -340,7 +341,7 @@ func (a *Server) GetSubscription(ctx context.Context, req *restapi.GetSubscripti
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		err = stacktrace.Propagate(err, "Could not get subscription")
 		errResp := &restapi.ErrorResponse{Message: dsserr.Handle(ctx, err)}
@@ -424,7 +425,7 @@ func (a *Server) QuerySubscriptions(ctx context.Context, req *restapi.QuerySubsc
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 
 		errResp := &restapi.ErrorResponse{Message: dsserr.Handle(ctx, err)}
@@ -517,7 +518,7 @@ func (a *Server) DeleteSubscription(ctx context.Context, req *restapi.DeleteSubs
 		return nil
 	}
 
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		err = stacktrace.Propagate(err, "Could not delete subscription")
 		errResp := &restapi.ErrorResponse{Message: dsserr.Handle(ctx, err)}

--- a/pkg/scd/uss_availability_handler.go
+++ b/pkg/scd/uss_availability_handler.go
@@ -10,6 +10,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	"github.com/interuss/dss/pkg/scd/repos"
+	dssstore "github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 	"github.com/jackc/pgx/v5"
 )
@@ -51,7 +52,7 @@ func (a *Server) GetUssAvailability(ctx context.Context, req *restapi.GetUssAvai
 		return nil
 	}
 
-	err := a.Store.Transact(ctx, action)
+	_, err := a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		// In case of older DB versions where availability table doesn't exist
 		if strings.Contains(err.Error(), "does not exist") {
@@ -121,7 +122,7 @@ func (a *Server) SetUssAvailability(ctx context.Context, req *restapi.SetUssAvai
 		}
 		return nil
 	}
-	err = a.Store.Transact(ctx, action)
+	_, err = a.Store.Transact(ctx, dssstore.NewFuncOperation(action))
 	if err != nil {
 		// In case of older DB versions where availability table doesn't exist
 		if strings.Contains(err.Error(), "does not exist") {

--- a/pkg/sqlstore/store.go
+++ b/pkg/sqlstore/store.go
@@ -35,6 +35,7 @@ type Store[R any] struct {
 	Clock         clockwork.Clock
 	schemaVersion *semver.Version
 	newRepo       func(dsssql.Queryable) R
+	registry      map[string]store.OperationHandler[R]
 	maxRetries    int
 }
 
@@ -45,6 +46,7 @@ type Config[R any] struct {
 	CrdbMajorSchemaVersion int64
 	YbMajorSchemaVersion   int64
 	NewRepo                func(q dsssql.Queryable, clock clockwork.Clock, v *Version) R
+	Registry               map[string]store.OperationHandler[R]
 }
 
 func checkMajorSchemaVersion[R any](ctx context.Context, db *Store[R], vs *semver.Version, crdbExpected int64, ybExpected int64) error {
@@ -155,6 +157,7 @@ func Init[R any](ctx context.Context, cfg Config[R], withCheckCron bool) (*Store
 	db.newRepo = func(q dsssql.Queryable) R {
 		return cfg.NewRepo(q, db.Clock, db.Version)
 	}
+	db.registry = cfg.Registry
 
 	if withCheckCron {
 		c := cron.New()
@@ -176,25 +179,31 @@ func (s *Store[R]) Interact(_ context.Context) (R, error) {
 	return s.newRepo(s.Pool), nil
 }
 
-func (s *Store[R]) Transact(ctx context.Context, f func(context.Context, R) error) error {
+func (s *Store[R]) Transact(ctx context.Context, request store.OperationRequest) (any, error) {
 	if s.Version.Type == Yugabyte {
-		return s.transactYugabyte(ctx, f)
+		return s.transactYugabyte(ctx, request)
 	}
 
 	ctx = crdb.WithMaxRetries(ctx, s.maxRetries)
-	return crdbpgx.ExecuteTx(ctx, s.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
-		return f(ctx, s.newRepo(tx))
+	var result any
+	var err error
+	err = crdbpgx.ExecuteTx(ctx, s.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
+		result, err = s.execute(ctx, s.newRepo(tx), request)
+		return err
 	})
+	return result, err
 }
 
-func (s *Store[R]) transactYugabyte(ctx context.Context, f func(context.Context, R) error) error {
+func (s *Store[R]) transactYugabyte(ctx context.Context, request store.OperationRequest) (any, error) {
+	var result any
 	var err error
 	for attempt := 0; attempt <= s.maxRetries; attempt++ {
 		err = pgx.BeginTxFunc(ctx, s.Pool, pgx.TxOptions{IsoLevel: pgx.Serializable}, func(tx pgx.Tx) error {
-			return f(ctx, s.newRepo(tx))
+			result, err = s.execute(ctx, s.newRepo(tx), request)
+			return err
 		})
 		if err == nil || !isYugabyteRetryable(err) {
-			return err
+			return result, err
 		}
 		if attempt == s.maxRetries {
 			break
@@ -202,11 +211,23 @@ func (s *Store[R]) transactYugabyte(ctx context.Context, f func(context.Context,
 		backoff := time.Duration(1<<min(attempt, 6)) * time.Millisecond
 		select {
 		case <-ctx.Done():
-			return err
+			return result, err
 		case <-time.After(backoff + time.Duration(rand.Int64N(int64(backoff)+1))):
 		}
 	}
-	return err
+	return result, err
+}
+
+func (s *Store[R]) execute(ctx context.Context, repo R, request store.OperationRequest) (any, error) {
+	// TODO: This should be removed once all operations are registered properly.
+	if fn, ok := request.(*store.FuncOperation[R]); ok {
+		return nil, fn.Execute(ctx, repo)
+	}
+	handler, ok := s.registry[request.OperationID()]
+	if !ok {
+		return nil, stacktrace.NewError("no handler registered for operation %q", request.OperationID())
+	}
+	return handler.Execute(ctx, repo, request)
 }
 
 func isYugabyteRetryable(err error) bool {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -14,10 +14,48 @@ type Store[R any] interface {
 	// Obtain a Repo (repo type R) that doesn't need transactional guarantees (for instance,
 	// read-only).
 	Interact(context.Context) (R, error)
-	// Attempt to apply the operations in f to the R Repo it is supplied.  All operations performed
-	// on the R Repo by f will be applied or rejected atomically.
-	Transact(ctx context.Context, f func(context.Context, R) error) error
+	// Apply the operation request to the R Repo atomically.
+	Transact(ctx context.Context, request OperationRequest) (any, error)
 }
+
+// OperationRequest identifies an operation to be performed on a Store.
+type OperationRequest interface {
+	OperationID() string
+}
+
+// OperationHandler holds the logic for the encoding and execution of a registered operation
+type OperationHandler[R any] struct {
+	Encode  func(req OperationRequest) ([]byte, error)
+	Decode  func(buf []byte) (OperationRequest, error)
+	Execute func(ctx context.Context, repo R, request OperationRequest) (any, error)
+}
+
+// TransactWithResult wraps Store.Transact and casts the result to ResultType, avoiding a cast at every call site.
+func TransactWithResult[R any, ResultType any](ctx context.Context, store Store[R], request OperationRequest) (ResultType, error) {
+	var empty ResultType
+	transactionResult, err := store.Transact(ctx, request)
+	if err != nil {
+		return empty, err
+	}
+	resultType, ok := transactionResult.(ResultType)
+	if !ok {
+		return empty, stacktrace.NewError("unexpected result type %T, want %T", transactionResult, empty)
+	}
+	return resultType, nil
+}
+
+// FuncOperation wraps a closure as an OperationRequest for gradual migration.
+// TODO: remove once all handlers use registered operations.
+type FuncOperation[R any] struct {
+	f func(context.Context, R) error
+}
+
+func NewFuncOperation[R any](f func(context.Context, R) error) *FuncOperation[R] {
+	return &FuncOperation[R]{f: f}
+}
+
+func (a *FuncOperation[R]) OperationID() string                    { return "" }
+func (a *FuncOperation[R]) Execute(ctx context.Context, r R) error { return a.f(ctx, r) }
 
 const (
 	CodeRetryable = stacktrace.ErrorCode(1)


### PR DESCRIPTION
`Transact` currently takes a raw `func(ctx, R) error` closure which works for the `sqlstore` but can't be replicated by the Raftstore since it needs to serialize the request, propose it and then apply it in a different thread and different nodes. 

This PR changes the interface to accept a `store.OperationRequest` instead, a value that carries an operation ID and can be selected using a `Registry` which holds the encoding and execution logic. 
The `OperationID` method would be generated automatically.

To keep changes minimal in this PR, the `FuncOperation[R]` adapter wraps the existing closures as a stub `OperationRequest`. Follow-up PRs will remove `FuncOperation[R]` and extract the actions for all handlers (see aux example in #1582).

The PR also adds `TransactWithResult[R, Res]`, a generic function wrapping `Transact` which serves as a helper for result type asserts to avoid code duplication on the handler side. The reason why we need a wrapper instead of making `Transact` generic is that Go [does not currently allow generic methods](https://github.com/golang/go/issues/77273#issuecomment-3962618141).

Implements #1701