### PR TITLE
[test] Add coverage for isYugabyteRetryable; fix TestNewRSAAuthClient on Windows

### DIFF
--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -97,7 +97,7 @@ func TestNewRSAAuthClient(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	tmpfile, err := os.CreateTemp("/tmp", "bad.pem")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "bad.pem")
 	require.NoError(t, err)
 	require.NoError(t, tmpfile.Close())
 	// Test catches previous segfault.

--- a/pkg/sqlstore/store_test.go
+++ b/pkg/sqlstore/store_test.go
@@ -1,0 +1,54 @@
+package sqlstore
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsYugabyteRetryable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "serialization_failure",
+			err:  &pgconn.PgError{Code: "40001"},
+			want: true,
+		},
+		{
+			name: "deadlock_detected",
+			err:  &pgconn.PgError{Code: "40P01"},
+			want: true,
+		},
+		{
+			name: "unrelated_pg_error",
+			err:  &pgconn.PgError{Code: "23505"}, // unique_violation
+			want: false,
+		},
+		{
+			name: "wrapped_retryable_pg_error",
+			err:  errors.Join(errors.New("tx failed"), &pgconn.PgError{Code: "40001"}),
+			want: true,
+		},
+		{
+			name: "non_pg_error",
+			err:  errors.New("connection reset"),
+			want: false,
+		},
+		{
+			name: "nil_error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, isYugabyteRetryable(c.err))
+		})
+	}
+}


### PR DESCRIPTION

`pkg/sqlstore/store.go` had no test coverage for `isYugabyteRetryable`, the function that determines whether a Yugabyte transaction error should trigger a retry. As a pure function over `pgconn.PgError` codes, it can be fully covered without a live database connection, so this adds a table-driven test for it.

This also fixes `TestNewRSAAuthClient`, which called `os.CreateTemp("/tmp", ...)` and consequently failed on Windows, where no `/tmp` directory exists. Replaced with `t.TempDir()`, which is portable and self-cleaning.

## Test plan

- `go test ./pkg/sqlstore/... ./pkg/auth/...` passes
- New `isYugabyteRetryable` cases cover both retryable Postgres error codes (`40001`, `40P01`), a non-retryable code, a wrapped error, a non-`PgError`, and `nil`

