### PR TITLE
[dev] Enable Local Metrics and Tracing

### DIFF
--- a/build/dev/docker-compose_dss.yaml
+++ b/build/dev/docker-compose_dss.yaml
@@ -165,7 +165,7 @@ services:
       start_interval: 5s
 
   local-dss-jaeger:
-    image: jaegertracing/jaeger:2.14.0
+    image: jaegertracing/jaeger:2.20.0
     ports:
       - "16686:16686"
       - "4317:4317"
@@ -175,7 +175,7 @@ services:
     profiles: ["with-monitoring"]
 
   local-dss-prometheus:
-    image: prom/prometheus:v3.8.1
+    image: prom/prometheus:v3.13.1
     command:
       - --config.file=/etc/prometheus/prometheus.yaml
     ports:

--- a/build/dev/docker-compose_dss.yaml
+++ b/build/dev/docker-compose_dss.yaml
@@ -115,6 +115,7 @@ services:
       COMPOSE_PROFILES: ${COMPOSE_PROFILES}
       # Note: requires the Dockerfile to have been built with "-cover" in the EXTRA_GO_INSTALL_FLAGS var
       GOCOVERDIR: "/startup/coverdata"
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://local-dss-jaeger:4317}
     command: /startup/core_service.sh ${DEBUG_ON:-0}
     ports:
       - "4000:4000"
@@ -135,6 +136,9 @@ services:
       local-dss-aux-bootstrapper-ybdb:
         condition: service_completed_successfully
         required: false
+      local-dss-jaeger:
+        condition: service_started
+        required: false
     networks:
       - dss_sandbox_default_network
     healthcheck:
@@ -142,7 +146,7 @@ services:
       interval: 3m
       start_period: 30s
       start_interval: 5s
-    profiles: ["", "with-yugabyte"]
+    profiles: ["", "with-yugabyte", "with-monitoring"]
 
   local-dss-dummy-oauth:
     build:
@@ -159,6 +163,51 @@ services:
       interval: 3m
       start_period: 30s
       start_interval: 5s
+
+  local-dss-jaeger:
+    image: jaegertracing/jaeger:2.14.0
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - dss_sandbox_default_network
+    profiles: ["with-monitoring"]
+
+  local-dss-prometheus:
+    image: prom/prometheus:v3.8.1
+    command:
+      - --config.file=/etc/prometheus/prometheus.yaml
+    ports:
+      - "9090:9090"
+    volumes:
+      - $PWD/monitoring/prometheus.yaml:/etc/prometheus/prometheus.yaml:ro
+    depends_on:
+      local-dss-core-service:
+        condition: service_healthy
+    networks:
+      - dss_sandbox_default_network
+    profiles: ["with-monitoring"]
+
+  local-dss-grafana:
+    image: grafana/grafana:13.0-ubuntu-slim
+    ports:
+      - "3000:3000"
+    volumes:
+      - $PWD/monitoring/grafana/datasources:/etc/grafana/provisioning/datasources:ro
+      - $PWD/monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - $PWD/../../deploy/services/tanka/grafana_dashboards/dss.json:/var/lib/grafana/dashboards/dss.json:ro
+    environment:
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/dss.json
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    depends_on:
+      local-dss-prometheus:
+        condition: service_started
+    networks:
+      - dss_sandbox_default_network
+    profiles: ["with-monitoring"]
 
 networks:
   dss_sandbox_default_network:

--- a/build/dev/monitoring/grafana/dashboards/dashboards.yaml
+++ b/build/dev/monitoring/grafana/dashboards/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: DSS
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: true
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/build/dev/monitoring/grafana/datasources/prometheus.yaml
+++ b/build/dev/monitoring/grafana/datasources/prometheus.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: prometheus
+    type: prometheus
+    access: proxy
+    url: http://local-dss-prometheus:9090
+    isDefault: true
+    editable: true

--- a/build/dev/monitoring/prometheus.yaml
+++ b/build/dev/monitoring/prometheus.yaml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: dss
+    static_configs:
+      - targets:
+          - local-dss-core-service:8079

--- a/build/dev/standalone_instance.md
+++ b/build/dev/standalone_instance.md
@@ -22,6 +22,12 @@ sandbox environment consisting of:
   http://localhost:8085/token externally to generate dummy JWT access tokens
   that validate against [the auth2.pem public key](../test-certs/auth2.pem)
 
+The optional `with-monitoring` profile also provides:
+
+* Prometheus for collecting DSS metrics
+* Grafana with the DSS metrics dashboard already configured
+* Jaeger for collecting and viewing DSS traces
+
 ## Prerequisites
 
 * Install [Docker](https://docs.docker.com/v17.12/install/)
@@ -98,6 +104,29 @@ The default option is `up --build` which forces to re-build the local deployment
 The system can be removed entirely with `run_locally.sh down`.
 See all `docker compose` verbs
 [here](https://docs.docker.com/compose/reference/overview/).
+
+### Monitoring
+
+To include the local metrics and tracing tools, enable the `with-monitoring`
+Docker Compose profile:
+
+```bash
+COMPOSE_PROFILES=with-monitoring ./run_locally.sh
+```
+
+The profile enables metrics and tracing in the DSS Core Service and provides:
+
+* DSS metrics dashboard in Grafana: http://localhost:3000 (username and password:
+  `admin`)
+* Prometheus: http://localhost:9090
+* Jaeger: http://localhost:16686
+
+To use the Yugabyte datastore and monitoring tools together, enable both
+profiles:
+
+```bash
+COMPOSE_PROFILES=with-yugabyte,with-monitoring ./run_locally.sh
+```
 
 ## Database migration and versioning
 

--- a/build/dev/startup/core_service.sh
+++ b/build/dev/startup/core_service.sh
@@ -14,12 +14,21 @@ else
   DATASTORE_CONNECTION="-datastore_host local-dss-crdb"
 fi
 
+if [ "${COMPOSE_PROFILES#*"with-monitoring"}" != "${COMPOSE_PROFILES}" ]; then
+  echo "Monitoring: enabled"
+  MONITORING_FLAGS="-enable_metrics -enable_tracing"
+else
+  echo "Monitoring: disabled"
+  MONITORING_FLAGS=""
+fi
+
 if [ "$DEBUG_ON" = "1" ]; then
   echo "Debug Mode: on"
 
-  # Linter is disabled to properly unwrap $DATASTORE_CONNECTION.
+  # Linter is disabled to properly unwrap connection and monitoring arguments.
   # shellcheck disable=SC2086
   dlv --headless --listen=:4000 --api-version=2 --accept-multiclient exec --continue /usr/bin/core-service -- ${DATASTORE_CONNECTION} \
+  ${MONITORING_FLAGS} \
   -public_key_files /var/test-certs/auth2.pem \
   -log_format console \
   -dump_requests \
@@ -32,10 +41,11 @@ if [ "$DEBUG_ON" = "1" ]; then
 else
   echo "Debug Mode: off"
   # Use exec so docker-compose's SIGTERM is forwarded to the binary
-  # Linter is disabled to properly unwrap $DATASTORE_CONNECTION.
+  # Linter is disabled to properly unwrap connection and monitoring arguments.
   # shellcheck disable=SC2086
   exec /usr/bin/core-service \
   ${DATASTORE_CONNECTION} \
+  ${MONITORING_FLAGS} \
   -public_key_files /var/test-certs/auth2.pem \
   -log_format console \
   -dump_requests \

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -169,48 +169,18 @@ You need to use the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to config
 
 [Other variables for telemetry](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) (and [variables in general](https://opentelemetry.io/docs/languages/sdk-configuration/general/)) supported by the Go language are available as well if needed.
 
-As an example for local debugging, when using the local Docker Compose file, you can patch it as shown below to add a Jaeger server and point the DSS toward it.
+For local debugging, enable the `with-monitoring` profile in the standalone
+Docker Compose deployment:
 
-```diff
-diff --git a/build/dev/docker-compose_dss.yaml b/build/dev/docker-compose_dss.yaml
-index e66d2ba4..d204104b 100644
---- a/build/dev/docker-compose_dss.yaml
-+++ b/build/dev/docker-compose_dss.yaml
-@@ -133,6 +133,7 @@ services:
-       COMPOSE_PROFILES: ${COMPOSE_PROFILES}
-       # Note: requires the Dockerfile to have been built with "-cover" in the EXTRA_GO_INSTALL_FLAGS var
-       GOCOVERDIR: "/startup/coverdata"
-+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4317"
-     command: /startup/core_service.sh ${DEBUG_ON:-0}
-     ports:
-       - "4000:4000"
-@@ -178,6 +179,16 @@ services:
-       start_period: 30s
-       start_interval: 5s
-
-+  jaeger:
-+    image: jaegertracing/jaeger:2.14.0
-+    ports:
-+      - "16686:16686"
-+      - "4317:4317"
-+      - "4318:4318"
-+      - "5778:5778"
-+      - "9411:9411"
-+    networks:
-+      - dss_sandbox_default_network
- networks:
-   dss_sandbox_default_network:
-     name: dss_sandbox-default
-diff --git a/build/dev/startup/core_service.sh b/build/dev/startup/core_service.sh
-index f09bda59..8c96cf3e 100755
---- a/build/dev/startup/core_service.sh
-+++ b/build/dev/startup/core_service.sh
-@@ -44,5 +44,6 @@ else
-   -enable_scd \
-   -allow_http_base_urls \
-   -locality local_dev \
--  -public_endpoint http://127.0.0.1:8082
-+  -public_endpoint http://127.0.0.1:8082 \
-+  -enable_tracing
- fi
+```bash
+COMPOSE_PROFILES=with-monitoring ./build/dev/run_locally.sh
 ```
+
+This enables DSS metrics and tracing and starts Prometheus, Grafana, and Jaeger.
+Grafana is available at http://localhost:3000 with the DSS dashboard already
+configured (use `admin` for both the username and password), Prometheus is
+available at http://localhost:9090, and Jaeger is available at
+http://localhost:16686.
+
+See the [standalone local instance documentation](../../build/dev/standalone_instance.md#monitoring)
+for more details.


### PR DESCRIPTION
 ## Summary

  - add an opt-in `with-monitoring` Docker Compose profile for local development
  - enable DSS metrics and tracing when the profile is active
  - start and configure Prometheus, Grafana, and Jaeger
  - provision the existing DSS Grafana dashboard and Prometheus datasource
  - replace the manual Jaeger patch instructions with the supported workflow

  ## Why

Local developers currently need to patch the standalone Docker Compose configuration manually to inspect DSS metrics and traces. This profile provides the complete local observability stack with one option while leaving the default development environment unchanged.

  Closes #1531

  ## Developer impact

  Developers can start the monitoring stack with:

  ```bash
  COMPOSE_PROFILES=with-monitoring ./build/dev/run_locally.sh

  Grafana is then available on port 3000, Prometheus on port 9090, and Jaeger on port 16686. The profile can also be combined with with-yugabyte.

  ## Validation

  - validated the default, with-monitoring, and combined Compose configurations
  - ran ShellCheck on the modified startup scripts
  - built and started the complete profile locally
  - confirmed the DSS Core Service was healthy
  - confirmed Prometheus reported the DSS scrape target as up
  - confirmed Grafana loaded the DSS Metrics dashboard and Prometheus datasource
  - confirmed Jaeger received traces from the dss service