### PR TITLE
[tooling] Test special flags with prober & qualify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,24 @@ jobs:
         name: coverage-data
         path: coverage.out
 
-  dss-tests-with-yugabyte:
-    name: DSS tests with Yugabyte
+  dss-tests-matrix:
+    name: DSS tests (${{ matrix.db }} ${{ matrix.flags }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        db: [crdb, yugabyte]
+        flags:
+          - ""
+          - "-enable_time_based_notification_index"
+          - "-enable_scd_global_lock"
+          - "-enable_scd_hash_lock"
+        exclude:
+          - db: crdb
+            flags: ""
     env:
-      COMPOSE_PROFILES: with-yugabyte
+      COMPOSE_PROFILES: ${{ matrix.db == 'yugabyte' && 'with-yugabyte' || '' }}
+      CORE_SERVICE_EXTRA_FLAGS: ${{ matrix.flags }}
     steps:
       - name: Job information
         run: |

--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -54,6 +54,11 @@ RESULTFILE="$(pwd)/e2e_test_result"
 touch "${RESULTFILE}"
 cat /dev/null > "${RESULTFILE}"
 
+PROBER_EXTRA_ARGS=()
+if [[ "${CORE_SERVICE_EXTRA_FLAGS:-}" == *"-enable_time_based_notification_index"* ]]; then
+	PROBER_EXTRA_ARGS+=(--scd-time-based-notification-index true)
+fi
+
 if ! docker run --rm --link "$OAUTH_CONTAINER":oauth \
 	--link "$CORE_SERVICE_CONTAINER":core-service \
 	--network dss_sandbox-default \
@@ -69,7 +74,8 @@ if ! docker run --rm --link "$OAUTH_CONTAINER":oauth \
 	--rid-v2-auth "DummyOAuth(http://oauth:8085/token,sub=fake_uss)" \
 	--scd-auth1 "DummyOAuth(http://oauth:8085/token,sub=fake_uss)" \
 	--scd-auth2 "DummyOAuth(http://oauth:8085/token,sub=fake_uss2)"	\
-	--scd-api-version 1.0.0; then
+	--scd-api-version 1.0.0 \
+    "${PROBER_EXTRA_ARGS[@]}"; then
 
     if [ "$CI" == "true" ]; then
         echo "=== END OF TEST RESULTS ==="

--- a/build/dev/qualify_locally.sh
+++ b/build/dev/qualify_locally.sh
@@ -49,6 +49,7 @@ for container_name in "${localhost_containers[@]}"; do
 	fi
 done
 
+
 if ! docker run --rm --link "$OAUTH_CONTAINER":oauth \
 	--link "$CORE_SERVICE_CONTAINER":core-service \
 	--network dss_sandbox-default \


### PR DESCRIPTION
This switch to a job matrix, to test various combination of flags & datastore, ensuring full coverage of possibilities automatically.

Base job with coverage (crdb, no flags) is kept as is.

This PR require the follows PRs to be merged to pass:

* #1617 
* #1616 
* https://github.com/interuss/dss/pull/1619
* https://github.com/interuss/monitoring/pull/1618
  * This will require a new release of monitoring tools. As of now I used a custom image build on that PR. 

