### PR TITLE
Change AWS storage class from gp2 to gp3

### DIFF
--- a/docs/infrastructure/google-manual.md
+++ b/docs/infrastructure/google-manual.md
@@ -326,7 +326,7 @@ your chosen provider.
         provider has some default storage classes that should work:
           - Google Cloud: `standard`
           - Azure: `default`
-          - AWS: `gp2`
+          - AWS: `gp3`
 
     1.  `VAR_INGRESS_NAME`: If using Google Kubernetes Engine, set this to the
         the name of the core-service static IP address created above (e.g.,


### PR DESCRIPTION
`gp2` is not just slower, but also currently more expensive than `gp3`