### PR TITLE
[auth] Don't panic on transient failures when refreshing JWKS keys

### DIFF
--- a/NEXT_RELEASE_NOTES.md
+++ b/NEXT_RELEASE_NOTES.md
@@ -64,6 +64,7 @@ The release notes should contain at least the following sections:
 * Server timeout flag has been renamed from `server timeout` to `server_timeout`.
 * The `duration` field, previously recorded as a string containing the unit, has been changed to `duration_ms`, a float representing the duration in milliseconds, rounded to 0.01.
 * Grafana version deployed by Helm charts or Tanka files have been upgraded to 13.0. Ensure to read grafana changelog based on your current version.
+* Improved the core-service so it doesn't shut down as soon as a single refresh of the JWKS keys fails. Keys that could not be refreshed due to a transient failure (unreachable endpoint, HTTP error status, malformed response) are now used from the cache for up to jwks_key_ttl (new flag, default 1h) before the service shuts down. Set it to 0 to restore the previous behavior. Other failures, such as a key ID missing from the key set, still shut the service down immediately. On startup, a transient failure now makes the service retry with a backoff instead of shutting down.
 * The Google Kubernetes Engine (GKE) node disk size has been increased from 15GB to 25GB to prevent issues with saturated system disks.
 
   * You will need to apply the Terraform state once to recreate the node pool.

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -23,6 +23,7 @@ import (
 	aux "github.com/interuss/dss/pkg/aux_"
 	auxs "github.com/interuss/dss/pkg/aux_/store"
 	"github.com/interuss/dss/pkg/build"
+	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/dss/pkg/rid/application"
 	rid_v1 "github.com/interuss/dss/pkg/rid/server/v1"
@@ -30,7 +31,6 @@ import (
 	rids "github.com/interuss/dss/pkg/rid/store"
 	"github.com/interuss/dss/pkg/scd"
 	scds "github.com/interuss/dss/pkg/scd/store"
-	"github.com/interuss/dss/pkg/store"
 	"github.com/interuss/dss/pkg/store/params"
 	"github.com/interuss/dss/pkg/timestamp"
 	"github.com/interuss/dss/pkg/version"
@@ -65,6 +65,7 @@ var (
 	jwksEndpoint      = flag.String("jwks_endpoint", "", "URL pointing to an endpoint serving JWKS")
 	jwksKeyIDs        = flag.String("jwks_key_ids", "", "IDs of a set of key in a JWKS, separated by commas")
 	keyRefreshTimeout = flag.Duration("key_refresh_timeout", 1*time.Minute, "Timeout for refreshing keys for JWT verification")
+	jwksKeyTTL        = flag.Duration("jwks_key_ttl", 1*time.Hour, "Maximum duration during which keys that could not be refreshed are still used before shutting down the service")
 	jwtAudiences      = flag.String("accepted_jwt_audiences", "", "comma-separated acceptable JWT `aud` claims")
 )
 
@@ -318,6 +319,7 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 		ctx, auth.Configuration{
 			KeyResolver:       keyResolver,
 			KeyRefreshTimeout: *keyRefreshTimeout,
+			KeyTTL:            *jwksKeyTTL,
 			AcceptedAudiences: strings.Split(*jwtAudiences, ","),
 		},
 	)
@@ -495,7 +497,7 @@ func main() {
 	backoff := 0
 	for {
 		if err := RunHTTPServer(ctx, cancel, *address, *locality); err != nil {
-			if stacktrace.GetCode(err) == store.CodeRetryable {
+			if stacktrace.GetCode(err) == dsserr.Unavailable {
 				logger.Info(fmt.Sprintf("Prerequisites not yet satisfied; waiting %.fs to retry...", backoffs[backoff].Seconds()), zap.Error(err))
 				time.Sleep(backoffs[backoff])
 				if backoff < len(backoffs)-1 {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -91,13 +91,17 @@ func (r *JWKSResolver) ResolveKeys(ctx context.Context) ([]interface{}, error) {
 
 	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "Error retrieving JWKS at %s", req.URL)
+		return nil, stacktrace.PropagateWithCode(err, dsserr.Unavailable, "Error retrieving JWKS at %s", req.URL)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode >= 400 {
+		return nil, stacktrace.NewErrorWithCode(dsserr.Unavailable, "Error retrieving JWKS at %s: status %d", req.URL, resp.StatusCode)
+	}
+
 	jwks := jose.JSONWebKeySet{}
 	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
-		return nil, stacktrace.Propagate(err, "Error decoding JWKS")
+		return nil, stacktrace.PropagateWithCode(err, dsserr.Unavailable, "Error decoding JWKS")
 	}
 
 	var keys []interface{}
@@ -131,6 +135,7 @@ type Authorizer struct {
 type Configuration struct {
 	KeyResolver       KeyResolver   // Used to initialize and periodically refresh keys.
 	KeyRefreshTimeout time.Duration // Keys are refreshed on this cadence.
+	KeyTTL            time.Duration // Maximum age of the cached keys before a failing refresh becomes fatal.
 	AcceptedAudiences []string      // AcceptedAudiences enforces the aud keyClaim on the jwt. An empty string allows no aud keyClaim.
 }
 
@@ -153,14 +158,22 @@ func NewRSAAuthorizer(ctx context.Context, configuration Configuration) (*Author
 		ticker := time.NewTicker(configuration.KeyRefreshTimeout)
 		defer ticker.Stop()
 
+		lastSuccess := time.Now()
+
 		for {
 			select {
 			case <-ticker.C:
 				keys, err := configuration.KeyResolver.ResolveKeys(ctx)
 				if err != nil {
-					logger.Panic("failed to refresh key", zap.Error(err))
+					if stacktrace.GetCode(err) != dsserr.Unavailable || time.Since(lastSuccess) >= configuration.KeyTTL {
+						logger.Panic("failed to refresh key", zap.Error(err))
+					} else {
+						logger.Error("failed to refresh key, using cached keys", zap.Error(err))
+					}
+					continue
 				}
 
+				lastSuccess = time.Now()
 				authorizer.setKeys(keys)
 			case <-ctx.Done():
 				logger.Warn("finalizing key refresh worker", zap.Error(ctx.Err()))

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -5,8 +5,11 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,10 +17,14 @@ import (
 	"github.com/interuss/dss/pkg/api/scdv1"
 	"github.com/interuss/dss/pkg/auth/claims"
 	dsserr "github.com/interuss/dss/pkg/errors"
+	"github.com/interuss/dss/pkg/logging"
 	"github.com/interuss/stacktrace"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func rsaTokenReq(key *rsa.PrivateKey, exp, nbf int64) *http.Request {
@@ -482,4 +489,178 @@ func TestHasScope(t *testing.T) {
 	require.True(t, HasScope(scopes, scdv1.UtmStrategicCoordinationScope))
 	require.True(t, HasScope(scopes, scdv1.UtmConformanceMonitoringSaScope))
 	require.False(t, HasScope(scopes, scdv1.UtmAvailabilityArbitrationScope))
+}
+
+type failingKeyResolver struct {
+	mu   sync.Mutex
+	keys []interface{}
+	err  error
+}
+
+func (r *failingKeyResolver) ResolveKeys(context.Context) ([]interface{}, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.keys, nil
+}
+
+func (r *failingKeyResolver) setErr(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
+}
+
+type ignorePanicHook struct{}
+
+func (ignorePanicHook) OnWrite(*zapcore.CheckedEntry, []zapcore.Field) {}
+
+func observeLogs(t *testing.T) *observer.ObservedLogs {
+	core, logs := observer.New(zapcore.DebugLevel)
+	previous := logging.Logger
+	logging.Logger = zap.New(core, zap.WithPanicHook(ignorePanicHook{}))
+	t.Cleanup(func() { logging.Logger = previous })
+	return logs
+}
+
+func TestKeyRefreshFailureKeepsCachedKeys(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	logs := observeLogs(t)
+	resolver := &failingKeyResolver{keys: []interface{}{&key.PublicKey}}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	a, err := NewRSAAuthorizer(ctx, Configuration{
+		KeyResolver:       resolver,
+		KeyRefreshTimeout: 1 * time.Millisecond,
+		KeyTTL:            1 * time.Hour,
+	})
+	require.NoError(t, err)
+
+	resolver.setErr(stacktrace.NewErrorWithCode(dsserr.Unavailable, "JWKS endpoint is unreachable"))
+
+	require.Eventually(t, func() bool {
+		return logs.FilterLevelExact(zapcore.ErrorLevel).Len() > 0
+	}, time.Second, time.Millisecond)
+
+	require.Zero(t, logs.FilterLevelExact(zapcore.PanicLevel).Len())
+
+	a.keyGuard.RLock()
+	defer a.keyGuard.RUnlock()
+	require.Equal(t, []interface{}{&key.PublicKey}, a.keys)
+}
+
+func TestKeyRefreshFailurePanicsAfterMaxCacheAge(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	logs := observeLogs(t)
+	resolver := &failingKeyResolver{keys: []interface{}{&key.PublicKey}}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	_, err = NewRSAAuthorizer(ctx, Configuration{
+		KeyResolver:       resolver,
+		KeyRefreshTimeout: 1 * time.Millisecond,
+		KeyTTL:            200 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	resolver.setErr(stacktrace.NewErrorWithCode(dsserr.Unavailable, "JWKS endpoint is unreachable"))
+
+	require.Eventually(t, func() bool {
+		return logs.FilterLevelExact(zapcore.ErrorLevel).Len() > 0
+	}, time.Second, time.Millisecond)
+	require.Zero(t, logs.FilterLevelExact(zapcore.PanicLevel).Len())
+
+	require.Eventually(t, func() bool {
+		return logs.FilterLevelExact(zapcore.PanicLevel).Len() > 0
+	}, time.Second, time.Millisecond)
+}
+
+func TestKeyRefreshFailurePanicsImmediatelyWithoutMaxCacheAge(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	logs := observeLogs(t)
+	resolver := &failingKeyResolver{keys: []interface{}{&key.PublicKey}, err: nil}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	_, err = NewRSAAuthorizer(ctx, Configuration{
+		KeyResolver:       resolver,
+		KeyRefreshTimeout: 1 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	resolver.setErr(stacktrace.NewErrorWithCode(dsserr.Unavailable, "JWKS endpoint is unreachable"))
+
+	require.Eventually(t, func() bool {
+		return logs.FilterLevelExact(zapcore.PanicLevel).Len() > 0
+	}, time.Second, time.Millisecond)
+
+	require.Zero(t, logs.FilterLevelExact(zapcore.ErrorLevel).Len())
+}
+
+func TestKeyRefreshFailurePanicsOnNonRetryableError(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	logs := observeLogs(t)
+	resolver := &failingKeyResolver{keys: []interface{}{&key.PublicKey}}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	_, err = NewRSAAuthorizer(ctx, Configuration{
+		KeyResolver:       resolver,
+		KeyRefreshTimeout: 1 * time.Millisecond,
+		KeyTTL:            1 * time.Hour,
+	})
+	require.NoError(t, err)
+
+	resolver.setErr(stacktrace.NewError("Failed to resolve key(s) for ID: unknown"))
+
+	require.Eventually(t, func() bool {
+		return logs.FilterLevelExact(zapcore.PanicLevel).Len() > 0
+	}, time.Second, time.Millisecond)
+
+	require.Zero(t, logs.FilterLevelExact(zapcore.ErrorLevel).Len())
+}
+
+func TestJWKSResolverErrorCodes(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		status int
+		body   string
+		keyIDs []string
+		code   stacktrace.ErrorCode
+	}{
+		{"server error", http.StatusInternalServerError, "", nil, dsserr.Unavailable},
+		{"client error", http.StatusNotFound, "", nil, dsserr.Unavailable},
+		{"invalid body", http.StatusOK, "not json", nil, dsserr.Unavailable},
+		{"unknown key id", http.StatusOK, `{"keys":[]}`, []string{"unknown"}, stacktrace.NoCode},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(c.status)
+				_, _ = w.Write([]byte(c.body))
+			}))
+			defer server.Close()
+
+			endpoint, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			resolver := &JWKSResolver{Endpoint: endpoint, KeyIDs: c.keyIDs}
+			_, err = resolver.ResolveKeys(t.Context())
+			require.Error(t, err)
+			require.Equal(t, c.code, stacktrace.GetCode(err))
+		})
+	}
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -45,6 +45,10 @@ const (
 
 	// NotImplemented is used when a feature needed for the operation has not yet been implemented.
 	NotImplemented
+
+	// Unavailable is used when an operation failed for a transient reason and
+	// may succeed if it is attempted again later.
+	Unavailable
 )
 
 func init() {

--- a/pkg/sqlstore/store.go
+++ b/pkg/sqlstore/store.go
@@ -12,6 +12,7 @@ import (
 	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
 	"github.com/coreos/go-semver/semver"
 	"github.com/exaring/otelpgx"
+	dsserr "github.com/interuss/dss/pkg/errors"
 	"github.com/interuss/dss/pkg/logging"
 	dsssql "github.com/interuss/dss/pkg/sql"
 	"github.com/interuss/dss/pkg/sqlstore/params"
@@ -133,7 +134,7 @@ func Init[R any](ctx context.Context, cfg Config[R], withCheckCron bool) (*Store
 	db, err := Dial[R](ctx, cp)
 	if err != nil {
 		if strings.Contains(err.Error(), "connect: connection refused") {
-			return nil, stacktrace.PropagateWithCode(err, store.CodeRetryable, "Failed to connect to database server for %s", cfg.DBName)
+			return nil, stacktrace.PropagateWithCode(err, dsserr.Unavailable, "Failed to connect to database server for %s", cfg.DBName)
 		}
 		return nil, stacktrace.Propagate(err, "Failed to connect to %s database", cfg.DBName)
 	}
@@ -146,7 +147,7 @@ func Init[R any](ctx context.Context, cfg Config[R], withCheckCron bool) (*Store
 	if err != nil {
 		db.Pool.Close()
 		if strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), fmt.Sprintf("database \"%s\" does not exist", cfg.DBName)) || strings.Contains(err.Error(), "database has not been bootstrapped with Schema Manager") {
-			return nil, stacktrace.PropagateWithCode(err, store.CodeRetryable, "Failed to create %s store", cfg.DBName)
+			return nil, stacktrace.PropagateWithCode(err, dsserr.Unavailable, "Failed to create %s store", cfg.DBName)
 		}
 		return nil, stacktrace.Propagate(err, "Failed to create %s store", cfg.DBName)
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -57,7 +57,3 @@ func NewFuncOperation[R any](f func(context.Context, R) error) *FuncOperation[R]
 
 func (a *FuncOperation[R]) OperationID() string                    { return "" }
 func (a *FuncOperation[R]) Execute(ctx context.Context, r R) error { return a.f(ctx, r) }
-
-const (
-	CodeRetryable = stacktrace.ErrorCode(1)
-)


### PR DESCRIPTION
This PR contributes to #1632 by implementing a retry mechanism for transient JWKS key refresh failures.

The service will still panic when receiving a valid reply where, e.g., the required key is not found.

Implementing it via the `CodeRetryable` system had the positive side effect of applying the same retry behavior on startup in case of issues - similar to the datastore - which makes sense instead of directly crashing, so I kept it.

No documentation changes are included as none currently exist. I will create follow-up PRs for that along with deployment changes.