### PR TITLE
[terraform/aws] Create gp3 storage class, add release notes

### DIFF
--- a/NEXT_RELEASE_NOTES.md
+++ b/NEXT_RELEASE_NOTES.md
@@ -55,6 +55,10 @@ The release notes should contain at least the following sections:
   * Details about migrations are available [there](https://interuss.github.io/dss/latest/operations/database-migrations/)
 * The 3.4.1 (or 1.1.1 for Yugabyte) migration for SCD is mandatory if you plan to use the new SCD hash lock option.
   * This migration can be applied without any impact if you do not plan to use it.
+* The default storage class for AWS changed from `gp2` to `gp3`.
+  * For existing clusters, ensure the value of `aws_kubernetes_storage_class` in your terraform config is set to `gp2` if it was not defined. Switching storage class is not supported.
+  * As `gp3` doesn't exist by default in EKS, terraform will now create the new storage class. If `gp3` already exists in your cluster, set `aws_create_storage_class` to false.
+  * There is a behaviour change between the previous default storage class and the new one: `reclaimPolicy` is set to `Retain` to limit accidental data deletion.
 
 ## Important information
 

--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/charts/storage-class/Chart.yaml
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/charts/storage-class/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: storage-class
+version: 0.1.0

--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/charts/storage-class/templates/storageclass.yaml
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/charts/storage-class/templates/storageclass.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
+parameters:
+  type: gp3
+  csi.storage.k8s.io/fstype: ext4

--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/storage.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/storage.tf
@@ -1,0 +1,10 @@
+resource "helm_release" "storage-class" {
+  count = var.aws_create_storage_class ? 1 : 0
+
+  chart = "${path.module}/charts/storage-class"
+  name  = "storage-class"
+  wait  = true
+  depends_on = [
+    aws_eks_addon.aws-ebs-csi-driver
+  ]
+}

--- a/deploy/infrastructure/dependencies/terraform-aws-kubernetes/variables.gen.tf
+++ b/deploy/infrastructure/dependencies/terraform-aws-kubernetes/variables.gen.tf
@@ -53,6 +53,20 @@ variable "aws_iam_permissions_boundary" {
 }
 
 
+variable "aws_create_storage_class" {
+  type        = bool
+  description = <<-EOT
+  Create storage class in cluster.
+
+  For now, create a gp3 storage class in the cluster and set it as the default one.
+
+  Example: `true`
+  EOT
+
+  default = true
+}
+
+
 variable "app_hostname" {
   type        = string
   description = <<-EOT

--- a/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
+++ b/deploy/infrastructure/modules/terraform-aws-dss/TFVARS.gen.md
@@ -63,6 +63,12 @@ Example:</li>
 </ul>
 </td>
             </tr><tr>
+                <td>aws_create_storage_class (<code>bool</code>)</td>
+                <td><p>Create storage class in cluster.</p>
+<p>For now, create a gp3 storage class in the cluster and set it as the default one.</p>
+<p>Example: <code>true</code></p>
+<br/>Default value: <code>true</code></td>
+            </tr><tr>
                 <td>aws_iam_permissions_boundary (<code>string</code>)</td>
                 <td><p>AWS IAM Policy ARN to be used for permissions boundaries on created roles.</p>
 <p>Example: <code>arn:aws:iam::123456789012:policy/GithubCIPermissionBoundaries</code></p>

--- a/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
+++ b/deploy/infrastructure/modules/terraform-aws-dss/variables.gen.tf
@@ -53,6 +53,20 @@ variable "aws_iam_permissions_boundary" {
 }
 
 
+variable "aws_create_storage_class" {
+  type        = bool
+  description = <<-EOT
+  Create storage class in cluster.
+
+  For now, create a gp3 storage class in the cluster and set it as the default one.
+
+  Example: `true`
+  EOT
+
+  default = true
+}
+
+
 variable "app_hostname" {
   type        = string
   description = <<-EOT

--- a/deploy/infrastructure/utils/definitions/aws_create_storage_class.tf
+++ b/deploy/infrastructure/utils/definitions/aws_create_storage_class.tf
@@ -1,0 +1,12 @@
+variable "aws_create_storage_class" {
+  type        = bool
+  description = <<-EOT
+  Create storage class in cluster.
+
+  For now, create a gp3 storage class in the cluster and set it as the default one.
+
+  Example: `true`
+  EOT
+
+  default = true
+}

--- a/deploy/infrastructure/utils/variables.py
+++ b/deploy/infrastructure/utils/variables.py
@@ -102,6 +102,7 @@ AWS_KUBERNETES_VARIABLES = [
     "aws_instance_type",
     "aws_route53_zone_id",
     "aws_iam_permissions_boundary",
+    "aws_create_storage_class",
 ] + COMMON_KUBERNETES_VARIABLES
 
 # modules/terraform-aws-dss

--- a/deploy/operations/ci/aws-1/variables.gen.tf
+++ b/deploy/operations/ci/aws-1/variables.gen.tf
@@ -53,6 +53,20 @@ variable "aws_iam_permissions_boundary" {
 }
 
 
+variable "aws_create_storage_class" {
+  type        = bool
+  description = <<-EOT
+  Create storage class in cluster.
+
+  For now, create a gp3 storage class in the cluster and set it as the default one.
+
+  Example: `true`
+  EOT
+
+  default = true
+}
+
+
 variable "app_hostname" {
   type        = string
   description = <<-EOT


### PR DESCRIPTION
#1606 changed the default storage class for AWS clusters, but the `gp3` storage class is not available by default in EKS clusters.

This PR adds a mechanism to terraform to create it. It can be opted out of, should someone with an existing cluster have created it by other means, e.g. manually.

Release notes have also been updated with information about the potential migration step needed.

This has been tested with a fresh cluster and a PVC that has been successfully provisioned.