### PR TITLE
[scd] Don't disable lock with timeBasedNotificationIndex on yugabyte

### DIFF
--- a/pkg/scd/store/sqlstore/store.go
+++ b/pkg/scd/store/sqlstore/store.go
@@ -29,6 +29,7 @@ type repo struct {
 	globalLock                 bool
 	hashLock                   bool
 	timeBasedNotificationIndex bool
+	version                    *sqlstore.Version
 }
 
 // Init initializes the SQL-backed sid store. It return a concrete sqlstore.Store[sid.repos.Repository] providing the
@@ -39,7 +40,7 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*sqlstor
 		DBName:                 "scd",
 		CrdbMajorSchemaVersion: currentCrdbMajorSchemaVersion,
 		YbMajorSchemaVersion:   currentYugabyteMajorSchemaVersion,
-		NewRepo: func(q dssql.Queryable, clock clockwork.Clock, _ *sqlstore.Version) repos.Repository {
+		NewRepo: func(q dssql.Queryable, clock clockwork.Clock, version *sqlstore.Version) repos.Repository {
 			return &repo{
 				q:                          q,
 				clock:                      clock,
@@ -47,6 +48,7 @@ func Init(ctx context.Context, logger *zap.Logger, withCheckCron bool) (*sqlstor
 				globalLock:                 opts.GlobalLock,
 				hashLock:                   opts.HashLock,
 				timeBasedNotificationIndex: opts.TimeBasedNotificationIndex,
+				version:                    version,
 			}
 		},
 		Registry: actions.Registry,

--- a/pkg/scd/store/sqlstore/subscriptions.go
+++ b/pkg/scd/store/sqlstore/subscriptions.go
@@ -12,6 +12,7 @@ import (
 	dssmodels "github.com/interuss/dss/pkg/models"
 	scdmodels "github.com/interuss/dss/pkg/scd/models"
 	dsssql "github.com/interuss/dss/pkg/sql"
+	"github.com/interuss/dss/pkg/sqlstore"
 	"github.com/interuss/stacktrace"
 	"go.uber.org/zap"
 
@@ -444,7 +445,7 @@ func cellLockKeys(cells s2.CellUnion) []int64 {
 
 func (c *repo) LockSubscriptionsOnCells(ctx context.Context, cells s2.CellUnion, subscriptionIds []dssmodels.ID, startTime *time.Time, endTime *time.Time) error {
 
-	if c.timeBasedNotificationIndex { // No lock when working with timeBasedNotificationIndex
+	if c.timeBasedNotificationIndex && c.version.Type == sqlstore.CockroachDB { // No lock when working with timeBasedNotificationIndex on CockroachDB
 		return nil
 	}
 


### PR DESCRIPTION
Disabling lock with yugabyte result in prober test not passing dues to performance. This enable it back only for yugabyte.