### PR TITLE
[raft/store] Generate OperationID() on API request types

### DIFF
--- a/cmds/dummy-oauth/api/dummyoauth/interface.gen.go
+++ b/cmds/dummy-oauth/api/dummyoauth/interface.gen.go
@@ -29,6 +29,11 @@ type GetTokenRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetTokenOperationID = "GetToken"
+
+func (request *GetTokenRequest) OperationID() string { return GetTokenOperationID }
+
 type GetTokenResponseSet struct {
 	// The requested token was generated successfully
 	Response200 *TokenResponse

--- a/interfaces/openapi-to-go-server/example/api/rid/interface.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/rid/interface.gen.go
@@ -77,6 +77,13 @@ type SearchIdentificationServiceAreasRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchIdentificationServiceAreasOperationID = "SearchIdentificationServiceAreas"
+
+func (request *SearchIdentificationServiceAreasRequest) OperationID() string {
+	return SearchIdentificationServiceAreasOperationID
+}
+
 type SearchIdentificationServiceAreasResponseSet struct {
 	// Identification Service Areas were successfully retrieved.
 	Response200 *SearchIdentificationServiceAreasResponse
@@ -104,6 +111,13 @@ type GetIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetIdentificationServiceAreaOperationID = "GetIdentificationServiceArea"
+
+func (request *GetIdentificationServiceAreaRequest) OperationID() string {
+	return GetIdentificationServiceAreaOperationID
+}
+
 type GetIdentificationServiceAreaResponseSet struct {
 	// Full information of the Identification Service Area was retrieved successfully.
 	Response200 *GetIdentificationServiceAreaResponse
@@ -137,6 +151,13 @@ type CreateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateIdentificationServiceAreaOperationID = "CreateIdentificationServiceArea"
+
+func (request *CreateIdentificationServiceAreaRequest) OperationID() string {
+	return CreateIdentificationServiceAreaOperationID
+}
+
 type CreateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was created successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -178,6 +199,13 @@ type UpdateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateIdentificationServiceAreaOperationID = "UpdateIdentificationServiceArea"
+
+func (request *UpdateIdentificationServiceAreaRequest) OperationID() string {
+	return UpdateIdentificationServiceAreaOperationID
+}
+
 type UpdateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was updated successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -213,6 +241,13 @@ type DeleteIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteIdentificationServiceAreaOperationID = "DeleteIdentificationServiceArea"
+
+func (request *DeleteIdentificationServiceAreaRequest) OperationID() string {
+	return DeleteIdentificationServiceAreaOperationID
+}
+
 type DeleteIdentificationServiceAreaResponseSet struct {
 	// Identification Service Area was successfully deleted from DSS.
 	Response200 *DeleteIdentificationServiceAreaResponse
@@ -245,6 +280,13 @@ type SearchSubscriptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchSubscriptionsOperationID = "SearchSubscriptions"
+
+func (request *SearchSubscriptionsRequest) OperationID() string {
+	return SearchSubscriptionsOperationID
+}
+
 type SearchSubscriptionsResponseSet struct {
 	// Subscriptions were retrieved successfully.
 	Response200 *SearchSubscriptionsResponse
@@ -272,6 +314,11 @@ type GetSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetSubscriptionOperationID = "GetSubscription"
+
+func (request *GetSubscriptionRequest) OperationID() string { return GetSubscriptionOperationID }
+
 type GetSubscriptionResponseSet struct {
 	// Subscription information was retrieved successfully.
 	Response200 *GetSubscriptionResponse
@@ -305,6 +352,11 @@ type CreateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateSubscriptionOperationID = "CreateSubscription"
+
+func (request *CreateSubscriptionRequest) OperationID() string { return CreateSubscriptionOperationID }
+
 type CreateSubscriptionResponseSet struct {
 	// A new Subscription was created successfully.
 	Response200 *PutSubscriptionResponse
@@ -347,6 +399,11 @@ type UpdateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateSubscriptionOperationID = "UpdateSubscription"
+
+func (request *UpdateSubscriptionRequest) OperationID() string { return UpdateSubscriptionOperationID }
+
 type UpdateSubscriptionResponseSet struct {
 	// An existing Subscription was updated successfully.
 	Response200 *PutSubscriptionResponse
@@ -383,6 +440,11 @@ type DeleteSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteSubscriptionOperationID = "DeleteSubscription"
+
+func (request *DeleteSubscriptionRequest) OperationID() string { return DeleteSubscriptionOperationID }
+
 type DeleteSubscriptionResponseSet struct {
 	// Subscription was deleted successfully.
 	Response200 *DeleteSubscriptionResponse

--- a/interfaces/openapi-to-go-server/example/api/scd/interface.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/scd/interface.gen.go
@@ -174,6 +174,13 @@ type QueryOperationalIntentReferencesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QueryOperationalIntentReferencesOperationID = "QueryOperationalIntentReferences"
+
+func (request *QueryOperationalIntentReferencesRequest) OperationID() string {
+	return QueryOperationalIntentReferencesOperationID
+}
+
 type QueryOperationalIntentReferencesResponseSet struct {
 	// Operational intents were successfully retrieved.
 	Response200 *QueryOperationalIntentReferenceResponse
@@ -204,6 +211,13 @@ type GetOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetOperationalIntentReferenceOperationID = "GetOperationalIntentReference"
+
+func (request *GetOperationalIntentReferenceRequest) OperationID() string {
+	return GetOperationalIntentReferenceOperationID
+}
+
 type GetOperationalIntentReferenceResponseSet struct {
 	// Operational intent reference was retrieved successfully.
 	Response200 *GetOperationalIntentReferenceResponse
@@ -240,6 +254,13 @@ type CreateOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateOperationalIntentReferenceOperationID = "CreateOperationalIntentReference"
+
+func (request *CreateOperationalIntentReferenceRequest) OperationID() string {
+	return CreateOperationalIntentReferenceOperationID
+}
+
 type CreateOperationalIntentReferenceResponseSet struct {
 	// An operational intent reference was created successfully in the DSS.
 	Response201 *ChangeOperationalIntentReferenceResponse
@@ -287,6 +308,13 @@ type UpdateOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateOperationalIntentReferenceOperationID = "UpdateOperationalIntentReference"
+
+func (request *UpdateOperationalIntentReferenceRequest) OperationID() string {
+	return UpdateOperationalIntentReferenceOperationID
+}
+
 type UpdateOperationalIntentReferenceResponseSet struct {
 	// An operational intent reference was updated successfully in the DSS.
 	Response200 *ChangeOperationalIntentReferenceResponse
@@ -329,6 +357,13 @@ type DeleteOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteOperationalIntentReferenceOperationID = "DeleteOperationalIntentReference"
+
+func (request *DeleteOperationalIntentReferenceRequest) OperationID() string {
+	return DeleteOperationalIntentReferenceOperationID
+}
+
 type DeleteOperationalIntentReferenceResponseSet struct {
 	// The specified operational intent was successfully removed from the DSS.
 	Response200 *ChangeOperationalIntentReferenceResponse
@@ -370,6 +405,13 @@ type QueryConstraintReferencesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QueryConstraintReferencesOperationID = "QueryConstraintReferences"
+
+func (request *QueryConstraintReferencesRequest) OperationID() string {
+	return QueryConstraintReferencesOperationID
+}
+
 type QueryConstraintReferencesResponseSet struct {
 	// Constraint references were successfully retrieved.
 	Response200 *QueryConstraintReferencesResponse
@@ -400,6 +442,13 @@ type GetConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetConstraintReferenceOperationID = "GetConstraintReference"
+
+func (request *GetConstraintReferenceRequest) OperationID() string {
+	return GetConstraintReferenceOperationID
+}
+
 type GetConstraintReferenceResponseSet struct {
 	// Constraint reference was retrieved successfully.
 	Response200 *GetConstraintReferenceResponse
@@ -436,6 +485,13 @@ type CreateConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateConstraintReferenceOperationID = "CreateConstraintReference"
+
+func (request *CreateConstraintReferenceRequest) OperationID() string {
+	return CreateConstraintReferenceOperationID
+}
+
 type CreateConstraintReferenceResponseSet struct {
 	// A constraint reference was created successfully in the DSS.
 	Response201 *ChangeConstraintReferenceResponse
@@ -480,6 +536,13 @@ type UpdateConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateConstraintReferenceOperationID = "UpdateConstraintReference"
+
+func (request *UpdateConstraintReferenceRequest) OperationID() string {
+	return UpdateConstraintReferenceOperationID
+}
+
 type UpdateConstraintReferenceResponseSet struct {
 	// A constraint reference was updated successfully in the DSS.
 	Response200 *ChangeConstraintReferenceResponse
@@ -518,6 +581,13 @@ type DeleteConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteConstraintReferenceOperationID = "DeleteConstraintReference"
+
+func (request *DeleteConstraintReferenceRequest) OperationID() string {
+	return DeleteConstraintReferenceOperationID
+}
+
 type DeleteConstraintReferenceResponseSet struct {
 	// The constraint was successfully removed from the DSS.
 	Response200 *ChangeConstraintReferenceResponse
@@ -556,6 +626,11 @@ type QuerySubscriptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QuerySubscriptionsOperationID = "QuerySubscriptions"
+
+func (request *QuerySubscriptionsRequest) OperationID() string { return QuerySubscriptionsOperationID }
+
 type QuerySubscriptionsResponseSet struct {
 	// Subscriptions were retrieved successfully.
 	Response200 *QuerySubscriptionsResponse
@@ -586,6 +661,11 @@ type GetSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetSubscriptionOperationID = "GetSubscription"
+
+func (request *GetSubscriptionRequest) OperationID() string { return GetSubscriptionOperationID }
+
 type GetSubscriptionResponseSet struct {
 	// Subscription information was retrieved successfully.
 	Response200 *GetSubscriptionResponse
@@ -622,6 +702,11 @@ type CreateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateSubscriptionOperationID = "CreateSubscription"
+
+func (request *CreateSubscriptionRequest) OperationID() string { return CreateSubscriptionOperationID }
+
 type CreateSubscriptionResponseSet struct {
 	// A new subscription was created successfully.
 	Response200 *PutSubscriptionResponse
@@ -664,6 +749,11 @@ type UpdateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateSubscriptionOperationID = "UpdateSubscription"
+
+func (request *UpdateSubscriptionRequest) OperationID() string { return UpdateSubscriptionOperationID }
+
 type UpdateSubscriptionResponseSet struct {
 	// A subscription was updated successfully.
 	Response200 *PutSubscriptionResponse
@@ -701,6 +791,11 @@ type DeleteSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteSubscriptionOperationID = "DeleteSubscription"
+
+func (request *DeleteSubscriptionRequest) OperationID() string { return DeleteSubscriptionOperationID }
+
 type DeleteSubscriptionResponseSet struct {
 	// Subscription was successfully removed from DSS.
 	Response200 *DeleteSubscriptionResponse
@@ -739,6 +834,11 @@ type MakeDssReportRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const MakeDssReportOperationID = "MakeDssReport"
+
+func (request *MakeDssReportRequest) OperationID() string { return MakeDssReportOperationID }
+
 type MakeDssReportResponseSet struct {
 	// A new Report was created successfully (and archived).
 	Response201 *ErrorReport
@@ -767,6 +867,11 @@ type GetUssAvailabilityRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetUssAvailabilityOperationID = "GetUssAvailability"
+
+func (request *GetUssAvailabilityRequest) OperationID() string { return GetUssAvailabilityOperationID }
+
 type GetUssAvailabilityResponseSet struct {
 	// Availability status of specified USS was successfully retrieved.
 	Response200 *UssAvailabilityStatusResponse
@@ -800,6 +905,11 @@ type SetUssAvailabilityRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SetUssAvailabilityOperationID = "SetUssAvailability"
+
+func (request *SetUssAvailabilityRequest) OperationID() string { return SetUssAvailabilityOperationID }
+
 type SetUssAvailabilityResponseSet struct {
 	// Availability status of specified USS was successfully updated.
 	Response200 *UssAvailabilityStatusResponse

--- a/interfaces/openapi-to-go-server/rendering.py
+++ b/interfaces/openapi-to-go-server/rendering.py
@@ -202,6 +202,19 @@ def implementation_interface(
         lines.extend(indent(body, 1))
 
         lines.append("}")
+        lines.append("")
+
+        lines.append(
+            'const {}OperationID = "{}"'.format(
+                operation.interface_name, operation.interface_name
+            )
+        )
+        lines.append("")
+        lines.append(
+            "func (request *{}) OperationID() string {{ return {}OperationID }}".format(
+                operation.request_type_name, operation.interface_name
+            )
+        )
 
         # Declare response type for operation
         lines.append("type {} struct {{".format(operation.response_type_name))

--- a/pkg/api/auxv1/interface.gen.go
+++ b/pkg/api/auxv1/interface.gen.go
@@ -48,6 +48,11 @@ type GetVersionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetVersionOperationID = "GetVersion"
+
+func (request *GetVersionRequest) OperationID() string { return GetVersionOperationID }
+
 type GetVersionResponseSet struct {
 	// The version of the DSS is successfully returned.
 	Response200 *VersionResponse
@@ -63,6 +68,11 @@ type ValidateOauthRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const ValidateOauthOperationID = "ValidateOauth"
+
+func (request *ValidateOauthRequest) OperationID() string { return ValidateOauthOperationID }
+
 type ValidateOauthResponseSet struct {
 	// The provided token was validated.
 	Response200 *api.EmptyResponseBody
@@ -81,6 +91,11 @@ type GetPoolRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetPoolOperationID = "GetPool"
+
+func (request *GetPoolRequest) OperationID() string { return GetPoolOperationID }
+
 type GetPoolResponseSet struct {
 	// The information is successfully returned.
 	Response200 *PoolResponse
@@ -102,6 +117,11 @@ type GetDSSInstancesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetDSSInstancesOperationID = "GetDSSInstances"
+
+func (request *GetDSSInstancesRequest) OperationID() string { return GetDSSInstancesOperationID }
+
 type GetDSSInstancesResponseSet struct {
 	// The known DSS instances participating in the pool are successfully returned.
 	Response200 *DSSInstancesResponse
@@ -132,6 +152,13 @@ type PutDSSInstancesHeartbeatRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const PutDSSInstancesHeartbeatOperationID = "PutDSSInstancesHeartbeat"
+
+func (request *PutDSSInstancesHeartbeatRequest) OperationID() string {
+	return PutDSSInstancesHeartbeatOperationID
+}
+
 type PutDSSInstancesHeartbeatResponseSet struct {
 	// The heartbeat have been recorded. The known DSS instances participating in the pool are successfully returned.
 	Response201 *DSSInstancesResponse
@@ -156,6 +183,11 @@ type GetAcceptedCAsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetAcceptedCAsOperationID = "GetAcceptedCAs"
+
+func (request *GetAcceptedCAsRequest) OperationID() string { return GetAcceptedCAsOperationID }
+
 type GetAcceptedCAsResponseSet struct {
 	// The information is successfully returned.
 	Response200 *CAsResponse
@@ -171,6 +203,11 @@ type GetInstanceCAsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetInstanceCAsOperationID = "GetInstanceCAs"
+
+func (request *GetInstanceCAsRequest) OperationID() string { return GetInstanceCAsOperationID }
+
 type GetInstanceCAsResponseSet struct {
 	// The information is successfully returned.
 	Response200 *CAsResponse
@@ -186,6 +223,11 @@ type GetGlobalOptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetGlobalOptionsOperationID = "GetGlobalOptions"
+
+func (request *GetGlobalOptionsRequest) OperationID() string { return GetGlobalOptionsOperationID }
+
 type GetGlobalOptionsResponseSet struct {
 	// The information is successfully returned.
 	Response200 *GlobalOptionsResponse

--- a/pkg/api/ridv1/interface.gen.go
+++ b/pkg/api/ridv1/interface.gen.go
@@ -77,6 +77,13 @@ type SearchIdentificationServiceAreasRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchIdentificationServiceAreasOperationID = "SearchIdentificationServiceAreas"
+
+func (request *SearchIdentificationServiceAreasRequest) OperationID() string {
+	return SearchIdentificationServiceAreasOperationID
+}
+
 type SearchIdentificationServiceAreasResponseSet struct {
 	// Identification Service Areas were successfully retrieved.
 	Response200 *SearchIdentificationServiceAreasResponse
@@ -104,6 +111,13 @@ type GetIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetIdentificationServiceAreaOperationID = "GetIdentificationServiceArea"
+
+func (request *GetIdentificationServiceAreaRequest) OperationID() string {
+	return GetIdentificationServiceAreaOperationID
+}
+
 type GetIdentificationServiceAreaResponseSet struct {
 	// Full information of the Identification Service Area was retrieved successfully.
 	Response200 *GetIdentificationServiceAreaResponse
@@ -137,6 +151,13 @@ type CreateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateIdentificationServiceAreaOperationID = "CreateIdentificationServiceArea"
+
+func (request *CreateIdentificationServiceAreaRequest) OperationID() string {
+	return CreateIdentificationServiceAreaOperationID
+}
+
 type CreateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was created successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -178,6 +199,13 @@ type UpdateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateIdentificationServiceAreaOperationID = "UpdateIdentificationServiceArea"
+
+func (request *UpdateIdentificationServiceAreaRequest) OperationID() string {
+	return UpdateIdentificationServiceAreaOperationID
+}
+
 type UpdateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was updated successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -213,6 +241,13 @@ type DeleteIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteIdentificationServiceAreaOperationID = "DeleteIdentificationServiceArea"
+
+func (request *DeleteIdentificationServiceAreaRequest) OperationID() string {
+	return DeleteIdentificationServiceAreaOperationID
+}
+
 type DeleteIdentificationServiceAreaResponseSet struct {
 	// Identification Service Area was successfully deleted from DSS.
 	Response200 *DeleteIdentificationServiceAreaResponse
@@ -245,6 +280,13 @@ type SearchSubscriptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchSubscriptionsOperationID = "SearchSubscriptions"
+
+func (request *SearchSubscriptionsRequest) OperationID() string {
+	return SearchSubscriptionsOperationID
+}
+
 type SearchSubscriptionsResponseSet struct {
 	// Subscriptions were retrieved successfully.
 	Response200 *SearchSubscriptionsResponse
@@ -272,6 +314,11 @@ type GetSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetSubscriptionOperationID = "GetSubscription"
+
+func (request *GetSubscriptionRequest) OperationID() string { return GetSubscriptionOperationID }
+
 type GetSubscriptionResponseSet struct {
 	// Subscription information was retrieved successfully.
 	Response200 *GetSubscriptionResponse
@@ -305,6 +352,11 @@ type CreateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateSubscriptionOperationID = "CreateSubscription"
+
+func (request *CreateSubscriptionRequest) OperationID() string { return CreateSubscriptionOperationID }
+
 type CreateSubscriptionResponseSet struct {
 	// A new Subscription was created successfully.
 	Response200 *PutSubscriptionResponse
@@ -347,6 +399,11 @@ type UpdateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateSubscriptionOperationID = "UpdateSubscription"
+
+func (request *UpdateSubscriptionRequest) OperationID() string { return UpdateSubscriptionOperationID }
+
 type UpdateSubscriptionResponseSet struct {
 	// An existing Subscription was updated successfully.
 	Response200 *PutSubscriptionResponse
@@ -383,6 +440,11 @@ type DeleteSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteSubscriptionOperationID = "DeleteSubscription"
+
+func (request *DeleteSubscriptionRequest) OperationID() string { return DeleteSubscriptionOperationID }
+
 type DeleteSubscriptionResponseSet struct {
 	// Subscription was deleted successfully.
 	Response200 *DeleteSubscriptionResponse

--- a/pkg/api/ridv2/interface.gen.go
+++ b/pkg/api/ridv2/interface.gen.go
@@ -80,6 +80,13 @@ type SearchIdentificationServiceAreasRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchIdentificationServiceAreasOperationID = "SearchIdentificationServiceAreas"
+
+func (request *SearchIdentificationServiceAreasRequest) OperationID() string {
+	return SearchIdentificationServiceAreasOperationID
+}
+
 type SearchIdentificationServiceAreasResponseSet struct {
 	// Identification Service Areas were successfully retrieved.
 	Response200 *SearchIdentificationServiceAreasResponse
@@ -107,6 +114,13 @@ type GetIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetIdentificationServiceAreaOperationID = "GetIdentificationServiceArea"
+
+func (request *GetIdentificationServiceAreaRequest) OperationID() string {
+	return GetIdentificationServiceAreaOperationID
+}
+
 type GetIdentificationServiceAreaResponseSet struct {
 	// Full information of the Identification Service Area was retrieved successfully.
 	Response200 *GetIdentificationServiceAreaResponse
@@ -140,6 +154,13 @@ type CreateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateIdentificationServiceAreaOperationID = "CreateIdentificationServiceArea"
+
+func (request *CreateIdentificationServiceAreaRequest) OperationID() string {
+	return CreateIdentificationServiceAreaOperationID
+}
+
 type CreateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was created successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -181,6 +202,13 @@ type UpdateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateIdentificationServiceAreaOperationID = "UpdateIdentificationServiceArea"
+
+func (request *UpdateIdentificationServiceAreaRequest) OperationID() string {
+	return UpdateIdentificationServiceAreaOperationID
+}
+
 type UpdateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was updated successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -216,6 +244,13 @@ type DeleteIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteIdentificationServiceAreaOperationID = "DeleteIdentificationServiceArea"
+
+func (request *DeleteIdentificationServiceAreaRequest) OperationID() string {
+	return DeleteIdentificationServiceAreaOperationID
+}
+
 type DeleteIdentificationServiceAreaResponseSet struct {
 	// Identification Service Area was successfully deleted from DSS.
 	Response200 *DeleteIdentificationServiceAreaResponse
@@ -248,6 +283,13 @@ type SearchSubscriptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchSubscriptionsOperationID = "SearchSubscriptions"
+
+func (request *SearchSubscriptionsRequest) OperationID() string {
+	return SearchSubscriptionsOperationID
+}
+
 type SearchSubscriptionsResponseSet struct {
 	// Subscriptions were retrieved successfully.
 	Response200 *SearchSubscriptionsResponse
@@ -275,6 +317,11 @@ type GetSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetSubscriptionOperationID = "GetSubscription"
+
+func (request *GetSubscriptionRequest) OperationID() string { return GetSubscriptionOperationID }
+
 type GetSubscriptionResponseSet struct {
 	// Subscription information was retrieved successfully.
 	Response200 *GetSubscriptionResponse
@@ -308,6 +355,11 @@ type CreateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateSubscriptionOperationID = "CreateSubscription"
+
+func (request *CreateSubscriptionRequest) OperationID() string { return CreateSubscriptionOperationID }
+
 type CreateSubscriptionResponseSet struct {
 	// A new Subscription was created successfully.
 	Response200 *PutSubscriptionResponse
@@ -349,6 +401,11 @@ type UpdateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateSubscriptionOperationID = "UpdateSubscription"
+
+func (request *UpdateSubscriptionRequest) OperationID() string { return UpdateSubscriptionOperationID }
+
 type UpdateSubscriptionResponseSet struct {
 	// An existing Subscription was updated successfully.
 	Response200 *PutSubscriptionResponse
@@ -384,6 +441,11 @@ type DeleteSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteSubscriptionOperationID = "DeleteSubscription"
+
+func (request *DeleteSubscriptionRequest) OperationID() string { return DeleteSubscriptionOperationID }
+
 type DeleteSubscriptionResponseSet struct {
 	// Subscription was deleted successfully.
 	Response200 *DeleteSubscriptionResponse

--- a/pkg/api/scdv1/interface.gen.go
+++ b/pkg/api/scdv1/interface.gen.go
@@ -174,6 +174,13 @@ type QueryOperationalIntentReferencesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QueryOperationalIntentReferencesOperationID = "QueryOperationalIntentReferences"
+
+func (request *QueryOperationalIntentReferencesRequest) OperationID() string {
+	return QueryOperationalIntentReferencesOperationID
+}
+
 type QueryOperationalIntentReferencesResponseSet struct {
 	// Operational intents were successfully retrieved.
 	Response200 *QueryOperationalIntentReferenceResponse
@@ -204,6 +211,13 @@ type GetOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetOperationalIntentReferenceOperationID = "GetOperationalIntentReference"
+
+func (request *GetOperationalIntentReferenceRequest) OperationID() string {
+	return GetOperationalIntentReferenceOperationID
+}
+
 type GetOperationalIntentReferenceResponseSet struct {
 	// Operational intent reference was retrieved successfully.
 	Response200 *GetOperationalIntentReferenceResponse
@@ -240,6 +254,13 @@ type CreateOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateOperationalIntentReferenceOperationID = "CreateOperationalIntentReference"
+
+func (request *CreateOperationalIntentReferenceRequest) OperationID() string {
+	return CreateOperationalIntentReferenceOperationID
+}
+
 type CreateOperationalIntentReferenceResponseSet struct {
 	// An operational intent reference was created successfully in the DSS.
 	Response201 *ChangeOperationalIntentReferenceResponse
@@ -287,6 +308,13 @@ type UpdateOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateOperationalIntentReferenceOperationID = "UpdateOperationalIntentReference"
+
+func (request *UpdateOperationalIntentReferenceRequest) OperationID() string {
+	return UpdateOperationalIntentReferenceOperationID
+}
+
 type UpdateOperationalIntentReferenceResponseSet struct {
 	// An operational intent reference was updated successfully in the DSS.
 	Response200 *ChangeOperationalIntentReferenceResponse
@@ -329,6 +357,13 @@ type DeleteOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteOperationalIntentReferenceOperationID = "DeleteOperationalIntentReference"
+
+func (request *DeleteOperationalIntentReferenceRequest) OperationID() string {
+	return DeleteOperationalIntentReferenceOperationID
+}
+
 type DeleteOperationalIntentReferenceResponseSet struct {
 	// The specified operational intent was successfully removed from the DSS.
 	Response200 *ChangeOperationalIntentReferenceResponse
@@ -370,6 +405,13 @@ type QueryConstraintReferencesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QueryConstraintReferencesOperationID = "QueryConstraintReferences"
+
+func (request *QueryConstraintReferencesRequest) OperationID() string {
+	return QueryConstraintReferencesOperationID
+}
+
 type QueryConstraintReferencesResponseSet struct {
 	// Constraint references were successfully retrieved.
 	Response200 *QueryConstraintReferencesResponse
@@ -400,6 +442,13 @@ type GetConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetConstraintReferenceOperationID = "GetConstraintReference"
+
+func (request *GetConstraintReferenceRequest) OperationID() string {
+	return GetConstraintReferenceOperationID
+}
+
 type GetConstraintReferenceResponseSet struct {
 	// Constraint reference was retrieved successfully.
 	Response200 *GetConstraintReferenceResponse
@@ -436,6 +485,13 @@ type CreateConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateConstraintReferenceOperationID = "CreateConstraintReference"
+
+func (request *CreateConstraintReferenceRequest) OperationID() string {
+	return CreateConstraintReferenceOperationID
+}
+
 type CreateConstraintReferenceResponseSet struct {
 	// A constraint reference was created successfully in the DSS.
 	Response201 *ChangeConstraintReferenceResponse
@@ -480,6 +536,13 @@ type UpdateConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateConstraintReferenceOperationID = "UpdateConstraintReference"
+
+func (request *UpdateConstraintReferenceRequest) OperationID() string {
+	return UpdateConstraintReferenceOperationID
+}
+
 type UpdateConstraintReferenceResponseSet struct {
 	// A constraint reference was updated successfully in the DSS.
 	Response200 *ChangeConstraintReferenceResponse
@@ -518,6 +581,13 @@ type DeleteConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteConstraintReferenceOperationID = "DeleteConstraintReference"
+
+func (request *DeleteConstraintReferenceRequest) OperationID() string {
+	return DeleteConstraintReferenceOperationID
+}
+
 type DeleteConstraintReferenceResponseSet struct {
 	// The constraint was successfully removed from the DSS.
 	Response200 *ChangeConstraintReferenceResponse
@@ -556,6 +626,11 @@ type QuerySubscriptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QuerySubscriptionsOperationID = "QuerySubscriptions"
+
+func (request *QuerySubscriptionsRequest) OperationID() string { return QuerySubscriptionsOperationID }
+
 type QuerySubscriptionsResponseSet struct {
 	// Subscriptions were retrieved successfully.
 	Response200 *QuerySubscriptionsResponse
@@ -586,6 +661,11 @@ type GetSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetSubscriptionOperationID = "GetSubscription"
+
+func (request *GetSubscriptionRequest) OperationID() string { return GetSubscriptionOperationID }
+
 type GetSubscriptionResponseSet struct {
 	// Subscription information was retrieved successfully.
 	Response200 *GetSubscriptionResponse
@@ -622,6 +702,11 @@ type CreateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateSubscriptionOperationID = "CreateSubscription"
+
+func (request *CreateSubscriptionRequest) OperationID() string { return CreateSubscriptionOperationID }
+
 type CreateSubscriptionResponseSet struct {
 	// A new subscription was created successfully.
 	Response200 *PutSubscriptionResponse
@@ -664,6 +749,11 @@ type UpdateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateSubscriptionOperationID = "UpdateSubscription"
+
+func (request *UpdateSubscriptionRequest) OperationID() string { return UpdateSubscriptionOperationID }
+
 type UpdateSubscriptionResponseSet struct {
 	// A subscription was updated successfully.
 	Response200 *PutSubscriptionResponse
@@ -701,6 +791,11 @@ type DeleteSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteSubscriptionOperationID = "DeleteSubscription"
+
+func (request *DeleteSubscriptionRequest) OperationID() string { return DeleteSubscriptionOperationID }
+
 type DeleteSubscriptionResponseSet struct {
 	// Subscription was successfully removed from DSS.
 	Response200 *DeleteSubscriptionResponse
@@ -739,6 +834,11 @@ type MakeDssReportRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const MakeDssReportOperationID = "MakeDssReport"
+
+func (request *MakeDssReportRequest) OperationID() string { return MakeDssReportOperationID }
+
 type MakeDssReportResponseSet struct {
 	// A new Report was created successfully (and archived).
 	Response201 *ErrorReport
@@ -767,6 +867,11 @@ type GetUssAvailabilityRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetUssAvailabilityOperationID = "GetUssAvailability"
+
+func (request *GetUssAvailabilityRequest) OperationID() string { return GetUssAvailabilityOperationID }
+
 type GetUssAvailabilityResponseSet struct {
 	// Availability status of specified USS was successfully retrieved.
 	Response200 *UssAvailabilityStatusResponse
@@ -800,6 +905,11 @@ type SetUssAvailabilityRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SetUssAvailabilityOperationID = "SetUssAvailability"
+
+func (request *SetUssAvailabilityRequest) OperationID() string { return SetUssAvailabilityOperationID }
+
 type SetUssAvailabilityResponseSet struct {
 	// Availability status of specified USS was successfully updated.
 	Response200 *UssAvailabilityStatusResponse


### PR DESCRIPTION
Generate the `OperationID()` method for restapi requests. This will allow them to be identifiable as Raft proposals.

Implements #1701