### PR TITLE
[ci] Decrease the concurrent workers for Yugabyte' with -enable_scd_hash_lock flag test

### DIFF
--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -61,9 +61,9 @@ fi
 
 # Following the extension of performance testing in https://github.com/interuss/dss/pull/1618
 # The Yugabyte test with the -enable_scd_hash_lock flag faces intermittent load-sensitive test failures, so we reduce the
-# concurrent worker count to 2 for that specific configuration.
+# concurrent worker count to 1 for that specific configuration.
 if [[ "${COMPOSE_PROFILES:-}" == *"yugabyte"* && "${CORE_SERVICE_EXTRA_FLAGS:-}" == *"-enable_scd_hash_lock"* ]]; then
-	PROBER_EXTRA_ARGS+=(--heavy_traffic_concurrent_workers 2)
+	PROBER_EXTRA_ARGS+=(--heavy_traffic_concurrent_workers 1)
 fi
 
 if ! docker run --rm --link "$OAUTH_CONTAINER":oauth \

--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -60,7 +60,7 @@ if [[ "${CORE_SERVICE_EXTRA_FLAGS:-}" == *"-enable_time_based_notification_index
 fi
 
 # Following the extension of performance testing in https://github.com/interuss/dss/pull/1618
-# The Yugabyte test with the -enable_scd_hash_lock flag is flaky, so we reduce the
+# The Yugabyte test with the -enable_scd_hash_lock flag faces intermittent load-sensitive test failures, so we reduce the
 # concurrent worker count to 8 for that specific configuration.
 if [[ "${COMPOSE_PROFILES:-}" == *"yugabyte"* && "${CORE_SERVICE_EXTRA_FLAGS:-}" == *"-enable_scd_hash_lock"* ]]; then
 	PROBER_EXTRA_ARGS+=(--heavy_traffic_concurrent_workers 8)

--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -59,6 +59,12 @@ if [[ "${CORE_SERVICE_EXTRA_FLAGS:-}" == *"-enable_time_based_notification_index
 	PROBER_EXTRA_ARGS+=(--scd-time-based-notification-index true)
 fi
 
+# The heavy traffic concurrency tests are flaky when running against Yugabyte
+# We reduce the concurrent worker count for that backend to 5
+if [[ "${COMPOSE_PROFILES:-}" == *"yugabyte"* ]]; then
+	PROBER_EXTRA_ARGS+=(--heavy_traffic_concurrent_workers 5)
+fi
+
 if ! docker run --rm --link "$OAUTH_CONTAINER":oauth \
 	--link "$CORE_SERVICE_CONTAINER":core-service \
 	--network dss_sandbox-default \

--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -61,9 +61,9 @@ fi
 
 # Following the extension of performance testing in https://github.com/interuss/dss/pull/1618
 # The Yugabyte test with the -enable_scd_hash_lock flag faces intermittent load-sensitive test failures, so we reduce the
-# concurrent worker count to 5 for that specific configuration.
+# concurrent worker count to 2 for that specific configuration.
 if [[ "${COMPOSE_PROFILES:-}" == *"yugabyte"* && "${CORE_SERVICE_EXTRA_FLAGS:-}" == *"-enable_scd_hash_lock"* ]]; then
-	PROBER_EXTRA_ARGS+=(--heavy_traffic_concurrent_workers 5)
+	PROBER_EXTRA_ARGS+=(--heavy_traffic_concurrent_workers 2)
 fi
 
 if ! docker run --rm --link "$OAUTH_CONTAINER":oauth \

--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -59,10 +59,11 @@ if [[ "${CORE_SERVICE_EXTRA_FLAGS:-}" == *"-enable_time_based_notification_index
 	PROBER_EXTRA_ARGS+=(--scd-time-based-notification-index true)
 fi
 
-# The heavy traffic concurrency tests are flaky when running against Yugabyte
-# We reduce the concurrent worker count for that backend to 5
-if [[ "${COMPOSE_PROFILES:-}" == *"yugabyte"* ]]; then
-	PROBER_EXTRA_ARGS+=(--heavy_traffic_concurrent_workers 5)
+# Following the extension of performance testing in https://github.com/interuss/dss/pull/1618
+# The Yugabyte test with the -enable_scd_hash_lock flag is flaky, so we reduce the
+# concurrent worker count to 8 for that specific configuration.
+if [[ "${COMPOSE_PROFILES:-}" == *"yugabyte"* && "${CORE_SERVICE_EXTRA_FLAGS:-}" == *"-enable_scd_hash_lock"* ]]; then
+	PROBER_EXTRA_ARGS+=(--heavy_traffic_concurrent_workers 8)
 fi
 
 if ! docker run --rm --link "$OAUTH_CONTAINER":oauth \

--- a/build/dev/probe_locally.sh
+++ b/build/dev/probe_locally.sh
@@ -61,9 +61,9 @@ fi
 
 # Following the extension of performance testing in https://github.com/interuss/dss/pull/1618
 # The Yugabyte test with the -enable_scd_hash_lock flag faces intermittent load-sensitive test failures, so we reduce the
-# concurrent worker count to 8 for that specific configuration.
+# concurrent worker count to 5 for that specific configuration.
 if [[ "${COMPOSE_PROFILES:-}" == *"yugabyte"* && "${CORE_SERVICE_EXTRA_FLAGS:-}" == *"-enable_scd_hash_lock"* ]]; then
-	PROBER_EXTRA_ARGS+=(--heavy_traffic_concurrent_workers 8)
+	PROBER_EXTRA_ARGS+=(--heavy_traffic_concurrent_workers 5)
 fi
 
 if ! docker run --rm --link "$OAUTH_CONTAINER":oauth \

--- a/docs/operations/performances.md
+++ b/docs/operations/performances.md
@@ -51,6 +51,8 @@ This should be better than global lock, as long as cells used don't collide and 
 
 The number of locks (65535) is a compromise between lock contention (the more locks, the less unrelated cells share the same one) and the size of the `scd_locks` table. It is fixed and cannot be changed.
 
+Note that since [#1618](https://github.com/interuss/dss/issues/1618), the `--heavy_traffic_concurrent_workers` flag needs to be reduced on the CI when testing with the `-enable_scd_hash_lock` configuration against Yugabyte due to intermittent load-sensitive test failures.
+
 ## The time-based notification index option
 
 !!! danger

--- a/docs/operations/performances.md
+++ b/docs/operations/performances.md
@@ -51,7 +51,7 @@ This should be better than global lock, as long as cells used don't collide and 
 
 The number of locks (65535) is a compromise between lock contention (the more locks, the less unrelated cells share the same one) and the size of the `scd_locks` table. It is fixed and cannot be changed.
 
-Note that since [#1618](https://github.com/interuss/dss/issues/1618), the `--heavy_traffic_concurrent_workers` flag needs to be reduced on the CI when testing with the `-enable_scd_hash_lock` configuration against Yugabyte due to intermittent load-sensitive test failures.
+Note that this flag creates intermittent load-sensitive test failures when used with Yugabyte. See PR [#1659](https://github.com/interuss/dss/pull/1659) for more details.
 
 ## The time-based notification index option
 


### PR DESCRIPTION
Following the extension of performance testing in #1618, the CI runs against Yugabyte with the `-enable_scd_hash_lock` flag can face intermittent load-sensitive test failures due to the high number of concurrent workers.  
This PR fixes this by decreasing the `--heavy_traffic_concurrent_workers` flag to 1.