### PR TITLE
[raft/aux] Implement aux Raftstore

### DIFF
--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -90,7 +90,7 @@ func createKeyResolver() (auth.KeyResolver, error) {
 }
 
 func createAuxServer(ctx context.Context, locality string, publicEndpoint string, opts params.Options, logger *zap.Logger) (*aux.Server, error) {
-	auxStore, err := auxs.Init(ctx, logger, true)
+	auxStore, err := auxs.Init(ctx, logger, true, locality)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func createAuxServer(ctx context.Context, locality string, publicEndpoint string
 
 func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) (*rid_v1.Server, *rid_v2.Server, error) {
 
-	ridStore, err := rids.Init(ctx, logger, true)
+	ridStore, err := rids.Init(ctx, logger, true, locality)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -141,9 +141,9 @@ func createRIDServers(ctx context.Context, locality string, logger *zap.Logger) 
 		}, nil
 }
 
-func createSCDServer(ctx context.Context, logger *zap.Logger) (*scd.Server, error) {
+func createSCDServer(ctx context.Context, logger *zap.Logger, locality string) (*scd.Server, error) {
 
-	scdStore, err := scds.Init(ctx, logger, true)
+	scdStore, err := scds.Init(ctx, logger, true, locality)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 
 	// Initialize strategic conflict detection
 	if *enableSCD {
-		scdV1Server, err = createSCDServer(ctx, logger)
+		scdV1Server, err = createSCDServer(ctx, logger, locality)
 		if err != nil {
 			return stacktrace.Propagate(err, "Failed to create strategic conflict detection server")
 		}

--- a/cmds/db-manager/cleanup/evict.go
+++ b/cmds/db-manager/cleanup/evict.go
@@ -55,12 +55,12 @@ func evict(cmd *cobra.Command, _ []string) error {
 
 	logger := logging.WithValuesFromContext(ctx, logging.Logger)
 
-	scdStore, err := scds.Init(ctx, logger, false)
+	scdStore, err := scds.Init(ctx, logger, false, *locality)
 	if err != nil {
 		return err
 	}
 
-	ridStore, err := rids.Init(ctx, logger, false)
+	ridStore, err := rids.Init(ctx, logger, false, *locality)
 	if err != nil {
 		return err
 	}

--- a/cmds/dummy-oauth/api/dummyoauth/interface.gen.go
+++ b/cmds/dummy-oauth/api/dummyoauth/interface.gen.go
@@ -29,6 +29,11 @@ type GetTokenRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetTokenOperationID = "GetToken"
+
+func (request *GetTokenRequest) OperationID() string { return GetTokenOperationID }
+
 type GetTokenResponseSet struct {
 	// The requested token was generated successfully
 	Response200 *TokenResponse

--- a/interfaces/openapi-to-go-server/example/api/rid/interface.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/rid/interface.gen.go
@@ -77,6 +77,13 @@ type SearchIdentificationServiceAreasRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchIdentificationServiceAreasOperationID = "SearchIdentificationServiceAreas"
+
+func (request *SearchIdentificationServiceAreasRequest) OperationID() string {
+	return SearchIdentificationServiceAreasOperationID
+}
+
 type SearchIdentificationServiceAreasResponseSet struct {
 	// Identification Service Areas were successfully retrieved.
 	Response200 *SearchIdentificationServiceAreasResponse
@@ -104,6 +111,13 @@ type GetIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetIdentificationServiceAreaOperationID = "GetIdentificationServiceArea"
+
+func (request *GetIdentificationServiceAreaRequest) OperationID() string {
+	return GetIdentificationServiceAreaOperationID
+}
+
 type GetIdentificationServiceAreaResponseSet struct {
 	// Full information of the Identification Service Area was retrieved successfully.
 	Response200 *GetIdentificationServiceAreaResponse
@@ -137,6 +151,13 @@ type CreateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateIdentificationServiceAreaOperationID = "CreateIdentificationServiceArea"
+
+func (request *CreateIdentificationServiceAreaRequest) OperationID() string {
+	return CreateIdentificationServiceAreaOperationID
+}
+
 type CreateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was created successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -178,6 +199,13 @@ type UpdateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateIdentificationServiceAreaOperationID = "UpdateIdentificationServiceArea"
+
+func (request *UpdateIdentificationServiceAreaRequest) OperationID() string {
+	return UpdateIdentificationServiceAreaOperationID
+}
+
 type UpdateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was updated successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -213,6 +241,13 @@ type DeleteIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteIdentificationServiceAreaOperationID = "DeleteIdentificationServiceArea"
+
+func (request *DeleteIdentificationServiceAreaRequest) OperationID() string {
+	return DeleteIdentificationServiceAreaOperationID
+}
+
 type DeleteIdentificationServiceAreaResponseSet struct {
 	// Identification Service Area was successfully deleted from DSS.
 	Response200 *DeleteIdentificationServiceAreaResponse
@@ -245,6 +280,13 @@ type SearchSubscriptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchSubscriptionsOperationID = "SearchSubscriptions"
+
+func (request *SearchSubscriptionsRequest) OperationID() string {
+	return SearchSubscriptionsOperationID
+}
+
 type SearchSubscriptionsResponseSet struct {
 	// Subscriptions were retrieved successfully.
 	Response200 *SearchSubscriptionsResponse
@@ -272,6 +314,11 @@ type GetSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetSubscriptionOperationID = "GetSubscription"
+
+func (request *GetSubscriptionRequest) OperationID() string { return GetSubscriptionOperationID }
+
 type GetSubscriptionResponseSet struct {
 	// Subscription information was retrieved successfully.
 	Response200 *GetSubscriptionResponse
@@ -305,6 +352,11 @@ type CreateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateSubscriptionOperationID = "CreateSubscription"
+
+func (request *CreateSubscriptionRequest) OperationID() string { return CreateSubscriptionOperationID }
+
 type CreateSubscriptionResponseSet struct {
 	// A new Subscription was created successfully.
 	Response200 *PutSubscriptionResponse
@@ -347,6 +399,11 @@ type UpdateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateSubscriptionOperationID = "UpdateSubscription"
+
+func (request *UpdateSubscriptionRequest) OperationID() string { return UpdateSubscriptionOperationID }
+
 type UpdateSubscriptionResponseSet struct {
 	// An existing Subscription was updated successfully.
 	Response200 *PutSubscriptionResponse
@@ -383,6 +440,11 @@ type DeleteSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteSubscriptionOperationID = "DeleteSubscription"
+
+func (request *DeleteSubscriptionRequest) OperationID() string { return DeleteSubscriptionOperationID }
+
 type DeleteSubscriptionResponseSet struct {
 	// Subscription was deleted successfully.
 	Response200 *DeleteSubscriptionResponse

--- a/interfaces/openapi-to-go-server/example/api/scd/interface.gen.go
+++ b/interfaces/openapi-to-go-server/example/api/scd/interface.gen.go
@@ -174,6 +174,13 @@ type QueryOperationalIntentReferencesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QueryOperationalIntentReferencesOperationID = "QueryOperationalIntentReferences"
+
+func (request *QueryOperationalIntentReferencesRequest) OperationID() string {
+	return QueryOperationalIntentReferencesOperationID
+}
+
 type QueryOperationalIntentReferencesResponseSet struct {
 	// Operational intents were successfully retrieved.
 	Response200 *QueryOperationalIntentReferenceResponse
@@ -204,6 +211,13 @@ type GetOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetOperationalIntentReferenceOperationID = "GetOperationalIntentReference"
+
+func (request *GetOperationalIntentReferenceRequest) OperationID() string {
+	return GetOperationalIntentReferenceOperationID
+}
+
 type GetOperationalIntentReferenceResponseSet struct {
 	// Operational intent reference was retrieved successfully.
 	Response200 *GetOperationalIntentReferenceResponse
@@ -240,6 +254,13 @@ type CreateOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateOperationalIntentReferenceOperationID = "CreateOperationalIntentReference"
+
+func (request *CreateOperationalIntentReferenceRequest) OperationID() string {
+	return CreateOperationalIntentReferenceOperationID
+}
+
 type CreateOperationalIntentReferenceResponseSet struct {
 	// An operational intent reference was created successfully in the DSS.
 	Response201 *ChangeOperationalIntentReferenceResponse
@@ -287,6 +308,13 @@ type UpdateOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateOperationalIntentReferenceOperationID = "UpdateOperationalIntentReference"
+
+func (request *UpdateOperationalIntentReferenceRequest) OperationID() string {
+	return UpdateOperationalIntentReferenceOperationID
+}
+
 type UpdateOperationalIntentReferenceResponseSet struct {
 	// An operational intent reference was updated successfully in the DSS.
 	Response200 *ChangeOperationalIntentReferenceResponse
@@ -329,6 +357,13 @@ type DeleteOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteOperationalIntentReferenceOperationID = "DeleteOperationalIntentReference"
+
+func (request *DeleteOperationalIntentReferenceRequest) OperationID() string {
+	return DeleteOperationalIntentReferenceOperationID
+}
+
 type DeleteOperationalIntentReferenceResponseSet struct {
 	// The specified operational intent was successfully removed from the DSS.
 	Response200 *ChangeOperationalIntentReferenceResponse
@@ -370,6 +405,13 @@ type QueryConstraintReferencesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QueryConstraintReferencesOperationID = "QueryConstraintReferences"
+
+func (request *QueryConstraintReferencesRequest) OperationID() string {
+	return QueryConstraintReferencesOperationID
+}
+
 type QueryConstraintReferencesResponseSet struct {
 	// Constraint references were successfully retrieved.
 	Response200 *QueryConstraintReferencesResponse
@@ -400,6 +442,13 @@ type GetConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetConstraintReferenceOperationID = "GetConstraintReference"
+
+func (request *GetConstraintReferenceRequest) OperationID() string {
+	return GetConstraintReferenceOperationID
+}
+
 type GetConstraintReferenceResponseSet struct {
 	// Constraint reference was retrieved successfully.
 	Response200 *GetConstraintReferenceResponse
@@ -436,6 +485,13 @@ type CreateConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateConstraintReferenceOperationID = "CreateConstraintReference"
+
+func (request *CreateConstraintReferenceRequest) OperationID() string {
+	return CreateConstraintReferenceOperationID
+}
+
 type CreateConstraintReferenceResponseSet struct {
 	// A constraint reference was created successfully in the DSS.
 	Response201 *ChangeConstraintReferenceResponse
@@ -480,6 +536,13 @@ type UpdateConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateConstraintReferenceOperationID = "UpdateConstraintReference"
+
+func (request *UpdateConstraintReferenceRequest) OperationID() string {
+	return UpdateConstraintReferenceOperationID
+}
+
 type UpdateConstraintReferenceResponseSet struct {
 	// A constraint reference was updated successfully in the DSS.
 	Response200 *ChangeConstraintReferenceResponse
@@ -518,6 +581,13 @@ type DeleteConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteConstraintReferenceOperationID = "DeleteConstraintReference"
+
+func (request *DeleteConstraintReferenceRequest) OperationID() string {
+	return DeleteConstraintReferenceOperationID
+}
+
 type DeleteConstraintReferenceResponseSet struct {
 	// The constraint was successfully removed from the DSS.
 	Response200 *ChangeConstraintReferenceResponse
@@ -556,6 +626,11 @@ type QuerySubscriptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QuerySubscriptionsOperationID = "QuerySubscriptions"
+
+func (request *QuerySubscriptionsRequest) OperationID() string { return QuerySubscriptionsOperationID }
+
 type QuerySubscriptionsResponseSet struct {
 	// Subscriptions were retrieved successfully.
 	Response200 *QuerySubscriptionsResponse
@@ -586,6 +661,11 @@ type GetSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetSubscriptionOperationID = "GetSubscription"
+
+func (request *GetSubscriptionRequest) OperationID() string { return GetSubscriptionOperationID }
+
 type GetSubscriptionResponseSet struct {
 	// Subscription information was retrieved successfully.
 	Response200 *GetSubscriptionResponse
@@ -622,6 +702,11 @@ type CreateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateSubscriptionOperationID = "CreateSubscription"
+
+func (request *CreateSubscriptionRequest) OperationID() string { return CreateSubscriptionOperationID }
+
 type CreateSubscriptionResponseSet struct {
 	// A new subscription was created successfully.
 	Response200 *PutSubscriptionResponse
@@ -664,6 +749,11 @@ type UpdateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateSubscriptionOperationID = "UpdateSubscription"
+
+func (request *UpdateSubscriptionRequest) OperationID() string { return UpdateSubscriptionOperationID }
+
 type UpdateSubscriptionResponseSet struct {
 	// A subscription was updated successfully.
 	Response200 *PutSubscriptionResponse
@@ -701,6 +791,11 @@ type DeleteSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteSubscriptionOperationID = "DeleteSubscription"
+
+func (request *DeleteSubscriptionRequest) OperationID() string { return DeleteSubscriptionOperationID }
+
 type DeleteSubscriptionResponseSet struct {
 	// Subscription was successfully removed from DSS.
 	Response200 *DeleteSubscriptionResponse
@@ -739,6 +834,11 @@ type MakeDssReportRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const MakeDssReportOperationID = "MakeDssReport"
+
+func (request *MakeDssReportRequest) OperationID() string { return MakeDssReportOperationID }
+
 type MakeDssReportResponseSet struct {
 	// A new Report was created successfully (and archived).
 	Response201 *ErrorReport
@@ -767,6 +867,11 @@ type GetUssAvailabilityRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetUssAvailabilityOperationID = "GetUssAvailability"
+
+func (request *GetUssAvailabilityRequest) OperationID() string { return GetUssAvailabilityOperationID }
+
 type GetUssAvailabilityResponseSet struct {
 	// Availability status of specified USS was successfully retrieved.
 	Response200 *UssAvailabilityStatusResponse
@@ -800,6 +905,11 @@ type SetUssAvailabilityRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SetUssAvailabilityOperationID = "SetUssAvailability"
+
+func (request *SetUssAvailabilityRequest) OperationID() string { return SetUssAvailabilityOperationID }
+
 type SetUssAvailabilityResponseSet struct {
 	// Availability status of specified USS was successfully updated.
 	Response200 *UssAvailabilityStatusResponse

--- a/interfaces/openapi-to-go-server/rendering.py
+++ b/interfaces/openapi-to-go-server/rendering.py
@@ -202,6 +202,19 @@ def implementation_interface(
         lines.extend(indent(body, 1))
 
         lines.append("}")
+        lines.append("")
+
+        lines.append(
+            'const {}OperationID = "{}"'.format(
+                operation.interface_name, operation.interface_name
+            )
+        )
+        lines.append("")
+        lines.append(
+            "func (request *{}) OperationID() string {{ return {}OperationID }}".format(
+                operation.request_type_name, operation.interface_name
+            )
+        )
 
         # Declare response type for operation
         lines.append("type {} struct {{".format(operation.response_type_name))

--- a/pkg/api/auxv1/interface.gen.go
+++ b/pkg/api/auxv1/interface.gen.go
@@ -48,6 +48,11 @@ type GetVersionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetVersionOperationID = "GetVersion"
+
+func (request *GetVersionRequest) OperationID() string { return GetVersionOperationID }
+
 type GetVersionResponseSet struct {
 	// The version of the DSS is successfully returned.
 	Response200 *VersionResponse
@@ -63,6 +68,11 @@ type ValidateOauthRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const ValidateOauthOperationID = "ValidateOauth"
+
+func (request *ValidateOauthRequest) OperationID() string { return ValidateOauthOperationID }
+
 type ValidateOauthResponseSet struct {
 	// The provided token was validated.
 	Response200 *api.EmptyResponseBody
@@ -81,6 +91,11 @@ type GetPoolRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetPoolOperationID = "GetPool"
+
+func (request *GetPoolRequest) OperationID() string { return GetPoolOperationID }
+
 type GetPoolResponseSet struct {
 	// The information is successfully returned.
 	Response200 *PoolResponse
@@ -102,6 +117,11 @@ type GetDSSInstancesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetDSSInstancesOperationID = "GetDSSInstances"
+
+func (request *GetDSSInstancesRequest) OperationID() string { return GetDSSInstancesOperationID }
+
 type GetDSSInstancesResponseSet struct {
 	// The known DSS instances participating in the pool are successfully returned.
 	Response200 *DSSInstancesResponse
@@ -132,6 +152,13 @@ type PutDSSInstancesHeartbeatRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const PutDSSInstancesHeartbeatOperationID = "PutDSSInstancesHeartbeat"
+
+func (request *PutDSSInstancesHeartbeatRequest) OperationID() string {
+	return PutDSSInstancesHeartbeatOperationID
+}
+
 type PutDSSInstancesHeartbeatResponseSet struct {
 	// The heartbeat have been recorded. The known DSS instances participating in the pool are successfully returned.
 	Response201 *DSSInstancesResponse
@@ -156,6 +183,11 @@ type GetAcceptedCAsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetAcceptedCAsOperationID = "GetAcceptedCAs"
+
+func (request *GetAcceptedCAsRequest) OperationID() string { return GetAcceptedCAsOperationID }
+
 type GetAcceptedCAsResponseSet struct {
 	// The information is successfully returned.
 	Response200 *CAsResponse
@@ -171,6 +203,11 @@ type GetInstanceCAsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetInstanceCAsOperationID = "GetInstanceCAs"
+
+func (request *GetInstanceCAsRequest) OperationID() string { return GetInstanceCAsOperationID }
+
 type GetInstanceCAsResponseSet struct {
 	// The information is successfully returned.
 	Response200 *CAsResponse
@@ -186,6 +223,11 @@ type GetGlobalOptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetGlobalOptionsOperationID = "GetGlobalOptions"
+
+func (request *GetGlobalOptionsRequest) OperationID() string { return GetGlobalOptionsOperationID }
+
 type GetGlobalOptionsResponseSet struct {
 	// The information is successfully returned.
 	Response200 *GlobalOptionsResponse

--- a/pkg/api/ridv1/interface.gen.go
+++ b/pkg/api/ridv1/interface.gen.go
@@ -77,6 +77,13 @@ type SearchIdentificationServiceAreasRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchIdentificationServiceAreasOperationID = "SearchIdentificationServiceAreas"
+
+func (request *SearchIdentificationServiceAreasRequest) OperationID() string {
+	return SearchIdentificationServiceAreasOperationID
+}
+
 type SearchIdentificationServiceAreasResponseSet struct {
 	// Identification Service Areas were successfully retrieved.
 	Response200 *SearchIdentificationServiceAreasResponse
@@ -104,6 +111,13 @@ type GetIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetIdentificationServiceAreaOperationID = "GetIdentificationServiceArea"
+
+func (request *GetIdentificationServiceAreaRequest) OperationID() string {
+	return GetIdentificationServiceAreaOperationID
+}
+
 type GetIdentificationServiceAreaResponseSet struct {
 	// Full information of the Identification Service Area was retrieved successfully.
 	Response200 *GetIdentificationServiceAreaResponse
@@ -137,6 +151,13 @@ type CreateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateIdentificationServiceAreaOperationID = "CreateIdentificationServiceArea"
+
+func (request *CreateIdentificationServiceAreaRequest) OperationID() string {
+	return CreateIdentificationServiceAreaOperationID
+}
+
 type CreateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was created successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -178,6 +199,13 @@ type UpdateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateIdentificationServiceAreaOperationID = "UpdateIdentificationServiceArea"
+
+func (request *UpdateIdentificationServiceAreaRequest) OperationID() string {
+	return UpdateIdentificationServiceAreaOperationID
+}
+
 type UpdateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was updated successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -213,6 +241,13 @@ type DeleteIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteIdentificationServiceAreaOperationID = "DeleteIdentificationServiceArea"
+
+func (request *DeleteIdentificationServiceAreaRequest) OperationID() string {
+	return DeleteIdentificationServiceAreaOperationID
+}
+
 type DeleteIdentificationServiceAreaResponseSet struct {
 	// Identification Service Area was successfully deleted from DSS.
 	Response200 *DeleteIdentificationServiceAreaResponse
@@ -245,6 +280,13 @@ type SearchSubscriptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchSubscriptionsOperationID = "SearchSubscriptions"
+
+func (request *SearchSubscriptionsRequest) OperationID() string {
+	return SearchSubscriptionsOperationID
+}
+
 type SearchSubscriptionsResponseSet struct {
 	// Subscriptions were retrieved successfully.
 	Response200 *SearchSubscriptionsResponse
@@ -272,6 +314,11 @@ type GetSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetSubscriptionOperationID = "GetSubscription"
+
+func (request *GetSubscriptionRequest) OperationID() string { return GetSubscriptionOperationID }
+
 type GetSubscriptionResponseSet struct {
 	// Subscription information was retrieved successfully.
 	Response200 *GetSubscriptionResponse
@@ -305,6 +352,11 @@ type CreateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateSubscriptionOperationID = "CreateSubscription"
+
+func (request *CreateSubscriptionRequest) OperationID() string { return CreateSubscriptionOperationID }
+
 type CreateSubscriptionResponseSet struct {
 	// A new Subscription was created successfully.
 	Response200 *PutSubscriptionResponse
@@ -347,6 +399,11 @@ type UpdateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateSubscriptionOperationID = "UpdateSubscription"
+
+func (request *UpdateSubscriptionRequest) OperationID() string { return UpdateSubscriptionOperationID }
+
 type UpdateSubscriptionResponseSet struct {
 	// An existing Subscription was updated successfully.
 	Response200 *PutSubscriptionResponse
@@ -383,6 +440,11 @@ type DeleteSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteSubscriptionOperationID = "DeleteSubscription"
+
+func (request *DeleteSubscriptionRequest) OperationID() string { return DeleteSubscriptionOperationID }
+
 type DeleteSubscriptionResponseSet struct {
 	// Subscription was deleted successfully.
 	Response200 *DeleteSubscriptionResponse

--- a/pkg/api/ridv2/interface.gen.go
+++ b/pkg/api/ridv2/interface.gen.go
@@ -80,6 +80,13 @@ type SearchIdentificationServiceAreasRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchIdentificationServiceAreasOperationID = "SearchIdentificationServiceAreas"
+
+func (request *SearchIdentificationServiceAreasRequest) OperationID() string {
+	return SearchIdentificationServiceAreasOperationID
+}
+
 type SearchIdentificationServiceAreasResponseSet struct {
 	// Identification Service Areas were successfully retrieved.
 	Response200 *SearchIdentificationServiceAreasResponse
@@ -107,6 +114,13 @@ type GetIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetIdentificationServiceAreaOperationID = "GetIdentificationServiceArea"
+
+func (request *GetIdentificationServiceAreaRequest) OperationID() string {
+	return GetIdentificationServiceAreaOperationID
+}
+
 type GetIdentificationServiceAreaResponseSet struct {
 	// Full information of the Identification Service Area was retrieved successfully.
 	Response200 *GetIdentificationServiceAreaResponse
@@ -140,6 +154,13 @@ type CreateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateIdentificationServiceAreaOperationID = "CreateIdentificationServiceArea"
+
+func (request *CreateIdentificationServiceAreaRequest) OperationID() string {
+	return CreateIdentificationServiceAreaOperationID
+}
+
 type CreateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was created successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -181,6 +202,13 @@ type UpdateIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateIdentificationServiceAreaOperationID = "UpdateIdentificationServiceArea"
+
+func (request *UpdateIdentificationServiceAreaRequest) OperationID() string {
+	return UpdateIdentificationServiceAreaOperationID
+}
+
 type UpdateIdentificationServiceAreaResponseSet struct {
 	// An existing Identification Service Area was updated successfully in the DSS.
 	Response200 *PutIdentificationServiceAreaResponse
@@ -216,6 +244,13 @@ type DeleteIdentificationServiceAreaRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteIdentificationServiceAreaOperationID = "DeleteIdentificationServiceArea"
+
+func (request *DeleteIdentificationServiceAreaRequest) OperationID() string {
+	return DeleteIdentificationServiceAreaOperationID
+}
+
 type DeleteIdentificationServiceAreaResponseSet struct {
 	// Identification Service Area was successfully deleted from DSS.
 	Response200 *DeleteIdentificationServiceAreaResponse
@@ -248,6 +283,13 @@ type SearchSubscriptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SearchSubscriptionsOperationID = "SearchSubscriptions"
+
+func (request *SearchSubscriptionsRequest) OperationID() string {
+	return SearchSubscriptionsOperationID
+}
+
 type SearchSubscriptionsResponseSet struct {
 	// Subscriptions were retrieved successfully.
 	Response200 *SearchSubscriptionsResponse
@@ -275,6 +317,11 @@ type GetSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetSubscriptionOperationID = "GetSubscription"
+
+func (request *GetSubscriptionRequest) OperationID() string { return GetSubscriptionOperationID }
+
 type GetSubscriptionResponseSet struct {
 	// Subscription information was retrieved successfully.
 	Response200 *GetSubscriptionResponse
@@ -308,6 +355,11 @@ type CreateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateSubscriptionOperationID = "CreateSubscription"
+
+func (request *CreateSubscriptionRequest) OperationID() string { return CreateSubscriptionOperationID }
+
 type CreateSubscriptionResponseSet struct {
 	// A new Subscription was created successfully.
 	Response200 *PutSubscriptionResponse
@@ -349,6 +401,11 @@ type UpdateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateSubscriptionOperationID = "UpdateSubscription"
+
+func (request *UpdateSubscriptionRequest) OperationID() string { return UpdateSubscriptionOperationID }
+
 type UpdateSubscriptionResponseSet struct {
 	// An existing Subscription was updated successfully.
 	Response200 *PutSubscriptionResponse
@@ -384,6 +441,11 @@ type DeleteSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteSubscriptionOperationID = "DeleteSubscription"
+
+func (request *DeleteSubscriptionRequest) OperationID() string { return DeleteSubscriptionOperationID }
+
 type DeleteSubscriptionResponseSet struct {
 	// Subscription was deleted successfully.
 	Response200 *DeleteSubscriptionResponse

--- a/pkg/api/scdv1/interface.gen.go
+++ b/pkg/api/scdv1/interface.gen.go
@@ -174,6 +174,13 @@ type QueryOperationalIntentReferencesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QueryOperationalIntentReferencesOperationID = "QueryOperationalIntentReferences"
+
+func (request *QueryOperationalIntentReferencesRequest) OperationID() string {
+	return QueryOperationalIntentReferencesOperationID
+}
+
 type QueryOperationalIntentReferencesResponseSet struct {
 	// Operational intents were successfully retrieved.
 	Response200 *QueryOperationalIntentReferenceResponse
@@ -204,6 +211,13 @@ type GetOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetOperationalIntentReferenceOperationID = "GetOperationalIntentReference"
+
+func (request *GetOperationalIntentReferenceRequest) OperationID() string {
+	return GetOperationalIntentReferenceOperationID
+}
+
 type GetOperationalIntentReferenceResponseSet struct {
 	// Operational intent reference was retrieved successfully.
 	Response200 *GetOperationalIntentReferenceResponse
@@ -240,6 +254,13 @@ type CreateOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateOperationalIntentReferenceOperationID = "CreateOperationalIntentReference"
+
+func (request *CreateOperationalIntentReferenceRequest) OperationID() string {
+	return CreateOperationalIntentReferenceOperationID
+}
+
 type CreateOperationalIntentReferenceResponseSet struct {
 	// An operational intent reference was created successfully in the DSS.
 	Response201 *ChangeOperationalIntentReferenceResponse
@@ -287,6 +308,13 @@ type UpdateOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateOperationalIntentReferenceOperationID = "UpdateOperationalIntentReference"
+
+func (request *UpdateOperationalIntentReferenceRequest) OperationID() string {
+	return UpdateOperationalIntentReferenceOperationID
+}
+
 type UpdateOperationalIntentReferenceResponseSet struct {
 	// An operational intent reference was updated successfully in the DSS.
 	Response200 *ChangeOperationalIntentReferenceResponse
@@ -329,6 +357,13 @@ type DeleteOperationalIntentReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteOperationalIntentReferenceOperationID = "DeleteOperationalIntentReference"
+
+func (request *DeleteOperationalIntentReferenceRequest) OperationID() string {
+	return DeleteOperationalIntentReferenceOperationID
+}
+
 type DeleteOperationalIntentReferenceResponseSet struct {
 	// The specified operational intent was successfully removed from the DSS.
 	Response200 *ChangeOperationalIntentReferenceResponse
@@ -370,6 +405,13 @@ type QueryConstraintReferencesRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QueryConstraintReferencesOperationID = "QueryConstraintReferences"
+
+func (request *QueryConstraintReferencesRequest) OperationID() string {
+	return QueryConstraintReferencesOperationID
+}
+
 type QueryConstraintReferencesResponseSet struct {
 	// Constraint references were successfully retrieved.
 	Response200 *QueryConstraintReferencesResponse
@@ -400,6 +442,13 @@ type GetConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetConstraintReferenceOperationID = "GetConstraintReference"
+
+func (request *GetConstraintReferenceRequest) OperationID() string {
+	return GetConstraintReferenceOperationID
+}
+
 type GetConstraintReferenceResponseSet struct {
 	// Constraint reference was retrieved successfully.
 	Response200 *GetConstraintReferenceResponse
@@ -436,6 +485,13 @@ type CreateConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateConstraintReferenceOperationID = "CreateConstraintReference"
+
+func (request *CreateConstraintReferenceRequest) OperationID() string {
+	return CreateConstraintReferenceOperationID
+}
+
 type CreateConstraintReferenceResponseSet struct {
 	// A constraint reference was created successfully in the DSS.
 	Response201 *ChangeConstraintReferenceResponse
@@ -480,6 +536,13 @@ type UpdateConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateConstraintReferenceOperationID = "UpdateConstraintReference"
+
+func (request *UpdateConstraintReferenceRequest) OperationID() string {
+	return UpdateConstraintReferenceOperationID
+}
+
 type UpdateConstraintReferenceResponseSet struct {
 	// A constraint reference was updated successfully in the DSS.
 	Response200 *ChangeConstraintReferenceResponse
@@ -518,6 +581,13 @@ type DeleteConstraintReferenceRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteConstraintReferenceOperationID = "DeleteConstraintReference"
+
+func (request *DeleteConstraintReferenceRequest) OperationID() string {
+	return DeleteConstraintReferenceOperationID
+}
+
 type DeleteConstraintReferenceResponseSet struct {
 	// The constraint was successfully removed from the DSS.
 	Response200 *ChangeConstraintReferenceResponse
@@ -556,6 +626,11 @@ type QuerySubscriptionsRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const QuerySubscriptionsOperationID = "QuerySubscriptions"
+
+func (request *QuerySubscriptionsRequest) OperationID() string { return QuerySubscriptionsOperationID }
+
 type QuerySubscriptionsResponseSet struct {
 	// Subscriptions were retrieved successfully.
 	Response200 *QuerySubscriptionsResponse
@@ -586,6 +661,11 @@ type GetSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetSubscriptionOperationID = "GetSubscription"
+
+func (request *GetSubscriptionRequest) OperationID() string { return GetSubscriptionOperationID }
+
 type GetSubscriptionResponseSet struct {
 	// Subscription information was retrieved successfully.
 	Response200 *GetSubscriptionResponse
@@ -622,6 +702,11 @@ type CreateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const CreateSubscriptionOperationID = "CreateSubscription"
+
+func (request *CreateSubscriptionRequest) OperationID() string { return CreateSubscriptionOperationID }
+
 type CreateSubscriptionResponseSet struct {
 	// A new subscription was created successfully.
 	Response200 *PutSubscriptionResponse
@@ -664,6 +749,11 @@ type UpdateSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const UpdateSubscriptionOperationID = "UpdateSubscription"
+
+func (request *UpdateSubscriptionRequest) OperationID() string { return UpdateSubscriptionOperationID }
+
 type UpdateSubscriptionResponseSet struct {
 	// A subscription was updated successfully.
 	Response200 *PutSubscriptionResponse
@@ -701,6 +791,11 @@ type DeleteSubscriptionRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const DeleteSubscriptionOperationID = "DeleteSubscription"
+
+func (request *DeleteSubscriptionRequest) OperationID() string { return DeleteSubscriptionOperationID }
+
 type DeleteSubscriptionResponseSet struct {
 	// Subscription was successfully removed from DSS.
 	Response200 *DeleteSubscriptionResponse
@@ -739,6 +834,11 @@ type MakeDssReportRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const MakeDssReportOperationID = "MakeDssReport"
+
+func (request *MakeDssReportRequest) OperationID() string { return MakeDssReportOperationID }
+
 type MakeDssReportResponseSet struct {
 	// A new Report was created successfully (and archived).
 	Response201 *ErrorReport
@@ -767,6 +867,11 @@ type GetUssAvailabilityRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const GetUssAvailabilityOperationID = "GetUssAvailability"
+
+func (request *GetUssAvailabilityRequest) OperationID() string { return GetUssAvailabilityOperationID }
+
 type GetUssAvailabilityResponseSet struct {
 	// Availability status of specified USS was successfully retrieved.
 	Response200 *UssAvailabilityStatusResponse
@@ -800,6 +905,11 @@ type SetUssAvailabilityRequest struct {
 	// The result of attempting to authorize this request
 	Auth api.AuthorizationResult
 }
+
+const SetUssAvailabilityOperationID = "SetUssAvailability"
+
+func (request *SetUssAvailabilityRequest) OperationID() string { return SetUssAvailabilityOperationID }
+
 type SetUssAvailabilityResponseSet struct {
 	// Availability status of specified USS was successfully updated.
 	Response200 *UssAvailabilityStatusResponse

--- a/pkg/aux_/actions/pool_participants.go
+++ b/pkg/aux_/actions/pool_participants.go
@@ -1,0 +1,78 @@
+package actions
+
+import (
+	"context"
+	"time"
+
+	restapi "github.com/interuss/dss/pkg/api/auxv1"
+	auxmodels "github.com/interuss/dss/pkg/aux_/models"
+	"github.com/interuss/dss/pkg/aux_/repos"
+	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/dss/pkg/locality"
+	"github.com/interuss/stacktrace"
+)
+
+func GetDSSInstances(ctx context.Context, r repos.Repository, _ *restapi.GetDSSInstancesRequest) (any, error) {
+	metadata, err := r.GetDSSMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	instances := make([]restapi.DSSInstance, len(metadata))
+	for index, instanceMetadata := range metadata {
+		instances[index] = restapi.DSSInstance{
+			Id:             instanceMetadata.Locality,
+			PublicEndpoint: &instanceMetadata.PublicEndpoint,
+		}
+
+		if instanceMetadata.LatestTimestamp.Source.Valid {
+			instances[index].MostRecentHeartbeat = &restapi.Heartbeat{
+				Timestamp: instanceMetadata.LatestTimestamp.Timestamp.Format(time.RFC3339Nano),
+				Reporter:  &instanceMetadata.LatestTimestamp.Reporter.String,
+				Source:    instanceMetadata.LatestTimestamp.Source.String,
+			}
+
+			if instanceMetadata.LatestTimestamp.NextHeartbeatExpectedBefore != nil {
+				nextExpectedTimestamp := instanceMetadata.LatestTimestamp.NextHeartbeatExpectedBefore.Format(time.RFC3339Nano)
+				instances[index].MostRecentHeartbeat.NextHeartbeatExpectedBefore = &nextExpectedTimestamp
+			}
+		}
+	}
+
+	return &restapi.DSSInstancesResponse{DssInstances: &instances}, nil
+}
+
+func PutDSSInstancesHeartbeat(ctx context.Context, r repos.Repository, a *restapi.PutDSSInstancesHeartbeatRequest) (any, error) {
+	if a.Source == nil {
+		return nil, stacktrace.NewErrorWithCode(dsserr.BadRequest, "Source not set")
+	}
+
+	locality, err := locality.LocalityFromContext(ctx)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "Unable to get request locality")
+	}
+
+	heartbeat := auxmodels.Heartbeat{
+		Source:   *a.Source,
+		Reporter: *a.Auth.ClientID,
+		Locality: locality,
+	}
+
+	if a.Timestamp != nil {
+		ts, err := time.Parse(time.RFC3339Nano, *a.Timestamp)
+		if err != nil {
+			return nil, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Unable to parse timestamp as RFC3339 time")
+		}
+		heartbeat.Timestamp = &ts
+	}
+
+	if a.NextHeartbeatExpectedBefore != nil {
+		ts, err := time.Parse(time.RFC3339Nano, *a.NextHeartbeatExpectedBefore)
+		if err != nil {
+			return nil, stacktrace.PropagateWithCode(err, dsserr.BadRequest, "Unable to parse next heartbeat expected before as RFC3339 time")
+		}
+		heartbeat.NextHeartbeatExpectedBefore = &ts
+	}
+
+	return nil, r.RecordHeartbeat(ctx, heartbeat)
+}

--- a/pkg/aux_/actions/registry.go
+++ b/pkg/aux_/actions/registry.go
@@ -1,10 +1,55 @@
 package actions
 
 import (
+	"context"
+	"encoding/json"
+
+	restapi "github.com/interuss/dss/pkg/api/auxv1"
 	"github.com/interuss/dss/pkg/aux_/repos"
 	dssstore "github.com/interuss/dss/pkg/store"
+	"github.com/interuss/stacktrace"
 )
 
 // Registry maps operation IDs to their handlers.
-// TODO: implement
-var Registry = map[string]dssstore.OperationHandler[repos.Repository]{}
+var Registry = map[string]dssstore.OperationHandler[repos.Repository]{
+	restapi.GetDSSInstancesOperationID: {
+		Encode: encodeRequest,
+		Decode: decodeGetDSSInstances,
+		Execute: func(ctx context.Context, r repos.Repository, req dssstore.OperationRequest) (any, error) {
+			return GetDSSInstances(ctx, r, req.(*restapi.GetDSSInstancesRequest))
+		},
+		IsReadOnly: true,
+	},
+	restapi.PutDSSInstancesHeartbeatOperationID: {
+		Encode: encodeRequest,
+		Decode: decodePutDSSInstancesHeartbeat,
+		Execute: func(ctx context.Context, r repos.Repository, req dssstore.OperationRequest) (any, error) {
+			return PutDSSInstancesHeartbeat(ctx, r, req.(*restapi.PutDSSInstancesHeartbeatRequest))
+		},
+		IsReadOnly: false,
+	},
+}
+
+func encodeRequest(req dssstore.OperationRequest) ([]byte, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to encode op %q", req.OperationID())
+	}
+	return data, nil
+}
+
+func decodeGetDSSInstances(buf []byte) (dssstore.OperationRequest, error) {
+	var req restapi.GetDSSInstancesRequest
+	if err := json.Unmarshal(buf, &req); err != nil {
+		return nil, stacktrace.Propagate(err, "failed to decode %s", restapi.GetDSSInstancesOperationID)
+	}
+	return &req, nil
+}
+
+func decodePutDSSInstancesHeartbeat(buf []byte) (dssstore.OperationRequest, error) {
+	var req restapi.PutDSSInstancesHeartbeatRequest
+	if err := json.Unmarshal(buf, &req); err != nil {
+		return nil, stacktrace.Propagate(err, "failed to decode %s", restapi.PutDSSInstancesHeartbeatOperationID)
+	}
+	return &req, nil
+}

--- a/pkg/aux_/pool_participants.go
+++ b/pkg/aux_/pool_participants.go
@@ -2,27 +2,19 @@ package aux
 
 import (
 	"context"
-	"time"
 
 	"github.com/interuss/dss/pkg/api"
 	restapi "github.com/interuss/dss/pkg/api/auxv1"
-	"github.com/interuss/dss/pkg/aux_/models"
+	"github.com/interuss/dss/pkg/aux_/repos"
 	dsserr "github.com/interuss/dss/pkg/errors"
+	dssstore "github.com/interuss/dss/pkg/store"
 	"github.com/interuss/stacktrace"
 )
 
 func (a *Server) GetDSSInstances(ctx context.Context, req *restapi.GetDSSInstancesRequest) restapi.GetDSSInstancesResponseSet {
-
 	resp := restapi.GetDSSInstancesResponseSet{}
 
-	repo, err := a.Store.Interact(ctx)
-	if err != nil {
-		resp.Response500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(err, "Unable to interact with the store"))}
-		return resp
-	}
-
-	metadata, err := repo.GetDSSMetadata(ctx)
-
+	instancesResponse, err := dssstore.TransactWithResult[repos.Repository, *restapi.DSSInstancesResponse](ctx, a.Store, req)
 	if err != nil {
 		switch stacktrace.GetCode(err) {
 		case dsserr.NotImplemented:
@@ -30,91 +22,26 @@ func (a *Server) GetDSSInstances(ctx context.Context, req *restapi.GetDSSInstanc
 		default:
 			resp.Response500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(err, "Could not retrieve DAR information"))}
 		}
-
 		return resp
 	}
 
-	instances := make([]restapi.DSSInstance, len(metadata))
-
-	for index, instanceMetadata := range metadata {
-
-		instances[index] = restapi.DSSInstance{
-			Id:             instanceMetadata.Locality,
-			PublicEndpoint: &instanceMetadata.PublicEndpoint,
-		}
-
-		if instanceMetadata.LatestTimestamp.Source.Valid {
-
-			instances[index].MostRecentHeartbeat = &restapi.Heartbeat{
-				Timestamp: instanceMetadata.LatestTimestamp.Timestamp.Format(time.RFC3339Nano),
-				Reporter:  &instanceMetadata.LatestTimestamp.Reporter.String,
-				Source:    instanceMetadata.LatestTimestamp.Source.String,
-			}
-
-			if instanceMetadata.LatestTimestamp.NextHeartbeatExpectedBefore != nil {
-				nextExpectedTimestamp := instanceMetadata.LatestTimestamp.NextHeartbeatExpectedBefore.Format(time.RFC3339Nano)
-				instances[index].MostRecentHeartbeat.NextHeartbeatExpectedBefore = &nextExpectedTimestamp
-			}
-
-		}
-
-	}
-
-	resp.Response200 = &restapi.DSSInstancesResponse{DssInstances: &instances}
-
+	resp.Response200 = instancesResponse
 	return resp
-
 }
 
 func (a *Server) PutDSSInstancesHeartbeat(ctx context.Context, req *restapi.PutDSSInstancesHeartbeatRequest) restapi.PutDSSInstancesHeartbeatResponseSet {
-
-	resp := restapi.PutDSSInstancesHeartbeatResponseSet{}
-
-	repo, err := a.Store.Interact(ctx)
+	_, err := a.Store.Transact(ctx, req)
 	if err != nil {
-		resp.Response500 = &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(err, "Unable to interact with the store"))}
-		return resp
-	}
-
-	if req.Source == nil {
-		resp.Response400 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(err, "Source not set"))}
-		return resp
-	}
-
-	heartbeat := models.Heartbeat{
-		Source:   *req.Source,
-		Reporter: *req.Auth.ClientID,
-		Locality: a.Locality,
-	}
-
-	if req.Timestamp != nil {
-		ts, err := time.Parse(time.RFC3339Nano, *req.Timestamp)
-		if err != nil {
-			resp.Response400 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(err, "Unable to parse timestamp as RFC3339 time"))}
-			return resp
+		switch stacktrace.GetCode(err) {
+		case dsserr.BadRequest:
+			return restapi.PutDSSInstancesHeartbeatResponseSet{Response400: &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(err, "Unable to record heartbeat"))}}
+		default:
+			return restapi.PutDSSInstancesHeartbeatResponseSet{Response500: &api.InternalServerErrorBody{ErrorMessage: *dsserr.Handle(ctx, stacktrace.Propagate(err, "Unable to record heartbeat"))}}
 		}
-		heartbeat.Timestamp = &ts
-	}
-
-	if req.NextHeartbeatExpectedBefore != nil {
-		ts, err := time.Parse(time.RFC3339Nano, *req.NextHeartbeatExpectedBefore)
-		if err != nil {
-			resp.Response400 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(err, "Unable to parse next heartbeat expected before as RFC3339 time"))}
-			return resp
-		}
-		heartbeat.NextHeartbeatExpectedBefore = &ts
-	}
-
-	err = repo.RecordHeartbeat(ctx, heartbeat)
-
-	if err != nil {
-		resp.Response400 = &restapi.ErrorResponse{Message: dsserr.Handle(ctx, stacktrace.Propagate(err, "Unable to record heartbeat"))}
-		return resp
 	}
 
 	// Return the same response as the get one
-
-	getResponse := a.GetDSSInstances(ctx, &restapi.GetDSSInstancesRequest{})
+	getResponse := a.GetDSSInstances(ctx, &restapi.GetDSSInstancesRequest{Auth: req.Auth})
 
 	return restapi.PutDSSInstancesHeartbeatResponseSet{
 		Response201: getResponse.Response200,

--- a/pkg/aux_/store/raftstore/store.go
+++ b/pkg/aux_/store/raftstore/store.go
@@ -16,12 +16,12 @@ import (
 // repo is a full implementation of aux_.repos.Repository for Raft-based storage.
 type repo struct{}
 
-func Init(ctx context.Context, logger *zap.Logger) (*raftstore.Store[repos.Repository], error) {
+func Init(ctx context.Context, logger *zap.Logger, locality string) (*raftstore.Store[repos.Repository], error) {
 	params, err := auxraftparams.GetConnectParameters()
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to get aux raft parameters")
 	}
-	return raftstore.Init(ctx, logger.With(zap.String("service", "aux_")), params, &repo{}, actions.Registry)
+	return raftstore.Init(ctx, logger.With(zap.String("service", "aux_")), locality, params, &repo{}, actions.Registry)
 }
 
 func (r *repo) GetRepo() repos.Repository { return r }

--- a/pkg/aux_/store/raftstore/store.go
+++ b/pkg/aux_/store/raftstore/store.go
@@ -3,9 +3,12 @@ package raftstore
 import (
 	"context"
 
+	"github.com/interuss/dss/pkg/aux_/actions"
 	"github.com/interuss/dss/pkg/aux_/repos"
 	auxraftparams "github.com/interuss/dss/pkg/aux_/store/raftstore/params"
+	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/raftstore"
+	"github.com/interuss/dss/pkg/raftstore/consensus"
 	"github.com/interuss/stacktrace"
 	"go.uber.org/zap"
 )
@@ -18,5 +21,19 @@ func Init(ctx context.Context, logger *zap.Logger) (*raftstore.Store[repos.Repos
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to get aux raft parameters")
 	}
-	return raftstore.Init(ctx, logger.With(zap.String("service", "aux_")), params, func() repos.Repository { return &repo{} })
+	return raftstore.Init(ctx, logger.With(zap.String("service", "aux_")), params, &repo{}, actions.Registry)
+}
+
+func (r *repo) GetRepo() repos.Repository { return r }
+
+func (r *repo) GetSnapshot() ([]byte, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "not implemented yet")
+}
+
+func (r *repo) RestoreFromSnapshot([]byte) error {
+	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "not implemented yet")
+}
+
+func (r *repo) Apply(_ context.Context, _ consensus.Proposal) (any, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "not implemented yet")
 }

--- a/pkg/aux_/store/store.go
+++ b/pkg/aux_/store/store.go
@@ -19,12 +19,12 @@ import (
 type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the aux store backend.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, locality string) (Store, error) {
 	switch storeType := params.GetStoreParameters().StoreType; storeType {
 	case params.SQLStoreType:
 		return auxsqlstore.Init(ctx, logger, withCheckCron)
 	case params.RaftStoreType:
-		return auxraftstore.Init(ctx, logger)
+		return auxraftstore.Init(ctx, logger, locality)
 	case params.MemStoreType:
 		return auxmemstore.Init(ctx, logger)
 	default:

--- a/pkg/locality/locality.go
+++ b/pkg/locality/locality.go
@@ -1,0 +1,23 @@
+package locality
+
+import (
+	"context"
+
+	"github.com/interuss/stacktrace"
+)
+
+type localityKey struct{}
+
+// LocalityFromContext returns the locality from the context, or an error if not present.
+func LocalityFromContext(ctx context.Context) (string, error) {
+	locality, ok := ctx.Value(localityKey{}).(string)
+	if !ok {
+		return "", stacktrace.NewError("locality not found in context")
+	}
+	return locality, nil
+}
+
+// WithLocality returns a new context with the given locality.
+func WithLocality(ctx context.Context, locality string) context.Context {
+	return context.WithValue(ctx, localityKey{}, locality)
+}

--- a/pkg/raftstore/consensus/consensus.go
+++ b/pkg/raftstore/consensus/consensus.go
@@ -24,8 +24,9 @@ import (
 type Consensus struct {
 	logger *zap.Logger
 
-	nodeID uint64
-	node   raft.Node
+	locality string
+	nodeID   uint64
+	node     raft.Node
 
 	transport *rafthttp.Transport
 	server    *http.Server
@@ -45,7 +46,7 @@ type Consensus struct {
 	appliedIndex  uint64
 }
 
-func NewConsensus(ctx context.Context, logger *zap.Logger, connectParams params.ConnectParameters, provider snapshotProvider, commitC chan<- EntryCommit) (*Consensus, error) {
+func NewConsensus(ctx context.Context, logger *zap.Logger, locality string, connectParams params.ConnectParameters, provider snapshotProvider, commitC chan<- EntryCommit) (*Consensus, error) {
 	storage, old, err := newStorage(ctx, logger.With(zap.String("component", "storage")), connectParams.DataDir, connectParams.NodeID, provider, connectParams.SnapshotCatchupEntries)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to initialize storage")
@@ -74,11 +75,11 @@ func NewConsensus(ctx context.Context, logger *zap.Logger, connectParams params.
 	consensus := &Consensus{
 		logger: logging.WithValuesFromContext(ctx, logger),
 
-		nodeID: connectParams.NodeID,
-		node:   node,
-
-		storage: storage,
-		commitC: commitC,
+		nodeID:   connectParams.NodeID,
+		node:     node,
+		locality: locality,
+		storage:  storage,
+		commitC:  commitC,
 
 		shutdownTimeout: 2 * connectParams.ElectionInterval(),
 		serverErrC:      make(chan error, 1),

--- a/pkg/raftstore/consensus/consensus.go
+++ b/pkg/raftstore/consensus/consensus.go
@@ -131,7 +131,7 @@ func (c *Consensus) Stop(ctx context.Context) {
 }
 
 // HandleClientRequest blocks until the proposal is committed and applied / dropped or until ctx is cancelled.
-func (c *Consensus) HandleClientRequest(ctx context.Context, requestType string, value any, readOnly bool) (any, error) {
+func (c *Consensus) HandleClientRequest(ctx context.Context, requestType string, value []byte, readOnly bool) (any, error) {
 	proposal, err := c.newProposal(ctx, requestType, value, readOnly)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to create proposal")

--- a/pkg/raftstore/consensus/proposal.go
+++ b/pkg/raftstore/consensus/proposal.go
@@ -19,6 +19,7 @@ type EntryCommit struct {
 
 type Proposal struct {
 	ID          string    `json:"id"`
+	Locality    string    `json:"locality"`
 	NodeID      uint64    `json:"node_id"`
 	Timestamp   time.Time `json:"timestamp"`
 	RequestType string    `json:"request_type"`
@@ -38,6 +39,7 @@ func (c *Consensus) newProposal(ctx context.Context, requestType string, value [
 
 	return Proposal{
 		ID:          uuid.NewString(),
+		Locality:    c.locality,
 		NodeID:      c.nodeID,
 		Timestamp:   timestamp,
 		RequestType: requestType,

--- a/pkg/raftstore/consensus/proposal.go
+++ b/pkg/raftstore/consensus/proposal.go
@@ -2,11 +2,11 @@ package consensus
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/interuss/stacktrace"
 )
 
@@ -30,17 +30,16 @@ type Proposal struct {
 	ReadOnly bool `json:"read_only"`
 }
 
-func (c *Consensus) newProposal(ctx context.Context, requestType string, payload any, readOnly bool) (Proposal, error) {
-	// TODO - Fetch timestamp from context
-	value, err := json.Marshal(payload)
-	if err != nil {
-		return Proposal{}, stacktrace.Propagate(err, "failed to serialize proposal payload")
+func (c *Consensus) newProposal(ctx context.Context, requestType string, value []byte, readOnly bool) (Proposal, error) {
+	timestamp, err := timestamp.RequestTimestampFromContext(ctx)
+	if err != nil || timestamp.IsZero() {
+		return Proposal{}, stacktrace.Propagate(err, "failed to get timestamp from context")
 	}
 
 	return Proposal{
 		ID:          uuid.NewString(),
 		NodeID:      c.nodeID,
-		Timestamp:   time.Now().UTC(),
+		Timestamp:   timestamp,
 		RequestType: requestType,
 		Value:       value,
 		ReadOnly:    readOnly,

--- a/pkg/raftstore/store.go
+++ b/pkg/raftstore/store.go
@@ -2,46 +2,109 @@ package raftstore
 
 import (
 	"context"
+	"sync"
 
+	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/raftstore/consensus"
 	raftparams "github.com/interuss/dss/pkg/raftstore/params"
 	"github.com/interuss/dss/pkg/store"
+	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/interuss/stacktrace"
 	"go.uber.org/zap"
 )
 
-type Store[R any] struct {
-	newRepo   func() R
-	consensus *consensus.Consensus
+type RaftRepo[R any] interface {
+	GetRepo() R
+	// Apply is called on every committed entry. The proposal must be applied atomically.
+	Apply(ctx context.Context, proposal consensus.Proposal) (any, error)
+	GetSnapshot() ([]byte, error)
+	RestoreFromSnapshot(data []byte) error
 }
 
-func Init[R any](ctx context.Context, logger *zap.Logger, params raftparams.ConnectParameters, newRepo func() R) (*Store[R], error) {
+type Store[R any] struct {
+	logger *zap.Logger
+
+	raftRepo RaftRepo[R]
+	cancel   context.CancelFunc
+	registry map[string]store.OperationHandler[R]
+
+	Consensus *consensus.Consensus
+
+	wg sync.WaitGroup
+}
+
+func Init[R any](ctx context.Context, logger *zap.Logger, params raftparams.ConnectParameters, r RaftRepo[R], registry map[string]store.OperationHandler[R]) (*Store[R], error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	store := &Store[R]{
+		raftRepo: r,
+		logger:   logging.WithValuesFromContext(ctx, logger),
+		cancel:   cancel,
+		registry: registry,
+	}
 	commitC := make(chan consensus.EntryCommit)
-	consensusInstance, err := consensus.NewConsensus(ctx, logger, params, func() ([]byte, error) { return nil, nil }, commitC)
+	store.wg.Go(func() { store.processCommits(ctx, commitC) })
+
+	consensusInstance, err := consensus.NewConsensus(ctx, logger, params, r.GetSnapshot, commitC)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to initialize consensus")
 	}
-	// TODO: start consumer goroutine reading from commitC
 
-	return &Store[R]{
-		newRepo:   newRepo,
-		consensus: consensusInstance,
-	}, nil
+	store.Consensus = consensusInstance
+
+	return store, nil
 }
 
 // Transact proposes the entry to Raft and blocks until it is committed and applied.
-func (s *Store[R]) Transact(_ context.Context, _ store.OperationRequest) (any, error) {
-	// TODO: implement
-	return nil, nil
+func (s *Store[R]) Transact(ctx context.Context, request store.OperationRequest) (any, error) {
+	handler, ok := s.registry[request.OperationID()]
+	if !ok {
+		return nil, stacktrace.NewError("no handler registered for operation %q", request.OperationID())
+	}
+	payload, err := handler.Encode(request)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to encode op %q", request.OperationID())
+	}
+	return s.Consensus.HandleClientRequest(ctx, request.OperationID(), payload, handler.IsReadOnly)
 }
 
-// Interact returns a repository that can be used to query the store without proposing a Raft entry.
+// Interact returns the underlying Raft repo which, for every operation, will propose it to Raft and return the results.
 func (s *Store[R]) Interact(_ context.Context) (R, error) {
-	return s.newRepo(), nil
+	return s.raftRepo.GetRepo(), nil
 }
 
-// Close shuts down the consensus instance.
+// Close shuts down the consensus instance and processCommits loop.
 func (s *Store[R]) Close() error {
-	// TODO: implement
+	s.Consensus.Stop(context.Background())
+	s.cancel()
+	s.logger.Info("waiting for commit processing goroutine to exit")
+	s.wg.Wait()
 	return nil
+}
+
+// processCommits reads committed entries from the consensus layer and applies them via Apply.
+func (s *Store[R]) processCommits(ctx context.Context, commitCh <-chan consensus.EntryCommit) {
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("stopping commit processing loop")
+			return
+		case commit, ok := <-commitCh:
+			if !ok {
+				s.logger.Info("commit channel closed, stopping commit processing loop")
+				return
+			}
+
+			if commit.SnapshotData != nil {
+				if err := s.raftRepo.RestoreFromSnapshot(commit.SnapshotData); err != nil {
+					s.logger.Fatal("failed to restore from snapshot", zap.Error(err))
+				}
+				continue
+			}
+
+			proposalCtx := timestamp.WithRequestTimestamp(ctx, commit.Prop.Timestamp)
+			result, err := s.raftRepo.Apply(proposalCtx, commit.Prop)
+			commit.Done <- consensus.ProposalResult{Result: result, Error: err}
+		}
+	}
 }

--- a/pkg/raftstore/store.go
+++ b/pkg/raftstore/store.go
@@ -33,7 +33,7 @@ type Store[R any] struct {
 	wg sync.WaitGroup
 }
 
-func Init[R any](ctx context.Context, logger *zap.Logger, params raftparams.ConnectParameters, r RaftRepo[R], registry map[string]store.OperationHandler[R]) (*Store[R], error) {
+func Init[R any](ctx context.Context, logger *zap.Logger, locality string, params raftparams.ConnectParameters, r RaftRepo[R], registry map[string]store.OperationHandler[R]) (*Store[R], error) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	store := &Store[R]{
@@ -45,7 +45,7 @@ func Init[R any](ctx context.Context, logger *zap.Logger, params raftparams.Conn
 	commitC := make(chan consensus.EntryCommit)
 	store.wg.Go(func() { store.processCommits(ctx, commitC) })
 
-	consensusInstance, err := consensus.NewConsensus(ctx, logger, params, r.GetSnapshot, commitC)
+	consensusInstance, err := consensus.NewConsensus(ctx, logger, locality, params, r.GetSnapshot, commitC)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to initialize consensus")
 	}

--- a/pkg/rid/store/raftstore/store.go
+++ b/pkg/rid/store/raftstore/store.go
@@ -3,7 +3,10 @@ package raftstore
 import (
 	"context"
 
+	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/raftstore"
+	"github.com/interuss/dss/pkg/raftstore/consensus"
+	"github.com/interuss/dss/pkg/rid/actions"
 	"github.com/interuss/dss/pkg/rid/repos"
 	ridraftparams "github.com/interuss/dss/pkg/rid/store/raftstore/params"
 	"github.com/interuss/stacktrace"
@@ -18,5 +21,19 @@ func Init(ctx context.Context, logger *zap.Logger) (*raftstore.Store[repos.Repos
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to get rid raft parameters")
 	}
-	return raftstore.Init(ctx, logger.With(zap.String("service", "rid")), params, func() repos.Repository { return &repo{} })
+	return raftstore.Init(ctx, logger.With(zap.String("service", "rid")), params, &repo{}, actions.Registry)
+}
+
+func (r *repo) GetRepo() repos.Repository { return r }
+
+func (r *repo) GetSnapshot() ([]byte, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "not implemented yet")
+}
+
+func (r *repo) RestoreFromSnapshot([]byte) error {
+	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "not implemented yet")
+}
+
+func (r *repo) Apply(_ context.Context, _ consensus.Proposal) (any, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "not implemented yet")
 }

--- a/pkg/rid/store/raftstore/store.go
+++ b/pkg/rid/store/raftstore/store.go
@@ -16,12 +16,12 @@ import (
 // repo is a full implementation of rid.repos.Repository for Raft-based storage.
 type repo struct{}
 
-func Init(ctx context.Context, logger *zap.Logger) (*raftstore.Store[repos.Repository], error) {
+func Init(ctx context.Context, logger *zap.Logger, locality string) (*raftstore.Store[repos.Repository], error) {
 	params, err := ridraftparams.GetConnectParameters()
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to get rid raft parameters")
 	}
-	return raftstore.Init(ctx, logger.With(zap.String("service", "rid")), params, &repo{}, actions.Registry)
+	return raftstore.Init(ctx, logger.With(zap.String("service", "rid")), locality, params, &repo{}, actions.Registry)
 }
 
 func (r *repo) GetRepo() repos.Repository { return r }

--- a/pkg/rid/store/store.go
+++ b/pkg/rid/store/store.go
@@ -18,13 +18,13 @@ import (
 type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the rid store backend.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, locality string) (Store, error) {
 	storeType := params.GetStoreParameters().StoreType
 	switch storeType {
 	case params.SQLStoreType:
 		return ridsqlstore.Init(ctx, logger, withCheckCron)
 	case params.RaftStoreType:
-		return ridraftstore.Init(ctx, logger)
+		return ridraftstore.Init(ctx, logger, locality)
 	case params.MemStoreType:
 		return ridmemstore.Init(ctx, logger)
 	default:

--- a/pkg/scd/store/raftstore/store.go
+++ b/pkg/scd/store/raftstore/store.go
@@ -16,12 +16,12 @@ import (
 // repo is a full implementation of scd.repos.Repository for Raft-based storage.
 type repo struct{}
 
-func Init(ctx context.Context, logger *zap.Logger) (*raftstore.Store[repos.Repository], error) {
+func Init(ctx context.Context, logger *zap.Logger, locality string) (*raftstore.Store[repos.Repository], error) {
 	params, err := scdraftparams.GetConnectParameters()
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to get scd raft parameters")
 	}
-	return raftstore.Init(ctx, logger.With(zap.String("service", "scd")), params, &repo{}, actions.Registry)
+	return raftstore.Init(ctx, logger.With(zap.String("service", "scd")), locality, params, &repo{}, actions.Registry)
 }
 
 func (r *repo) GetRepo() repos.Repository { return r }

--- a/pkg/scd/store/raftstore/store.go
+++ b/pkg/scd/store/raftstore/store.go
@@ -3,7 +3,10 @@ package raftstore
 import (
 	"context"
 
+	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/raftstore"
+	"github.com/interuss/dss/pkg/raftstore/consensus"
+	"github.com/interuss/dss/pkg/scd/actions"
 	"github.com/interuss/dss/pkg/scd/repos"
 	scdraftparams "github.com/interuss/dss/pkg/scd/store/raftstore/params"
 	"github.com/interuss/stacktrace"
@@ -18,5 +21,19 @@ func Init(ctx context.Context, logger *zap.Logger) (*raftstore.Store[repos.Repos
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to get scd raft parameters")
 	}
-	return raftstore.Init(ctx, logger.With(zap.String("service", "scd")), params, func() repos.Repository { return &repo{} })
+	return raftstore.Init(ctx, logger.With(zap.String("service", "scd")), params, &repo{}, actions.Registry)
+}
+
+func (r *repo) GetRepo() repos.Repository { return r }
+
+func (r *repo) GetSnapshot() ([]byte, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "not implemented yet")
+}
+
+func (r *repo) RestoreFromSnapshot([]byte) error {
+	return stacktrace.NewErrorWithCode(dsserr.NotImplemented, "not implemented yet")
+}
+
+func (r *repo) Apply(_ context.Context, _ consensus.Proposal) (any, error) {
+	return nil, stacktrace.NewErrorWithCode(dsserr.NotImplemented, "not implemented yet")
 }

--- a/pkg/scd/store/store.go
+++ b/pkg/scd/store/store.go
@@ -18,13 +18,13 @@ import (
 type Store = dssstore.Store[repos.Repository]
 
 // Init selects and initializes the scd store backend.
-func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (Store, error) {
+func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool, locality string) (Store, error) {
 	storeType := params.GetStoreParameters().StoreType
 	switch storeType {
 	case params.SQLStoreType:
 		return scdsqlstore.Init(ctx, logger, withCheckCron)
 	case params.RaftStoreType:
-		return scdraftstore.Init(ctx, logger)
+		return scdraftstore.Init(ctx, logger, locality)
 	case params.MemStoreType:
 		return scdmemstore.Init(ctx, logger)
 	default:

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -25,9 +25,10 @@ type OperationRequest interface {
 
 // OperationHandler holds the logic for the encoding and execution of a registered operation
 type OperationHandler[R any] struct {
-	Encode  func(req OperationRequest) ([]byte, error)
-	Decode  func(buf []byte) (OperationRequest, error)
-	Execute func(ctx context.Context, repo R, request OperationRequest) (any, error)
+	Encode     func(req OperationRequest) ([]byte, error)
+	Decode     func(buf []byte) (OperationRequest, error)
+	Execute    func(ctx context.Context, repo R, request OperationRequest) (any, error)
+	IsReadOnly bool
 }
 
 // TransactWithResult wraps Store.Transact and casts the result to ResultType, avoiding a cast at every call site.


### PR DESCRIPTION
- Moves the business logic of the request handlers to `pkg/aux_/actions`.
- The handlers now build a `store.ActionAdapter` then use `a.Store.TransactResult`.
- Implements the aux Raftstore. 