### PR TITLE
[doc] Add documentation about authentication and keys

### DIFF
--- a/docs/deployment_checklist.md
+++ b/docs/deployment_checklist.md
@@ -22,3 +22,4 @@ This checklist outlines the major decisions and steps required to deploy a non-l
 * [ ] If needed, [monitor metrics](operations/monitoring.md) of your DSS instance.
 * [ ] If needed, track the availability of your DSS instance using [health checks](operations/healthchecks.md).
 * [ ] Review the [database cleanup documentation](operations/cleanup.md) and enable cleanup cron jobs if required.
+* [ ] Review the [authentication documentation](operations/authentication.md) to configure how access tokens are verified.

--- a/docs/operations/.nav.yml
+++ b/docs/operations/.nav.yml
@@ -10,4 +10,5 @@ nav:
   - "Database migrations": database-migrations.md
   - "Performances": performances.md
   - "Cleanup": cleanup.md
+  - "Authentication": authentication.md
   - "Troubleshooting": troubleshooting.md

--- a/docs/operations/authentication.md
+++ b/docs/operations/authentication.md
@@ -1,0 +1,39 @@
+# Authentication
+
+Every request to the core-service must include an access token verified against a set of public keys. You can provide these keys either through local files or a JWKS endpoint (the two options are mutually exclusive).
+
+Regardless of the approach, use `accepted_jwt_audiences` to specify a comma-separated list of `aud` claims accepted by the core-service.
+
+## Static keys
+
+Use `public_key_files` to supply a comma-separated list of paths to PEM files containing the public keys.
+
+These files are loaded only once at startup. Rotating a key requires a service restart.
+
+## JWKS endpoint
+
+To use a JWKS endpoint, set `jwks_endpoint` to the endpoint URL and `jwks_key_ids` to a comma-separated list of key IDs to extract.
+
+The service fetches keys on startup and refreshes them every `jwks_refresh_interval`. A successful refresh replaces the entire active key set, allowing key rotations on the authorization server without restarting the core-service.
+
+### Handling endpoint failures
+
+A refresh fails transiently if the endpoint is unreachable, returns an error status code ($\ge 400$), or provides an invalid JWK set. In these cases, the service logs an error and continues using the last successfully retrieved keys. It will shut down only if it fails to refresh keys for longer than `jwks_key_ttl`.
+
+Missing key IDs listed in `jwks_key_ids` are treated as non-transient errors. This signals a mismatch between the endpoint and core-service configuration, so the service shuts down immediately.
+
+If a transient failure occurs during startup, the core-service retries with exponential backoff until the endpoint becomes available rather than crashing immediately.
+
+`jwks_key_ttl` balances key rotation with service availability. It keeps the DSS running when the authorization server goes down, provided the key set hasn't changed. However, retired keys remain valid during this window - if a key was revoked due to a leak, an attacker with that key can continue signing accepted tokens for up to `jwks_key_ttl` (especially if they can keep the endpoint unreachable). Setting this value close to your maximum token lifespan offers a good balance.
+
+To disable key caching entirely, set `jwks_key_ttl` to `0`.
+
+## Development keys
+
+For local development, the repository includes a pre-configured key pair in [`build/test-certs`](https://github.com/interuss/dss/blob/master/build/test-certs):
+
+* `auth2.pem`: Passed to `public_key_files`
+* `auth2.key`: Used by [dummy-oauth](https://github.com/interuss/dss/blob/master/cmds/dummy-oauth) to sign test tokens
+
+!!! danger
+    These keys are public. Never use them in production or on environments handling real traffic. Check the directory's README for instructions on generating new key pairs.

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -24,7 +24,6 @@ See [Leaving a pool](pooling.md#leaving-a-pool)
 
 See [Monitoring](monitoring.md)
 
-
 ## Health checks
 
 See [Health checks](healthchecks.md)
@@ -36,6 +35,10 @@ See [Database migrations](database-migrations.md)
 ## Performances
 
 See [Performances](performances.md)
+
+## Authentication
+
+See [Authentication](authentication.md)
 
 ## Troubleshooting
 


### PR DESCRIPTION
This PR follows #1635.

It adds general documentation on handling keys, which was not previously present.