### PR TITLE
[auth] Rename key_refresh_timeout flag to jwks_refresh_interval

### DIFF
--- a/NEXT_RELEASE_NOTES.md
+++ b/NEXT_RELEASE_NOTES.md
@@ -59,6 +59,7 @@ The release notes should contain at least the following sections:
   * For existing clusters, ensure the value of `aws_kubernetes_storage_class` in your terraform config is set to `gp2` if it was not defined. Switching storage class is not supported.
   * As `gp3` doesn't exist by default in EKS, terraform will now create the new storage class. If `gp3` already exists in your cluster, set `aws_create_storage_class` to false.
   * There is a behaviour change between the previous default storage class and the new one: `reclaimPolicy` is set to `Retain` to limit accidental data deletion.
+* The `key_refresh_timeout` flag has been renamed to `jwks_refresh_interval`. The former is still accepted but is deprecated and will be removed in a future release.
 
 ## Important information
 

--- a/cmds/core-service/main.go
+++ b/cmds/core-service/main.go
@@ -61,12 +61,13 @@ var (
 	enableTracing           = flag.Bool("enable_tracing", false, "Enable tracing")
 	metricsListeningAddress = flag.String("metrics_addr", ":8079", "Address and port that the for the prometheus-compatible metric service binds to and listens on for incoming connections")
 
-	pkFile            = flag.String("public_key_files", "", "Path to public Keys to use for JWT decoding, separated by commas.")
-	jwksEndpoint      = flag.String("jwks_endpoint", "", "URL pointing to an endpoint serving JWKS")
-	jwksKeyIDs        = flag.String("jwks_key_ids", "", "IDs of a set of key in a JWKS, separated by commas")
-	keyRefreshTimeout = flag.Duration("key_refresh_timeout", 1*time.Minute, "Timeout for refreshing keys for JWT verification")
-	jwksKeyTTL        = flag.Duration("jwks_key_ttl", 1*time.Hour, "Maximum duration during which keys that could not be refreshed are still used before shutting down the service")
-	jwtAudiences      = flag.String("accepted_jwt_audiences", "", "comma-separated acceptable JWT `aud` claims")
+	pkFile                  = flag.String("public_key_files", "", "Path to public Keys to use for JWT decoding, separated by commas.")
+	jwksEndpoint            = flag.String("jwks_endpoint", "", "URL pointing to an endpoint serving JWKS")
+	jwksKeyIDs              = flag.String("jwks_key_ids", "", "IDs of a set of key in a JWKS, separated by commas")
+	legacyKeyRefreshTimeout = flag.Duration("key_refresh_timeout", 1*time.Minute, "DEPRECATED (replaced by jwks_refresh_interval) Cadence at which the keys used for JWT verification are refreshed")
+	jwksRefreshInterval     = flag.Duration("jwks_refresh_interval", 1*time.Minute, "Cadence at which the keys used for JWT verification are refreshed")
+	jwksKeyTTL              = flag.Duration("jwks_key_ttl", 1*time.Hour, "Maximum duration during which keys that could not be refreshed are still used before shutting down the service")
+	jwtAudiences            = flag.String("accepted_jwt_audiences", "", "comma-separated acceptable JWT `aud` claims")
 )
 
 func createKeyResolver() (auth.KeyResolver, error) {
@@ -317,10 +318,10 @@ func RunHTTPServer(ctx context.Context, ctxCanceler func(), address, locality st
 
 	authorizer, err := auth.NewRSAAuthorizer(
 		ctx, auth.Configuration{
-			KeyResolver:       keyResolver,
-			KeyRefreshTimeout: *keyRefreshTimeout,
-			KeyTTL:            *jwksKeyTTL,
-			AcceptedAudiences: strings.Split(*jwtAudiences, ","),
+			KeyResolver:        keyResolver,
+			KeyRefreshInterval: *jwksRefreshInterval,
+			KeyTTL:             *jwksKeyTTL,
+			AcceptedAudiences:  strings.Split(*jwtAudiences, ","),
 		},
 	)
 	if err != nil {
@@ -465,6 +466,10 @@ func main() {
 		if f.Name == "server timeout" {
 			*timeout = *legacyTimeout
 			logger.Warn("'server timeout' has been renamed to 'server_timeout'")
+		}
+		if f.Name == "key_refresh_timeout" {
+			*jwksRefreshInterval = *legacyKeyRefreshTimeout
+			logger.Warn("'key_refresh_timeout' has been renamed to 'jwks_refresh_interval'")
 		}
 	})
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -133,10 +133,10 @@ type Authorizer struct {
 
 // Configuration bundles up creation-time parameters for an Authorizer instance.
 type Configuration struct {
-	KeyResolver       KeyResolver   // Used to initialize and periodically refresh keys.
-	KeyRefreshTimeout time.Duration // Keys are refreshed on this cadence.
-	KeyTTL            time.Duration // Maximum age of the cached keys before a failing refresh becomes fatal.
-	AcceptedAudiences []string      // AcceptedAudiences enforces the aud keyClaim on the jwt. An empty string allows no aud keyClaim.
+	KeyResolver        KeyResolver   // Used to initialize and periodically refresh keys.
+	KeyRefreshInterval time.Duration // Keys are refreshed on this cadence.
+	KeyTTL             time.Duration // Maximum age of the cached keys before a failing refresh becomes fatal.
+	AcceptedAudiences  []string      // AcceptedAudiences enforces the aud keyClaim on the jwt. An empty string allows no aud keyClaim.
 }
 
 // NewRSAAuthorizer returns an Authorizer instance using values from configuration.
@@ -155,7 +155,7 @@ func NewRSAAuthorizer(ctx context.Context, configuration Configuration) (*Author
 	}
 
 	go func() {
-		ticker := time.NewTicker(configuration.KeyRefreshTimeout)
+		ticker := time.NewTicker(configuration.KeyRefreshInterval)
 		defer ticker.Stop()
 
 		lastSuccess := time.Now()

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -112,7 +112,7 @@ func TestNewRSAAuthClient(t *testing.T) {
 		KeyResolver: &FromFileKeyResolver{
 			KeyFiles: []string{tmpfile.Name()},
 		},
-		KeyRefreshTimeout: 1 * time.Millisecond,
+		KeyRefreshInterval: 1 * time.Millisecond,
 	})
 	require.Error(t, err)
 	require.NoError(t, os.Remove(tmpfile.Name()))
@@ -158,8 +158,8 @@ func TestRSAAuthInterceptor(t *testing.T) {
 		KeyResolver: &fromMemoryKeyResolver{
 			Keys: []interface{}{&key.PublicKey},
 		},
-		KeyRefreshTimeout: 1 * time.Millisecond,
-		AcceptedAudiences: []string{"test-aud"},
+		KeyRefreshInterval: 1 * time.Millisecond,
+		AcceptedAudiences:  []string{"test-aud"},
 	})
 
 	require.NoError(t, err)
@@ -352,8 +352,8 @@ func TestRSAAuthAudiences(t *testing.T) {
 				KeyResolver: &fromMemoryKeyResolver{
 					Keys: []interface{}{&key.PublicKey},
 				},
-				KeyRefreshTimeout: 1 * time.Millisecond,
-				AcceptedAudiences: test.Accepted,
+				KeyRefreshInterval: 1 * time.Millisecond,
+				AcceptedAudiences:  test.Accepted,
 			})
 			require.NoError(t, err)
 
@@ -535,9 +535,9 @@ func TestKeyRefreshFailureKeepsCachedKeys(t *testing.T) {
 	defer cancel()
 
 	a, err := NewRSAAuthorizer(ctx, Configuration{
-		KeyResolver:       resolver,
-		KeyRefreshTimeout: 1 * time.Millisecond,
-		KeyTTL:            1 * time.Hour,
+		KeyResolver:        resolver,
+		KeyRefreshInterval: 1 * time.Millisecond,
+		KeyTTL:             1 * time.Hour,
 	})
 	require.NoError(t, err)
 
@@ -565,9 +565,9 @@ func TestKeyRefreshFailurePanicsAfterMaxCacheAge(t *testing.T) {
 	defer cancel()
 
 	_, err = NewRSAAuthorizer(ctx, Configuration{
-		KeyResolver:       resolver,
-		KeyRefreshTimeout: 1 * time.Millisecond,
-		KeyTTL:            200 * time.Millisecond,
+		KeyResolver:        resolver,
+		KeyRefreshInterval: 1 * time.Millisecond,
+		KeyTTL:             200 * time.Millisecond,
 	})
 	require.NoError(t, err)
 
@@ -594,8 +594,8 @@ func TestKeyRefreshFailurePanicsImmediatelyWithoutMaxCacheAge(t *testing.T) {
 	defer cancel()
 
 	_, err = NewRSAAuthorizer(ctx, Configuration{
-		KeyResolver:       resolver,
-		KeyRefreshTimeout: 1 * time.Millisecond,
+		KeyResolver:        resolver,
+		KeyRefreshInterval: 1 * time.Millisecond,
 	})
 	require.NoError(t, err)
 
@@ -619,9 +619,9 @@ func TestKeyRefreshFailurePanicsOnNonRetryableError(t *testing.T) {
 	defer cancel()
 
 	_, err = NewRSAAuthorizer(ctx, Configuration{
-		KeyResolver:       resolver,
-		KeyRefreshTimeout: 1 * time.Millisecond,
-		KeyTTL:            1 * time.Hour,
+		KeyResolver:        resolver,
+		KeyRefreshInterval: 1 * time.Millisecond,
+		KeyTTL:             1 * time.Hour,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR follows #1634.

 It normalizes the `key_refresh_timeout` flag to be consistent with other JWKS flags and improves its description.